### PR TITLE
deb: all flavors recommend hostmot2-firmware-all now

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -141,7 +141,6 @@ esac
 DOC_BUILD=
 MAIN_PACKAGE_NAME=linuxcnc
 OTHER_MAIN_PACKAGE_NAME=linuxcnc-uspace
-EXTRA_RECOMMENDS=hostmot2-firmware
 case $TARGET in
     uspace|sim)
 	TARGET=uspace
@@ -156,7 +155,7 @@ case $TARGET in
 	MAIN_PACKAGE_NAME=linuxcnc-uspace
         OTHER_MAIN_PACKAGE_NAME=linuxcnc
 
-        EXTRA_RECOMMENDS="$EXTRA_RECOMMENDS, linux-image-rt-amd64 [linux-amd64], linux-image-rt-686-pae [linux-i386]"
+        EXTRA_RECOMMENDS="linux-image-rt-amd64 [linux-amd64], linux-image-rt-686-pae [linux-i386]"
     ;;
     2.6.12-magma)
         KERNEL_HEADERS=$KERNEL_HEADERS,gcc-3.4

--- a/debian/control.in
+++ b/debian/control.in
@@ -36,7 +36,7 @@ Description: PC based motion controller for real-time Linux
 Package: @MAIN_PACKAGE_NAME@
 Conflicts: linuxcnc-sim, @OTHER_MAIN_PACKAGE_NAME@
 Architecture: any
-Recommends: linuxcnc-doc-en | linuxcnc-doc, @EXTRA_RECOMMENDS@
+Recommends: linuxcnc-doc-en | linuxcnc-doc, hostmot2-firmware-all, @EXTRA_RECOMMENDS@
 Depends: ${shlibs:Depends}, @KERNEL_DEPENDS@,
     tcl@TCLTK_VERSION@, tk@TCLTK_VERSION@, bwidget (>= 1.7), libtk-img (>=1.13),
     python (>= @PYTHON_VERSION@), python (<< @PYTHON_VERSION_NEXT@),


### PR DESCRIPTION
We have two package flavors in master now: uspace (aka sim, aka rtpreempt)
and regular (rtai kernel).  Both can drive Mesa hardware, so both should
recommend hostmot2-firmware-all.

Signed-off-by: Sebastian Kuzminsky seb@highlab.com
