### PR TITLE
Using POSIX timers instead of clock_nanosleep

### DIFF
--- a/src/rtapi/rtapi_uspace.hh
+++ b/src/rtapi/rtapi_uspace.hh
@@ -34,10 +34,7 @@ struct rtapi_task {
   int magic;			/* to check for valid handle */
   int id;
   int owner;
-  union {
-      pthread_t thr;                /* thread's context */
-      void *appspecific;          /* app-specific storage */
-  };
+  void *appspecific;          /* app-specific storage */
   size_t stacksize;
   int prio;
   long period;

--- a/src/rtapi/rtapi_uspace.hh
+++ b/src/rtapi/rtapi_uspace.hh
@@ -28,6 +28,25 @@ struct WithRoot
     static int level;
 };
 
+struct rtapi_task {
+  rtapi_task();
+
+  int magic;			/* to check for valid handle */
+  int id;
+  int owner;
+  union {
+      pthread_t thr;                /* thread's context */
+      void *appspecific;          /* app-specific storage */
+  };
+  size_t stacksize;
+  int prio;
+  long period;
+  struct timespec nextstart;
+  unsigned ratio;
+  void *arg;
+  void (*taskcode) (void*);	/* pointer to task function */
+};
+
 struct RtapiApp
 {
 
@@ -40,7 +59,8 @@ struct RtapiApp
     long clock_set_period(long int period_nsec);
     int task_new(void (*taskcode)(void*), void *arg,
             int prio, int owner, unsigned long int stacksize, int uses_fp);
-    static int allocate_task();
+    virtual rtapi_task *do_task_new() = 0;
+    static int allocate_task_id();
     static struct rtapi_task *get_task(int task_id);
     virtual int task_delete(int id) = 0;
     virtual int task_start(int task_id, unsigned long period_nsec) = 0;
@@ -57,25 +77,9 @@ struct RtapiApp
 
 #define MAX_TASKS  64
 #define TASK_MAGIC    21979	/* random numbers used as signatures */
-#define TASK_MAGIC_INIT   ~21979
+#define TASK_MAGIC_INIT   ((rtapi_task*)(-1))
 
-struct rtapi_task {
-  int magic;			/* to check for valid handle */
-  int owner;
-  union {
-      pthread_t thr;                /* thread's context */
-      void *appspecific;          /* app-specific storage */
-  };
-  size_t stacksize;
-  int prio;
-  long period;
-  struct timespec nextstart;
-  unsigned ratio;
-  void *arg;
-  void (*taskcode) (void*);	/* pointer to task function */
-};
-
-extern struct rtapi_task task_array[MAX_TASKS];
+extern struct rtapi_task *task_array[MAX_TASKS];
 
 #define WITH_ROOT WithRoot root
 #endif

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -519,8 +519,17 @@ struct rtapi_module {
 #define MAX_MODULES  64
 #define MODULE_OFFSET 32768
 
+rtapi_task::rtapi_task()
+    : magic{}, id{}, owner{}, thr{}, stacksize{}, prio{}, period{}, nextstart{},
+      ratio{}, arg{}, taskcode{}
+{}
+
 namespace
 {
+struct PosixTask : rtapi_task
+{
+};
+
 struct Posix : RtapiApp
 {
     Posix(int policy = SCHED_FIFO) : RtapiApp(policy), do_thread_lock(policy != SCHED_FIFO) {
@@ -534,6 +543,9 @@ struct Posix : RtapiApp
     int task_resume(int task_id);
     int task_self();
     void wait();
+    struct rtapi_task *do_task_new() {
+        return new PosixTask;
+    }   
     unsigned char do_inb(unsigned int port);
     void do_outb(unsigned char value, unsigned int port);
     int run_threads(int fd, int (*callback)(int fd));
@@ -704,7 +716,7 @@ RtapiApp &App()
 
 }
 /* data for all tasks */
-struct rtapi_task task_array[MAX_TASKS] = {{0},};
+struct rtapi_task *task_array[MAX_TASKS];
 
 /* Priority functions.  Uspace uses POSIX task priorities. */
 
@@ -741,12 +753,12 @@ int RtapiApp::prio_next_lower(int prio)
   return prio - 1;
 }
 
-int RtapiApp::allocate_task()
+int RtapiApp::allocate_task_id()
 {
     for(int n=0; n<MAX_TASKS; n++)
     {
-        rtapi_task *task = &(task_array[n]);
-        if(__sync_bool_compare_and_swap(&task->magic, 0, TASK_MAGIC_INIT))
+        rtapi_task **taskptr = &(task_array[n]);
+        if(__sync_bool_compare_and_swap(taskptr, (rtapi_task*)0, TASK_MAGIC_INIT))
             return n;
     }
     return -ENOSPC;
@@ -761,20 +773,21 @@ int RtapiApp::task_new(void (*taskcode) (void*), void *arg,
   }
 
   /* label as a valid task structure */
-  int n = allocate_task();
+  int n = allocate_task_id();
   if(n < 0) return n;
 
   // cannot use get_task, since task->magic is TASK_MAGIC_INIT
-  struct rtapi_task *task = &(task_array[n]);
-
+  struct rtapi_task *task = do_task_new();
   if(stacksize < (1024*1024)) stacksize = (1024*1024);
   memset(task, 0, sizeof(*task));
+  task->id = n;
   task->owner = owner;
   task->arg = arg;
   task->stacksize = stacksize;
   task->taskcode = taskcode;
   task->prio = prio;
   task->magic = TASK_MAGIC;
+  task_array[n] = task;
 
   /* and return handle to the caller */
 
@@ -784,8 +797,8 @@ int RtapiApp::task_new(void (*taskcode) (void*), void *arg,
 rtapi_task *RtapiApp::get_task(int task_id) {
     if(task_id < 0 || task_id >= MAX_TASKS) return NULL;
     /* validate task handle */
-    rtapi_task *task = &task_array[task_id];
-    if(!task || task->magic != TASK_MAGIC)
+    rtapi_task *task = task_array[task_id];
+    if(!task || task == TASK_MAGIC_INIT || task->magic != TASK_MAGIC)
         return NULL;
 
     return task;
@@ -799,6 +812,8 @@ int Posix::task_delete(int id)
   pthread_cancel(task->thr);
   pthread_join(task->thr, 0);
   task->magic = 0;
+  task_array[id] = 0;
+  delete task;
   return 0;
 }
 
@@ -890,7 +905,7 @@ void *Posix::wrapper(void *arg)
   /* call the task function with the task argument */
   (task->taskcode) (task->arg);
 
-  rtapi_print("ERROR: reached end of wrapper for task %d\n", (int)(task - task_array));
+  rtapi_print("ERROR: reached end of wrapper for task %d\n", task->id);
   return NULL;
 }
 
@@ -905,7 +920,7 @@ int Posix::task_resume(int) {
 int Posix::task_self() {
     struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
     if(!task) return -EINVAL;
-    return task - task_array;
+    return task->id;
 }
 
 static bool ts_less(const struct timespec &ta, const struct timespec &tb) {
@@ -927,10 +942,11 @@ void Posix::wait() {
         static int printed = 0;
         if(policy == SCHED_FIFO && !printed)
         {
-            rtapi_print_msg(RTAPI_MSG_ERR, "Unexpected realtime delay on task %zd\n"
+            rtapi_print_msg(RTAPI_MSG_ERR,
+                    "Unexpected realtime delay on task %d with period %ld\n"
 		    "This Message will only display once per session.\n"
 		    "Run the Latency Test and resolve before continuing.\n", 
-                    task - task_array);
+                    task->id, task->period);
             printed = 1;
         }
     }


### PR DESCRIPTION
@trasz I cooked this up because it might be helpful for freebsd.  It gets rid of all use of clock_nanosleep(CLOCK_ABSTIME) by instead using POSIX timers.  It does use an extension to posix (SIGEV_THREAD_ID) but this identifier is seen in /usr/include/sys/signal.h on the freebsd 9.2 machine I have handy for grepping.
