### PR TITLE
tests: hm2-idrom: exit early when a test fails

### DIFF
--- a/tests/hm2-idrom/test.sh
+++ b/tests/hm2-idrom/test.sh
@@ -22,7 +22,7 @@ TEST_PATTERN=0
 while [ ! -z "${Error[$TEST_PATTERN]}" ]; do
     export TEST_PATTERN
     halrun -f broken-load-test.hal >halrun-stdout 2>halrun-stderr
-    ./check-dmesg "${Error[$TEST_PATTERN]}" || result=$?
+    ./check-dmesg "${Error[$TEST_PATTERN]}" || exit $?
     TEST_PATTERN=$(($TEST_PATTERN+1))
 done
 


### PR DESCRIPTION
I found this one left over in my source tree.  I appear to have been troubleshooting failures in hm2-idrom, and found that the evidence was always destroyed by the time I wanted to look at it, because after a failure the test went on to the next test pattern.