### PR TITLE
sampler: Update fifo-depth and fifo-full pins even when sampler is not enabled

### DIFF
--- a/src/hal/components/sampler.c
+++ b/src/hal/components/sampler.c
@@ -160,7 +160,8 @@ static void sample(void *arg, long period)
     samp = arg;
     /* are we enabled? */
     if ( ! *(samp->enable) ) {
-	/* no, done */
+    *(samp->curr_depth) = hal_stream_depth(&samp->fifo);            // update fifo-depth
+	*(samp->full) = !hal_stream_writable(&samp->fifo);             // update if fifo is not-full
 	return;
     }
     /* point at pins in hal shmem */


### PR DESCRIPTION
Currently this pins do not provide live/actual values of fifo.
If halsampler (ULAPI) is reading fifo after sampler is disabled then fifo-depth is altered which is not updated on this pin; Similarly if fifo was full before diabling it and then halsampler emptied it, still sampler will show that fifo is full.

Signed-off-by: Rushabh Loladia <rushabh.loladia@gmail.com>