### PR TITLE
configure: use (more) portable pgrep

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -24,7 +24,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 
 LSMOD=@LSMOD@
-PIDOF="@PIDOF@ -x"
+PGREP="@PGREP@ -x"
 PS=@PS@
 AWK=@AWK@
 IPCS=@IPCS@
@@ -500,7 +500,7 @@ KILL_TIMEOUT=20
 ################################################################################
 function KillTaskWithTimeout() {
     if [ ! -n "$KILL_PIDS" ] ; then
-	KILL_PIDS=`$PIDOF $KILL_TASK`
+	KILL_PIDS=`$PGREP $KILL_TASK`
     fi
     if [ ! -n "$KILL_PIDS" ] ; then
 	echo "Could not find pid(s) for task $KILL_TASK"
@@ -559,7 +559,7 @@ function Cleanup() {
     # Kill displays first - that should cause an orderly
     #   shutdown of the rest of linuxcnc
     for KILL_TASK in linuxcncpanel iosh linuxcncsh linuxcncrsh linuxcnctop mdi debuglevel; do
-	if $PIDOF $KILL_TASK >>$DEBUG_FILE ; then
+	if $PGREP $KILL_TASK >>$DEBUG_FILE ; then
 	    KillTaskWithTimeout
 	fi
     done
@@ -592,7 +592,7 @@ function Cleanup() {
 
     # now kill all the other user space components
     for KILL_TASK in linuxcncsvr milltask; do
-	if $PIDOF $KILL_TASK >>$DEBUG_FILE ; then
+	if $PGREP $KILL_TASK >>$DEBUG_FILE ; then
 	    KillTaskWithTimeout
 	fi
     done

--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -6,7 +6,7 @@
 
 export LANG=C
 
-PIDOF=@PIDOF@
+PGREP=@PGREP@
 
 CheckKernel() {
     case "@KERNEL_VERS@" in
@@ -104,7 +104,7 @@ CheckConfig(){
 CheckStatus(){
     case $RTPREFIX in
     uspace)
-        if [ -z "$($PIDOF rtapi_app)" ]; then
+        if [ -z "$($PGREP rtapi_app)" ]; then
             exit 1
         else
             exit 0

--- a/src/configure.in
+++ b/src/configure.in
@@ -825,10 +825,10 @@ then
     AC_MSG_ERROR([lsmod not found])
 fi
 
-AC_PATH_PROG(PIDOF, pidof, "none", $SPATH)
+AC_PATH_PROG(PGREP, pgrep, "none", $SPATH)
 if test $PIDOF = "none"
 then
-    AC_MSG_ERROR([pidof not found])
+    AC_MSG_ERROR([pgrep not found])
 fi
 
 AC_PATH_PROG(IPCS, ipcs, "none")


### PR DESCRIPTION
pgrep exists on linux and freebsd, while pidof is linux-specific.  Some sources even refer to pidof as deprecated.  Go ahead and use pgrep everywhere.  This passes on all linux architectures on our buildbot.

@trasz does this work for freebsd?