### PR TITLE
halshow.tcl: use no special grouping for signals

### DIFF
--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -171,7 +171,7 @@ proc listHAL {} {
                 makeNodeP $node [set ${node}str]
             }
             sig {
-                makeNodeSig $sigstr
+                makeNodeP $node [set ${node}str]
             }
             comp {-}
             funct {-}


### PR DESCRIPTION
        as no example I am aware of, does use sensible signal names, I would
        like to get rid of the special grouping for signals.
	(Which makes it really hard, to read dot-delimited signal names)
        I'm able to propose a standard-naming scheme, which would make configs
        much more readable - just had not time, to adapt some of the sample
        configs.

Signed-off-by: Florian Kerle <flo.kerle@gmx.at>