### PR TITLE
rs274: work around boost::python bug

### DIFF
--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -44,12 +44,21 @@
 
 extern const char *strstore(const char *s);
 
+// boost python versions from 1.58 to 1.61 (the latest at the time of
+// writing) all have a bug in boost::python::execfile that results in a
+// double free.  Work around it by using the Python implementation of
+// execfile instead.
+// The bug was introduced at https://github.com/boostorg/python/commit/fe24ab9dd5440562e27422cd38f7de03356bfd16
+bp::object working_execfile(const char *filename, bp::object globals, bp::object locals) {
+    return bp::import("__builtin__").attr("execfile")(filename, globals, locals);
+}
+
 int PythonPlugin::run_string(const char *cmd, bp::object &retval, bool as_file)
 {
     reload();
     try {
 	if (as_file)
-	    retval = bp::exec_file(cmd, main_namespace, main_namespace);
+	    retval = working_execfile(cmd, main_namespace, main_namespace);
 	else
 	    retval = bp::exec(cmd, main_namespace, main_namespace);
 	status = PLUGIN_OK;
@@ -249,7 +258,7 @@ int PythonPlugin::initialize()
 		main_namespace[inittab_entries[i]] = bp::import(inittab_entries[i].c_str());
 	    }
 	    if (toplevel) // only execute a file if there's one configured.
-		bp::object result = bp::exec_file(abs_path,
+		bp::object result = working_execfile(abs_path,
 						  main_namespace,
 						  main_namespace);
 	    status = PLUGIN_OK;


### PR DESCRIPTION
This fixes these test failures observed in Ubuntu 16.04:
    interp/pymove
    interp/python-self
    interp/value-returned
    remap/fail/body-py
    remap/fail/canon_error
    remap/fail/epilog
    remap/fail/prolog
    remap/introspect
    remap/oword-pycall
    remap/predefined-named-params
    remap/variable-injection

Signed-off-by: Jeff Epler <jepler@unpythonic.net>