### PR TITLE
Add libmodbus version checks

### DIFF
--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -359,14 +359,22 @@ retCode get_tx_connection(const int this_mb_tx_num, int *ret_connected)
     //set response and byte timeout according to each mb_tx
     timeout.tv_sec  = this_mb_tx->mb_response_timeout_ms / 1000;
     timeout.tv_usec = (this_mb_tx->mb_response_timeout_ms % 1000) * 1000;
+#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+    modbus_set_response_timeout(this_mb_link->modbus, timeout.tv_sec, timeout.tv_usec);
+#else
     modbus_set_response_timeout(this_mb_link->modbus, &timeout);
+#endif
     //DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] response timeout [%d] ([%d] [%d])",
     //    this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_tx->mb_response_timeout_ms,
     //    (int) timeout.tv_sec, (int) timeout.tv_usec);
 
     timeout.tv_sec  = this_mb_tx->mb_byte_timeout_ms / 1000;
     timeout.tv_usec = (this_mb_tx->mb_byte_timeout_ms % 1000) * 1000;
+#if (LIBMODBUS_VERSION_CHECK(3, 1, 2))
+    modbus_set_byte_timeout(this_mb_link->modbus, timeout.tv_sec, timeout.tv_usec);
+#else
     modbus_set_byte_timeout(this_mb_link->modbus, &timeout);
+#endif
     //DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] byte timeout [%d] ([%d] [%d])",
     //    this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_tx->mb_byte_timeout_ms,
     //    (int) timeout.tv_sec, (int) timeout.tv_usec);


### PR DESCRIPTION
libmodbus version 3.1.0 introduced backwards incompatible API changes in
modbus_set_response_timeout and modbus_set_byte_timeout functions. This
patch adds conditional compilation to use the API appropriately based
upon the result of the LIBMODBUS_VERSION_CHECK macro.

Issue: https://github.com/LinuxCNC/linuxcnc/issues/105