### PR TITLE
Allow specifying of device on wj200_vfd init

### DIFF
--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -149,6 +149,7 @@ void userinit(int argc, char **argv)
 		{"parity", required_argument, 0, 0 },
 		{"databits", required_argument, 0, 0 },
 		{"stopbits", required_argument, 0, 0 },
+		{"device", required_argument, 0, 0 },
 		{0, 0, 0, 0}
 	};	
 
@@ -206,6 +207,10 @@ void userinit(int argc, char **argv)
 					exit(1);
 				}
 				break;
+			case 4:
+				device = optarg;
+				break;
+
 
 			default:
                                 fprintf(stderr, "internal error: invalid option index!\n");


### PR DESCRIPTION
Make sure you can check all these boxes before submitting your issue—Thank you!

 - [x] The submitted code is available under the GNU GPL version 2 with the "or later" clause
 - [x] You have certified that this is the case by including a "Signed-off-by" message in each commit
 - [x] You used your real name and a working e-mail address in this message

I had the need to use the wj200_vfd module over a USB to RS485 converter, so I'm making this pull request.

This commit adds the --device option to the wj200_vfd HAL component.
It allows the user to select which device to use for Modbus communication
to the VFD. For example, to use a USB to RS485 converter on /dev/ttyUSB0
you would run this command:

    loadusr -W wj200_vfd --device /dev/ttyUSB0

The default is `/dev/ttyS0` if `--device` is not specified. 

Signed-off-by: James Waples <jamwaffles@gmail.com>