### PR TITLE
Change field size so data from libmodbus fits

### DIFF
--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -91,7 +91,7 @@ bool wj200_run(modbus_t* ctx, bool runBit)
 bool wj200_getStatus(modbus_t* ctx, wj200_status* status)
 {
         int rc;
-        uint8_t bits[10];
+        uint8_t bits[16];
         uint16_t registers[2];
 
         /*read coils 0x000F thru 0x0019 in one step*/


### PR DESCRIPTION
Make sure you can check all these boxes before submitting your issue—Thank you!

 - [x] The submitted code is available under the GNU GPL version 2 with the "or later" clause
 - [x] You have certified that this is the case by including a "Signed-off-by" message in each commit
 - [x] You used your real name and a working e-mail address in this message

I've been trying to get my new WJ200 VFD working but the module kept segfaulting. It seems this is a really old issue, so I'm having a go at fixing it. Taking inspiration from this forum post I changed a buffer size to work better with libmodbus:

https://forum.linuxcnc.org/forum/38-general-linuxcnc-questions/28946-wj200-vfd-segfaulting-after-updates?start=10

Not absolutely sure what I'm doing, but I tested this with the v2.4.7 tag and latest master
and it works fine, whereas before the module would segfault on initialisation. Is this because something in libmodbus changed?

Signed-off-by: James Waples <jamwaffles@gmail.com>