### PR TITLE
Wj200 extra registers

### DIFF
--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -8,7 +8,8 @@ pin out bit is_running            "1 when running";
 pin out bit is_at_speed           "1 when running at assigned frequency";
 pin out bit is_ready              "1 when vfd is ready to run";
 pin out bit is_alarm              "1 when vfd alarm is set";
-pin out float motor_current       "output current";
+pin out float motor_current       "Output current in amps";
+pin out float heatsink_temp       "Temperature of drive heatsink";
 pin out bit watchdog_out          "Alternates between 1 and 0 after every update cycle. Feed into a watchdog component to ensure vfd driver is communicating with the vfd properly.";
 option userspace;
 option userinit yes;
@@ -53,6 +54,7 @@ typedef struct
         uint8_t at_speed;
         uint8_t alarm;
 	float output_current;
+	float sink_temp;
         uint16_t frequency;
 } wj200_status;
 
@@ -95,7 +97,8 @@ bool wj200_getStatus(modbus_t* ctx, wj200_status* status)
         int rc;
         uint8_t bits[16];
         uint16_t registers[2];
-	uint16_t monitoringRegisters[1];
+	uint16_t currentRegister[1];
+	uint16_t temperatureRegister[1];
 
         /*read coils 0x000F thru 0x0019 in one step*/
         rc = modbus_read_bits(ctx, 0x000F-1, 11, bits);
@@ -113,12 +116,21 @@ bool wj200_getStatus(modbus_t* ctx, wj200_status* status)
                 return false;
         }
 
-        rc = modbus_read_registers(ctx, 0x1003-1, 1, monitoringRegisters);
+	// Read 1003h (output current) to 1019h (heatsink temp)
+        rc = modbus_read_registers(ctx, 0x1003-1, 1, currentRegister);
 
         if(rc < 0)
         {
                 return false;
         }
+
+	rc = modbus_read_registers(ctx, 0x1019-1, 1, temperatureRegister);
+
+        if(rc < 0)
+        {
+                return false;
+        }
+
 
         status->running = bits[0];
         status->direction = bits[1];
@@ -126,7 +138,8 @@ bool wj200_getStatus(modbus_t* ctx, wj200_status* status)
         status->alarm = bits[9];
         status->at_speed = bits[5];
         status->frequency = registers[1];
-	status->output_current = monitoringRegisters[0];
+	status->output_current = currentRegister[0];
+	status->sink_temp = temperatureRegister[0];
 
         return true;
 }
@@ -323,6 +336,7 @@ void user_mainloop(void) {
 
 			watchdog_out = !watchdog_out;
 			motor_current = status.output_current / 100;
+			heatsink_temp = status.sink_temp / 10;
 		}
 	}
 	}

--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -8,6 +8,7 @@ pin out bit is_running            "1 when running";
 pin out bit is_at_speed           "1 when running at assigned frequency";
 pin out bit is_ready              "1 when vfd is ready to run";
 pin out bit is_alarm              "1 when vfd alarm is set";
+pin out float motor_current       "output current";
 pin out bit watchdog_out          "Alternates between 1 and 0 after every update cycle. Feed into a watchdog component to ensure vfd driver is communicating with the vfd properly.";
 option userspace;
 option userinit yes;
@@ -51,6 +52,7 @@ typedef struct
         uint8_t direction;
         uint8_t at_speed;
         uint8_t alarm;
+	float output_current;
         uint16_t frequency;
 } wj200_status;
 
@@ -93,6 +95,7 @@ bool wj200_getStatus(modbus_t* ctx, wj200_status* status)
         int rc;
         uint8_t bits[16];
         uint16_t registers[2];
+	uint16_t monitoringRegisters[1];
 
         /*read coils 0x000F thru 0x0019 in one step*/
         rc = modbus_read_bits(ctx, 0x000F-1, 11, bits);
@@ -110,12 +113,20 @@ bool wj200_getStatus(modbus_t* ctx, wj200_status* status)
                 return false;
         }
 
+        rc = modbus_read_registers(ctx, 0x1003-1, 1, monitoringRegisters);
+
+        if(rc < 0)
+        {
+                return false;
+        }
+
         status->running = bits[0];
         status->direction = bits[1];
         status->ready = bits[2];
         status->alarm = bits[9];
         status->at_speed = bits[5];
         status->frequency = registers[1];
+	status->output_current = monitoringRegisters[0];
 
         return true;
 }
@@ -311,6 +322,7 @@ void user_mainloop(void) {
 			}
 
 			watchdog_out = !watchdog_out;
+			motor_current = status.output_current / 100;
 		}
 	}
 	}


### PR DESCRIPTION
This commit adds two more pins to the wj200_vfd HAL component:

- `wj200-vfd.N.motor-current` (from register `0x1003`) and
- `wj200-vfd.N.heatsink-temp` (from register `0x1019`)

You can make nice looking readouts like this now:

![screenshot - 230716 - 16 18 12](https://cloud.githubusercontent.com/assets/800791/17078757/318c33f6-50f3-11e6-910a-cd5c589c1f9c.png)
