### PR TITLE
Jepler/2.6/issue 131 lcd

### DIFF
--- a/src/hal/components/lcd.c
+++ b/src/hal/components/lcd.c
@@ -235,6 +235,9 @@ int rtapi_app_main(void){
         lcd->insts[i].buff[0] = 0;
         lcd->insts[i].c_ptr = 0;
     }
+
+    hal_ready(comp_id);
+
     return 0;
 }
 

--- a/src/hal/components/lcd.c
+++ b/src/hal/components/lcd.c
@@ -269,7 +269,6 @@ static void write_one(lcd_inst_t *inst){
     
     if (*inst->page_num != inst->last_page){
         inst->last_page = *inst->page_num;
-        if (*inst->page_num >= inst->num_pages) return; // should this error?
         *inst->out = 0x11; //cursor off
         inst->buff[0] = 0x1A; //dummy
         inst->buff[1] = 0; //end
@@ -279,6 +278,8 @@ static void write_one(lcd_inst_t *inst){
         return;
     }    
     
+    if (*inst->page_num >= inst->num_pages) return; // should this error?
+
     if (inst->f_ptr > inst->pages[*inst->page_num].length){
         *inst->out = 0x18; // clear line
         inst->buff[0] = 0x1E; // home


### PR DESCRIPTION
I believe that this fixes #131.

It's worth noting that as a potential buglet, changes to the pin to control LCD contrast won't be tracked while trying to display an invalid page.  This could be fixed by rearranging the blocks within write_one.