### PR TITLE
genhexkins: add new functionality

### DIFF
--- a/docs/man/man9/kins.9
+++ b/docs/man/man9/kins.9
@@ -134,6 +134,10 @@ forward kinematics iteration is controlled by hal pins.
 .B genhexkins.platform.\fIN\fB.z
 Parameters describing the \fIN\fRth joint's coordinates.
 .TQ
+.B genhexkins.spindle-offset
+Added to all joints Z coordinates to change the machine origin.
+Facilitates adjusting spindle position.
+.TQ
 .B genhexkins.convergence-criterion
 Minimum error value that ends iterations with converged solution.
 .TQ

--- a/docs/man/man9/kins.9
+++ b/docs/man/man9/kins.9
@@ -138,6 +138,28 @@ Parameters describing the \fIN\fRth joint's coordinates.
 Added to all joints Z coordinates to change the machine origin.
 Facilitates adjusting spindle position.
 .TQ
+.B genhexkins.base-n.\fIN\fB.x
+.TQ
+.B genhexkins.base-n.\fIN\fB.y
+.TQ
+.B genhexkins.base-n.\fIN\fB.z
+.TQ
+.B genhexkins.platform-n.\fIN\fB.x
+.TQ
+.B genhexkins.platform-n.\fIN\fB.y
+.TQ
+.B genhexkins.platform-n.\fIN\fB.z
+Parameters describing unit vectors of \fIN\fRth joint's axis. Used to
+calculate strut length correction for cardanic joints and non-captive
+actuators.
+.TQ
+.B genhexkins.screw-lead
+Lead of strut actuator screw, positive for the right-handed thread.
+Default is 0 (strut length correction disabled).
+.TQ
+.B genhexkins.correction.\fIN\fB
+Current values of strut length correction for non-captive actuators with
+cardanic joints.
 .B genhexkins.convergence-criterion
 Minimum error value that ends iterations with converged solution.
 .TQ

--- a/src/emc/kinematics/genhexkins.c
+++ b/src/emc/kinematics/genhexkins.c
@@ -10,8 +10,6 @@
 * System: Linux
 *    
 * Copyright (c) 2004 All rights reserved.
-*
-* Last change: 2016.08.04
 *********************************************************************
 
   These are the forward and inverse kinematic functions for a class of

--- a/src/emc/kinematics/genhexkins.c
+++ b/src/emc/kinematics/genhexkins.c
@@ -46,6 +46,29 @@
                            implements RTCP function when connected to
                            motion.tooloffset.Z.
 
+  To avoid joints jump change tool offset (G43, G49) only when the
+  platform is not tilted (A = B = 0).
+
+  Some hexapods use non-captive screw actuators and universal (cardanic)
+  joints, thus the strut lengths depend on orientation of joints axes.
+  Strut length correction is implemented to compensate for this.
+  The calculations use orientation (unit vectors) of base and platform
+  joint axes and the lead of actuator screws:
+
+  genhexkins.base-n.N.x
+  genhexkins.base-n.N.y
+  genhexkins.base-n.N.z - unit vectors of base joint axes;
+
+  genhexkins.platform-n.N.x
+  genhexkins.platform-n.N.y
+  genhexkins.platform-n.N.z - unit vectors of platform joint axes
+                              in platform CS.
+  genhexkins.screw-lead - lead of strut actuator screw, positive for
+                          right-hand thread. Default is 0 (strut length
+                          correction disabled).
+  genhexkins.correction.N - pins showing current values of strut length
+                            correction.
+
   The kinematicsInverse function solves the inverse kinematics using
   a closed form algorithm.  The inverse kinematics problem is given
   the pose of the platform and returns the strut lengths. For this
@@ -97,6 +120,14 @@ struct haldata {
     hal_float_t platformx[NUM_STRUTS];
     hal_float_t platformy[NUM_STRUTS];
     hal_float_t platformz[NUM_STRUTS];
+    hal_float_t basenx[NUM_STRUTS];
+    hal_float_t baseny[NUM_STRUTS];
+    hal_float_t basenz[NUM_STRUTS];
+    hal_float_t platformnx[NUM_STRUTS];
+    hal_float_t platformny[NUM_STRUTS];
+    hal_float_t platformnz[NUM_STRUTS];
+    hal_float_t *correction[NUM_STRUTS];
+    hal_float_t screw_lead;
     hal_u32_t *last_iter;
     hal_u32_t *max_iter;
     hal_u32_t iter_limit;
@@ -212,6 +243,11 @@ static void MatMult(double J[][6], const double x[], double Ans[])
 static PmCartesian b[NUM_STRUTS];
 static PmCartesian a[NUM_STRUTS];
 
+/* declare base and platform joint axes vectors */
+
+static PmCartesian nb1[NUM_STRUTS];
+static PmCartesian na0[NUM_STRUTS];
+
 /************************genhexkins_read_hal_pins**************************/
 
 int genhexkins_read_hal_pins(void) {
@@ -225,9 +261,46 @@ int genhexkins_read_hal_pins(void) {
         a[t].x = haldata->platformx[t];
         a[t].y = haldata->platformy[t];
         a[t].z = haldata->platformz[t] + haldata->spindle_offset + *haldata->tool_offset;
+
+        nb1[t].x = haldata->basenx[t];
+        nb1[t].y = haldata->baseny[t];
+        nb1[t].z = haldata->basenz[t];
+        na0[t].x = haldata->platformnx[t];
+        na0[t].y = haldata->platformny[t];
+        na0[t].z = haldata->platformnz[t];
+
     }
     return 0;
 }
+
+/***************************StrutLengthCorrection***************************/
+
+int StrutLengthCorrection(const PmCartesian * StrutVectUnit,
+                          const PmRotationMatrix * RMatrix,
+                          const int strut_number,
+                          double * correction)
+{
+  PmCartesian nb2, nb3, na1, na2;
+  double dotprod;
+
+  /* define base joints axis vectors */
+  pmCartCartCross(&nb1[strut_number], StrutVectUnit, &nb2);
+  pmCartCartCross(StrutVectUnit, &nb2, &nb3);
+  pmCartUnitEq(&nb3);
+
+  /* define platform joints axis vectors */
+  pmMatCartMult(RMatrix, &na0[strut_number], &na1);
+  pmCartCartCross(&na1, StrutVectUnit, &na2);
+  pmCartUnitEq(&na2);
+
+  /* define dot product */
+  pmCartCartDot(&nb3, &na2, &dotprod);
+
+  *correction = haldata->screw_lead * asin(dotprod) / PM_2_PI;
+
+  return 0;
+}
+
 
 /**************************** kinematicsForward() ***************************/
 
@@ -246,6 +319,7 @@ int kinematicsForward(const double * joints,
   double InvKinStrutLength, StrutLengthDiff[NUM_STRUTS];
   double delta[NUM_STRUTS];
   double conv_err = 1.0;
+  double corr;
 
   PmRotationMatrix RMatrix;
   PmRpy q_RPY;
@@ -310,6 +384,14 @@ int kinematicsForward(const double * joints,
         return -1;
       }
       pmCartMag(&InvKinStrutVect, &InvKinStrutLength);
+
+      if (haldata->screw_lead != 0.0) {
+        /* enable strut length correction */
+        StrutLengthCorrection(&InvKinStrutVectUnit, &RMatrix, i, &corr);
+        /* define corrected joint lengths */
+        InvKinStrutLength += corr;
+      }
+
       StrutLengthDiff[i] = InvKinStrutLength - joints[i];
 
       /* Determine RMatrix_a_cross_strut */
@@ -385,9 +467,11 @@ int kinematicsInverse(const EmcPose * pos,
 {
 
   PmCartesian aw, temp;
+  PmCartesian InvKinStrutVect, InvKinStrutVectUnit;
   PmRotationMatrix RMatrix;
   PmRpy rpy;
   int i;
+  double InvKinStrutLength, corr;
 
   genhexkins_read_hal_pins();
 
@@ -405,8 +489,22 @@ int kinematicsInverse(const EmcPose * pos,
     pmCartCartAdd(&pos->tran, &temp, &aw);
 
     /* define strut lengths */
-    pmCartCartSub(&aw, &b[i], &temp);
-    pmCartMag(&temp, &joints[i]);
+    pmCartCartSub(&aw, &b[i], &InvKinStrutVect);
+    pmCartMag(&InvKinStrutVect, &InvKinStrutLength);
+
+    if (haldata->screw_lead != 0.0) {
+      /* enable strut length correction */
+      /* define unit strut vector */
+      if (0 != pmCartUnit(&InvKinStrutVect, &InvKinStrutVectUnit)) {
+          return -1;
+      }
+      /* define correction value and corrected joint lengths */
+      StrutLengthCorrection(&InvKinStrutVectUnit, &RMatrix, i, &corr);
+      *haldata->correction[i] = corr;
+      InvKinStrutLength += corr;
+    }
+
+    joints[i] = InvKinStrutLength;
   }
 
   return 0;
@@ -468,6 +566,36 @@ int rtapi_app_main(void)
         if ((res = hal_param_float_newf(HAL_RW, &haldata->platformz[i], comp_id,
             "genhexkins.platform.%d.z", i)) < 0)
         goto error;
+
+        if ((res = hal_param_float_newf(HAL_RW, &haldata->basenx[i], comp_id,
+            "genhexkins.base-n.%d.x", i)) < 0)
+        goto error;
+
+        if ((res = hal_param_float_newf(HAL_RW, &haldata->baseny[i], comp_id,
+            "genhexkins.base-n.%d.y", i)) < 0)
+        goto error;
+
+        if ((res = hal_param_float_newf(HAL_RW, &haldata->basenz[i], comp_id,
+            "genhexkins.base-n.%d.z", i)) < 0)
+        goto error;
+
+        if ((res = hal_param_float_newf(HAL_RW, &haldata->platformnx[i], comp_id,
+            "genhexkins.platform-n.%d.x", i)) < 0)
+        goto error;
+
+        if ((res = hal_param_float_newf(HAL_RW, &haldata->platformny[i], comp_id,
+            "genhexkins.platform-n.%d.y", i)) < 0)
+        goto error;
+
+        if ((res = hal_param_float_newf(HAL_RW, &haldata->platformnz[i], comp_id,
+            "genhexkins.platform-n.%d.z", i)) < 0)
+        goto error;
+
+        if ((res = hal_pin_float_newf(HAL_OUT, &haldata->correction[i], comp_id,
+            "genhexkins.correction.%d", i)) < 0)
+        goto error;
+        *haldata->correction[i] = 0.0;
+
     }
 
     if ((res = hal_pin_u32_newf(HAL_OUT, &haldata->last_iter, comp_id,
@@ -504,6 +632,11 @@ int rtapi_app_main(void)
         "genhexkins.spindle-offset")) < 0)
     goto error;
     haldata->spindle_offset = 0.0;
+
+    if ((res = hal_param_float_newf(HAL_RW, &haldata->screw_lead, comp_id,
+        "genhexkins.screw-lead")) < 0)
+    goto error;
+    haldata->screw_lead = DEFAULT_SCREW_LEAD;
 
     haldata->basex[0] = DEFAULT_BASE_0_X;
     haldata->basey[0] = DEFAULT_BASE_0_Y;
@@ -542,6 +675,44 @@ int rtapi_app_main(void)
     haldata->platformx[5] = DEFAULT_PLATFORM_5_X;
     haldata->platformy[5] = DEFAULT_PLATFORM_5_Y;
     haldata->platformz[5] = DEFAULT_PLATFORM_5_Z;
+
+    haldata->basenx[0] = DEFAULT_BASE_0_NX;
+    haldata->baseny[0] = DEFAULT_BASE_0_NY;
+    haldata->basenz[0] = DEFAULT_BASE_0_NZ;
+    haldata->basenx[1] = DEFAULT_BASE_1_NX;
+    haldata->baseny[1] = DEFAULT_BASE_1_NY;
+    haldata->basenz[1] = DEFAULT_BASE_1_NZ;
+    haldata->basenx[2] = DEFAULT_BASE_2_NX;
+    haldata->baseny[2] = DEFAULT_BASE_2_NY;
+    haldata->basenz[2] = DEFAULT_BASE_2_NZ;
+    haldata->basenx[3] = DEFAULT_BASE_3_NX;
+    haldata->baseny[3] = DEFAULT_BASE_3_NY;
+    haldata->basenz[3] = DEFAULT_BASE_3_NZ;
+    haldata->basenx[4] = DEFAULT_BASE_4_NX;
+    haldata->baseny[4] = DEFAULT_BASE_4_NY;
+    haldata->basenz[4] = DEFAULT_BASE_4_NZ;
+    haldata->basenx[5] = DEFAULT_BASE_5_NX;
+    haldata->baseny[5] = DEFAULT_BASE_5_NY;
+    haldata->basenz[5] = DEFAULT_BASE_5_NZ;
+
+    haldata->platformnx[0] = DEFAULT_PLATFORM_0_NX;
+    haldata->platformny[0] = DEFAULT_PLATFORM_0_NY;
+    haldata->platformnz[0] = DEFAULT_PLATFORM_0_NZ;
+    haldata->platformnx[1] = DEFAULT_PLATFORM_1_NX;
+    haldata->platformny[1] = DEFAULT_PLATFORM_1_NY;
+    haldata->platformnz[1] = DEFAULT_PLATFORM_1_NZ;
+    haldata->platformnx[2] = DEFAULT_PLATFORM_2_NX;
+    haldata->platformny[2] = DEFAULT_PLATFORM_2_NY;
+    haldata->platformnz[2] = DEFAULT_PLATFORM_2_NZ;
+    haldata->platformnx[3] = DEFAULT_PLATFORM_3_NX;
+    haldata->platformny[3] = DEFAULT_PLATFORM_3_NY;
+    haldata->platformnz[3] = DEFAULT_PLATFORM_3_NZ;
+    haldata->platformnx[4] = DEFAULT_PLATFORM_4_NX;
+    haldata->platformny[4] = DEFAULT_PLATFORM_4_NY;
+    haldata->platformnz[4] = DEFAULT_PLATFORM_4_NZ;
+    haldata->platformnx[5] = DEFAULT_PLATFORM_5_NX;
+    haldata->platformny[5] = DEFAULT_PLATFORM_5_NY;
+    haldata->platformnz[5] = DEFAULT_PLATFORM_5_NZ;
 
     hal_ready(comp_id);
     return 0;

--- a/src/emc/kinematics/genhexkins.h
+++ b/src/emc/kinematics/genhexkins.h
@@ -10,8 +10,6 @@
 * System: Linux
 *    
 * Copyright (c) 2004 All rights reserved.
-*
-* Last change: 2016.08.04
 ********************************************************************
 
   This is the header file to accompany genhexkins.c.  This header file

--- a/src/emc/kinematics/genhexkins.h
+++ b/src/emc/kinematics/genhexkins.h
@@ -11,7 +11,7 @@
 *    
 * Copyright (c) 2004 All rights reserved.
 *
-* Last change: 2014.12.22
+* Last change: 2016.08.04
 ********************************************************************
 
   This is the header file to accompany genhexkins.c.  This header file
@@ -68,3 +68,58 @@
 #define DEFAULT_PLATFORM_4_Z   0.000
 #define DEFAULT_PLATFORM_5_Z   0.000
 
+/* Default unit vectors of base joints axes in world coordinates */
+
+#define DEFAULT_BASE_0_NX  0.707107
+#define DEFAULT_BASE_0_NY  0.0
+#define DEFAULT_BASE_0_NZ  0.707107
+
+#define DEFAULT_BASE_1_NX  0.0
+#define DEFAULT_BASE_1_NY -0.707107
+#define DEFAULT_BASE_1_NZ  0.707107
+
+#define DEFAULT_BASE_2_NX -0.707107
+#define DEFAULT_BASE_2_NY  0.0
+#define DEFAULT_BASE_2_NZ  0.707107
+
+#define DEFAULT_BASE_3_NX -0.707107
+#define DEFAULT_BASE_3_NY  0.0
+#define DEFAULT_BASE_3_NZ  0.707107
+
+#define DEFAULT_BASE_4_NX  0.0
+#define DEFAULT_BASE_4_NY  0.707107
+#define DEFAULT_BASE_4_NZ  0.707107
+
+#define DEFAULT_BASE_5_NX  0.707107
+#define DEFAULT_BASE_5_NY  0.0
+#define DEFAULT_BASE_5_NZ  0.707107
+
+/* Default unit vectors of platform joints axes in platform coordinates */
+
+#define DEFAULT_PLATFORM_0_NX -1.0
+#define DEFAULT_PLATFORM_0_NY  0.0
+#define DEFAULT_PLATFORM_0_NZ  0.0
+
+#define DEFAULT_PLATFORM_1_NX  0.866025
+#define DEFAULT_PLATFORM_1_NY  0.5
+#define DEFAULT_PLATFORM_1_NZ  0.0
+
+#define DEFAULT_PLATFORM_2_NX  0.866025
+#define DEFAULT_PLATFORM_2_NY  0.5
+#define DEFAULT_PLATFORM_2_NZ  0.0
+
+#define DEFAULT_PLATFORM_3_NX  0.866025
+#define DEFAULT_PLATFORM_3_NY -0.5
+#define DEFAULT_PLATFORM_3_NZ  0.0
+
+#define DEFAULT_PLATFORM_4_NX  0.866025
+#define DEFAULT_PLATFORM_4_NY -0.5
+#define DEFAULT_PLATFORM_4_NZ  0.0
+
+#define DEFAULT_PLATFORM_5_NX -1.0
+#define DEFAULT_PLATFORM_5_NY  0.0
+#define DEFAULT_PLATFORM_5_NZ  0.0
+
+/* Default lead of strut actuator screw */
+
+#define DEFAULT_SCREW_LEAD 0.0


### PR DESCRIPTION
Add strut length correction for non-captive screw actuators with universal joints.
Add spindle-offset pin to adjust the spindle position (CS origin) easily.
Remove obsolete code.
Update manpage.

Tested on a hardware. Doesn't break hexapod-sim config.