### PR TITLE
build: include metadata for Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: required
+language: c++
+before_install: ./scripts/travis-install-build-deps.sh
+script: ./scripts/travis-build-test.sh
+

--- a/scripts/travis-build-test.sh
+++ b/scripts/travis-build-test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+cd src
+./autogen.sh
+./configure --with-realtime=uspace --disable-check-runtime-deps
+make -j2  # cores: ~2, bursted
+../scripts/rip-environment runtests

--- a/scripts/travis-install-build-deps.sh
+++ b/scripts/travis-install-build-deps.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+sudo apt-get update -qq
+sudo apt-get install -y devscripts equivs build-essential --no-install-recommends
+debian/configure uspace
+mk-build-deps
+sudo dpkg -i linuxcnc-*.deb || true
+sudo apt-get -f install -y --no-install-recommends


### PR DESCRIPTION
Travis CI is not the equal of buildbot (it can't run RT kernels and can only test building on Ubuntu with amd64) but adopting it *in addition to* buildbot would let us do things like automatically build-test pull requests on github without developer interference (i.e., by pushing a temporary branch to glo)

In addition to these commits, additional behind the scenes configuration of the (free as in beer) travis-ci.org webservice is required.

I've mildly tested this (it took just an hour or so to get it working) using my fork of linuxcnc.  You can see the result of a travis build of linuxcnc here: https://travis-ci.org/jepler/linuxcnc