### PR TITLE
limit1 & limit2: change params to pins

### DIFF
--- a/src/hal/components/limit1.comp
+++ b/src/hal/components/limit1.comp
@@ -1,8 +1,8 @@
 component limit1 "Limit the output signal to fall between min and max";
 pin in float in;
 pin out float out;
-param rw float min_=-1e20;
-param rw float max_=1e20;
+pin in float min_=-1e20;
+pin in float max_=1e20;
 function _;
 license "GPL";
 ;;

--- a/src/hal/components/limit2.comp
+++ b/src/hal/components/limit2.comp
@@ -2,9 +2,9 @@ component limit2 "Limit the output signal to fall between min and max and limit 
 pin in float in;
 pin out float out;
 pin in bit load "When TRUE, immediately set \\fBout\\fB to \\fBin\\fR, ignoring maxv";
-param rw float min_=-1e20;
-param rw float max_=1e20;
-param rw float maxv=1e20;
+pin in float min_=-1e20;
+pin in float max_=1e20;
+pin in float maxv=1e20;
 option data limit2_data;
 function _;
 license "GPL";


### PR DESCRIPTION
The limit value inputs were parameters, but are more
flexible if implemented as pins.  The change is pretty
transparent, since setp will set either a param or a
pin.  This change was done for limit3 in 2010, just
bringing the other two up to date.

Signed-off-by: John Kasunich <jmkasunich@fastmail.fm>