### PR TITLE
interp_o_word.cc:  remove unused `tmpFileName` variable

### DIFF
--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -472,7 +472,6 @@ int Interp::control_back_to( block_pointer block, // pointer to block
 {
     static char name[] = "control_back_to";
     char newFileName[PATH_MAX+1];
-    char tmpFileName[PATH_MAX+1];
     FILE *newFP;
     offset_map_iterator it;
     offset_pointer op;
@@ -536,7 +535,7 @@ int Interp::control_back_to( block_pointer block, // pointer to block
 	logOword("fopen: |%s| failed CWD:|%s|", newFileName,
 		 dirname);
 	free(dirname);
-	ERS(NCE_UNABLE_TO_OPEN_FILE,tmpFileName);
+	ERS(NCE_UNABLE_TO_OPEN_FILE,newFileName);
     }
 
     settings->skipping_o = block->o_name; // start skipping


### PR DESCRIPTION
This fix came from another branch without the
`ERS(NCE_UNABLE_TO_OPEN_FILE,tmpFileName);` line; there, it probably
caused an unused variable compiler warning.  Here, with that line, it
would do something else wacky.

Remove the variable and substitute the correct file name variable into
the error.
