### PR TITLE
Halcompile rawstring

### DIFF
--- a/docs/src/hal/comp.txt
+++ b/docs/src/hal/comp.txt
@@ -180,6 +180,9 @@ Hopefully these paragraphs have allowed you to understand "zot"
 better."""
 ----
 +
+Or a string may be preceded by the literal character 'r', in which
+case the string is interpreted like a Python raw-string.
++
 The documentation string is in "groff -man" format. For more
 information on this markup format, see 'groff_man(7)'. Remember that
 'halcompile' interprets backslash escapes in strings, so for instance
@@ -187,6 +190,13 @@ to set the italic font for the word 'example', write:
 +
 ----
 "\\fIexample\\fB"
+----
++
+In this case, r-strings are particularly useful, because the backslashes
+in an r-string need not be doubled:
++
+----
+r"\fIexample\fB"
 ----
 
 * 'TYPE' - One of the HAL types: 'bit', 'signed', 'unsigned', or 'float'. The old

--- a/src/hal/components/or2.comp
+++ b/src/hal/components/or2.comp
@@ -1,16 +1,16 @@
 component or2 "Two-input OR gate";
 pin in bit in0;
 pin in bit in1;
-pin out bit out """\
-\\fBout\\fR is computed from the value of \\fBin0\\fR and \\fBin1\\fR according
+pin out bit out r"""
+\fBout\fR is computed from the value of \fBin0\fR and \fBin1\fR according
 to the following rule:
 .RS
 .TP
-\\fBin0=FALSE in1=FALSE\\fB
-\\fBout=FALSE\\fR
+\fBin0=FALSE in1=FALSE\fB
+\fBout=FALSE\fR
 .TP
 Otherwise,
-\\fBout=TRUE\\fR
+\fBout=TRUE\fR
 .RE"""
 ;
 function _ nofp;

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -38,7 +38,7 @@ parser Hal:
     token STRING: "\"(\\.|[^\\\"])*\""
     token HEADER: "<.*?>"
     token POP: "[-()+*/]|&&|\\|\\||personality|==|&|!=|<<|<|<=|>>|>|>="
-    token TSTRING: "\"\"\"(\\.|\\\n|[^\\\"]|\"(?!\"\")|\n)*\"\"\""
+    token TSTRING: "r?\"\"\"(\\.|\\\n|[^\\\"]|\"(?!\"\")|\n)*\"\"\""
 
     rule File: ComponentDeclaration Declaration* "$" {{ return True }}
     rule ComponentDeclaration:


### PR DESCRIPTION
This adds support for raw strings to halcompile.  It makes writing roff in docstrings less painful.