### PR TITLE
configure: All supported platforms have asciidoc 8.6

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -1004,19 +1004,6 @@ if ( test "$BUILD_DOCS" = "yes" ) ; then
 	AC_MSG_ERROR([no a2x, documentation cannot be built])
     fi
 
-    AC_MSG_CHECKING([asciidoc version])
-    set -- `asciidoc --version`; ASCIIDOC_VER=$2
-    set -- `echo $ASCIIDOC_VER | sed 's/\./ /g'`
-
-    if test $1 -lt 8 -o \( $1 -eq 8 -a $2 -lt 5 \); then
-        AC_MSG_ERROR([asciidoc version $ASCIIDOC_VER less than 8.5.
-Documentation cannot be built.
-On Lucid, install the regular asciidoc from Ubuntu by running "sudo apt-get install asciidoc".
-On Hardy, install the backported asciidoc available from the linuxcnc.org debian archive.
-On other systems, do what you need to install asciidoc version 8.5 or newer.])
-    fi
-    AC_MSG_RESULT([$ASCIIDOC_VER])
-
     AC_MSG_CHECKING([whether to specify latex.encoding])
     temp_asciidoc=`tempfile --suffix=.txt`
     cat > $temp_asciidoc <<EOF


### PR DESCRIPTION
.. so ditch this unneeded check