### PR TITLE
pncconf: don't refer to kernel_version when not is_kernelspace

### DIFF
--- a/src/emc/usr_intf/pncconf/pncconf.py
+++ b/src/emc/usr_intf/pncconf/pncconf.py
@@ -1637,7 +1637,7 @@ class App:
                 return True
             else:
                 return False
-        elif hal.is_rt and not hal.kernel_version == actual_kernel:
+        elif hal.is_kernelspace and hal.kernel_version != actual_kernel:
             self.warning_dialog(self._p.MESS_KERNEL_WRONG + '%s'%hal.kernel_version,True)
             if self.debugstate:
                 return True


### PR DESCRIPTION
This is intended to fix #159.  Tested on an XU4 (no mesa board actually attached), now it works to open the "tune" windows (but nothing can be done since there's no board attached)
