### PR TITLE
Preview "ungrounded" programs better

### DIFF
--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -1765,9 +1765,9 @@ class GlCanonDraw:
         if self.canon: self.canon.draw(0, False)
         glEndList()
 
-    def load_preview(self, f, canon, unitcode, initcode, interpname=""):
+    def load_preview(self, f, canon, *args):
         self.set_canon(canon)
-        result, seq = gcode.parse(f, canon, unitcode, initcode, interpname)
+        result, seq = gcode.parse(f, canon, *args)
 
         if result <= gcode.MIN_ERROR:
             self.canon.progress.nextphase(1)

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1167,12 +1167,35 @@ def open_file_guts(f, filtered=False, addrecent=True):
         initcode = inifile.find("EMC", "RS274NGC_STARTUP_CODE") or ""
         if initcode == "":
             initcode = inifile.find("RS274NGC", "RS274NGC_STARTUP_CODE") or ""
+        initcodes = []
+        if initcode:
+            initcodes.append(initcode)
         if not interpname:
             unitcode = "G%d" % (20 + (s.linear_units == 1))
-        else:
-            unitcode = ''
+            initcodes.append(unitcode)
+            initcodes.append("g90")
+            initcodes.append("t%d m6" % s.tool_in_spindle)
+            position = "g53 g0"
+            for i in range(9):
+                if s.axis_mask & (1<<i):
+                    position += " %s%.8f" % ("XYZABCUVW"[i], s.position[i])
+            initcodes.append(position)
+            for g in s.gcodes[1:]:
+                if g == -1: continue
+                initcodes.append("G%.1f" % (g * .1))
+            tool_offset = "G43.1"
+            for i in range(9):
+                if s.axis_mask & (1<<i):
+                    tool_offset += " %s%.8f" % ("XYZABCUVW"[i], s.tool_offset[i])
+            initcodes.append(tool_offset)
+            for m in s.mcodes:
+                if m == -1: continue
+                initcodes.append("M%d" % m)
+        print "initcodes"
+        for i in initcodes: print repr(i)
+        print
         try:
-            result, seq = o.load_preview(f, canon, unitcode, initcode, interpname)
+            result, seq = o.load_preview(f, canon, initcodes, interpname)
         except KeyboardInterrupt:
             result, seq = 0, 0
         # According to the documentation, MIN_ERROR is the largest value that is


### PR DESCRIPTION
This pull request tackles a different part of issue #185: better preview of "ungrounded" programs.

This is done by having the preview-interpreter execute a bunch of additional preparatory gcodes, to
- set the initial position
- load the tool, if any
- set the tool length offsets, if any
- apply all modal G- and M-codes based on the stat buffer

As a result, my test "ungrounded" program behaves a lot better as I do things like jog around, MDI to load/unload a tool, etc.

```
;ungrounded.ngc
f100
g42
G1 X1
G1 X5
G1 Y8
M2
```
