### PR TITLE
fix docs/2.7/2.8 add img alt

### DIFF
--- a/docs/src/config/pncconf.txt
+++ b/docs/src/config/pncconf.txt
@@ -36,7 +36,7 @@ TIP: PNCconf's help page should have the most up to date info and has additional
 
 .PnCConf Splash
 
-image::images/pncconf-splash.png[]
+image::images/pncconf-splash.png[alt="PnCConf Configuration Wizard"]
 
 == Create or Edit
 
@@ -58,7 +58,7 @@ Selector 'LinuxCNC' found in CNC menu and selecting your config name.
 
 .PnCConf Basic
 
-image::images/pncconf-basic.png[]
+image::images/pncconf-basic.png[alt="PnCConf Basic machine information"]
 
 Machine Basics::
 If you use a name with spaces PNCconf will replace the spaces with underscore 
@@ -195,7 +195,7 @@ overrides.
 
 .GUI External
 
-image::images/pncconf-external.png[]
+image::images/pncconf-external.png[alt="GUI External"]
 
 If you select a Joystick for jogging, You will need it always connected for LinuxCNC 
 to load. To use the analog sticks for useful jogging you probably need to add 
@@ -246,7 +246,7 @@ Here you can set defaults for the display screens, add virtual control panels
 
 .GUI Configuration
 
-image::images/pncconf-gui.png[]
+image::images/pncconf-gui.png[alt="GUI Configuration"]
 
 Front-end GUI Options::
 
@@ -365,7 +365,7 @@ and select what and how many components are available.
 
 .Mesa Configuration
 
-image::images/pncconf-mesa-config.png[]
+image::images/pncconf-mesa-config.png[alt="Mesa Configuration"]
 
 Parport address is used only with Mesa parport card, the 7i43. An on board 
 parallel port usually uses 0x278 or 0x378 though you should be able to find the 
@@ -422,7 +422,7 @@ PNCconf allows one to create custom signal names for use in custom HAL files.
 
 .Mesa I/O C2
 
-image::images/pncconf-mesa-io2.png[]
+image::images/pncconf-mesa-io2.png[alt="Mesa I/O C2"]
 
 On this tab with this firmware the components are setup for a 7i33 daughter 
 board, usually used with closed loop servos. Note the component numbers of the 
@@ -431,7 +431,7 @@ daughter board requirements.
 
 .Mesa I/O C3
 
-image::images/pncconf-mesa-io3.png[]
+image::images/pncconf-mesa-io3.png[alt="Mesa I/O C3"]
 
 On this tab all the pins are GPIO. Note the 3 digit numbers - they will match 
 the HAL pin number. GPIO pins can be selected as input or output and can be 
@@ -439,7 +439,7 @@ inverted.
 
 .Mesa I/O C4
 
-image::images/pncconf-mesa-io4.png[]
+image::images/pncconf-mesa-io4.png[alt="Mesa I/O C4"]
 
 On this tab there are a mix of step generators and GPIO.
 Step generators output and direction pins can be inverted. Note that inverting a
@@ -448,7 +448,7 @@ what your controller expects.
 
 == Parport configuration
 
-image::images/pncconf-parport.png[]
+image::images/pncconf-parport.png[alt="Parport configuration"]
 
 The parallel port can be used for simple I/O similar to Mesa's GPIO pins.
 
@@ -456,7 +456,7 @@ The parallel port can be used for simple I/O similar to Mesa's GPIO pins.
 
 .Axis Drive Configuration
 
-image::images/pncconf-axis-drive.png[]
+image::images/pncconf-axis-drive.png[alt="Axis Drive Configuration"]
 
 This page allows configuring and testing of the motor and/or encoder combination
 . If using a servo motor an open loop test is available, if using a stepper a 
@@ -563,7 +563,7 @@ more help.
 
 .Axis Scale Calculation
 
-image::images/pncconf-scale-calc.png[]
+image::images/pncconf-scale-calc.png[alt="Axis Scale Calculation"]
 
 The scale settings can be directly entered or one can use the 'calculate scale' 
 button to assist. Use the check boxes to select appropriate calculations. Note 
@@ -574,7 +574,7 @@ scale press apply otherwise push cancel and enter the scale directly.
 
 .Axis Configuration
 
-image::images/pncconf-axis-config.png[]
+image::images/pncconf-axis-config.png[alt="Axis Configuration"]
 
 Also refer to the diagram tab for two examples of
 home and limit switches. These are two examples of
@@ -757,7 +757,7 @@ Use Backlash Compensation::
 
 .AXIS Help Diagram
 
-image::images/pncconf-diagram-lathe.png[]
+image::images/pncconf-diagram-lathe.png[alt="AXIS Help Diagram"]
 
 The diagrams should help to demonstrate an example of limit switches and 
 standard axis movement directions.
@@ -781,7 +781,7 @@ selected on previous pages!
 
 .Spindle Configuration
 
-image::images/pncconf-spindle-config.png[]
+image::images/pncconf-spindle-config.png[alt="Spindle Configuration"]
 
 This page is similar to the axis motor configuration page.
 
@@ -831,7 +831,7 @@ classicladder for serial modbus. See the
   
 .Advanced Options
 
-image::images/pncconf-advanced.png[]
+image::images/pncconf-advanced.png[alt="Advanced Options"]
 
 == HAL Components
 
@@ -842,7 +842,7 @@ allowing user needed components.
 
 .HAL Components
 
-image::images/pncconf-hal.png[]
+image::images/pncconf-hal.png[alt="HAL Components"]
 
 The first selection is components that pncconf uses internally.
 You may configure pncconf to load extra instances of the components for your 

--- a/docs/src/config/stepconf-es.txt
+++ b/docs/src/config/stepconf-es.txt
@@ -28,7 +28,7 @@ para que los botones de la parte baja de la pantalla sean visibles.
 
 .Pagina de entrada[[cap:Entry-Page]]
 
-image::images/stepconf-config.png[align="center"]
+image::images/stepconf-config.png[align="center", alt="Pagina de entrada"]
 
 Create New::
     Crea una configuracion nueva.
@@ -53,7 +53,7 @@ Create Desktop Launcher::
 
 .Informacion Basica[[cap:Basic-Information-Page]]
 
-image::images/stepconf-basic.png[]
+image::images/stepconf-basic.png[align="center", alt="Informacion Basica"]
 
 Machine Name::
     (((Machine Name)))
@@ -148,7 +148,7 @@ No ejecute LinuxCNC mientras realiza la prueba de latencia.
 
 .Prueba de Latencia[[cap:Latency-Test]]
 
-image::images/latency.png[align="center"]
+image::images/latency.png[align="center", alt="Prueba de Latencia"]
 
 Latencia es cuanto le tomara a la PC detenerse en lo que esta haciendo
 y responder a una solicitud externa. En este caso, la solicitud
@@ -190,7 +190,7 @@ usa generacion de pulsos de paso por software o no.
 
 .Pagina de ajuste del Puerto Paralelo[[cap:Parallel-Port-Setup]]
 
-image::images/stepconf-pinout.png[align="center"]
+image::images/stepconf-pinout.png[align="center", alt="Pagina de ajuste del Puerto Paralelo"]
 
 Para cada pin se devera seleccionar la señal de control
 que concuerde con la configuracion del puerto.
@@ -226,7 +226,7 @@ Bomba de Carga (Charge Pump)::
 
 .Pagina de configuracion de eje[[cap:Axis-Configuration-Page]]
 
-image::images/stepconf-axis.png[align="center"]
+image::images/stepconf-axis.png[align="center", alt="Pagina de configuracion de eje"]
 
 Pasos del motor por revolucion (Motor Steps Per Revolution)::
     (((Motor Steps Per Revolution)))
@@ -349,7 +349,7 @@ Probar este Eje (Test this axis)::
 
 .Probar este Eje[[cap:Test-This-Axis]]
 
-image::images/stepconf-test.png[align="center"]
+image::images/stepconf-test.png[align="center", alt="Probar este Eje"]
 
 Con Stepconf es sencillo probar diferentes valores de aceleracion y velocidad.
  
@@ -417,7 +417,7 @@ durante la prueba, redusca el valor encontrado un 10% y utilice este nuevo valor
 
 .Pagina configuracion del Husillo[[cap:Spindle-Configuration-Page]]
 
-image::images/stepconf-spindle.png[align="center"]
+image::images/stepconf-spindle.png[align="center", alt="Pagina configuracion del Husillo"]
 
 Esta pagina solo aparece cuando la opcion 'Spindle PWM' es seleccionada en la 
 pagina de seleccion de las salidad 'Parallel Port Pinout
@@ -508,7 +508,6 @@ para 'PWM' introdusca el valor del parametro S dividido entre 1000.
 Recuerde que deve tener dos valores del parametro S y sus correspondientes 
 RPM proporcionadas por el husillo para generar un ajuste de velocidad lineal.
 
-
 Devido a que la mayoria de los controladores de husillo precentan nolinealidades en su respuesta
 es mejor hacer lo siguiente:
 
@@ -524,7 +523,7 @@ vusque los valores de PWM que proporcionen 1600 RPM (40%) y 2800 RPM (70%).
 
 .Configuracion avanzada[[cap:Advanced-Configuration]]
 
-image::images/stepconf-advanced.png[align="center"]
+image::images/stepconf-advanced.png[align="center", alt="Configuracion avanzada"]
 
 Incluir Halui::
     Esta opcion incluira la interface de usuario Halui.
@@ -630,13 +629,13 @@ Un balor tipoco de resistencia de polarizacion es de 47K.
 
 Cableado de Interruptores Normalmente Cerrados en serie (diagrama simplificado)
 
-image::images/switch-nc-series.png[]
+image::images/switch-nc-series.png[align="center", alt="Interruptores normalmente cerrados"]
 
 .Interruptores normalmente abiertos[[cap:Normally-Open-Switches]]
 
 Cableado de interruptores normalmente abiertos en paralelo (diagrama simplificado)
 
-image::images/switch-no-parallel.png[]
+image::images/switch-no-parallel.png[align="center", alt="Interruptores normalmente abiertos"]
 
 Las siguientes configuraciones de interruptores estan permitidas en Stepconf:
 

--- a/docs/src/config/stepconf.txt
+++ b/docs/src/config/stepconf.txt
@@ -27,7 +27,7 @@ The Stepconf Wizard works best with at least 800 x 600 screen resolution.
 
 .Entry Page
 
-image::images/stepconf-config.png[align="center"]
+image::images/stepconf-config.png[align="center", alt="Entry Page"]
 
 * 'Create New' - Creates a fresh configuration.
 
@@ -58,7 +58,7 @@ even if you don't have the actual hardware.
 
 .Basic Information Page
 
-image::images/stepconf-basic.png[align="center"]
+image::images/stepconf-basic.png[align="center", alt="Basic Information Page"]
 
 * 'Machine Name' - Choose a name for your machine. Use only uppercase letters,
 lowercase letters, digits, - and _.
@@ -132,7 +132,7 @@ Do not attempt run LinuxCNC while the latency test is running.
 
 .Latency Test
 
-image::images/latency.png[align="center"]
+image::images/latency.png[align="center", alt="Latency Test"]
 
 Latency is how long it takes the PC to stop what it is doing and
 respond to an external request. In our case, the request is the
@@ -171,7 +171,7 @@ whether you use software stepping or not.
 
 .Parallel Port Setup Page
 
-image::images/stepconf-pinout.png[align="center"]
+image::images/stepconf-pinout.png[align="center", alt="Parallel Port Setup Page"]
 You may specify the address as a hexidecimal (often 0x378) or as linux's default
  port number (probably 0)
 
@@ -203,7 +203,7 @@ step rate shown on the Basic Machine Configuration page.
 
 .Parallel Port 2 Setup Page
 
-image::images/stepconf-parport2.png[align="center"]
+image::images/stepconf-parport2.png[align="center", alt="Parallel Port 2 Setup Page"]
 
 The second Parallel port (if selected) can be configured and It's pins
 assigned on this page. +
@@ -217,7 +217,7 @@ You may specify the address as a hexidecimal (often 0x378) or as linux's default
 
 .Axis Configuration Page
 
-image::images/stepconf-axis.png[align="center"]
+image::images/stepconf-axis.png[align="center", alt="Axis Configuration Page"]
 
 * 'Motor Steps Per Revolution' - The number of full steps per motor revolution.
 If you know how many degrees per step the motor is (e.g., 1.8 degree), then
@@ -298,7 +298,7 @@ This can be used after filling out all the information for this axis.
 
 .Test This Axis
 
-image::images/stepconf-test.png[align="center"]
+image::images/stepconf-test.png[align="center", alt="Test This Axis"]
 
 Test this axis is a basic tester that only outputs step and direction signals
 to try different values for acceleration and velocity.
@@ -372,7 +372,7 @@ reduce it by 10% and use that as the axis Maximum Acceleration.
 
 .Spindle Configuration Page
 
-image::images/stepconf-spindle.png[align="center"]
+image::images/stepconf-spindle.png[align="center", alt="Spindle Configuration Page"]
 
 This page only appears when 'Spindle PWM' is chosen in the
 'Parallel Port Pinout' page for one of the outputs.
@@ -463,7 +463,7 @@ then find the PWM values that give 1600 RPM (40%) and 2800 RPM (70%).
 
 .Advanced Configuration
 
-image::images/stepconf-advanced.png[align="center"]
+image::images/stepconf-advanced.png[align="center", alt="Advanced Configuration"]
 
 * 'Include Halui' - This will add the Halui user interface component. See the
 <<cha:hal-user-interface,HALUI Chapter>> for more information on.
@@ -560,13 +560,13 @@ Typically for a parallel port you might use 47k.
 
 Wiring N/C switches in series (simplified diagram)
 
-image::images/switch-nc-series.png[align="center"]
+image::images/switch-nc-series.png[align="center", alt="Normally Closed Switches"]
 
 .Normally Open Switches
 
 Wiring N/O switches in parallel (simplified diagram)
 
-image::images/switch-no-parallel.png[align="center"]
+image::images/switch-no-parallel.png[align="center", alt="Normally Open Switches"]
 
 The following combinations of switches are permitted in Stepconf:
 

--- a/docs/src/drivers/gm.txt
+++ b/docs/src/drivers/gm.txt
@@ -27,7 +27,7 @@ system:
    connection of two end switch and one homing sensor for each joint. And
    additionally, two optically isolated E-stop inputs.
 
-image::images/GMsystem.png[align="center", scaledwidth="70%",alt="GM servo control system"]
+image::images/GMsystem.png[align="center", scaledwidth="70%", alt="GM servo control system"]
 
 Installing:
 ----
@@ -43,14 +43,14 @@ The following connectors can be found on the GM6-PCI card:
 
 .GM6-PCI card connectors and LEDs(((pci-card connectors)))
 
-image::images/GM_PCIpinout.png[align="center",scaledwidth="70%"]
+image::images/GM_PCIpinout.png[align="center",scaledwidth="70%", alt="GM6-PCI card connectors and LEDs"]
 
 
 == I/O connectors
 
 .Pin numbering of GPIO connectors(((pin-numbering-gpio)))
 
-image::images/GM_IOpinout.png[align="center"]
+image::images/GM_IOpinout.png[align="center", alt="Pin numbering of GPIO connectors"]
 
 .Pinout of GPIO connectors
 
@@ -115,7 +115,7 @@ gm.<nr of card>.read
 
 .Pin numbering of axis connectors(((pin-numbering-axis)))
 
-image::images/GM_AXISpinout.png[align="center"]
+image::images/GM_AXISpinout.png[align="center", alt="Pin numbering of axis connectors"]
 
 .Pinout of axis connectors
 
@@ -147,7 +147,7 @@ have to be connected as the following block diagram shows:
 
 .Servo axis interfaces(((axis-iterface)))
 
-image::images/GM_AxisInterface.png[align="center", scaledwidth="100%"]
+image::images/GM_AxisInterface.png[align="center", scaledwidth="100%", alt"Servo axis interfaces"]
 
 
 === Encoder
@@ -341,7 +341,7 @@ For evaluating the appropriate values see the timing diagrams below:
 
 .Reference signal timing diagrams(((refsig-timing-diagram)))
 
-image::images/GM_RefSignals.png[align="center", scaledwidth="70%"]
+image::images/GM_RefSignals.png[align="center", scaledwidth="70%", alt="Reference signal timing diagrams"]
 
 .HAL example
 
@@ -565,7 +565,7 @@ Watchdog timer overrun causes the set of power-enable to low in hardware.
 
 .Pin numbering of homing & end switch connector(((pin-numbering-endsw)))
 
-image::images/GM_ENDSWpinout.png[align="center"]
+image::images/GM_ENDSWpinout.png[align="center", alt="Pin numbering of homing & end switch connector"]
 
 .End- and homing switch connector pinout
 
@@ -700,7 +700,7 @@ card, and the end is the last module.
 
 .Connecting the RS485 nodes to the GM6-PCI card(((connecting-rs485)))
 
-image::images/GM_RS485topology.png[align="center", scaledwidth="60%"]
+image::images/GM_RS485topology.png[align="center", scaledwidth="60%", alt="Connecting the RS485 nodes to the GM6-PCI card"]
 
 *Adressing:*
 

--- a/docs/src/drivers/hostmot2.txt
+++ b/docs/src/drivers/hostmot2.txt
@@ -249,7 +249,7 @@ configuration used above.
 
 .5i20 HAL Pins[[cap:5i20-HAL-Pins]]
 
-image::images/5i20-halpins.png[]
+image::images/5i20-halpins.png[alt="5i20 HAL Pins"]
 
 == Configurations
 

--- a/docs/src/drivers/hostmot2_fr.txt
+++ b/docs/src/drivers/hostmot2_fr.txt
@@ -231,7 +231,7 @@ configuration used above.
 
 .5i20 HAL Pins[[cap:5i20-HAL-Pins]]
 
-image::images/5i20-halpins.png[]
+image::images/5i20-halpins.png[alt="5i20 HAL Pins"]
 
 == Configurations
 

--- a/docs/src/drivers/pluto-p.txt
+++ b/docs/src/drivers/pluto-p.txt
@@ -161,7 +161,7 @@ This driver features:
 
 .Pluto-Servo Pinout(((pluto-servo pinout)))
 
-image::images/pluto-pinout.png[align="center"]
+image::images/pluto-pinout.png[align="center", alt="Pluto-Servo Pinout"]
 
 .Pluto-Servo Alternate Pin Functions
 
@@ -259,7 +259,7 @@ connector.
 
 .Pluto-Step Pinout (((pluto-step pinout)))
 
-image::images/pluto-step-pinout.png[align="center"]
+image::images/pluto-step-pinout.png[align="center", alt="Pluto-Step Pinout"]
 
 === Input latching and output updating
 
@@ -280,7 +280,7 @@ step timings are always applied to all channels.
 
 .Pluto-Step Timings (((pluto-step timings)))
 
-image::images/pluto_step_waveform.png[align="center"]
+image::images/pluto_step_waveform.png[align="center", alt="Pluto-Step Timings"]
 
 === HAL Functions, Pins and Parameters
 

--- a/docs/src/drivers/pluto_p_fr.txt
+++ b/docs/src/drivers/pluto_p_fr.txt
@@ -157,7 +157,7 @@ VCC::
 
 .Pluto-Servo Pinout[[fig:Pluto-Servo-Pinout]](((pluto-servo pinout)))
 
-image::images/pluto-pinout.png[]
+image::images/pluto-pinout.png[alt="Pluto-Servo Pinout"]
 
 .Pluto-Servo Alternate Pin Functions[[table:Pluto-Servo-Alternate-Pin]](((pluto-servo alternate pin functions)))
 
@@ -219,7 +219,6 @@ problem for motors with high stall currents. For higher currents and
 voltages, some users have reported success with International
 Rectifier's integrated high-side/low-side drivers.
 
-
 == Pluto-step: 300kHz Hardware Step Generator[[sec:Pluto-step:-Hardware-step]](((pluto-step)))
 
 Pluto-step is suitable for control of a 3- or 4-axis CNC mill with
@@ -262,7 +261,7 @@ connector.
 
 .Pluto-Step Pinout[[fig:Pluto-Step-Pinout]](((pluto-step pinout)))
 
-image::images/pluto-step-pinout.png[]
+image::images/pluto-step-pinout.png[alt="Pluto-Step Pinout"]
 
 === Input latching and output updating
 
@@ -283,7 +282,7 @@ step timings are always applied to all channels.
 
 .Pluto-Step Timings[[fig:Pluto-Step-Timings]](((pluto-step timings)))
 
-image::images/pluto_step_waveform.png[]
+image::images/pluto_step_waveform.png[alt="Pluto-Step Timings"]
 
 === HAL Functions, Pins and Parameters
 

--- a/docs/src/examples/gcode_fr.txt
+++ b/docs/src/examples/gcode_fr.txt
@@ -25,7 +25,7 @@ paramètres.
 
 .Les différents usinages de l'exemple
 
-image::images/useful-subroutines-ngc.png[]
+image::images/useful-subroutines-ngc.png[alt="Les différents usinages de l'exemple"]
 
 === Palpage d'une grille rectangulaire de points
 
@@ -39,7 +39,7 @@ _probe-results.txt_ situé dans le même répertoire que le fichier .ini.
 
 .La grille de palpage
 
-image::images/gridprobe-ngc.png[]
+image::images/gridprobe-ngc.png[alt="La grille de palpage"]
 
 === Amélioration du palpage d'une grille rectangulaire de points
 
@@ -54,7 +54,7 @@ répertoire que le fichier .ini.
 
 .La grille de palpage plus fine
 
-image::images/smartprobe-ngc.png[]
+image::images/smartprobe-ngc.png[alt="La grille de palpage plus fine"]
 
 === Mesure de longueur d'outil
 

--- a/docs/src/gcode/coordinates.txt
+++ b/docs/src/gcode/coordinates.txt
@@ -29,7 +29,7 @@ based upon absolute machine position is desired.
 == Coordinate Systems
 
 .Example of Coordinate Systems
-image::images/offsets.png[align="center"]
+image::images/offsets.png[align="center", alt="Example of Coordinate Systems"]
 
 .Coordinate System Offsets
 

--- a/docs/src/gcode/coordinates_fr.txt
+++ b/docs/src/gcode/coordinates_fr.txt
@@ -46,7 +46,7 @@ ligne où un mouvement basé sur les coordonnées machine est souhaité.
 [[fig:decalages-ilots]]
 == Décalages pièce (G54 à G59.3)
 
-image::images/offsets.png[]
+image::images/offsets.png[alt="Exemple de décalages pour 8 ilots"]
 
 .Exemple de décalages pour 8 ilots
 

--- a/docs/src/gcode/g-code.txt
+++ b/docs/src/gcode/g-code.txt
@@ -1750,7 +1750,7 @@ The G98 to the second line above means that the return move will be to
 the value of Z in the first line since it is higher that the R value
 specified.
 
-image::images/eight.png[align="center", alt="Twelve Holes in a Square"]
+image::images/eight.png[align="center"]
 
 
 .Twelve Holes in a Square
@@ -1774,7 +1774,7 @@ N1090 Z0
 N1100 M2 (program end)
 ----
 
-image::images/twelve.png[align="center", alt="Here we produce 12 holes using five lines of code in the canned motion mode"]
+image::images/twelve.png[align="center"]
 
 The second reason to use a canned cycle is that they all produce
 preliminary moves and returns that you can anticipate and control
@@ -1904,7 +1904,7 @@ The following moves take place:
 
 . a rapid move parallel to the Z-axis to (Z3)
 
-image::images/G81ex1.png[align="center", alt="Example 2 - Relative Position G81"]
+image::images/G81ex1.png[align="center"]
 
 .Example 2 - Relative Position G81
 
@@ -1952,7 +1952,7 @@ The third repeat consists of 3 moves. The X position is reset to
 
 . a rapid move parallel to the Z-axis to (X13, Y17, Z4.8)
 
-image::images/G81ex2.png[align="center", alt="Example 3 - Relative Position G81"]
+image::images/G81ex2.png[align="center"]
 
 .Example 3 - Relative Position G81
 
@@ -1968,7 +1968,7 @@ nothing for the motion but since the initial value of Z is less than
 the value specified in R, there will be an initial Z move during the
 preliminary moves.
 
-image::images/G81.png[align="center", alt="Example 4 - Absolute G81 R > Z"]
+image::images/G81.png[align="center"]
 
 .Example 4 - Absolute G81 R > Z
 
@@ -1983,7 +1983,7 @@ initial Z0 and R1.8 and rapid moves to that location. After that initial Z
 move, the repeat feature works the same as it did in example 3 with the
 final Z depth being 0.6 below the R value.
 
-image::images/G81a.png[align="center", alt="Example 5 - Relative position R > Z"]
+image::images/G81a.png[align="center"]
 
 .Example 5 - Relative position R > Z
 

--- a/docs/src/gcode/g-code.txt
+++ b/docs/src/gcode/g-code.txt
@@ -359,7 +359,7 @@ G2 X1 Y1 I1 F10 (clockwise arc in the XY plane)
 
 .G2 Example
 
-image::images/g2.png[align="center"]
+image::images/g2.png[align="center", alt="G2 Example"]
 
 In the next example we see the difference between the offsets for Y if
 we are doing a G2 or a G3 move. For the G2 move the start position is
@@ -377,7 +377,7 @@ G3 X0 Y0 I1 J-0.5 F25 (counterclockwise arc in the XY plane)
 
 .G2-G3 Example
 
-image::images/g2-3.png[align="center"]
+image::images/g2-3.png[align="center", alt="G2-G3 Example"]
 
 In the next example we show how the arc can make a helix in the Z axis
 by adding the Z word.
@@ -591,7 +591,7 @@ M2
 
 .Sample NURBS Output
 
-image:images/nurbs01.png[align="center"]
+image:images/nurbs01.png[align="center", alt="Sample NURBS Output"]
 
 More information on NURBS can be found here:
 
@@ -1492,7 +1492,7 @@ G76 P- Z- I- J- R- K- Q- H- E- L-
 
 .G76 Threading
 
-image::images/g76-threads.png[align="center"]
+image::images/g76-threads.png[align="center", alt="G76 Threading"]
 
 
 * 'Drive Line' - A line through the initial X position parallel to the Z.
@@ -1609,7 +1609,7 @@ are the cutting moves.
 
 .G76 Example
 
-image::images/g76-01.png[align="center"]
+image::images/g76-01.png[align="center", alt="G76 Example"]
 
 [[gcode:g80-g89]]
 == Canned Cycles
@@ -1750,7 +1750,7 @@ The G98 to the second line above means that the return move will be to
 the value of Z in the first line since it is higher that the R value
 specified.
 
-image::images/eight.png[align="center"]
+image::images/eight.png[align="center", alt="Twelve Holes in a Square"]
 
 
 .Twelve Holes in a Square
@@ -1774,7 +1774,7 @@ N1090 Z0
 N1100 M2 (program end)
 ----
 
-image::images/twelve.png[align="center"]
+image::images/twelve.png[align="center", alt="Here we produce 12 holes using five lines of code in the canned motion mode"]
 
 The second reason to use a canned cycle is that they all produce
 preliminary moves and returns that you can anticipate and control
@@ -1845,7 +1845,7 @@ being able to point a reader to a specific line of code.
 
 .G80 Cycle
     
-image::images/G81mult.png[align="center"]
+image::images/G81mult.png[align="center", alt="G80 Cycle"]
 
 The use of G80 in line N200 is optional because the G0 on the next
 line will turn off the G81 cycle. But using the G80 as shown in 
@@ -1904,7 +1904,7 @@ The following moves take place:
 
 . a rapid move parallel to the Z-axis to (Z3)
 
-image::images/G81ex1.png[align="center"]
+image::images/G81ex1.png[align="center", alt="Example 2 - Relative Position G81"]
 
 .Example 2 - Relative Position G81
 
@@ -1952,7 +1952,7 @@ The third repeat consists of 3 moves. The X position is reset to
 
 . a rapid move parallel to the Z-axis to (X13, Y17, Z4.8)
 
-image::images/G81ex2.png[align="center"]
+image::images/G81ex2.png[align="center", alt="Example 3 - Relative Position G81"]
 
 .Example 3 - Relative Position G81
 
@@ -1968,7 +1968,7 @@ nothing for the motion but since the initial value of Z is less than
 the value specified in R, there will be an initial Z move during the
 preliminary moves.
 
-image::images/G81.png[align="center"]
+image::images/G81.png[align="center", alt="Example 4 - Absolute G81 R > Z"]
 
 .Example 4 - Absolute G81 R > Z
 
@@ -1983,7 +1983,7 @@ initial Z0 and R1.8 and rapid moves to that location. After that initial Z
 move, the repeat feature works the same as it did in example 3 with the
 final Z depth being 0.6 below the R value.
 
-image::images/G81a.png[align="center"]
+image::images/G81a.png[align="center", alt="Example 5 - Relative position R > Z"]
 
 .Example 5 - Relative position R > Z
 

--- a/docs/src/gcode/gcode_fr.txt
+++ b/docs/src/gcode/gcode_fr.txt
@@ -374,7 +374,7 @@ G2 X1 Y1 I1 F10 (arc en sens horaire dans le plan XY)
 [[fig:G2-Exemple]]
 .Exemple avec G2
 
-image::images/g2_fr.png[align="center"]
+image::images/g2_fr.png[align="center", alt="Exemple avec G2"]
 
 Dans cet autre exemple, nous pouvons voir les différences de décalages
 pour Y selon que nous faisons un mouvement G2 ou un mouvement G3.
@@ -393,7 +393,7 @@ G3 X0 Y0 I1 J-0.5 F25 (arc en sens anti-horaire dans le plan XY)
 [[fig:G2-G3-Exemple]]
 .Exemple avec G2-G3
 
-image::images/g2-3_fr.png[align="center"]
+image::images/g2-3_fr.png[align="center", alt="Exemple avec G2-G3"]
 
 Voici un exemple au format centre pour usiner une hélice:
 ----
@@ -623,7 +623,7 @@ M2
 
 .Simple sortie NURBS
 
-image:images/nurbs01.png[align="center"]
+image:images/nurbs01.png[align="center", alt="Simple sortie NURBS"]
 
 D'autres informations sur NURBS sont disponibles ici:
 
@@ -1629,7 +1629,7 @@ spécifié par L2 E0.045. Les lignes blanches sont les mouvements de coupe.
 
 .Parcours d'outil de l'exemple[[fig:G76-cycle-de-filetage]]
 
-image::images/g76-01.png[]
+image::images/g76-01.png[alt="Parcours d'outil de l'exemple"]
 
 [[sec:G81-a-G89]]
 == Les cycles de perçage G81 à G89

--- a/docs/src/gcode/overview.txt
+++ b/docs/src/gcode/overview.txt
@@ -909,7 +909,7 @@ distance from the XY zero position increased with each line.
 
 .Polar Spiral
 
-image::images/polar01.png[align="center"]
+image::images/polar01.png[align="center", alt="Polar Spiral"]
 
 The following code will produce our square pattern.
 
@@ -927,7 +927,7 @@ end point distance is the same for each line.
 
 .Polar Square
 
-image::images/polar02.png[align="center"]
+image::images/polar02.png[align="center", alt="Polar Square"]
 
 It is an error if:
 
@@ -1265,15 +1265,4 @@ material removal rate.
   on the same line.
 * 'File ended with no percent sign or program end' - Every G code file must
   end in a M2 or M30 or be wrapped with the percent sign %.
-
-
-
-
-
-
-
-
-
-
-
 

--- a/docs/src/gcode/overview_fr.txt
+++ b/docs/src/gcode/overview_fr.txt
@@ -798,7 +798,7 @@ celle à laquelle vous vous attendiez, parce-que avons ajouté
 
 .Spirale polaire[[fig:Spirale-polaire]]
 
-image::images/polar01.png[]
+image::images/polar01.png[alt="Spirale polaire"]
 
 Le code suivant va produire notre modèle carré. 
 ----
@@ -815,7 +815,7 @@ chaque ligne. La distance du point final est la même pour chaque ligne.
 
 .Carré polaire[[fig:Carre-polaire]]
 
-image::images/polar02.png[]
+image::images/polar02.png[alt="Carré polaire"]
 
 C'est une erreur si:
 

--- a/docs/src/gcode/tool-compensation.txt
+++ b/docs/src/gcode/tool-compensation.txt
@@ -26,7 +26,7 @@ available when a tool is loaded with 'Tn M6'.
 
 .Touch Off Tool Table
 
-image::images/ToolTable-TouchOff.png[align="center"]
+image::images/ToolTable-TouchOff.png[align="center", alt="Touch Off Tool Table"]
 
 === Using G10 L1/L10/L11
 
@@ -239,7 +239,7 @@ on the next move.
 
 .Compensation End Point
 
-image::images/comp-path.png[align="center"]
+image::images/comp-path.png[align="center", alt="Compensation End Point"]
 
 === Overview
 
@@ -265,7 +265,7 @@ entry move.
 
 .Entry Move
 
-image::images/comp02.png[]
+image::images/comp02.png[alt="Entry Move"]
 
 .Z Motion
 
@@ -288,11 +288,11 @@ Rapid moves may be programed while compensation is turned on.
 
 .Outside Profile
 
-image::images/outside-comp.png[]
+image::images/outside-comp.png[alt="Outside Profile"]
 
 .Inside Profile
 
 .Inside Profile
 
-image::images/inside-comp.png[]
+image::images/inside-comp.png[alt="Inside Profile"]
 

--- a/docs/src/gcode/tool_compensation_fr.txt
+++ b/docs/src/gcode/tool_compensation_fr.txt
@@ -34,7 +34,7 @@ avec 'Tn M6'.
 
 .Toucher et table d'outils[[cap:Touch-Off-Tool]]
 
-image::images/ToolTable-TouchOff_fr.png[]
+image::images/ToolTable-TouchOff_fr.png[alt="Toucher et table d'outils"]
 
 === Utilisation de G10 L1/L10/L11
 
@@ -282,7 +282,7 @@ différents endroits, dépendants du mouvement suivant.
 
 .Point final de la compensation[[cap:Compensation-End-Point]]
 
-image::images/comp-path_fr.png[]
+image::images/comp-path_fr.png[alt="Point final de la compensation"]
 
 === Vue générale
 
@@ -308,7 +308,7 @@ de compensation et de l'arrondi de l'outil.
 
 .Mouvement d'entrée[[cap:Entry-Move]]
 
-image::images/comp02.png[]
+image::images/comp02.png[alt="Mouvement d'entrée"]
 
 ==== Mouvement en Z
 
@@ -332,13 +332,13 @@ désactivée.
 
 .Profil extérieur[[cap:Outside-Profile]]
 
-image::images/outside-comp_fr.png[]
+image::images/outside-comp_fr.png[alt="Profil extérieur"]
 
 ==== Profil intérieur
 
 .Profil intérieur[[cap:Inside-Profile]]
 
-image::images/inside-comp_fr.png[]
+image::images/inside-comp_fr.png[alt="Profil intérieur"]
 
 
 == Deux exposés sur les compensations d'outil

--- a/docs/src/getting-started/Running-LinuxCNC_fr.txt
+++ b/docs/src/getting-started/Running-LinuxCNC_fr.txt
@@ -17,7 +17,7 @@ matériel raccordé, ce sont des simulations de machines.
 
 .Sélecteur de configuration pour LinuxCNC[[cap:Selecteur-de-configuration]]
 
-image::images/configuration-selector1_fr.png[]
+image::images/configuration-selector1_fr.png[alt="Sélecteur de configuration pour LinuxCNC"]
 
 Cliquez dans la liste, sur les différentes configurations pour afficher les 
 informations les concernant. Double-cliquez sur une configuration ou cliquez _OK_ 
@@ -38,7 +38,7 @@ peuvent être enregistrés.
 
 .Dialogue de copie de la configuration
 
-image::images/copy-configuration_fr.png[]
+image::images/copy-configuration_fr.png[alt="Dialogue de copie de la configuration"]
 
 == L'interface utilisateur graphique Axis
 
@@ -50,7 +50,7 @@ C'est aussi la plus populaire.
 
 .Interface Axis[[cap:Interface-Axis]]
 
-image::../user/images/axis_25_fr.png[]
+image::../user/images/axis_25_fr.png[alt="Interface Axis"]
 
 == Les étapes suivantes de la configuration
 

--- a/docs/src/getting-started/pncconf_fr.txt
+++ b/docs/src/getting-started/pncconf_fr.txt
@@ -57,13 +57,13 @@ pncconf
 
 .Écran d'accueil de PnCConf
 
-image::images/pncconf-splash_fr.png[]
+image::images/pncconf-splash_fr.png[alt="Écran d'accueil de PnCConf"]
 
 == Créer ou éditer une configuration
 
 .Créer ou éditer
 
-image::images/pncconf-file_fr.png[]
+image::images/pncconf-file_fr.png[alt="Créer ou éditer"]
 
 Il est possible de créer une nouvelle configuration ou d'en modifier une
 existante.
@@ -83,7 +83,7 @@ la liste.
 
 .Informations machine
 
-image::images/pncconf-basic_fr.png[]
+image::images/pncconf-basic_fr.png[alt="Informations machine"]
 
 _Éléments de base_
 
@@ -254,7 +254,7 @@ manuelle de déplacement des axes (jog) ou des curseurs des correcteurs de vites
 
 .Contrôles externes
 
-image::images/pncconf-external_fr.png[]
+image::images/pncconf-external_fr.png[alt="Contrôles externes"]
 
 Si une manette de jeu externe est sélectionnée pour le jog, il faudra
 toujours la connecter à LinuxCNC avant de démarrer celui-ci. Si la manette est
@@ -313,7 +313,7 @@ d'LinuxCNC.
 
 .Configuration des GUI
 
-image::images/pncconf-gui_fr.png[]
+image::images/pncconf-gui_fr.png[alt="Configuration des GUI"]
 
 _Options des interfaces graphiques_
 
@@ -436,7 +436,7 @@ le paramétrage des composants nécessaires à la machine.
 
 .Configuration Mesa
 
-image::images/pncconf-mesa-config_fr.png[]
+image::images/pncconf-mesa-config_fr.png[alt="Configuration Mesa"]
 
 Adresse du port parallèle MESA::
      Un port parallèle est utilisé seulement avec la carte Mesa 7i43.
@@ -506,7 +506,7 @@ des cartes Mesa. PNCconf permet de créer des noms de signaux personnalisés
 
 .Réglages des E/S Mesa C2
 
-image::images/pncconf-mesa-io2_fr.png[]
+image::images/pncconf-mesa-io2_fr.png[alt="Réglages des E/S Mesa C2"]
 Sur cet onglet, avec ce micro logiciel, les composants sont liés à l'installation
 d'une carte fille 7i33, généralement utilisée avec des servomoteurs en boucle fermée.
 Noter que les numéros de composant des codeurs, des compteurs et des pilotes PWM
@@ -515,7 +515,7 @@ l'architecture des cartes filles.
 
 .Réglages des E/S Mesa C3
 
-image::images/pncconf-mesa-io3_fr.png[]
+image::images/pncconf-mesa-io3_fr.png[alt="Réglages des E/S Mesa C3"]
 Sur cet onglet, il n'y a que des broches GPIO. Noter les numéros à trois
 chiffres, ils correspondent au numéros des _HAL pins_. Les broches GPIO
 peuvent être sélectionnées comme des entrées ou des sorties et elles peuvent
@@ -523,7 +523,7 @@ peuvent être sélectionnées comme des entrées ou des sorties et elles peuvent
 
 .Réglages des E/S Mesa C4
 
-image::images/pncconf-mesa-io4_fr.png[]
+image::images/pncconf-mesa-io4_fr.png[alt="Réglages des E/S Mesa C4"]
 Sur cet onglet, il y a un mélange entre des broches GPIO et des générateurs de pas.
 Les sorties générateur de pas et de direction peuvent être inversées.
 Noter que l'inversion d'un signal Step Gen modifie les délais de pas,
@@ -531,7 +531,7 @@ il doivent correspondre à ce que le contrôleur attend.
 
 _Configuration des ports parallèles_
 
-image::images/pncconf-parport_fr.png[]
+image::images/pncconf-parport_fr.png[alt="Configuration des ports parallèles"]
 
 Les ports parallèles peuvent être utilisés pour de simples E/S similaires aux
 broches GPIO Mesa.
@@ -541,7 +541,7 @@ broches GPIO Mesa.
 
 .Configuration des axes
 
-image::images/pncconf-axis-drive_fr.png[]
+image::images/pncconf-axis-drive_fr.png[alt="Configuration des axes"]
 
 Cette page permet de configurer et tester un moteur combiné ou non à un codeur.
 Si un servomoteur est utilisé, un test en boucle ouverte est disponible.
@@ -661,7 +661,7 @@ forum pour avoir de l'aide.
 
 .Calcul de l'échelle d'axe
 
-image::images/pncconf-scale-calc_fr.png[]
+image::images/pncconf-scale-calc_fr.png[alt="Calcul de l'échelle d'axe"]
 Les paramètres d'échelle peuvent être saisis directement ou, on peut utiliser le
 bouton _calculer échelle_ pour être assisté. Utiliser alors les cases à cocher
 pour sélectionner les calculs appropriés. Noter que _Dents des poulies_ exige
@@ -673,7 +673,7 @@ l'assistant.
 
 .Configuration des axes
 
-image::images/pncconf-axis-config_fr.png[]
+image::images/pncconf-axis-config_fr.png[alt="Configuration des axes"]
 
 Se référer également à l'onglet diagramme pour deux exemples de disposition des
 contacts de fin de course d'origine machine et de limites. Ce sont deux exemples
@@ -840,7 +840,7 @@ Utiliser la compensation de jeu::
 
 .Dessin d'aide à l'identification des axes et fins de course
 
-image::images/pncconf-diagram-lathe_fr.png[]
+image::images/pncconf-diagram-lathe_fr.png[alt="Dessin d'aide à l'identification des axes et fins de course"]
 
 Ce dessin devrait aider à comprendre un exemple de positionnement des contacts
 de fin de course et les directions standards sur un tour.
@@ -865,7 +865,7 @@ ont été sélectionnés, alors cette page est disponible pour les configurer.
 
 .Configuration de la broche
 
-image::images/pncconf-spindle-config_fr.png[]
+image::images/pncconf-spindle-config_fr.png[alt="Configuration de la broche"]
 
 Cette page est semblable à la page de configuration des moteurs d'axe mais il y a
 quelques différences: À moins que l'on ait choisi un moteur pas à pas pour la
@@ -921,7 +921,7 @@ classicladder dans le manuel.
 
 .Options avancées
 
-image::images/pncconf-advanced_fr.png[]
+image::images/pncconf-advanced_fr.png[alt="Options avancées"]
 
 == Composants de HAL
 
@@ -932,7 +932,7 @@ définir ses propres composants.
 
 .Composants de HAL
 
-image::images/pncconf-hal_fr.png[]
+image::images/pncconf-hal_fr.png[alt="Composants de HAL"]
 
 La première sélection est prévue pour les composants que pncconf utilise en interne.
 Il est possible de configurer pncconf pour qu'il charge les instances additionnelles
@@ -1026,7 +1026,4 @@ Fichiers HAL Personnalisés::
     contrôlée.
 
 // vim: set syntax=asciidoc:
-
-
-
 

--- a/docs/src/getting-started/running-linuxcnc-es.txt
+++ b/docs/src/getting-started/running-linuxcnc-es.txt
@@ -24,7 +24,7 @@ De ventana de selección de configuración.
 
 .LinuxCNC seleccion de configuración[[cap:LinuxCNC-Configuration-Selector]]
 
-image::images/configuration-selector.png[]
+image::images/configuration-selector.png[alt="LinuxCNC seleccion de configuración"]
 
 De click en cualquiera de las configuraciones que se indican
 para mostrar información específica al respecto.

--- a/docs/src/getting-started/running-linuxcnc.txt
+++ b/docs/src/getting-started/running-linuxcnc.txt
@@ -107,7 +107,7 @@ by the user are offered for copying to the user's directory.
 
 .LinuxCNC Configuration Selector[[cap:LinuxCNC-Configuration-Selector]]
 
-image::images/configuration-selector.png[]
+image::images/configuration-selector.png[alt="LinuxCNC Configuration Selector"]
 
 Click any of the listed configurations 
 to display specific information about it. 

--- a/docs/src/getting-started/stepconf_fr.txt
+++ b/docs/src/getting-started/stepconf_fr.txt
@@ -31,7 +31,7 @@ pour que les boutons sur le bas des pages soient apparents.
 
 .La page d'accueil de stepconf
 
-image::images/stepconf-config_fr.png[]
+image::images/stepconf-config_fr.png[alt="La page d'accueil de stepconf"]
 
 * _Créer une nouvelle configuration_ - 
 Créera une configuration nouvelle.
@@ -57,7 +57,7 @@ configuration.
 
 .Page d'informations sur la machine
 
-image::images/stepconf-basic_fr.png[]
+image::images/stepconf-basic_fr.png[alt="Page d'informations sur la machine"]
 
 * _Nom de la machine_ - 
 (((Nom de la machine)))
@@ -171,7 +171,7 @@ automatique est prévu dans un fichier personnalisé HAL.
 
 .Configuration avancée
 
-image::images/stepconf-advanced_fr.png[]
+image::images/stepconf-advanced_fr.png[alt="Configuration avancée"]
 
 
 * _Inclure l'interface Halui_ - 
@@ -198,7 +198,7 @@ Voir le manuel de l'intégrateur pour plus d'information sur ClassicLadder.
 
 .Page de réglage du port parallèle
 
-image::images/stepconf-pinout_fr.png[]
+image::images/stepconf-pinout_fr.png[alt="Page de réglage du port parallèle"]
 
 * _Sorties (PC vers machine)_ - 
 Pour chacune des broches, choisir le signal correspondant au brochage entre
@@ -241,7 +241,7 @@ maxi des pas affichée sur la page des informations machine.
 
 .Page de configuration des axes
 
-image::images/stepconf-axis_fr.png[]
+image::images/stepconf-axis_fr.png[alt="Page de configuration des axes"]
 
 * _Nombre de pas moteur par tour_ - 
 (((Nombre de pas par tour)))
@@ -374,7 +374,7 @@ Plus de détails à ce sujet sont disponibles dans le manuel de l'intégrateur.
 
 .Tester cet axe
 
-image::images/stepconf-test_fr.png[]
+image::images/stepconf-test_fr.png[alt="Tester cet axe"]
 
 Tester cet axe et un test simple pour définir les signaux de directions et de
 pas, ainsi que les valeurs d'accélération et de vitesse.
@@ -440,7 +440,7 @@ accélération maximale pour cet axe.
 
 .Page configuration de la broche[[cap:Page-Configuration-de-la-broche]]
 
-image::images/stepconf-spindle_fr.png[]
+image::images/stepconf-spindle_fr.png[alt="Page configuration de la broche"]
 
 Ces options ne sont accessibles que quand _PWM broche_,
 _Phase A codeur broche_ ou _index broche_ sont configurés dans le
@@ -648,13 +648,13 @@ de commande souple.
 
 .Contacts normalement fermés[[cap:Contacts-Normalement-Fermes]]
 
-image::images/switch-nc-series_fr.png[]
+image::images/switch-nc-series_fr.png[alt="Contacts normalement fermés"]
 
 Câblage de contacts NC en série (schéma simplifié)
 
 .Contacts normalement ouverts[[cap:Contacts-Normalement-Ouverts]]
 
-image::images/switch-no-parallel_fr.png[]
+image::images/switch-no-parallel_fr.png[alt="Contacts normalement ouverts"]
 
 Câblage de contacts NO en parallèle (schéma simplifié)
 

--- a/docs/src/getting-started/updating-linuxcnc.txt
+++ b/docs/src/getting-started/updating-linuxcnc.txt
@@ -89,7 +89,7 @@ or Ubuntu Lucid.
 | Ubuntu Lucid   | `deb http://linuxcnc.org lucid base 2.7-rtai`
 |====
 
-image::images/upgrading-to-2.7.png[align="left"]
+image::images/upgrading-to-2.7.png[align="left", alt="Setting apt sources"]
 
 * Click `Add Source`, then `Close` in the Software Sources window.
   If it pops up a window informing you that the information about

--- a/docs/src/gui/axis.txt
+++ b/docs/src/gui/axis.txt
@@ -10,7 +10,7 @@ Tk and OpenGL to display its user interface.
 
 .AXIS Window
 
-image::images/axis.png[align="center"]
+image::images/axis.png[align="center", alt="AXIS Window"]
 
 == Getting Started
 
@@ -310,43 +310,43 @@ So be familiar with your machine's design and interpret the display as needed.
 
 From left to right in the Axis display, the toolbar buttons (keyboard shortcuts shown [in brackets]) are: 
 
-* image:images/tool_estop.gif[] Toggle Emergency Stop [F1] (also called E-Stop)
+* image:images/tool_estop.gif[alt="Toggle Emergency Stop"] Toggle Emergency Stop [F1] (also called E-Stop)
 
-* image:images/tool_power.gif[] Toggle Machine Power [F2]
+* image:images/tool_power.gif[alt="Toggle Machine Power"] Toggle Machine Power [F2]
 
-* image:images/tool_open.gif[] Open G Code file [O]
+* image:images/tool_open.gif[alt="Open G Code file"] Open G Code file [O]
 
-* image:images/tool_reload.gif[] Reload current file [Ctrl-R]
+* image:images/tool_reload.gif[alt="Reload current file"] Reload current file [Ctrl-R]
 
-* image:images/tool_run.gif[] Begin executing the current file [R]
+* image:images/tool_run.gif[alt="Begin executing the current file"] Begin executing the current file [R]
 
-* image:images/tool_step.gif[] Execute next line [T]
+* image:images/tool_step.gif[alt="Execute next line"] Execute next line [T]
 
-* image:images/tool_pause.gif[] Pause Execution [P] Resume Execution[S]
+* image:images/tool_pause.gif[alt="Pause Execution - Resume Execution"] Pause Execution [P] Resume Execution [S]
 
-* image:images/tool_stop.gif[] Stop Program Execution [ESC]
+* image:images/tool_stop.gif[alt="Stop Program Execution"] Stop Program Execution [ESC]
 
-* image:images/tool_blockdelete.gif[] Toggle Skip lines with "/" [Alt-M-/]
+* image:images/tool_blockdelete.gif[alt="Toggle Skip lines"] Toggle Skip lines with "/" [Alt-M-/]
 
-* image:images/tool_optpause.gif[] Toggle Optional Pause [Alt-M-1]
+* image:images/tool_optpause.gif[alt="Toggle Optional Pause"] Toggle Optional Pause [Alt-M-1]
 
-* image:images/tool_zoomin.gif[] Zoom In
+* image:images/tool_zoomin.gif[alt="Zoom In"] Zoom In
 
-* image:images/tool_zoomout.gif[] Zoom Out
+* image:images/tool_zoomout.gif[alt="Zoom Out"] Zoom Out
 
-* image:images/tool_axis_z.gif[] Top view
+* image:images/tool_axis_z.gif[alt="Top view"] Top view
 
-* image:images/tool_axis_z2.gif[] Rotated Top view
+* image:images/tool_axis_z2.gif[alt="Rotated Top view"] Rotated Top view
 
-* image:images/tool_axis_x.gif[] Side view
+* image:images/tool_axis_x.gif[alt="Side view"] Side view
 
-* image:images/tool_axis_y.gif[] Front view
+* image:images/tool_axis_y.gif[alt="Front view"] Front view
 
-* image:images/tool_axis_p.gif[] Perspective view
+* image:images/tool_axis_p.gif[alt="Perspective view"] Perspective view
 
-* image:images/tool_rotate.gif[] Toggle between Drag and Rotate Mode [D]
+* image:images/tool_rotate.gif[alt="Toggle between Drag and Rotate Mode"] Toggle between Drag and Rotate Mode [D]
 
-* image:images/tool_clear.gif[] Clear live backplot [Ctrl-K]
+* image:images/tool_clear.gif[alt="Clear live backplot"] Clear live backplot [Ctrl-K]
 
 
 === Graphical Display Area
@@ -355,9 +355,9 @@ From left to right in the Axis display, the toolbar buttons (keyboard shortcuts 
 
 In the upper-left corner of the program display is the coordinate position
 display for each axis. To the right of the number an origin symbol
-image:images/axis-homed.png[] is shown if the axis has been homed.
+image:images/axis-homed.png[alt="origin symbol is shown if the axis has been homed"] is shown if the axis has been homed.
 
-A limit symbol image:images/axis-limit.png[] is shown on the right side of the
+A limit symbol image:images/axis-limit.png[alt="limit symbol"] is shown on the right side of the
 coordinate position number if the axis is on one of its limit switches.
 
 To properly interpret the coordinate position numbers, refer to the 'Position:'
@@ -366,7 +366,7 @@ displayed number is in the machine coordinate system. If it is
 'Relative Actual', then the displayed number is in the offset coordinate
 system. When the coordinates displayed are relative and an offset has been set,
 the display will include a cyan 'machine origin'
-image:images/axis-machineorigin.png[] marker.
+image:images/axis-machineorigin.png[alt="cyan machine origin"] marker.
 
 If the position is 'Commanded', then the exact coordinate given in a G code
 command is displayed. If it is 'Actual', then it is the position the machine
@@ -411,7 +411,7 @@ and the program requires 3.83 inches of X travel.
 To move the program so it's within the machine's travel in this case, 
 jog to the left and Touch Off X again.
 
-image::images/axis-outofrange.png[align="center"]
+image::images/axis-outofrange.png[align="center",alt="The extents of the program in x axis are shown"]
 
 .Tool Cone
 When no tool is loaded, the location of the tip of the tool is
@@ -480,7 +480,7 @@ the text display will automatically scroll to show the current line.
 
 .Current and Selected Lines
 
-image::images/axis-currentandselected.png[align="center"]
+image::images/axis-currentandselected.png[align="center", alt="Current and Selected Lines"]
 
 === Manual Control
 
@@ -552,7 +552,7 @@ resulting value is shown as a number.
 
 .Touch Off
 
-image::images/touchoff.png[align="center"]
+image::images/touchoff.png[align="center", alt="Touch Off"]
 
 See also the 'Tool touch off to workpiece' and 'Tool touch off to fixture' 
 options in the Machine menu.
@@ -593,7 +593,7 @@ running, the MDI controls are unavailable.
 
 .The MDI tab
 
-image::images/axis-mdi.png[align="center"]
+image::images/axis-mdi.png[align="center", alt="MDI tab"]
 
 * 'History' - This shows MDI commands that have been typed earlier in this session.
 
@@ -697,7 +697,7 @@ Show LinuxCNC Status
 
 .LinuxCNC Status Window
 
-image::images/axis-emc-status.png[align="center"]
+image::images/axis-emc-status.png[align="center", alt="LinuxCNC Status Window"]
 
 The name of each item is shown in the left column. The current value
 is shown in the right column. If the value has recently changed, it is
@@ -765,7 +765,7 @@ program a G1 with no move after the T<n>.
 
 .The Manual Toolchange Window
 
-image::images/manual-tool-change.png[align="center"]
+image::images/manual-tool-change.png[align="center", alt="The Manual Toolchange Window"]
 
 == Python modules 
 
@@ -802,7 +802,7 @@ When in lathe mode, the shape of the loaded tool (if any) is shown.
 
 .Lathe Tool Shape
 
-image:images/axis-lathe-tool.png[align="center"]
+image::images/axis-lathe-tool.png[align="center", alt="Lathe Tool Shape"]
 
 == Using AXIS in Foam Cutting mode
 
@@ -815,7 +815,7 @@ set the Z coordinates of these planes, which default to 0 and 1.5 machine units.
 
 .Foam cutting mode
 
-image:images/axis-foam.png[align="center"]
+image::images/axis-foam.png[align="center", alt="Foam cutting mode"]
 
 
 == Advanced Configuration
@@ -866,7 +866,7 @@ series of holes along the circumference of a circle.
 
 .Circular Holes
 
-image::images/holes.png[align="center"]
+image::images/holes.png[align="center", alt="Circular Holes"]
 
 If the environment variable AXIS_PROGRESS_BAR is set, then lines
 written to stderr of the form

--- a/docs/src/gui/axis_fr.txt
+++ b/docs/src/gui/axis_fr.txt
@@ -15,7 +15,7 @@ afficher son interface graphique.
 [[cap:Fenetre-AXIS]]
 .Fenêtre d'AXIS
 
-image::../user/images/axis_25_fr.png[]
+image::../user/images/axis_25_fr.png[alt="Fenêtre d'AXIS"]
 
 == Commencer avec AXIS
 
@@ -349,46 +349,45 @@ l'affichage comme il se doit.
 
 Signification des boutons de la fenêtre d'AXIS, de gauche à droite:
 
-* image:images/tool_estop.gif[align="center"] 'Arrêt d'urgence' (A/U)
+* image:images/tool_estop.gif[alt="Arrêt d'urgence (A/U)"] 'Arrêt d'urgence' (A/U)
     (en Anglais, E-Stop)(((Arrêt d'urgence)))
 
-* image:images/tool_power.gif[] Marche/Arrêt puissance machine(((Marche/Arret)))
+* image:images/tool_power.gif[alt="Marche/Arrêt puissance machine"] Marche/Arrêt puissance machine(((Marche/Arret)))
 
-* image:images/tool_open.gif[] Ouvrir un fichier
+* image:images/tool_open.gif[alt="Ouvrir un fichier"] Ouvrir un fichier
 
-* image:images/tool_reload.gif[] Recharger le fichier courant
+* image:images/tool_reload.gif[alt="Recharger le fichier courant"] Recharger le fichier courant
 
-* image:images/tool_run.gif[] Départ cycle
+* image:images/tool_run.gif[alt="Départ cycle"] Départ cycle
 
-* image:images/tool_step.gif[] Cycle en pas à pas
+* image:images/tool_step.gif[alt="Cycle en pas à pas"] Cycle en pas à pas
 
-* image:images/tool_pause.gif[] Pause/Reprise
+* image:images/tool_pause.gif[alt="Pause/Reprise"] Pause/Reprise
 
-* image:images/tool_stop.gif[] Stopper l'exécution du programme
+* image:images/tool_stop.gif[alt="Stopper l'exécution du programme"] Stopper l'exécution du programme
 
-* image:images/tool_blockdelete.gif[] Sauter ou non les lignes commençant par */*
+* image:images/tool_blockdelete.gif[alt="Sauter ou non les lignes commençant par /"] Sauter ou non les lignes commençant par */*
 
-* image:images/tool_optpause.gif[] Avec ou sans pause optionnelle
+* image:images/tool_optpause.gif[alt="Avec ou sans pause optionnelle"] Avec ou sans pause optionnelle
 
-* image:images/tool_zoomin.gif[] Zoom plus
+* image:images/tool_zoomin.gif[alt="Zoom plus"] Zoom plus
 
-* image:images/tool_zoomout.gif[] Zoom moins
+* image:images/tool_zoomout.gif[alt="Zoom moins"] Zoom moins
 
-* image:images/tool_axis_z.gif[] Vue prédéfinie *Z* (vue de dessus)
+* image:images/tool_axis_z.gif[alt="Vue prédéfinie Z (vue de dessus)"] Vue prédéfinie *Z* (vue de dessus)
 
-* image:images/tool_axis_z2.gif[] Vue prédéfinie *Z basculée*
+* image:images/tool_axis_z2.gif[alt="Vue prédéfinie Z basculée"] Vue prédéfinie *Z basculée*
 
-* image:images/tool_axis_x.gif[] Vue prédéfinie *X* (vue de côté)
+* image:images/tool_axis_x.gif[alt="Vue prédéfinie X (vue de côté)"] Vue prédéfinie *X* (vue de côté)
 
-* image:images/tool_axis_y.gif[] Vue prédéfinie *Y* (vue de face)
+* image:images/tool_axis_y.gif[alt="Vue prédéfinie Y (vue de face)"] Vue prédéfinie *Y* (vue de face)
 
-* image:images/tool_axis_p.gif[] Vue prédéfinie *P* (vue en perspective)
+* image:images/tool_axis_p.gif[alt="Vue prédéfinie P (vue en perspective)"] Vue prédéfinie *P* (vue en perspective)
 
-* image:images/tool_rotate.gif[align="center"] Orienter la vue avec le bouton
+* image:images/tool_rotate.gif[alt="Orienter la vue avec le bouton"] Orienter la vue avec le bouton
 gauche de la souris
 
-* image:images/tool_clear.gif[] Rafraîchir le parcours d'outil
-
+* image:images/tool_clear.gif[alt="Rafraîchir le parcours d'outil"] Rafraîchir le parcours d'outil
 
 === Zones d'affichage graphique du programme
 
@@ -399,13 +398,12 @@ Il montre les positions de la machine.
 A gauche du nom de l'axe, un symbole d'origine est visible
 si la prise d'origine de l'axe a été faite.
 
-image:images/axis-homed.png[] Symbole de prise d'origine faite.
-
+image:images/axis-homed.png[alt="Symbole de prise d'origine faite"] Symbole de prise d'origine faite.
 
 A droite du nom de l'axe, un symbole de limite est visible si l'axe est sur
 un de ses capteurs de limite.
 
-image:images/axis-limit.png[] Symbole de limite d'axe.
+image:images/axis-limit.png[alt="Symbole de limite d'axe"] Symbole de limite d'axe.
 
 Pour interpréter correctement ces valeurs, référez vous à l'indicateur
 'Position' de la barre d'état. Si la position est 'Absolue', alors les
@@ -415,7 +413,7 @@ coordonnées relatives à la pièce. Quand les coordonnées affichées sont
 relatives, une marque d'origine de couleur cyan est visible pour
 représenter l'origine machine.
 
-image:images/axis-machineorigin.png[] Symbole d'origine machine.
+image:images/axis-machineorigin.png[Symbole d'origine machine] Symbole d'origine machine.
 
 Si la position est 'Commandée', alors il s'agit de la position à atteindre.
 Par exemple, les coordonnées passées dans une commande *G0*.
@@ -467,7 +465,7 @@ l'origine pièce.
 [[cap:Etendues-Depassees]]
 .Limites logicielles
 
-image::images/axis-outofrange.png[]
+image::images/axis-outofrange.png[alt="Limites logicielles"]
 
 .Le cône d'outil
 
@@ -522,7 +520,7 @@ le texte défile automatiquement pour toujours laisser la ligne courante visible
 
 .Ligne courante et ligne en surbrillance
 
-image::images/axis-currentandselected_fr.png[]
+image::images/axis-currentandselected_fr.png[alt="Ligne courante et ligne en surbrillance"]
 
 === Contrôle manuel
 (((Contrôle manuel)))
@@ -595,7 +593,7 @@ du bloc.
 
 .Fenêtre du Toucher
 
-image::images/touchoff_fr.png[]
+image::images/touchoff_fr.png[alt="Fenêtre du Toucher"]
 
 Voir aussi les options du menu Machine: 'Toucher la pièce' et
 'Toucher le porte-pièce'.
@@ -638,7 +636,7 @@ programme est en cours d'exécution, cet onglet n'est pas opérationnel.
 
 .L'onglet 'Données manuelles'
 
-image::images/axis-codeentry_fr.png[]
+image::images/axis-codeentry_fr.png[alt="L'onglet 'Données manuelles"]
 
 * 'Historique' - Affiche les commandes précédemment tapées et au cours des
    session précédentes.
@@ -750,7 +748,7 @@ d'état de LinuxCNC.
 
 .Fenêtre d'état de LinuxCNC
 
-image::images/axis-emc-status.png[]
+image::images/axis-emc-status.png[alt="Fenêtre d'état de LinuxCNC"]
 
 Le nom de chaque entrée est affiché dans la colonne de gauche. La
 valeur courante de chaque entrée s'affiche dans la colonne de droite.
@@ -819,7 +817,7 @@ après un M6 T<n>.
 [[cap:Changement-manuel-d-outil]]
 .La fenêtre de changement manuel d'outil
 
-image::images/manualtoolchange_fr.png[]
+image::images/manualtoolchange_fr.png[alt="La fenêtre de changement manuel d'outil"]
 
 == Modules en Python 
 
@@ -864,7 +862,7 @@ représentés.
 
 .Représentation de l'outil en mode tour
 
-image::images/axis-lathe-tool.png[]
+image::images/axis-lathe-tool.png[alt="Représentation de l'outil en mode tour"]
 
 == Configuration avancée d'AXIS
 
@@ -910,7 +908,7 @@ une série de trous suivant un arc de cercle.
 
 .Perçages circulaires 
 
-image::images/holes.png[]
+image::images/holes.png[alt="Perçages circulaires"]
 
 Si la variable d'environnement: AXIS_PROGRESS_BAR est active, alors
 les lignes seront écrites sur stderr de la forme:
@@ -1016,5 +1014,4 @@ aperçu sur certaines parties qui sont déjà fonctionnelles).
  - (AXIS,notify,le_texte) Affiche 'le_texte' à l'écran, comme une info.
 Cet affichage peut être très utile lors du pré-affichage du parcours d'outil,
 quand les commentaires (debug,message) ne sont pas affichés.
-
 

--- a/docs/src/gui/gscreen.txt
+++ b/docs/src/gui/gscreen.txt
@@ -16,10 +16,10 @@ Gscreen you use the Glade editor. Gscreen is not restricted to adding a custom
 panel on the right or a custom tab it is fully editable.
 
 .Gscreen Mill Base Screen
-image::images/gscreen-mill.png["Gscreen Mill",align="center"]
+image::images/gscreen-mill.png[align="center", alt="Gscreen Mill Base Screen"]
 
 .Gscreen Lathe Base Screen
-image::images/gscreen-lathe.png[align='center']
+image::images/gscreen-lathe.png[align="center", alt="Gscreen Lathe Base Screen"]
 
 Gscreen is based on 'Glade' (the editor), 'PyGTK' (the widget toolkit), and
 'GladeVCP' (LinuxCNC's connection to Glade and PyGTK). GladeVCP has some
@@ -185,7 +185,7 @@ Remember, if you use a custom screen option YOU are responsible for fixing it
 
 == Building a simple clean-sheet custom screen
 
-image::images/tester.png[align="center"]
+image::images/tester.png[align="center", alt="simple usable screen"]
 
 Lets build a simple usable screen. Build this in the Glade editor (if using a
 RIP package run it from a terminal after using . scripts/rip-environment ).
@@ -209,7 +209,7 @@ RIP package run it from a terminal after using . scripts/rip-environment ).
 * The buttons in this example are regular buttons not HAL buttons. We don't
   need the HAL pins.
 
-image::images/tester_editor.png[align="center"]
+image::images/tester_editor.png[align="center", alt="Glade editor tester.glade"]
 
 In this screen we are using VCP_actions to communicate to LinuxCNC the actions
 we want. This allows us standard functions without adding python code in the

--- a/docs/src/gui/image-to-gcode.txt
+++ b/docs/src/gui/image-to-gcode.txt
@@ -2,7 +2,7 @@
 
 = Image to G Code
 
-image::images/image-to-gcode.png[align="center"]
+image::images/image-to-gcode.png[align="center", alt="Image to G Code"]
 
 == What is a depth map?
 
@@ -179,5 +179,5 @@ offset is 0.1 inches.
 
 .Roughing passes and final pass
 
-image::images/i2g-roughing.png[]
+image::images/i2g-roughing.png[alt="Roughing passes and final pass"]
 

--- a/docs/src/gui/image-to-gcode_fr.txt
+++ b/docs/src/gui/image-to-gcode_fr.txt
@@ -3,7 +3,7 @@
 
 = Image-to-gcode: Usiner un depth maps
 
-image::images/image-to-gcode.png[]
+image::images/image-to-gcode.png[alt="Image-to-gcode: Usiner un depth maps"]
 
 == Qu'est-ce qu'un _depth map_?
 
@@ -185,5 +185,5 @@ pouces et Roughing Offset de 0.1 pouces.
 
 .Passes d'ébauche[[cap:Passes-Ebauche]]
 
-image::images/i2g-roughing.png[]
+image::images/i2g-roughing.png[alt="Passes d'ébauche"]
 

--- a/docs/src/gui/pyvcp-examples.txt
+++ b/docs/src/gui/pyvcp-examples.txt
@@ -58,7 +58,7 @@ Wizard.
 
 .XYZ Wizard Configuration[[cap:XYZ-Wizard-Configuration]]
 
-image::images/xyz_ACO.png[]
+image::images/xyz_ACO.png[alt="XYZ Wizard Configuration"]
 
 The Stepconf Wizard will create several files and place them in the
 linuxcnc/configs/pyvcp_xyz directory. If you left the create link checked
@@ -166,7 +166,7 @@ will be there.
 
 .Jog Buttons[[cap:Jog-Buttons]]
     
-image::images/xyz_buttons.png[]
+image::images/xyz_buttons.png[alt="Jog Buttons"]
 
 === Make Connections
 
@@ -271,7 +271,7 @@ of in pins and a couple of out pins.
 
 .Port Tester Panel[[cap:Port-Tester-Panel]]
 
-image::images/ptest.png[]
+image::images/ptest.png[alt="Port Tester Panel"]
 
 To run the HAL commands that we need to get everything up and running
 we put the following in our ptest.hal file.
@@ -300,7 +300,7 @@ The following figure shows what a complete panel might look like.
 
 .Port Tester Complete[[cap:Port-Tester-Complete]]
 
-image::images/ptest-final.png[]
+image::images/ptest-final.png[alt="Port Tester Complete"]
 
 To add the rest of the parallel port pins just modify the .xml and
 .hal files.
@@ -446,7 +446,7 @@ The above gives us a PyVCP panel that looks like the following.
 
 .GS2 Panel[[cap:GS2-Panel]]
 
-image::images/gs2_panel.png[]
+image::images/gs2_panel.png[alt="GS2 Panel"]
 
 === The Connections
 

--- a/docs/src/gui/pyvcp_examples_fr.txt
+++ b/docs/src/gui/pyvcp_examples_fr.txt
@@ -58,7 +58,7 @@ page _Basic Machine Information_ de l'assistant Stepconf.
 
 .Assistant de configuration XYZ[[cap:XYZ-Wizard-Configuration]]
 
-image::images/xyz_ACO.png[]
+image::images/xyz_ACO.png[alt="Assistant de configuration XYZ"]
 
 L'assistant Stepconf Wizard va créer plusieurs fichiers et les placer dans le
 répertoire _/emc/configs/pyvcp_xyz_. Si la case _Créer un lien_ est cochée,
@@ -166,7 +166,7 @@ conviendra tout d'abord de vérifier soigneusement.
 
 .Boutons de Jog[[cap:Jog-Buttons]]
 
-image::images/xyz_buttons.png[]
+image::images/xyz_buttons.png[alt="Boutons de Jog"]
 
 === Effectuer les connections
 
@@ -273,7 +273,7 @@ HAL de sortie.
 
 .Panneau flottant testeur de port parallèle[[cap:Port-Tester-Panel]]
 
-image::images/ptest.png[]
+image::images/ptest.png[alt="Panneau flottant testeur de port parallèle"]
 
 Pour lancer les commandes de HAL dont nous avons besoin et démarrer tout ce
 qi'il nous faut, nous avons mis le code suivant dans notre fichier ptest.hal.
@@ -302,7 +302,7 @@ La figure suivante montre à quoi ressemble le panneau complet.
 
 .Testeur de port parallèle, complet[[cap:Port-Tester-Complete]]
 
-image::images/ptest-final.png[]
+image::images/ptest-final.png[alt="Testeur de port parallèle, complet"]
 
 Pour ajouter le reste des pins du port parallèle, il suffi de modifier les 
 fichiers .xml et .hal.
@@ -452,7 +452,7 @@ L'image ci-dessous montre notre panneau PyVCP en fonctionnement.
 
 .Panneau pour GS2[[cap:Panneau-GS2]]
 
-image::images/gs2_panel.png[]
+image::images/gs2_panel.png[alt="Panneau pour GS2"]
 
 === Les connections
 

--- a/docs/src/gui/tklinuxcnc.txt
+++ b/docs/src/gui/tklinuxcnc.txt
@@ -12,7 +12,7 @@ shown.
 
 .TkLinuxCNC Window
 
-image::images/tkemc.png[align="center"]
+image::images/tkemc.png[align="center", alt="TkLinuxCNC Window"]
 
 == Getting Started
 
@@ -130,7 +130,7 @@ optional stop switch (if the button is green the program execution will
 be stopped on any M1 encountered).
 
 .TkLinuxCNC Interpreter / program control
-image::images/tkemc-interp.png[align="center"]
+image::images/tkemc-interp.png[align="center", alt="TkLinuxCNC Interpreter / program control"]
 
 .Text Program Display Area
 
@@ -167,7 +167,7 @@ color).
 
 .TkLinuxCNC Override Limits & Jogging increments example
 
-image::images/tkemc-override-limits.png[align="center"]
+image::images/tkemc-override-limits.png[align="center", alt="TkLinuxCNC Override Limits & Jogging increments example"]
 
 .The Spindle group
 
@@ -192,7 +192,7 @@ on, and not set to MDI mode, the code entry controls are unavailable.
 
 .The Code Entry tab
 
-image::images/tkemc-mdi.png[align="center"]
+image::images/tkemc-mdi.png[align="center", alt="The Code Entry tab"]
 
 .MDI:
 

--- a/docs/src/gui/tklinuxcnc_fr.txt
+++ b/docs/src/gui/tklinuxcnc_fr.txt
@@ -16,7 +16,7 @@ portable (elle fonctionne sur une multitude de plateformes).
 [[cap:affichage-TkLinuxCNC]]
 .L'affichage de TkLinuxCNC
 
-image::images/tklinuxcnc_fr.png[]
+image::images/tklinuxcnc_fr.png[alt="L'affichage de TkLinuxCNC"]
 
 == Utiliser TkLinuxCNC
 
@@ -135,7 +135,7 @@ menu _Vues → Parcours d'outil_.
 [[cap:TkLinuxCNC-Interpreteur]]
 .Interpréteur de TkLinuxCNC
 
-image::images/tklinuxcnc_interp_fr.png[]
+image::images/tklinuxcnc_interp_fr.png[alt="Interpréteur de TkLinuxCNC"]
 
 ==== Boutons de contrôle
 
@@ -193,7 +193,7 @@ s'affiche en rouge.
 [[cap:Override-Limits]]
 .Exemple de dépassement de limite et incréments de jog
 
-image::images/tkemc-override-limits.png[]
+image::images/tkemc-override-limits.png[alt="Exemple de dépassement de limite et incréments de jog"]
 
 ==== Le groupe de boutons _Broche_(((broche)))
 
@@ -217,9 +217,10 @@ pas en marche ni mise en mode MDI, l'entrée de code n'est pas possible.
 
 .Le champ de saisie des entrées manuelles
 
-image::images/tkemc-mdi.png[]
+image::images/tkemc-mdi.png[alt="Le champ de saisie des entrées manuelles"]
 
-==== MDI:
+docs: image alt-tags added
+Signed-off-by: Thoren Seufl <t_seufl@gmx.de>==== MDI:
 
 Le mode MDI permet d'exécuter une commande en G-code en pressant la
 touche _Entrée_.

--- a/docs/src/gui/tooledit.txt
+++ b/docs/src/gui/tooledit.txt
@@ -4,7 +4,7 @@
 
 == Overview
 
-image::images/tooledit.png[align="center",width=640]
+image::images/tooledit.png[align="center", width="640", alt="Tool Edit GUI - Overview"]
 
 The 'tooledit' program can update the tool table file with
 edited changes by using the SaveFile button.  The SaveFile button
@@ -21,7 +21,7 @@ order by clicking on the column header.  A second click sorts
 in descending order.  Column sorting requires that the machine
 is configured with the default tcl version >= 8.5.
 
-image::images/tooledit-sort.png[align="center"]
+image::images/tooledit-sort.png[align="center", alt="Tool Edit GUI - Column Sorting"]
 
 On Ubuntu Lucid 10.04 tcl/tk8.4 is the default.  You can add tcl/tk8.5 with
 the commands:
@@ -42,7 +42,7 @@ tool table parameter columns.  Since few machines use all
 parameters, the columns displayed can be limited with the
 following ini file setting:
 
-image::images/tooledit-columns.png[align="center"]
+image::images/tooledit-columns.png[align="center", alt="Tool Edit GUI - Column Selection"]
 
 .INI File Syntax
 ----

--- a/docs/src/gui/tooledit_fr.txt
+++ b/docs/src/gui/tooledit_fr.txt
@@ -11,7 +11,7 @@ Les éléments de tooledit modifiables décrits ici sont disponibles
 dans les versions 2.5.1 et suivantes. Dans la version 2.5.0, l'interface
 graphique ne permet pas ces ajustements.
 
-image::images/tooledit_fr.png[align="left",width=640]
+image::images/tooledit_fr.png[align="left", width="640", alt="Éditeur graphique de table d’outils"]
 
 Le programme tooledit rafraichi le fichier de la table d'outils avec les
 changements édités puis enregistrés avec le bouton _EnregistrerFichier_.
@@ -42,7 +42,7 @@ TOOL_EDITOR = tooledit Z DIAM
 ----
 
 .Résultat obtenu
-image::images/tooledit-columns_fr.png[align="left"]
+image::images/tooledit-columns_fr.png[align="left", alt="Éditeur graphique de table d’outils - Choix des colonnes"]
 
 == Tri par colonne
 Les outils de la table affichée peuvent être triés selon n'importe quelle
@@ -50,7 +50,7 @@ colonne, par ordre croissant ou décroissant, en cliquant sur l'entête de la
 colonne. Un second clic inverse l'ordre de tri. Le tri par colonne nécessite
 une version de TCL/TK >= 8.5
 
-image::images/tooledit-sort_fr.png[align="left"]
+image::images/tooledit-sort_fr.png[align="left", alt="Éditeur graphique de table d’outils - Tri par colonne"]
 
 Sous Ubuntu Lucid 10.04 tcl/tk8.4 est installé par défaut. Il est possible
 d'ajouter tcl/tk8.5 avec la commande suivante:
@@ -87,7 +87,7 @@ l'exécution d'un g-code ou d'un autre programme peut altérer les données de l
 table d'outils. Toute modification est alors détectée par tooledit qui affiche
 le message: Attention: Fichier modifié par un autre process
 
-image::images/tooledit-warning_fr.png[align="left"]
+image::images/tooledit-warning_fr.png[align="left", alt="Éditeur graphique de table d’outils - Utilisation autonome"]
 
 L'affichage de la table d'outils dans tooledit peut être rafraichi par le
 bouton _Relire_, pour relire le fichier modifié.

--- a/docs/src/gui/touchy.txt
+++ b/docs/src/gui/touchy.txt
@@ -10,7 +10,7 @@ with a wheel/MPG and a few buttons and switches.
 
 .Touchy
 
-image::images/touchy.png[align="center"]
+image::images/touchy.png[align="center", alt="Touchy GUI"]
 
 == Panel Configuration
 

--- a/docs/src/gui/touchy_fr.txt
+++ b/docs/src/gui/touchy_fr.txt
@@ -13,7 +13,7 @@ avec une manivelle électronique (MPG) et des boutons et interrupteurs.
 
 .L'interface tactile Touchy
 
-image::images/touchy_fr.png[]
+image::images/touchy_fr.png[alt="L'interface tactile Touchy"]
 
 == Panneau de Configuration
 

--- a/docs/src/gui/vismach.txt
+++ b/docs/src/gui/vismach.txt
@@ -6,7 +6,7 @@ Vismach is a set of Python functions that can be used to create and animate
 models of machines. Vismach displays the model in a 3D viewport and the model
 parts are animated as the values of associated HAL pins change.
 
-image::images/vismach.png[align="center"]
+image::images/vismach.png[align="center", alt="Vismach displays the model in a 3D viewport"]
 
 The Vismach viewport view can be manipulated as follows
 

--- a/docs/src/hal/basic-hal.txt
+++ b/docs/src/hal/basic-hal.txt
@@ -17,7 +17,7 @@ and it will be added to the watch window.
 
 .HAL Configuration Window
 
-image::images/HAL_Configuration.png[align="center"]
+image::images/HAL_Configuration.png[align="center", alt="HAL Configuration Window"]
 
 === loadrt
 
@@ -129,7 +129,7 @@ additional pins, as long as the rules above are obeyed.
 
 .Signal Direction
 
-image::images/signal-direction.png[align="center"]
+image::images/signal-direction.png[align="center", alt="Signal Direction"]
 
 This example shows the signal xStep with the source being
 stepgen.0.out and with two readers, parport.0.pin-02-out and

--- a/docs/src/hal/basic_hal_fr.txt
+++ b/docs/src/hal/basic_hal_fr.txt
@@ -17,7 +17,7 @@ dans la fenêtre watch.
 
 .Fenêtre de configuration de HAL
 
-image::images/HAL_Configuration.png[]
+image::images/HAL_Configuration.png[alt="Fenêtre de configuration de HAL"]
 
 === loadrt
 
@@ -122,7 +122,7 @@ connecter des pins additionnelles, tant que les règles précédentes sont obser
 
 .Direction du signal[[cap:Signal-Direction]]
 
-image::images/signal-direction.png[align="left"]
+image::images/signal-direction.png[align="left", alt="Direction du signal"]
 
 Voici un exemple qui montre le signal xStep avec la source qui est stepgen.0.out
 et avec deux lecteurs, parport.0.pin-02-out etparport.0.pin-08-out. Simplement

--- a/docs/src/hal/hal-examples.txt
+++ b/docs/src/hal/hal-examples.txt
@@ -98,7 +98,7 @@ from either the abs.0.out pin or the X-IPM signal.
 
 .Velocity Example[[cap:Velocity-Example]]
 
-image::images/velocity-01.png[]
+image::images/velocity-01.png[alt="Velocity Example"]
 
 == Soft Start
 
@@ -172,7 +172,7 @@ then use the Pos slider in the Vertical box to set the positions.
 
 .Softstart[[cap:Softstart]]
 
-image::images/softstart-scope.png[]
+image::images/softstart-scope.png[alt="Softstart"]
 
 To see the effect of changing the set point values of any of the
 components you can change them in the terminal window. To see what

--- a/docs/src/hal/halshow.txt
+++ b/docs/src/hal/halshow.txt
@@ -28,7 +28,7 @@ tabs for show and watch.
 
 .Halshow Layout
 
-image::images/halshow-1.png[align="center"]
+image::images/halshow-1.png[align="center", alt="Halshow Layout"]
 
 The tree shows all of the major parts of a HAL. In front of each is a
 small plus (+) or minus (-) sign in a box. Clicking the plus will
@@ -43,7 +43,7 @@ previously set watches, you cannot erase just one watch.)
 
 .Show Menu
 
-image::images/halshow-3.png[align="center"]
+image::images/halshow-3.png[align="center", alt="Show Menu"]
 
 == HAL Show Area
 
@@ -165,7 +165,7 @@ after this command has been issued.
 
 .Addf Command
 
-image::images/halshow-2.png[align="center"]
+image::images/halshow-2.png[align="center", alt="Addf Command"]
 
 Next we need to connect ddt to something. But how do we know
 what pins are available? The answer is to look under pins. There we
@@ -235,7 +235,7 @@ turn true until the machine has been turned on.
 
 .Watch Tab
 
-image::images/halshow-4.png[align="center"]
+image::images/halshow-4.png[align="center", alt="Watch Tab"]
 
 Watch displays bit type (binary) values using colored circles
 representing LEDs. They show as dark brown when a bit signal or pin is

--- a/docs/src/hal/halshow_fr.txt
+++ b/docs/src/hal/halshow_fr.txt
@@ -31,7 +31,7 @@ MONTRER et WATCH.
 [[cap:Fenetre-Halshow]]
 .La fenêtre de Halshow
 
-image::images/halshow-1_fr.png[]
+image::images/halshow-1_fr.png[alt="La fenêtre de Halshow"]
 
 L'arborescence montre toutes les parties principales de HAL. En face
 de chacune d'entre elles, se trouve un petit signe + ou - dans une
@@ -45,7 +45,7 @@ complète depuis le menu _Arborescence_.
 [[cap:onglet-Montrer]]
 .L'onglet Montrer
 
-image::images/halshow-3.png[]
+image::images/halshow-3.png[alt="L'onglet Montrer"]
 
 === Zone de l'onglet MONTRER
 
@@ -167,7 +167,7 @@ que cette commande a été exécutée.
 [[cap:Commande-addf]]
 .Commande Addf
 
-image::images/halshow-2_fr.png[]
+image::images/halshow-2_fr.png[alt="Commande Addf"]
 
 Ensuite, nous devons connecter ce bloc à quelque chose. Mais comment
 savoir quelles pins sont disponibles? La réponse se trouve dans
@@ -238,7 +238,7 @@ machine ne sera pas mise en marche.
 .L'onglet WATCH
 (((L'onglet watch)))
 
-image::images/halshow-4.png[]
+image::images/halshow-4.png[alt="L'onglet WATCH"]
 
 Les cercles de deux couleurs, simili Leds, sont toujours bruns foncé
 quand un signal est faux. Elle sont jaunes quand le signal est vrai.

--- a/docs/src/hal/halui-examples.txt
+++ b/docs/src/hal/halui-examples.txt
@@ -25,7 +25,7 @@ If both the inputs to the `and2.0` component are on the
 `and2.0.out` will be on and this will start the program.
 
 .Remote Start Example
-image::images/remote-start.png[]
+image::images/remote-start.png[alt="Remote Start Example"]
 
 The hal commands needed to accomplish the above are:
 

--- a/docs/src/hal/halui_fr.txt
+++ b/docs/src/hal/halui_fr.txt
@@ -262,7 +262,7 @@ Si les deux entrées du composant _and2.0_ sont TRUE, la sortie _and2.0.out_
 sera TRUE également et le programme sera démarré. 
 
 .Exemple de commande distante
-image::images/remote-start.png[]
+image::images/remote-start.png[alt="Exemple de commande distante"]
 
 Les commandes de Hal pour accomplir ces actions sont les suivantes: 
 ----

--- a/docs/src/hal/intro.txt
+++ b/docs/src/hal/intro.txt
@@ -91,7 +91,7 @@ of hardware system integration, but who do not know how to connect the
 hardware to LinuxCNC. See the <<sec:halui-remote-start,Remote Start
 Example>> section in the HAL UI Examples documentation.
 
-image::images/remote-start.png[]
+image::images/remote-start.png[alt="Remote Start Example"]
 
 The traditional hardware design as described above ends at the edge of
 the main control. Outside the control are a bunch of relatively simple

--- a/docs/src/hal/parallel_port_fr.txt
+++ b/docs/src/hal/parallel_port_fr.txt
@@ -112,7 +112,7 @@ moins une adresse, c'est une erreur.
 
 .Diagrammes blocs de parport
 
-image::images/parport-block-diag.png[]
+image::images/parport-block-diag.png[alt="Diagrammes blocs de parport"]
 
 === Pins
 

--- a/docs/src/hal/tools.txt
+++ b/docs/src/hal/tools.txt
@@ -80,9 +80,9 @@ See the man page for more options. See section <<sec:halmeter,Halmeter>>.
   
 .Halmeter
 
-image::images/hal-meter01.png[]
+image::images/hal-meter01.png[alt="Halmeter"]
 
-image::images/hal-meter02.png[]
+image::images/hal-meter02.png[alt="Halmeter"]
 
 == Halshow
 
@@ -189,7 +189,7 @@ Example (with LinuxCNC running):
 halcmd loadrt mux2 names=example; halcmd net sig_example example.in0
 sim_pin example.sel example.in1 sig_example &
 ----
-image::images/sim_pin.png[]
+image::images/sim_pin.png[alt="sim_pin is a command line utility to display and update any number of writable pins, parameters or signals"]
 
 == Simulate Probe
 
@@ -199,7 +199,8 @@ motion.probe-input.  Usage:
 simulate_probe &
 ----
 
-image::images/simulate_probe.png[]
+image::images/simulate_probe.png[alt="simulate_probe is a simple gui to simulate activation of the pin
+motion.probe-input"]
 
 == Hal Histogram
 
@@ -229,5 +230,5 @@ Notes:
      For a base thread, this may require using:
      loadrt motmod ... base_thread_fp=1
 ----
-image::images/hal-histogram.png[]
+image::images/hal-histogram.png[alt="hal-histogram is a command line utility to display histograms for hal pins"]
 

--- a/docs/src/hal/tutorial.txt
+++ b/docs/src/hal/tutorial.txt
@@ -447,7 +447,7 @@ The first window you will see is the 'Select Item to Probe' window.
 
 .Halmeter Select Window
 
-image::images/halmeter-select.png[align="center"]
+image::images/halmeter-select.png[align="center", alt="Halmeter Select Window"]
 
 This dialog has three tabs. The first tab displays all of the HAL pins
 in the system. The second one displays all the signals, and the third
@@ -459,7 +459,7 @@ following figure.
 
 .Halmeter
 
-image::images/halmeter-1.png[align="center"]
+image::images/halmeter-1.png[align="center", alt="Halmeter"]
 
 To change what the meter displays press the 'Select' button which
 brings back the 'Select Item to Probe' window.
@@ -821,7 +821,7 @@ figure.
 
 .Realtime function not linked dialog
 
-image::images/halscope-01.png[align="center"]
+image::images/halscope-01.png[align="center", alt="Realtime function not linked dialog"]
 
 This dialog is where you set the sampling rate for the oscilloscope.
 For now we want to sample once per millisecond, so click on the 989 us
@@ -833,7 +833,7 @@ figure.
 
 .Initial scope window
 
-image::images/halscope-02.png[align="center"]
+image::images/halscope-02.png[align="center", alt="Initial scope window"]
 
 === Hooking up the scope probes
 
@@ -854,7 +854,7 @@ of the signals in the HAL (only two for this example).
 
 .Select Channel Source
 
-image::images/halscope-03.png[align="center"]
+image::images/halscope-03.png[align="center", alt="Select Channel Source"]
 
 To choose a signal, just click on it. In this case, we want channel 1
 to display the signal 'X-vel'. Click on the Signals tab then click on
@@ -862,7 +862,7 @@ to display the signal 'X-vel'. Click on the Signals tab then click on
 
 .Select Signal
 
-image::images/halscope-04.png[align="center"]
+image::images/halscope-04.png[align="center", alt="Select Signal"]
 
 The channel 1 button is pressed in, and channel number 1 and the name
 'X-vel' appear below the row of buttons. That display always indicates
@@ -872,7 +872,7 @@ position and scale always work on the selected one.
 
 .Halscope
 
-image::images/halscope-05.png[align="center"]
+image::images/halscope-05.png[align="center", alt="Halscope"]
 
 To add a signal to channel 2, click the '2' button. When the dialog
 pops up, click the 'Signals' tab, then click on 'Y-vel'. We also want
@@ -898,7 +898,7 @@ something like the following figure.
 
 .Captured Waveforms
 
-image::images/halscope-06.png[align="center"]
+image::images/halscope-06.png[align="center", alt="Captured Waveforms"]
 
 The 'Selected Channel' box at the bottom tells you that the purple
 trace is the currently selected one, channel 4, which is displaying the
@@ -918,7 +918,7 @@ only. For larger adjustments the offset button should be used.
 
 .Vertical Adjustment
 
-image::images/halscope-07.png[align="center"]
+image::images/halscope-07.png[align="center", alt="Vertical Adjustment"]
 
 === Triggering
 
@@ -931,7 +931,7 @@ use channel 3, the triangle wave as shown in the following figure.
 
 .Trigger Source Dialog
 
-image::images/halscope-08.png[align="center"]
+image::images/halscope-08.png[align="center", alt="Trigger Source Dialog"]
 
 After setting the trigger source, you can adjust the trigger level and
 trigger position using the sliders in the 'Trigger' box along the right
@@ -951,7 +951,7 @@ scope display looks something like the following figure.
 
 .Waveforms with Triggering
 
-image::images/halscope-09.png[align="center"]
+image::images/halscope-09.png[align="center", alt="Waveforms with Triggering"]
 
 === Horizontal Adjustments
 
@@ -971,7 +971,7 @@ samples at 20KHz, or about 0.20 seconds.
 
 .Sample Rate Dialog
 
-image::images/halscope-10.png[align="center"]
+image::images/halscope-10.png[align="center", alt="Sample Rate Dialog"]
 
 === More Channels
 
@@ -994,7 +994,7 @@ following figure.
 
 .Step Pulses
 
-image::images/halscope-11.png[align="center"]
+image::images/halscope-11.png[align="center", alt="Step Pulses"]
 
 === More samples
 

--- a/docs/src/hal/tutorial_fr.txt
+++ b/docs/src/hal/tutorial_fr.txt
@@ -487,7 +487,7 @@ sélectionner l'item à observer.
 .Fenêtre de sélection de halmeter
 (((Fenêtre de sélection)))
 
-image::images/halmeter-select_fr.png[]
+image::images/halmeter-select_fr.png[alt="Fenêtre de sélection de halmeter"]
 
 Ce dialogue contient trois onglets. Le premier onglet affiche toutes
 les HAL pins du système. La seconde affiche tous les signaux et le
@@ -500,7 +500,7 @@ dans une fenêtre semblable à la figure ci-dessous.
 .Affichage de la valeur
 (((Affichage de la valeur)))
 
-image::images/halmeter-1_fr.png[]
+image::images/halmeter-1_fr.png[alt="Affichage de la valeur"]
 
 Pour modifier ce qui est affiché sur halmeter pressez le bouton
 _Sélectionner_ qui vous ramènera à la fenêtre de sélection précédente.
@@ -877,7 +877,7 @@ dialogue _Fonction temps réel non liée_ visible sur la figure ci-dessous:
 .Dialogue _Fonction temps réel non liée_
 (((Fonction non liée)))
 
-image::images/halscope-01_fr.png[]
+image::images/halscope-01_fr.png[alt="Dialogue Fonction temps réel non liée"]
 
 C'est dans ce dialogue que vous définissez le taux d'échantillonnage
 de l'oscilloscope. Pour le moment nous voulons un échantillon par
@@ -892,7 +892,7 @@ dialogue disparaît et la fenêtre initiale du scope s'ouvre, comme ci-dessous.
 .Fenêtre initiale du scope
 (((Fenêtre initiale)))
 
-image::images/halscope-02_fr.png[]
+image::images/halscope-02_fr.png[alt="Fenêtre initiale du scope"]
 
 === Branchement des sondes du scope
 
@@ -915,7 +915,7 @@ Ce dialogue est très similaire à celui utilisé par halmeter.
 .Dialogue de sélection des sources
 (((Sélection de la source)))
 
-image::images/halscope-03_fr.png[]
+image::images/halscope-03_fr.png[alt="Dialogue de sélection des sources"]
 
 Nous aimerions bien regarder les signaux que nous avons défini
 précédemment, pour cela, cliquons sur l'onglet _Signaux_ et le dialogue
@@ -931,7 +931,7 @@ Lorsque l'on clique sur _X-vel_, la fenêtre se ferme et le canal a
 .Sélection du signal
 (((Sélection du signal)))
 
-image::images/halscope-04_fr.png[]
+image::images/halscope-04_fr.png[alt="Sélection du signal"]
 
 Le bouton du canal _1_ est pressé, le numéro du canal 1 et le nom 
 _X-vel_ apparaissent sous la rangée de boutons. L'affichage indique
@@ -942,7 +942,7 @@ l'écran, mais celui qui est actif sera en surbrillance.
 .halscope
 (((halscope)))
 
-image::images/halscope-05_fr.png[]
+image::images/halscope-05_fr.png[alt="halscope"]
 
 Les différents contrôles comme la position verticale et l'amplitude
 sont toujours relatifs au canal 1. Pour ajouter un signal sur le canal
@@ -975,7 +975,7 @@ figure ci-dessous.
 .Capture d'ondes
 (((Capture d'onde)))
 
-image::images/halscope-06_fr.png[]
+image::images/halscope-06_fr.png[alt="Capture d'ondes"]
 
 === Ajustement vertical
 
@@ -993,7 +993,7 @@ grands ajustements le bouton _Offset_ peut être utilisé.
 .Ajustement vertical
 (((Ajustement vertical)))
 
-image::images/halscope-07_fr.png[]
+image::images/halscope-07_fr.png[alt="Ajustement vertical"]
 
 Le grand bouton _Canal sélectionné_ en bas, indique que le canal 1 est
 actuellement le canal sélectionné et qu'il correspond au signal
@@ -1016,7 +1016,7 @@ où n est le numéro du canal venant d'être choisi comme déclencheur.
 .Dialogue des sources de déclenchement
 (((Dialogue des sources de déclenchement)))
 
-image::images/halscope-08_fr.png[]
+image::images/halscope-08_fr.png[alt="Dialogue des sources de déclenchement"]
 
 Après avoir défini la source de déclenchement, il est possible
 d'ajuster le niveau de déclenchement avec les curseurs du groupe 
@@ -1044,7 +1044,7 @@ déclenchement, l'écran doit ressembler à la figure ci-dessous.
 .Formes d'ondes avec déclenchement
 (((Formes d'onde)))
 
-image::images/halscope-09_fr.png[]
+image::images/halscope-09_fr.png[alt="Formes d'ondes avec déclenchement"]
 
 === Ajustement horizontal
 
@@ -1068,7 +1068,7 @@ environ 0.20 seconde.
 .Dialogue de choix d'échantillonnage
 (((Choix d'échantillonnage)))
 
-image::images/halscope-10_fr.png[]
+image::images/halscope-10_fr.png[alt="Dialogue de choix d'échantillonnage"]
 
 === Plus de canaux
 
@@ -1097,7 +1097,7 @@ X-vel assez plate et les impulsions de pas très resserrées.
 .Observer les impulsions de pas
 (((Observer les impulsions)))
 
-image::images/halscope-11_fr.png[]
+image::images/halscope-11_fr.png[alt="Observer les impulsions de pas"]
 
 === Plus d'échantillons
 

--- a/docs/src/install/Latency_Test_fr.txt
+++ b/docs/src/install/Latency_Test_fr.txt
@@ -40,7 +40,7 @@ Une fenêtre comme ci-dessous devrait s'ouvrir:
 
 .Test de latence de HAL
 
-image::../config/images/latency.png[]
+image::../config/images/latency.png[alt="Test de latence de HAL"]
 
 Alors que le test est en cours d'exécution, il faut charger l'ordinateur au
 maximum. Déplacer les fenêtres sur l'écran. Surfer sur le Web. Écouter de la

--- a/docs/src/install/latency-test.txt
+++ b/docs/src/install/latency-test.txt
@@ -48,7 +48,7 @@ You should see something like this:
 
 .HAL Latency Test
 
-image::../config/images/latency.png[align="center"]
+image::../config/images/latency.png[align="center", alt="HAL Latency Test"]
 
 While the test is running, you should 'abuse' the computer. 
 Move windows around on the screen. Surf the web. Copy some large files 
@@ -115,7 +115,7 @@ Options:
       --relative (relative clock time (default))
       --actual   (actual clock time)
 ----
-image::../config/images/latency-plot.png[]
+image::../config/images/latency-plot.png[alt="latency-plot makes a strip chart recording for a base and a servo thread"]
 
 
 latency-histogram displays a histogram of latency (jitter) for
@@ -148,7 +148,7 @@ Notes:
   with special end bars.  Use --show to show count for
   the off-chart [pos|neg] bin
 ----
-image::../config/images/latency-histogram.png[]
+image::../config/images/latency-histogram.png[alt="latency-histogram displays a histogram of latency (jitter) for a base and servo thread"]
 
 // vim: set syntax=asciidoc:
 

--- a/docs/src/ladder/classic-ladder.txt
+++ b/docs/src/ladder/classic-ladder.txt
@@ -188,7 +188,7 @@ Manager window.
 
 .Sections Manager Default Window
 
-image::images/Default_Sections_Manager.png[align="center"]
+image::images/Default_Sections_Manager.png[align="center", alt="Sections Manager Default Window"]
 
 This window allows you to name, create or delete sections and choose
 what language that section uses. This is also how you name a subroutine
@@ -201,7 +201,7 @@ Display window. Displayed is one empty rung.
 
 .Section Display Default Window
 
-image::images/Default_Section_Display.png[align="center"]
+image::images/Default_Section_Display.png[align="center", alt="Section Display Default Window"]
 
 Most of the buttons are self explanatory:
 
@@ -243,7 +243,7 @@ display one, the other, both, then none of the variable windows.
 
 .Bit Status Window
 
-image::images/Bit_Status.png[align="center"]
+image::images/Bit_Status.png[align="center",alt="Bit Status Window"]
 
 The Bit Status Window displays some of the boolean (on/off) variable data. 
 Notice all variables start with the % sign. The %I variables represent
@@ -261,7 +261,7 @@ unchecked if off.
 
 .Watch Window
 
-image::images/watch_window.png[align="center"]
+image::images/watch_window.png[align="center", alt="Watch Window"]
 
 The Watch Window displays variable status. The edit box beside it is
 the number stored in the variable and the drop-down box beside that
@@ -278,7 +278,7 @@ number/name and press the Enter Key.
 
 .Symbol Names window
 
-image::images/Default_Symbols_names.png[align="center"]
+image::images/Default_Symbols_names.png[align="center", alt="Symbol Names window"]
 
 This is a list of 'symbol' names to use instead of variable names to
 be displayed in the section window when the 'display symbols' check box
@@ -296,7 +296,7 @@ ladder program is connected to!
 
 .Editor Window
 
-image::images/Editor.png[align="center"]
+image::images/Editor.png[align="center", alt="Editor Window"]
 
 * 'Add' - adds a rung after the selected rung
 * 'Insert' - inserts a rung before the selected rung
@@ -355,7 +355,7 @@ setup tabs.
 
 .Config Window
 
-image::images/Config.png[align="center"]
+image::images/Config.png[align="center", alt="Config Window"]
 
 == Ladder objects
 
@@ -375,9 +375,9 @@ like to call it). If %B7 coil is 'energized' (on, true, etc) then %B7
 N.O. contact would be on. If %Q1 coil is 'energized' then %Q1 N.O.
 contact would be on (and HAL pin classicladder.0.out-01 would be true.)
 
-* 'N.O. Contact' -  image:images/ladder_action_load.png[] (Normally Open)
+* 'N.O. Contact' -  image:images/ladder_action_load.png[alt="Normally Open Contact"] (Normally Open)
    When the variable is false the switch is off.
-* 'N.C. Contact' - image:images/ladder_action_loadbar.png[] (Normally
+* 'N.C. Contact' - image:images/ladder_action_loadbar.png[alt="Normally Closed Contact"] (Normally
    Closed) When the variable is false the switch is on.
 * 'Rising Edge Contact' - When the variable changes from false to true,
    the switch is PULSED on.
@@ -572,7 +572,7 @@ will be set to True.
 
 .Assign/Compare Example
 
-image::images/AssignCompare-Ladder.png[align="center"]
+image::images/AssignCompare-Ladder.png[align="center", alt="Assign/Compare Example"]
 
 image::images/Assignment_Expression.png[align="center"]
 
@@ -788,11 +788,11 @@ program this page will not be displayed.
 
 .Config I/O
 
-image::images/Config-io.png[align="center"]
+image::images/Config-io.png[align="center", alt="Config I/O"]
 
 .Config Coms
 
-image::images/Config-com.png[align="center"]
+image::images/Config-com.png[align="center", alt="Config Coms"]
 
 * 'SERIAL PORT' - For IP blank. For serial the location/name of serial driver eg.
     /dev/ttyS0 ( or /dev/ttyUSB0 for a USB-to-serial converter).
@@ -956,7 +956,7 @@ Options page of Stepconf Wizard check off "Include Classic Ladder PLC".
 
 .Stepconf Classic Ladder
 
-image::images/stepconf_ladder.png[align="center"]
+image::images/stepconf_ladder.png[align="center", alt="Stepconf Classic Ladder"]
 
 === Add the Modules
 
@@ -992,20 +992,20 @@ circuit in a run the results are not predictable.
 
 .Section Display with Grid
 
-image::images/Section_Display_Grid.png[align="center"]
+image::images/Section_Display_Grid.png[align="center", alt="Section Display with Grid"]
 
 Now click on the N.O. Input in the Editor Window.
 
 .Editor Window
 
-image::images/Editor_NO_Input.png[align="center"]
+image::images/Editor_NO_Input.png[align="center", alt="Editor Window"]
 
 Now click in the upper left grid to place the N.O. Input into the
 ladder.
 
 .Section Display with Input
 
-image::images/Section_Display_Build01.png[align="center"]
+image::images/Section_Display_Build01.png[align="center", alt="Section Display with Input"]
 
 Repeat the above steps to add a N.O. Output to the upper right grid
 and use the Horizontal Connection to connect the two. It should look
@@ -1013,14 +1013,14 @@ like the following. If not, use the Eraser to remove unwanted sections.
 
 .Section Display with Rung
 
-image::images/Section_Display_Build02.png[align="center"]
+image::images/Section_Display_Build02.png[align="center", alt="Section Display with Rung"]
 
 Now click on the OK button in the Editor window. Now your Section
 Display should look like this.
 
 .Section Display Finished
 
-image::images/Section_Display_Build03.png[align="center"]
+image::images/Section_Display_Build03.png[align="center", alt="Section Display Finished"]
 
 To save the new file select Save As and give it a name. The .clp
 extension will be added automatically. It should default to the running
@@ -1028,7 +1028,7 @@ config directory as the place to save it.
 
 .Save As Dialog
 
-image::images/SaveAs.png[align="center"]
+image::images/SaveAs.png[align="center", alt="Save As Dialog"]
 
 Again if you used the Stepconf Wizard to add Classic Ladder you can
 skip this step.

--- a/docs/src/ladder/classic_ladder_fr.txt
+++ b/docs/src/ladder/classic_ladder_fr.txt
@@ -185,7 +185,7 @@ Manager window.
 
 .Sections Manager Default Window[[cap:Sections-Manager-Default]]
 
-image::images/Default_Sections_Manager.png[align="center"]
+image::images/Default_Sections_Manager.png[align="center", alt="Sections Manager Default Window"]
 
 This window allows you to name, create or delete sections and choose
 what language that section uses. This is also how you name a subroutine
@@ -198,7 +198,7 @@ Display window. Displayed is one empty rung.
 
 .Section Display Default Window[[cap:Section-Display-Default]]
 
-image::images/Default_Section_Display.png[align="center"]
+image::images/Default_Section_Display.png[align="center", alt="Section Display Default Window"]
 
 Most of the buttons are self explanatory:
 
@@ -240,7 +240,7 @@ display one, the other, both, then none of the variable windows.
 
 .Bit Status Window[[cap:Bit-Status-Window]]
 
-image::images/Bit_Status.png[align="center"]
+image::images/Bit_Status.png[align="center", alt="Bit Status Window"]
 
 The Bit Status Window displays some of the boolean (on/off) variable data. 
 Notice all variables start with the % sign. The %I variables represent
@@ -258,7 +258,7 @@ unchecked if off.
 
 .Watch Window[[cap:Watch-Window]]
 
-image::images/watch_window.png[align="center"]
+image::images/watch_window.png[align="center", alt="Watch Window"]
 
 The Watch Window displays variable status. The edit box beside it is
 the number stored in the variable and the drop-down box beside that
@@ -275,7 +275,7 @@ number/name and press the Enter Key.
 
 .Symbol Names window[[cap:Symbol-Names-window]]
 
-image::images/Default_Symbols_names.png[align="center"]
+image::images/Default_Symbols_names.png[align="center", alt="Symbol Names window"]
 
 This is a list of 'symbol' names to use instead of variable names to
 be displayed in the section window when the 'display symbols' check box
@@ -293,7 +293,7 @@ ladder program is connected to!
 
 .Editor Window[[cap:Editor-Window]]
 
-image::images/Editor.png[align="center"]
+image::images/Editor.png[align="center", alt="Editor Window"]
 
 * 'Add' - adds a rung after the selected rung
 * 'Insert' - inserts a rung before the selected rung
@@ -352,7 +352,7 @@ setup tabs.
 
 .Config Window[[cap:Config-Window]]
 
-image::images/Config.png[align="center"]
+image::images/Config.png[align="center", alt="Config Window"]
 
 == Ladder objects
 
@@ -372,9 +372,9 @@ like to call it). If %B7 coil is 'energized' (on, true, etc) then %B7
 N.O. contact would be on. If %Q1 coil is 'energized' then %Q1 N.O.
 contact would be on (and HAL pin classicladder.0.out-01 would be true.)
 
-* 'N.O. Contact' -  image:images/ladder_action_load.png[] (Normally Open)
+* 'N.O. Contact' -  image:images/ladder_action_load.png[alt="Normally Open Contact"] (Normally Open)
    When the variable is false the switch is off.
-* 'N.C. Contact' - image:images/ladder_action_loadbar.png[] (Normally
+* 'N.C. Contact' - image:images/ladder_action_loadbar.png[alt="Normally Closed Contact"] (Normally
    Closed) When the variable is false the switch is on.
 * 'Rising Edge Contact' - When the variable changes from false to true,
    the switch is PULSED on.
@@ -567,7 +567,7 @@ will be set to True.
 
 .Assign/Compare Example[[cap:Assign/Compare-Example]]
 
-image::images/AssignCompare-Ladder.png[align="center"]
+image::images/AssignCompare-Ladder.png[align="center", alt="Assign/Compare Example"]
 
 image::images/Assignment_Expression.png[align="center"]
 
@@ -783,11 +783,11 @@ program this page will not be displayed.
 
 .Config I/O[[cap:Config-I/O]]
 
-image::images/Config-io.png[align="center"]
+image::images/Config-io.png[align="center", alt="Config I/O"]
 
 .Config Coms[[cap:Config-Coms]]
 
-image::images/Config-com.png[align="center"]
+image::images/Config-com.png[align="center", alt="Config Coms"]
 
 * 'SERIAL PORT' - For IP blank. For serial the location/name of serial driver eg.
     /dev/ttyS0 ( or /dev/ttyUSB0 for a USB-to-serial converter).
@@ -951,7 +951,7 @@ Options page of Stepconf Wizard check off "Include Classic Ladder PLC".
 
 .Stepconf Classic Ladder[[cap:Stepconf-Classicladder]]
 
-image::images/stepconf_ladder.png[align="center"]
+image::images/stepconf_ladder.png[align="center", alt="Stepconf Classic Ladder"]
 
 === Add the Modules
 
@@ -987,20 +987,20 @@ circuit in a run the results are not predictable.
 
 .Section Display with Grid[[cap:Section-Display-with-Grid]]
 
-image::images/Section_Display_Grid.png[align="center"]
+image::images/Section_Display_Grid.png[align="center", alt="Section Display with Grid"]
 
 Now click on the N.O. Input in the Editor Window.
 
 .Editor Window[[cap:Editor-Window-NO]]
 
-image::images/Editor_NO_Input.png[align="center"]
+image::images/Editor_NO_Input.png[align="center", alt="Editor Window"]
 
 Now click in the upper left grid to place the N.O. Input into the
 ladder.
 
 .Section Display with Input[[cap:Section-Display-with-Input]]
 
-image::images/Section_Display_Build01.png[align="center"]
+image::images/Section_Display_Build01.png[align="center", alt="Section Display with Input"]
 
 Repeat the above steps to add a N.O. Output to the upper right grid
 and use the Horizontal Connection to connect the two. It should look
@@ -1008,14 +1008,14 @@ like the following. If not, use the Eraser to remove unwanted sections.
 
 .Section Display with Rung[[cap:Section-Display-with-Rung]]
 
-image::images/Section_Display_Build02.png[align="center"]
+image::images/Section_Display_Build02.png[align="center", alt="Section Display with Rung"]
 
 Now click on the OK button in the Editor window. Now your Section
 Display should look like this.
 
 .Section Display Finished[[cap:Section-Display-Finished]]
 
-image::images/Section_Display_Build03.png[align="center"]
+image::images/Section_Display_Build03.png[align="center", alt="Section Display Finished"]
 
 To save the new file select Save As and give it a name. The .clp
 extension will be added automatically. It should default to the running
@@ -1023,7 +1023,7 @@ config directory as the place to save it.
 
 .Save As Dialog[[cap:Save-As-Dialog]]
 
-image::images/SaveAs.png[align="center"]
+image::images/SaveAs.png[align="center", alt="Save As Dialog"]
 
 Again if you used the Stepconf Wizard to add Classic Ladder you can
 skip this step.

--- a/docs/src/ladder/ladder-examples.txt
+++ b/docs/src/ladder/ladder-examples.txt
@@ -16,7 +16,7 @@ counting backwards.
 
 .Wrapping Counter
 
-image::images/wrapping-counter.png[align="center"]
+image::images/wrapping-counter.png[align="center", alt="Wrapping Counter"]
 
 == Reject Extra Pulses
 
@@ -31,7 +31,7 @@ output until it times out.
 
 .Reject Extra Pulse
 
-image::images/extra-pulse-reject.png[align="center"]
+image::images/extra-pulse-reject.png[align="center", alt="Reject Extra Pulse"]
 
 == External E-Stop
 
@@ -63,7 +63,7 @@ Next we run our config and build the ladder as shown here.
 
 .E-Stop Section Display[[cap:E-Stop-Section-Display]]
 
-image::images/EStop_Section_Display.png[align="center"]
+image::images/EStop_Section_Display.png[align="center", alt="E-Stop Section Display"]
 
 After building the ladder select Save As and save the ladder as
 estop.clp
@@ -140,7 +140,7 @@ Now start up your config and it should look like this.
 
 .AXIS E-Stop[[cap:AXIS-E-Stop]]
 
-image::images/axis_cl-estop.png[align="center"]
+image::images/axis_cl-estop.png[align="center", alt="AXIS E-Stop"]
 
 Note that in this example like in real life you must clear the remote
 E-Stop (simulated by the checkbox) before the AXIS E-Stop or the
@@ -155,7 +155,7 @@ the timer preset based on if an input is on or off.
 
 .Timer/Operate Example[[cap:Timer/Operate-Example]]
 
-image::images/Tmr_Section_Display.png[align="center"]
+image::images/Tmr_Section_Display.png[align="center", alt="Timer/Operate Example"]
 
 In this case %I0 is true so the timer preset value is 10. If %I0 was
 false the timer preset would be 5.

--- a/docs/src/ladder/ladder_examples_fr.txt
+++ b/docs/src/ladder/ladder_examples_fr.txt
@@ -16,7 +16,7 @@ counting backwards.
 
 .Wrapping Counter[[fig:Wrapping-Counter]]
 
-image::images/wrapping-counter.png[]
+image::images/wrapping-counter.png[alt="Wrapping Counter"]
 
 === Reject Extra Pulses
 
@@ -31,7 +31,7 @@ output until it times out.
 
 .Reject Extra Pulse[[fig:Reject-Extra-Pulse]]
 
-image::images/extra-pulse-reject.png[]
+image::images/extra-pulse-reject.png[alt="Reject Extra Pulse"]
 
 === External E-Stop
 
@@ -59,7 +59,7 @@ Next we run our config and build the ladder as shown here.
 
 .E-Stop Section Display[[cap:E-Stop-Section-Display]]
 
-image::images/EStop_Section_Display.png[]
+image::images/EStop_Section_Display.png[alt="E-Stop Section Display"]
 
 After building the ladder select Save As and save the ladder as
 estop.clp
@@ -132,7 +132,7 @@ Now start up your config and it should look like this.
 
 .AXIS E-Stop[[cap:AXIS-E-Stop]]
 
-image::images/axis_cl-estop.png[]
+image::images/axis_cl-estop.png[alt="AXIS E-Stop"]
 
 Note that in this example like in real life you must clear the remote
 E-Stop (simulated by the checkbox) before the AXIS E-Stop or the
@@ -147,7 +147,7 @@ the timer preset based on if an input is on or off.
 
 .Timer/Operate Example[[cap:Timer/Operate-Example]]
 
-image::images/Tmr_Section_Display.png[]
+image::images/Tmr_Section_Display.png[alt="Timer/Operate Example"]
 
 In this case %I0 is true so the timer preset value is 10. If %I0 was
 false the timer preset would be 5.

--- a/docs/src/lathe/lathe-user.txt
+++ b/docs/src/lathe/lathe-user.txt
@@ -61,23 +61,23 @@ The FRONTANGLE and BACKANGLE are clockwise starting at a line parallel to Z+.
 
 .Lathe Tool Orientations
 
-image::images/tool_positions.png[align="center"]
+image::images/tool_positions.png[align="center", alt="Lathe Tool Orientations"]
 
 In AXIS the following figures show what the Tool Positions look like, as entered in the tool table.
 
 .Tool Positions 1, 2, 3 & 4
 
-image:images/tool_pos_1.png[]
-image:images/tool_pos_2.png[]
-image:images/tool_pos_3.png[]
-image:images/tool_pos_4.png[]
+image:images/tool_pos_1.png[alt="Tool Position 1"]
+image:images/tool_pos_2.png[alt="Tool Position 2"]
+image:images/tool_pos_3.png[alt="Tool Position 3"]
+image:images/tool_pos_4.png[alt="Tool Position 4"]
 
 .Tool Positions 5, 6, 7 & 8
 
-image:images/tool_pos_5.png[]
-image:images/tool_pos_6.png[]
-image:images/tool_pos_7.png[]
-image:images/tool_pos_8.png[]
+image:images/tool_pos_5.png[alt="Tool Position 5"]
+image:images/tool_pos_6.png[alt="Tool Position 6"]
+image:images/tool_pos_7.png[alt="Tool Position 7"]
+image:images/tool_pos_8.png[alt="Tool Position 8"]
 
 == Tool Touch Off
 
@@ -247,7 +247,7 @@ as you might assume.
 
 .Control Point
 
-image::images/control_point.png[align="center"]
+image::images/control_point.png[align="center", alt="Control Point"]
 
 === Cutting Angles without Cutter Comp
 
@@ -258,7 +258,7 @@ as we are moving in an X or Z direction only.
 
 .Ramp Entry
 
-image::images/ramp_entry.png[align="center"]
+image::images/ramp_entry.png[align="center", alt="Ramp Entry"]
 
 Now as the control point progresses along the programmed path the
 actual cutter edge does not follow the programmed path as shown in the
@@ -267,7 +267,7 @@ adjusting your programmed path to compensate for tip radius.
 
 .Ramp Path
 
-image::images/ramp_cut.png[align="center"]
+image::images/ramp_cut.png[align="center", alt="Ramp Path"]
 
 In the above example it is a simple exercise to adjust the programmed
 path to give the desired actual path by moving the programmed path for
@@ -282,7 +282,7 @@ path and the tool is touching the OD of the part.
 
 .Turning Cut
 
-image::images/radius_1.png[align="center"]
+image::images/radius_1.png[align="center", alt="Turning Cut"]
 
 In this next figure you can see as the tool approaches the end of the
 part the control point still follows the path but the tool tip has left
@@ -291,14 +291,14 @@ has been programmed the part will actually end up with a square corner.
 
 .Radius Cut
 
-image::images/radius_2.png[align="center"]
+image::images/radius_2.png[align="center", alt="Radius Cut"]
 
 Now you can see as the control point follows the radius programmed the
 tool tip has left the part and is now cutting air.
 
 .Radius Cut
 
-image::images/radius_3.png[align="center"]
+image::images/radius_3.png[align="center", alt="Radius Cut"]
 
 In the final figure we can see the tool tip will finish cutting the
 face but leave a square corner instead of a nice radius. Notice also
@@ -309,7 +309,7 @@ past center at least the nose radius of the tool.
 
 .Face Cut
 
-image::images/radius_4.png[align="center"]
+image::images/radius_4.png[align="center", alt="Face Cut"]
 
 === Using Cutter Comp
 

--- a/docs/src/lathe/lathe-user_fr.txt
+++ b/docs/src/lathe/lathe-user_fr.txt
@@ -65,7 +65,7 @@ parallèle à l'axe Z, le zéro étant côté Z+.
 
 .Orientations des outils de tournage
 
-image::images/tool_positions_fr.png[]
+image::images/tool_positions_fr.png[alt="Orientations des outils de tournage"]
 
 
 Les images ci-dessous montrent la représentation qu'Axis donne des orientations
@@ -74,18 +74,18 @@ de l'outil, en se référant à la figure ci-dessus.
 .Outil dans les positions 1, 2, 3 et 4[[fig:Outil-Positions-1-2-3-4]]
 (((Outils en positions 1, 2, 3 et 4)))
 
-image::images/tool_pos_1.png[]
-image::images/tool_pos_2.png[]
-image::images/tool_pos_3.png[]
-image::images/tool_pos_4.png[]
+image:images/tool_pos_1.png[alt="Outil dans les position 1"]
+image:images/tool_pos_2.png[alt="Outil dans les position 2"]
+image:images/tool_pos_3.png[alt="Outil dans les position 3"]
+image:images/tool_pos_4.png[alt="Outil dans les position 4"]
 
 .Outil dans les positions 5, 6, 7 et 8[[fig:Outil-Positions-5-6-7-8]]
 (((Outils en positions 5, 6, 7 et 8)))
 
-image::images/tool_pos_5.png[]
-image::images/tool_pos_6.png[]
-image::images/tool_pos_7.png[]
-image::images/tool_pos_8.png[]
+image:images/tool_pos_5.png[alt="Outil dans les position 5"]
+image:images/tool_pos_6.png[alt="Outil dans les position 6"]
+image:images/tool_pos_7.png[alt="Outil dans les position 7"]
+image:images/tool_pos_8.png[alt="Outil dans les position 8"]
 
 == Correction d'outil
 
@@ -254,7 +254,7 @@ comme on pourrait le supposer.
 [[fig:Control-Point]]
 .Point contrôlé
 
-image::images/control_point.png[]
+image::images/control_point.png[alt="Point contrôlé"]
 
 === Tourner les angles sans compensation d'outil
 
@@ -265,7 +265,7 @@ identiques uniquement si les mouvements de tournage suivent les axes X et Z.
 
 .Tournage en rampe
 
-image::images/ramp_entry.png[]
+image::images/ramp_entry.png[alt="Tournage en rampe"]
 
 Le point contrôlé progresse en suivant la trajectoire programmée mais l'arête de
 coupe ne suit pas cette trajectoire comme c'est visible sur la figure suivante.
@@ -274,7 +274,7 @@ et d'ajuster la trajectoire programmée pour compenser le rayon de bec de l'outi
 
 .Trajectoire en rampe
 
-image::images/ramp_cut.png[]
+image::images/ramp_cut.png[alt="Trajectoire en rampe"]
 
 Dans l'exemple ci-dessus, pour suivre la rampe programmée et obtenir la bonne
 trajectoire, il suffi de décaler la trajectoire de la rampe vers la
@@ -290,7 +290,7 @@ pièce.
 
 .Tournage du diamètre
 
-image::images/radius_1.png[]
+image::images/radius_1.png[alt="Tournage du diamètre"]
 
 Sur la figure suivante, on voit que quand l'outil approche la fin la pièce,
 le point contrôlé continue de suivre la trajectoire alors que l'arête de coupe
@@ -299,14 +299,14 @@ a été programmé, la pièce conserve son angle d'extrémité.
 
 .Tournage du rayon
 
-image::images/radius_2.png[]
+image::images/radius_2.png[alt="Tournage du rayon"]
 
 Maintenant, comme on le voit, le point contrôlé suit bien la trajectoire
 programmée mais l'arête de coupe est en dehors de la matière.
 
 .Tournage du rayon
 
-image::images/radius_3.png[]
+image::images/radius_3.png[alt="Tournage du rayon"]
 
 Sur la figure finale, on voit que l'arête de coupe a terminé le dressage de la
 face mais en laissant un coin carré à la place du beau rayon attendu. Noter aussi
@@ -316,7 +316,7 @@ valeur d'un rayon de bec de l'outil.
 
 .Dressage de la face
 
-image::images/radius_4.png[]
+image::images/radius_4.png[alt="Dressage de la face"]
 
 === Utiliser la compensation d'outil
 

--- a/docs/src/motion/kinematics.txt
+++ b/docs/src/motion/kinematics.txt
@@ -154,7 +154,7 @@ version of the hexapod).
 
 .Bipod setup
 
-image::images/bipod.png[]
+image::images/bipod.png[alt="Bipod setup"]
 
 The Bipod we are talking about is a device that consists of 2 motors
 placed on a wall, from which a device is hung using some wire. The

--- a/docs/src/motion/kinematics_fr.txt
+++ b/docs/src/motion/kinematics_fr.txt
@@ -108,7 +108,7 @@ version simplifiée de l'hexapode).
 
 .Définir un bipode[[cap:Bipod-setup]]
 
-image::images/bipod.png[]
+image::images/bipod.png[alt="Définir un bipode"]
 
 Le bipode dont nous parlons est un appareil, composé de deux moteurs
 placés sur un mur, à cet appareil un mobile est suspendu par des fils.

--- a/docs/src/user/starting-linuxcnc.txt
+++ b/docs/src/user/starting-linuxcnc.txt
@@ -33,4 +33,4 @@ The configuration files are saved in linuxcnc/configs directory.
 
 .Configuration Selector
 
-image::images/configuration-selector.png[align="center"]
+image::images/configuration-selector.png[align="center", alt="LinuxCNC Configuration Selector"]

--- a/docs/src/user/user-concepts-fr.txt
+++ b/docs/src/user/user-concepts-fr.txt
@@ -24,13 +24,13 @@ et deux cames mobiles pour l'actionner. Dans ce cas les limites seront inversée
 point de vue du sens de déplacement de l'outil.
 
 .Configuration typique d'une fraiseuse
-image::images/mill-diagram.png[align="left"]
+image::images/mill-diagram.png[align="left", alt="Configuration typique d'une fraiseuse"]
 
 Le dessin suivant montre les directions de déplacement de l'outil et la position
 des fins de course de limite sur un tour classique.
 
 .Configuration typique d'un tour
-image::images/lathe-diagram.png[align="left"]
+image::images/lathe-diagram.png[align="left", alt="Configuration typique d'un tour"]
 
 == Contrôle de trajectoire
 
@@ -167,7 +167,7 @@ programmée.
 
 .Détecteur Naive Cam
 
-image::images/naive-cam.png[]
+image::images/naive-cam.png[alt="Détecteur Naive Cam"]
 
 === Planification des mouvements
 

--- a/docs/src/user/user-concepts.txt
+++ b/docs/src/user/user-concepts.txt
@@ -128,7 +128,7 @@ velocity as planned.
 
 .Naive Cam Detector
 
-image::images/naive-cam.png[align="center"]
+image::images/naive-cam.png[align="center", alt="Naive Cam Detector"]
 
 === Planning Moves
 
@@ -297,12 +297,12 @@ shown by the 'Tool Direction' image. This makes the 'tool' move in the
 correct direction in relation to the material.
 
 .Mill Configuration
-image::images/mill-diagram.png[align="center"]
+image::images/mill-diagram.png[align="center", alt="Mill Configuration"]
 
 The following diagram shows a typical lathe showing direction of travel
 of the tool and limit switches.
 
 .Lathe Configuration
-image::images/lathe-diagram.png[align="center"]
+image::images/lathe-diagram.png[align="center", alt="Lathe Configuration"]
 
 // vim: set syntax=asciidoc:

--- a/docs/src/user/user-intro-fr.txt
+++ b/docs/src/user/user-intro-fr.txt
@@ -34,7 +34,7 @@ En outre il existe une couche appelée HAL (couche d'abstraction du matériel)
 qui permet la configuration de LinuxCNC sans avoir besoin de recompiler.
 
 .Machine simple contrôlée par LinuxCNC
-image::images/whatstep1.png[align="center"]
+image::images/whatstep1.png[align="center", alt="Machine simple contrôlée par LinuxCNC"]
 
 La figure ci-dessus montre un diagramme bloc
 représentant une machine 3 axes typique comme LinuxCNC les aime. Cette
@@ -59,13 +59,13 @@ interfaces utilisateurs graphiques:
 * <<cha:Axis,_Axis_>>, l'interface utilisateur standard.
 
 .L'interface graphique AXIS[[fig:Interface-graphique-AXIS]]
-image::images/axis_25_fr.png[align="center"]
+image::images/axis_25_fr.png[align="center", alt="L'interface graphique AXIS"]
 
 * <<cha:touchy-gui,_Touchy_>>, une interface graphique pour écran tactile.
 
 .L'interface graphique Touchy[[fig:touchy-gui]]
 
-image::images/touchy_fr.png[align="center"]
+image::images/touchy_fr.png[align="center", alt="L'interface graphique Touchy"]
 
 * <<cha:ngcgui,_NGCGUI_>>, une interface graphique gérant les sous-programmes.
 Elle permet très simplement de créer des programme G-code. Elle supporte
@@ -73,13 +73,13 @@ surtout la concaténation de fichiers de sous-programmes, ce qui permet de
 construire des programmes G-code complets sans aucune programmation.
 
 .L'interface graphique NGCGUI intégrée dans Axis[[fig:ngcgui-gui]]
-image::images/ngcgui_fr.png[align="center"]
+image::images/ngcgui_fr.png[align="center", alt="L'interface graphique NGCGUI intégrée dans Axis"]
 
 * <<cha:TkLinuxCNC,_TkLinuxCNC_>>, une autre interface basée sur Tcl/Tk.
 C'est l'interface la plus populaire après Axis
 
 .L'interface graphique tklinuxcnc[[fig:L-interface-graphique-tklinuxcnc]]
-image::images/tklinuxcnc_fr.png[align="center"]
+image::images/tklinuxcnc_fr.png[align="center", alt="L'interface graphique tklinuxcnc"]
 
 * _Xemc_, un programme X-Windows
 

--- a/docs/src/user/user-intro.txt
+++ b/docs/src/user/user-intro.txt
@@ -47,7 +47,7 @@ There are five main components to the LinuxCNC software:
 
 .Simple LinuxCNC Controlled Machine
 
-image::images/whatstep1.png[align="center"]
+image::images/whatstep1.png[align="center", alt="Simple LinuxCNC Controlled Machine"]
 
 The above figure shows a simple block diagram showing
 what a typical 3-axis LinuxCNC system might look like. This diagram shows a
@@ -68,26 +68,26 @@ interfaces:
 
 <<cha:axis-gui,'Axis'>>, the standard keyboard GUI interface.
 
-image::../gui/images/axis.png[align="center"]
+image::../gui/images/axis.png[align="center", alt="Axis, the standard keyboard GUI interface"]
 
 <<cha:touchy-gui,'Touchy'>>, a touch screen GUI.
 
-image::../gui/images/touchy.png[align="center"]
+image::../gui/images/touchy.png[align="center", alt="Touchy, a touch screen GUI"]
 
 <<cha:gscreen,'Gscreen'>>, a configurable base touch screen GUI.
 
-image::../gui/images/gscreen-mill.png[align="center"]
+image::../gui/images/gscreen-mill.png[align="center", alt="Gscreen, a configurable base touch screen GUI"]
 
 <<cha:gmoccapy,'gmoccapy'>>, a touch screen GUI based on Gscreen.
 
-image::../gui/images/gmoccapy_3_axis.png[align="center"]
+image::../gui/images/gmoccapy_3_axis.png[align="center", alt="gmoccapy, a touch screen GUI based on Gscreen"]
 
 <<cha:ngcgui,'NGCGUI'>>, a subroutine GUI that provides 'fill in the blanks'
    programming of G code. It also supports concatenation of subroutine files
    to enable you to build a complete G code file without programming. The
    following screen shot shows NGCGUI imbedded into Axis.
 
-image::../gui/images/ngcgui.png[align="center"]
+image::../gui/images/ngcgui.png[align="center", alt="NGCGUI, a subroutine GUI that provides fill in the blanks programming of G code"]
 
 === Additional Features
 
@@ -108,14 +108,14 @@ image::../gui/images/ngcgui.png[align="center"]
 
 .PyVCP with Axis
 
-image::../gui/images/axis-pyvcp.png[align="center"]
+image::../gui/images/axis-pyvcp.png[align="center", alt="PyVCP with Axis"]
 
 * 'GladeVCP' - a glade based virtual control panel that can be added to
    the Axis GUI or be stand alone.
 
 .GladeVCP with Axis
 
-image::../gui/images/axis-gladevcp.png[align="center"]
+image::../gui/images/axis-gladevcp.png[align="center", alt="GladeVCP with Axis"]
 
 See the <<cha:pyvcp,PyVCP chapter>> and the<<cha:glade-vcp,GladeVCP chapter>> for more information on Virtual Control Panels.
 


### PR DESCRIPTION
For HTML output, it is recommended with asciidocs the alt-tag to use on images (e. g. for seo).
Recommended for PDF output with asciidocs it is to use the "caption" attribute.
At the moment a ".title" command is this still about 90 percent of cases used for captions.
Maybe I'll replace later this ".title" commands with caption tags ...
Signed-off-by: Thoren Seufl <t_seufl@gmx.de>