### PR TITLE
fix docs/2.7/2.8 broken/unnecessary links in index.es.tmpl + index_fr.tmpl

### DIFF
--- a/docs/src/index_es.tmpl
+++ b/docs/src/index_es.tmpl
@@ -62,16 +62,16 @@ function change(el)
 			<LI><A HREF="getting-started/system-requirements-es.html">Requerimientos del sistema</A>
 			<LI><A HREF="getting-started/getting-linuxcnc-es.html">Obteniendo LinuxCNC</A>
 			<LI><A HREF="getting-started/running-linuxcnc-es.html">Ejecutando LinuxCNC</A>
-			<LI><A HREF="getting-started/opdating-linuxcnc.html">Updating LinuxCNC</A>
-			<LI><A HREF="getting-started/linux-faq-es.html">Linux FAQ</A> 
+			<LI><A HREF="getting-started/updating-linuxcnc.html">Updating LinuxCNC</A>
+			<LI><A HREF="common/linux-faq-es.html">Linux FAQ</A> 
 		</UL>
 	</div>
 
 <li><a onclick="return toggle('sec1')"><img id="sec1_image" src="plus.png" style="border:0;margin-right:5px;vertical-align:middle;" />Configuration Wizards</a>
 	<div id="sec1" style="display:none;">
 		<UL>
-			<LI><A class="tooltips" HREF="getting-started/stepconf-es.html">Stepper Configuration Wizard<span>For Parallel Port Stepper Machine</span></A>
-			<LI><A class="tooltips" HREF="getting-started/pncconf.html">Mesa Configuration Wizard<span>For Mesa Servo &amp; Stepper Machines</span></A>
+			<LI><A class="tooltips" HREF="config/stepconf-es.html">Stepper Configuration Wizard<span>For Parallel Port Stepper Machine</span></A>
+			<LI><A class="tooltips" HREF="config/pncconf.html">Mesa Configuration Wizard<span>For Mesa Servo &amp; Stepper Machines</span></A>
 		</UL>
 	</div>
 
@@ -117,9 +117,9 @@ function change(el)
 		<li><a onclick="return toggle('sec5')"><img id="sec5_image" src="plus.png" style="border:0;margin-right:5px;vertical-align:middle;" />Configuration</a>
 	<div id="sec5" style="display:none;">
 		<UL>
-			<LI><A HREF="common/integrator-concepts.html">Integrator Concepts</A>
+			<LI><A HREF="config/integrator-concepts.html">Integrator Concepts</A>
 			<LI><A HREF="install/latency-test.html">Latency Test</A>
-			<LI><A HREF="common/starting-linuxcnc.html">Starting LinuxCNC</A>
+			<LI><A HREF="user/starting-linuxcnc.html">Starting LinuxCNC</A>
 			<LI><A HREF="motion/tweaking-steppers.html">Stepper Tuning</A>
 			<LI><A HREF="config/ini-config.html">INI Configuration</A>
 			<LI><A HREF="config/ini-homing.html">Homing Configuration</A>
@@ -142,7 +142,7 @@ function change(el)
 		<UL>
 			<LI><A class="tooltips" HREF="gui/halui.html">HALUI<span>HAL User Interface</span></A>
 			<LI><A HREF="hal/halui-examples.html">HALUI examples</A>
-			<LI><A HREF="common/python-interface.html">Python Interface</A>
+			<LI><A HREF="config/python-interface.html">Python Interface</A>
 		</UL>
 	</div>
 		<li><a onclick="return toggle('sec8')"><img id="sec8_image" src="plus.png" style="border:0;margin-right:5px;vertical-align:middle;" />Hardware Drivers</a>
@@ -205,7 +205,7 @@ function change(el)
 		<UL>
 			<LI><A HREF="motion/kinematics.html">Kinematics</A>
 			<LI><A HREF="motion/pid-theory.html">PID theory</A>
-			<LI><A HREF="remap/structure.html">Remap: Extending LinuxCNC</A>
+			<LI><A HREF="remap/remap.html">Remap: Extending LinuxCNC</A>
 			<LI><A HREF="config/moveoff.html">Moveoff Component</A>
 		</UL>
 	</div>

--- a/docs/src/index_fr.tmpl
+++ b/docs/src/index_fr.tmpl
@@ -18,7 +18,7 @@
 <LI><A HREF="gcode_fr.html">Aide m&eacute;moire des r&eacute;f&eacute;rences du G Code</A>
 <LI><A HREF="http://wiki.linuxcnc.org/cgi-bin/wiki.pl">Le Wiki de la communaut&eacute; LinuxCNC (en anglais)</A>
 <p></p>
-<LI><a href="getting-started/index-fr.html"></a>Guide de d&eacute;marrage</a> (<a href="getting-started/index.html">en</a>) (<a href="getting-started/index-es.html">es</a>)
+<LI><a href="getting-started/index-fr.html"></a>Guide de d&eacute;marrage</a>
 <p></p>
 <LI><a name="Manuel d'utilisation"></a> Manuel d'utilisation
 	<UL>
@@ -70,8 +70,8 @@
 	<LI><A HREF="hal/haltcl_fr.html">Fichiers TCL pour HAL</A>
 	<LI><A HREF="config/linuxcnc2hal_fr.html">Interface entre LinuxCNC et HAL</A>
 	<LI><A HREF="config/stepper_fr.html">Configuration des moteurs pas &agrave; pas</A>
-	<LI><A HREF="hal/pyvcp_fr.html">Panneaux de commande virtuels avec PyVCP</A>
-	<LI><A HREF="hal/pyvcp_examples_fr.html">Exemples avec pyVCP</A>
+	<LI><A HREF="gui/pyvcp_fr.html">Panneaux de commande virtuels avec PyVCP</A>
+	<LI><A HREF="gui/pyvcp_examples_fr.html">Exemples avec pyVCP</A>
 	<LI><A HREF="gui/gladevcp_fr.html">Outil de cr&eacute;ation d'interfaces graphiques GladeVCP</A>
 	<LI><A HREF="hal/parallel_port_fr.html">Pilote de port parall&egrave;le</A>
 	<LI><A HREF="drivers/AX5214H_fr.html">Pilote AX5214H (en anglais)</A>
@@ -83,7 +83,7 @@
 	<LI><A HREF="drivers/pico_ppmc_fr.html">Pilote Pico PPMC Driver</A>
 	<LI><A HREF="drivers/pluto_p_fr.html">Pilote Pluto-P Driver (en anglais)</A>
 	<LI><A HREF="drivers/servo_to_go_fr.html">Pilote Servo-To-Go Driver (en anglais)</A>
-	<LI><A HREF="common/python-interface.html">Python Interface (en anglais)</A>
+	<LI><A HREF="config/python-interface.html">Python Interface (en anglais)</A>
 	<LI><A HREF="motion/kinematics_fr.html">Notions de cin&eacute;matique</A>
 	<LI><A HREF="motion/tweaking_steppers_fr.html">R&eacute;glage des moteurs pas &agrave; pas</A>
 	<LI><A HREF="motion/pid_theory_fr.html">Th&eacute;orie du PID</A>
@@ -95,7 +95,7 @@
 	<LI><A HREF="examples/mpg_fr.html">Exemple: Utiliser une manivelle &eacute;lectronique</A>
 	<LI><A HREF="examples/gs2_example_fr.html">Exemple: Utiliser un GS2</A>
 	<LI><A HREF="common/Stepper_Diagnostics_fr.html">Diagnostic des moteurs pas &agrave; pas</A>
-	<LI><A HREF="common/Updating_linuxcnc_fr.html">Mises &agrave; jour de LinuxCNC</A>
+	<LI><A HREF="getting-started/updating-linuxcnc.html">Mises &agrave; jour de LinuxCNC (en anglais)</A>
 	</UL>
 <p></p>
 <LI><a name="Manuel du d&eacute;veloppeur"></a> Manuel du d&eacute;veloppeur
@@ -112,7 +112,7 @@
 <LI><a name="Index, glossaire et Copyright"></a> Glossaire et Copyright
 	<UL>	
 <!--	<LI><A HREF="./xref_fr.html">Index</A> -->
-	<LI><A HREF="common/glossary.html">Glossaire (En Anglais)</A>
+	<LI><A HREF="common/glossary.html">Glossaire (en anglais)</A>
 	<LI><A HREF="common/GPLD_Copyright_fr.html">Copyright et license de la documentation</A>
 	</UL>
 


### PR DESCRIPTION
fixed urls in the html output of the homepage
Signed-off-by: Thoren Seufl t_seufl@gmx.de
