### PR TITLE
configs 2.7/2.8: intf-pico readme typo/adding "www"

### DIFF
--- a/configs/by_interface/pico/README
+++ b/configs/by_interface/pico/README
@@ -1,3 +1,3 @@
 Pico Systems
 
-pico-systems.com
+www.pico-systems.com


### PR DESCRIPTION
For better recognizability of the left as a link and in harmony with the other links in the section of the interfaces.
The site (pico) supports both formats: with and without -www- ...
Signed-off-by: Thoren Seufl <t_seufl@gmx.de>