### PR TITLE
configs 2.7/2.8 sim: typo, update, partially reformatted

### DIFF
--- a/configs/sim/axis/README
+++ b/configs/sim/axis/README
@@ -5,12 +5,12 @@ The principal Axis gui sim ini files:
 axis.ini             basic demo (in)
 axis_9axis.ini       9 axes
 axis_mm.ini          basic demo (mm)
-canterp              demo for a non-gcode interpreter
+canterp.ini          demo for a non-gcode interpreter
 gantry.ini           gantry demo
 gantry_mm.ini        gantry demo (mm)
 histogram_demo.ini   hal-histogram examples
 historical_lathe.ini configured with 3 joints (XYZ with Y unused)
-ini_hal_demo         ini hal pins demo
+ini_hal_demo.ini     ini hal pins demo
 lathe.ini            lathe demo
 ldelta.ini           linear delta robot
 ldelta_demo.ini      linear delta with jog guis

--- a/configs/sim/gmoccapy/README
+++ b/configs/sim/gmoccapy/README
@@ -5,7 +5,7 @@ This screen is based of the design of moccagui, an GUI coded in FreePascal.
 
 gmoccapy is using Python instead.
 
-gmoccapy is designed to bring the feel of industrial controls to linuxccn users,
+gmoccapy is designed to bring the feel of industrial controls to LinuxCNC users,
 most controls can be used with a touch screen and also most are accesible through
 hal pins, so real hardware can be used.
 

--- a/configs/sim/gscreen/README
+++ b/configs/sim/gscreen/README
@@ -1,16 +1,15 @@
-Gscreen is a customizable operator screen for linuxcnc.
+Gscreen is a customizable operator screen for LinuxCNC.
 Built with python, GLADE, and GTK
 
 Usable with touchscreens or a mouse.
-           These show the native look of Gscreen.
+These show the native look of Gscreen.
 
-
-gscreen
+gscreen.ini
   -Imperial milling screen,
   -includes optionnal gladevcp panels
 
-gscreen_lathe
+gscreen_lathe.ini
   -Imperial basic lathe
 
-gscreen_mm
+gscreen_mm.ini
   -Metric milling screen

--- a/configs/sim/gscreen/gscreen_custom/README
+++ b/configs/sim/gscreen/gscreen_custom/README
@@ -1,29 +1,32 @@
-Gscreen is a customizable operator screen for linuxcnc.
+Gscreen is a customizable operator screen for LinuxCNC.
 
 Built with python, GLADE, and GTK
 
 Usable with touchscreens or a mouse.
 These show some custom looks of Gscreen.
 
-gscreen_custom
+9axis.ini
   -9 axis screen
 
-gscreen_gaxis
+gaxis_no_plot.ini
+gscreen_gaxis.ini
   -A similar-to-AXIS demo
 
-industrial
-  -Design influenced by Industrial CNC controls.
-    (System page unlock code is '123')
+industrial.ini
+industrial_lathe.ini
+  -Design influenced by
+   Industrial CNC controls.
+   (System page unlock code is '123')
 
-tester
-    -Tester is used to load a GLADE file without
-initializing anything beyond the window.
-The glade file must be called tester.glade
-The toplevel window must be called window1
-tester_handler.py is also a template of a 
-handler file for adding python code for more
-sophisticated customizations.
-If you run this without adding a GLADE file to
-the folder, it will load a default gscreen file.
-
+tester.ini
+  -Tester is used to load a GLADE file without
+   initializing anything beyond the window.
+   The glade file must be called tester.glade
+   The toplevel window must be called window1
+   tester_handler.py is also a template of a 
+   handler file for adding python code for
+   more sophisticated customizations.
+   If you run this without adding a GLADE
+   file to the folder, it will load a default
+   gscreen file.
 

--- a/configs/sim/tklinuxcnc/README
+++ b/configs/sim/tklinuxcnc/README
@@ -1,6 +1,6 @@
 Sim files using tklinuxcnc gui:
 
-delta.ini
+ldelta.ini
   -delta robot with linear joints
 
 servo_sim.ini

--- a/configs/sim/tklinuxcnc/README
+++ b/configs/sim/tklinuxcnc/README
@@ -1,10 +1,13 @@
 Sim files using tklinuxcnc gui:
 
-tklinuxcnc.ini
-   tcl/tk interface
+delta.ini
+  -delta robot with linear joints
 
 servo_sim.ini
-   simulation for a servo machine
+  -simulation for a servo machine
+
+tklinuxcnc.ini
+  -tcl/tk interface
 
 tripod.ini
-   non-trivial kinematics machine
+  -non-trivial kinematics machine


### PR DESCRIPTION
There are numerous variations and formatting in the README files of various configs.
First step: small typos and small reformatting in unison with other configs.
Signed-off-by: Thoren Seufl <t_seufl@gmx.de>