### PR TITLE
scripts: axis.py typo

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -144,7 +144,7 @@ except TclError:
     raise
 
 def General_Halt():
-    text = "Do you really want to close linuxcnc?"
+    text = "Do you really want to close LinuxCNC?"
     if not root_window.tk.call("nf_dialog", ".error", "Confirm Close", text, "warning", 1, "Yes", "No"):
         root_window.destroy()
 


### PR DESCRIPTION
little typo: linuxcnc -> LinuxCNC (Unified name Use)
(adaptation of * .po files is not necessary as far as I could see)
Signed-off-by: Thoren Seufl <t_seufl@gmx.de>