### PR TITLE
Screwtop/docs/inifile vars

### DIFF
--- a/docs/src/config/ini-config.txt
+++ b/docs/src/config/ini-config.txt
@@ -119,17 +119,8 @@ names and variable names as shown. In the following example the variable
 Most sample configurations use custom sections and variables to put all of the
 settings into one location for convenience.
 
-To use a custom section variable in your HAL file add the section and
-variable to the INI file.
-
-.Custom Section Example
-----
-[OFFSETS]
-OFFSET_1 = 0.1234
-----
-
-To add a custom variable to a LinuxCNC section simply include the variable
-in that section.
+To add a custom variable to an existing LinuxCNC section, simply include
+the variable in that section.
 
 .Custom Variable Example
 ----
@@ -139,18 +130,62 @@ TYPE = LINEAR
 SCALE = 16000
 ----
 
-To use the custom variables in your HAL file put the section and variable
-name in place of the value. 
+To introduce a custom section with its own variables, add the section
+and variables to the INI file.
+
+.Custom Section Example
+----
+[PROBE]
+Z_FEEDRATE = 50
+Z_OFFSET = 12
+Z_SAFE_DISTANCE = -10
+----
+
+To use the custom variables in your HAL file, put the section and
+variable name in place of the value. 
 
 .HAL Example
 ----
-setp offset.1.offset [OFFSETS]OFFSET_1
+setp offset.1.offset [PROBE]Z_OFFSET
 setp stepgen.0.position-scale [JOINT_0]SCALE
 ----
 
 [NOTE]
 The value stored in the variable must match the type specified by the
 component pin.
+
+To use the custom variables in G-code, use the global variable syntax
+`#<_ini[section]variable>`. The following example shows a simple
+touch-off routine for a router or mill using a probe plate.
+
+.G-code Example
+[source,{ngc}]
+---------------------------------------------------------------------
+G91
+F#<_ini[probe]z_feedrate>
+G38.2 Z#<_ini[probe]z_safe_distance>
+G90
+G1 Z#5063
+G10 L20 P0 Z#<_ini[probe]z_offset>
+---------------------------------------------------------------------
+
+[NOTE]
+====
+Referring to INI-file variables from G-code is currently an experimental
+feature. To enable it, specify the appropriate FEATURES bitmask value in
+the RS274NGC section of the INI file, e.g.
+
+[source,{ini}]
+---------------------------------------------------------------------
+[RS274NGC]
+...
+FEATURES=4
+---------------------------------------------------------------------
+
+See <<remap:ini-features,Optional Interpreter Features>> in
+<<remap#,Remap Extending G-Code>> for details.
+====
+
 
 === Include Files
 

--- a/docs/src/config/ini-config.txt
+++ b/docs/src/config/ini-config.txt
@@ -182,8 +182,8 @@ the RS274NGC section of the INI file, e.g.
 FEATURES=4
 ---------------------------------------------------------------------
 
-See <<cha:remap#ini-features,Optional Interpreter Features>> in
-<<cha:remap,Remap Extending G-Code>> for details.
+See <<cha:remap#ini-features,Optional Interpreter Features>> in the
+<<cha:remap,Remap Extending G-Code>> Chapter for details.
 ====
 
 

--- a/docs/src/config/ini-config.txt
+++ b/docs/src/config/ini-config.txt
@@ -182,8 +182,8 @@ the RS274NGC section of the INI file, e.g.
 FEATURES=4
 ---------------------------------------------------------------------
 
-See <<remap:ini-features,Optional Interpreter Features>> in
-<<remap#,Remap Extending G-Code>> for details.
+See <<cha:remap#ini-features,Optional Interpreter Features>> in
+<<cha:remap,Remap Extending G-Code>> for details.
 ====
 
 

--- a/docs/src/config/ini-config.txt
+++ b/docs/src/config/ini-config.txt
@@ -552,8 +552,14 @@ A search is made for each possible user defined function, typically
 +
 The first executable M1xx found in the search is used for each M1xx.
 
-* 'USER_DEFINED_FUNCTION_MAX_DIRS=5'. The maximum number of directories defined
-   at compile time. 
+* 'USER_DEFINED_FUNCTION_MAX_DIRS = 5' - The maximum number of directories defined
+    at compile time.
+
+* 'FEATURES = 0' - An integer value representing the bitmask of optional
+    features to be enabled. These are typically non-backward-compatible and
+    experimental in nature. See
+    <<cha:remap#ini-features,Optional Interpreter Features>> in the
+    <<cha:remap,Remap Extending G-Code>> Chapter for details.
 
 [NOTE]
 [WIZARD]WIZARD_ROOT is a valid search path but the Wizard has not been fully

--- a/docs/src/config/ini-config.txt
+++ b/docs/src/config/ini-config.txt
@@ -156,14 +156,13 @@ component pin.
 
 To use the custom variables in G-code, use the global variable syntax
 `#<_ini[section]variable>`. The following example shows a simple
-touch-off routine for a router or mill using a probe plate.
+Z-axis touch-off routine for a router or mill using a probe plate.
 
 .G-code Example
 [source,{ngc}]
 ---------------------------------------------------------------------
 G91
-F#<_ini[probe]z_feedrate>
-G38.2 Z#<_ini[probe]z_safe_distance>
+G38.2 Z#<_ini[probe]z_safe_distance> F#<_ini[probe]z_feedrate>
 G90
 G1 Z#5063
 G10 L20 P0 Z#<_ini[probe]z_offset>
@@ -173,7 +172,7 @@ G10 L20 P0 Z#<_ini[probe]z_offset>
 ====
 Referring to INI-file variables from G-code is currently an experimental
 feature. To enable it, specify the appropriate FEATURES bitmask value in
-the RS274NGC section of the INI file, e.g.
+the <<sec:rs274ngc-section,RS274NGC>> section of the INI file, e.g.
 
 [source,{ini}]
 ---------------------------------------------------------------------
@@ -182,8 +181,8 @@ the RS274NGC section of the INI file, e.g.
 FEATURES=4
 ---------------------------------------------------------------------
 
-See <<cha:remap#ini-features,Optional Interpreter Features>> in the
-<<cha:remap,Remap Extending G-Code>> Chapter for details.
+See <<remap:ini-features,Optional Interpreter Features>> in the
+<<cha:remap,Remap Extending G-Code>> chapter for details.
 ====
 
 
@@ -558,8 +557,8 @@ The first executable M1xx found in the search is used for each M1xx.
 * 'FEATURES = 0' - An integer value representing the bitmask of optional
     features to be enabled. These are typically non-backward-compatible and
     experimental in nature. See
-    <<cha:remap#ini-features,Optional Interpreter Features>> in the
-    <<cha:remap,Remap Extending G-Code>> Chapter for details.
+    <<remap:ini-features,Optional Interpreter Features>> in the
+    <<cha:remap,Remap Extending G-Code>> chapter for details.
 
 [NOTE]
 [WIZARD]WIZARD_ROOT is a valid search path but the Wizard has not been fully

--- a/docs/src/remap/remap.txt
+++ b/docs/src/remap/remap.txt
@@ -1107,8 +1107,8 @@ o100 if [..] (some error condition)
      (abort, Bad Things! p42=#42 q=#<q> ini=#<_ini[a]x> pin=#<_hal[component.pin])
 o100 endif
 ---------------------------------------------------------------------
-NB: ini and HAL variable expansion need explicit enabling with
-<<remap:ini-features,FEATURE>>.
+NOTE: ini and HAL variable expansion need explicit enabling with the
+<<remap:ini-features,FEATURES>> mask.
 
 If more fine grained recovery action is needed, use the idiom
 laid out in the previous example:

--- a/docs/src/remap/remap.txt
+++ b/docs/src/remap/remap.txt
@@ -2612,7 +2612,7 @@ need to replace ini variables which are currently used in the
 hard-coded tool change process, like the `[EMCIO]TOOL_CHANGE_POSITION` parameter.
 
 CAUTION: this section doesn't really belong here but since it comes with
-the same branch, here it rests for now until its clear this will be
+the same branch, here it rests for now until it's clear this will be
 merged. It should go into the gcode/overview Named Parameters section.
 
 [[remap:referto-hal-items]]
@@ -2654,13 +2654,13 @@ This feature was motivated by the desire for stronger coupling between
 user interface components like `GladeVCP` and `PyVCP` to act as
 parameter source for driving NGC file behavior. The alternative -
 going through the M6x pins and wiring them - has a limited,
-non-mmemonic namespace and is unnecessary cumbersome just as a
+non-mnemonic namespace and is unnecessarily cumbersome just as a
 UI/Interpreter communications mechanism.
 
 NOTE: The values are are only updated when the G code is not running.
 
 CAUTION: this section doesn't really belong here but since it comes with
-the same branch, here it rests for now until its clear this will be
+the same branch, here it rests for now until it's clear this will be
 merged. It should go into the gcode/overview Named Parameters section.
 
 ==  Status


### PR DESCRIPTION
Implemented some changes to the documentation on custom variables and sections in INI files.

Configuration chapter:
 - Added an explanation of how to use INI-file variables from G-code, with example
 - Rearranged custom INI-file vars examples so the simple case appears first
 - Added FEATURES item to RS274NGC section, with cross-ref to main discussion of this

Remap chapter:
 - A few writing corrections found nearby.

Original discussion here:
https://forum.linuxcnc.org/32-documents/31886-features-variable-in-ini-file-rs274ngc-section

Signed-off-by: Chris Edwards <cedwards@cedwards.geek.nz>