### PR TITLE
uspace: allow calculated parameter array sizes

### DIFF
--- a/src/rtapi/rtapi.h
+++ b/src/rtapi/rtapi.h
@@ -817,17 +817,19 @@ RTAPI_BEGIN_DECLS
   MODULE_PARM(var,"s");            \
   MODULE_PARM_DESC(var,descr);
 
-#define RTAPI_MP_ARRAY_INT(var,num,descr)          \
-  MODULE_PARM(var,"1-" RTAPI_STRINGIFY(num) "i");  \
+#define RTAPI_MP_ARRAY(type, var, num, descr)      \
+  MODULE_PARM(var,type);                           \
+  MODULE_INFO2(int, size, var, num);               \
   MODULE_PARM_DESC(var,descr);
+
+#define RTAPI_MP_ARRAY_INT(var,num,descr)          \
+  RTAPI_MP_ARRAY("i", var, num, descr);
 
 #define RTAPI_MP_ARRAY_LONG(var,num,descr)         \
-  MODULE_PARM(var,"1-" RTAPI_STRINGIFY(num) "l");  \
-  MODULE_PARM_DESC(var,descr);
+  RTAPI_MP_ARRAY("l", var, num, descr);
 
 #define RTAPI_MP_ARRAY_STRING(var,num,descr)       \
-  MODULE_PARM(var,"1-" RTAPI_STRINGIFY(num) "s");  \
-  MODULE_PARM_DESC(var,descr);
+  RTAPI_MP_ARRAY("s", var, num, descr);
 
 #else /* kernel */
 

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -170,29 +170,19 @@ static int do_comp_args(void *module, vector<string> args) {
                     s.c_str());
             return -1;
         }
-        string item_type_string = *item_type;
 
-        if(item_type_string.size() > 1) {
-            int a, b;
-            char item_type_char;
-            int r = sscanf(item_type_string.c_str(), "%d-%d%c",
-                    &a, &b, &item_type_char);
-            if(r != 3)
-                r = sscanf(item_type_string.c_str(), "%d-(%d)%c",
-                    &a, &b, &item_type_char);
-            if(r != 3) {
-                rtapi_print_msg(RTAPI_MSG_ERR,
-                    "Unknown parameter `%s' (corrupt array type information '%s' r=%d)\n",
-                    s.c_str(), item_type_string.c_str(), r);
-                return -1;
-            }
+        int*max_size_ptr=DLSYM<int*>(module, "rtapi_info_size_" + param_name);
+
+        char item_type_char = **item_type;
+        if(max_size_ptr) {
+            int max_size = *max_size_ptr;
             size_t idx = 0;
             int i = 0;
             while(idx != string::npos) {
-                if(i == b) {
+                if(i == max_size) {
                     rtapi_print_msg(RTAPI_MSG_ERR,
                             "%s: can only take %d arguments\n",
-                            s.c_str(), b);
+                            s.c_str(), max_size);
                     return -1;
                 }
                 size_t idx1 = param_value.find(",", idx);
@@ -203,7 +193,6 @@ static int do_comp_args(void *module, vector<string> args) {
                 idx = idx1 == string::npos ? idx1 : idx1 + 1;
             }
         } else {
-            char item_type_char = item_type_string[0];
             int result = do_one_item(item_type_char, s, param_value, item);
             if(result != 0) return result;
         }


### PR DESCRIPTION
In the original formulation, a use like
~~~~
RTAPI_MP_ARRAY_INT(arr, 3*FOO, "array of three times foo items");
~~~~
gave a weird error on uspace only when arr= was actually specified on the loadrt commandline.  This is because the 'num' value was communited to rtapi_app as a string rather than an integer, so the string "3*FOO" was received where a string like "24" was expected, resulting in an error.

Happily we have good test coverage for comp's use of RTAPI_MP_ARRAY via tests/module_loading/or2* so even though this was encountered and reported in the non-runtested hal_ppmc driver, we can have confidence about the solution.

Close #242.

Signed-off-by: Jeff Epler <jepler@unpythonic.net>