### PR TITLE
Issue 248: Remove reference to Ubuntu 10.04 in tooledit.

### DIFF
--- a/docs/src/gui/tooledit.txt
+++ b/docs/src/gui/tooledit.txt
@@ -23,12 +23,6 @@ is configured with the default tcl version >= 8.5.
 
 image::images/tooledit-sort.png[align="center"]
 
-On Ubuntu Lucid 10.04 tcl/tk8.4 is the default.  You can add tcl/tk8.5 with
-the commands:
-----
-sudo apt-get install tcl8.5 tk8.5
-----
-
 Depending upon other applications installed on the system, it may be
 necessary to enable tcl/tk8.5 with the commands:
 ----


### PR DESCRIPTION
Signed-off-by: Joe Hildreth <joeh@threerivershospital.com>

Make sure you can check all these boxes before submitting your issue—Thank you!

 - [x] The submitted code is available under the GNU GPL version 2 with the "or later" clause
 - [x] You have certified that this is the case by including a "Signed-off-by" message in each commit
 - [x] You used your real name and a working e-mail address in this message

I removed the reference to Ubuntu 10.04 in part 2 of the tooledit docs in master as per request for Issue 248.  I seen no reference to Ubuntu in the French version of the document.
