### PR TITLE
axis: joint mode keyboard jogging

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1704,8 +1704,9 @@ def get_jog_speed(a):
             return vars.jog_aspeed.get()/60.
 
 def get_jog_speed_map(a):
-    if a >= len(jog_order): return 0
+    if get_jog_mode() and a >= num_joints: return 0
     if not get_jog_mode():
+    	if a >= len(jog_order): return 0
         axis_letter = jog_order[a]
         a = "XYZABCUVW".index(axis_letter)
     return get_jog_speed(a)


### PR DESCRIPTION
when jogging in joint mode from the keyboard direction keys, if the
joint number is larger than the number of axes then the joint will not jog

this shows up in sim/axis/gantry when trying to jog joint 3 with the 
left/right bracket keys

Signed-off-by: Phillip Carter <phillcarter54@gmail.com>
