### PR TITLE
rtapi: rt_free_timers definition is needed for RTAI 4

### DIFF
--- a/src/rtapi/rtai_rtapi.c
+++ b/src/rtapi/rtai_rtapi.c
@@ -90,7 +90,7 @@
 #define RTAI_NR_TRAPS HAL_NR_FAULTS
 #endif
 
-#if RTAI <= 3
+#if RTAI < 5
 #define rt_free_timers rt_free_timer
 #endif
 


### PR DESCRIPTION
RTAI 4 and RTAI 4.1 need the definition for rt_free_timers

Signed-off-by: Alec Ari <neotheuser@ymail.com>