### PR TITLE
halui: Add outputs that track whether joint limit override is enabled

### DIFF
--- a/docs/man/man1/halui.1
+++ b/docs/man/man1/halui.1
@@ -333,6 +333,9 @@ status pin telling that joint N is on the positive software limit
 .B halui.joint.N.on-soft-min-limit\fR bit out \fR
 status pin telling that joint N is on the negative software limit
 .TP
+.B halui.joint.N.override-limits\fR bit out \fR
+status pin telling that joint N's limits are temporarily overridden
+.TP
 .B halui.joint.N.unhome\fR bit in \fR
 pin for unhoming joint N
 .TP
@@ -359,6 +362,9 @@ status pin telling that the selected joint is on the positive software limit
 .TP
 .B halui.joint.selected.on-soft-min-limit\fR bit out \fR
 status pin telling that the selected joint is on the negative software limit
+.TP
+.B halui.joint.selected.override-limits\fR bit out \fR
+status pin telling that the selected joint's limits are temporarily overridden
 .TP
 .B halui.joint.selected.unhome\fR bit in \fR
 pin for unhoming the selected joint

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -120,6 +120,7 @@ static int axis_mask = 0;
     ARRAY(hal_bit_t,joint_on_soft_max_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the software max limit */ \
     ARRAY(hal_bit_t,joint_on_hard_min_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the hardware min limit */ \
     ARRAY(hal_bit_t,joint_on_hard_max_limit,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the hardware max limit */ \
+    ARRAY(hal_bit_t,joint_override_limits,EMCMOT_MAX_JOINTS+1) /* status pin that the joint is on the hardware max limit */ \
     ARRAY(hal_bit_t,joint_has_fault,EMCMOT_MAX_JOINTS+1) /* status pin that the joint has a fault */ \
     FIELD(hal_u32_t,joint_selected) /* status pin for the joint selected */ \
     FIELD(hal_u32_t,axis_selected) /* status pin for the axis selected */ \
@@ -626,6 +627,8 @@ int halui_hal_init(void)
 	if (retval < 0) return retval;
 	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_hard_max_limit[joint]), comp_id, "halui.joint.%d.on-hard-max-limit", joint);
 	if (retval < 0) return retval;
+	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_override_limits[joint]), comp_id, "halui.joint.%d.override-limits", joint);
+	if (retval < 0) return retval;
 	retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_has_fault[joint]), comp_id, "halui.joint.%d.has-fault", joint);
 	if (retval < 0) return retval;
     }
@@ -637,6 +640,8 @@ int halui_hal_init(void)
     retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_hard_min_limit[num_joints]), comp_id, "halui.joint.selected.on-hard-min-limit");
     if (retval < 0) return retval;
     retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_on_hard_max_limit[num_joints]), comp_id, "halui.joint.selected.on-hard-max-limit");
+    if (retval < 0) return retval;
+    retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_override_limits[num_joints]), comp_id, "halui.joint.selected.override-limits");
     if (retval < 0) return retval;
     retval =  hal_pin_bit_newf(HAL_OUT, &(halui_data->joint_has_fault[num_joints]), comp_id, "halui.joint.selected.has-fault");
     if (retval < 0) return retval;
@@ -2169,6 +2174,7 @@ static void modify_hal_pins()
 	*(halui_data->joint_on_soft_max_limit[joint]) = emcStatus->motion.joint[joint].maxSoftLimit;
 	*(halui_data->joint_on_hard_min_limit[joint]) = emcStatus->motion.joint[joint].minHardLimit;
 	*(halui_data->joint_on_hard_max_limit[joint]) = emcStatus->motion.joint[joint].maxHardLimit;
+	*(halui_data->joint_override_limits[joint]) = emcStatus->motion.joint[joint].overrideLimits;
 	*(halui_data->joint_has_fault[joint]) = emcStatus->motion.joint[joint].fault;
     }
 
@@ -2230,6 +2236,7 @@ static void modify_hal_pins()
     *(halui_data->joint_on_soft_min_limit[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].minSoftLimit;
     *(halui_data->joint_on_soft_max_limit[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].maxSoftLimit;
     *(halui_data->joint_on_hard_min_limit[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].minHardLimit;
+    *(halui_data->joint_override_limits[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].overrideLimits;
     *(halui_data->joint_on_hard_max_limit[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].maxHardLimit;
     *(halui_data->joint_has_fault[num_joints]) = emcStatus->motion.joint[*(halui_data->joint_selected)].fault;
 


### PR DESCRIPTION
Issue #237 adds a pin for gmoccapy to show the state of "ignore limits".  This adds the same to halui, so that it can be used in conjunction with other GUIs. (this is not to say #237 should not be merged, that's up to @gmoccapy IMO)