### PR TITLE
axis: default touchoff coordinate system

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -885,8 +885,12 @@ class LivePlotter:
             if i == -1: continue
             if i % 10 == 0:
                 active_codes.append("G%d" % (i/10))
+                if i/10 > 53 and i/10 < 60:
+                   vars.touch_off_system.set("P%(p)d  G%(ones)d" % {'p': i/10-53, 'ones': i/10})
             else:
                 active_codes.append("G%(ones)d.%(tenths)d" % {'ones': i/10, 'tenths': i%10})
+                if i > 590 and i < 594:
+                    vars.touch_off_system.set("P%(p)d  G%(ones)d.%(tenths)d" % {'p': i-584, 'ones': i/10, 'tenths': i%10})
 
         for i in self.stat.mcodes[1:]:
             if i == -1: continue
@@ -2889,8 +2893,6 @@ vars.optional_stop.set(ap.getpref("optional_stop", True))
 # placeholder function for LivePlotter.update():
 def user_live_update():
     pass
-
-vars.touch_off_system.set("P1  G54")
 
 update_recent_menu()
 


### PR DESCRIPTION
set default touchoff coordinate system to the currently active coordinate system
see issue #61

Signed-off-by: Phillip Carter <phillcarter54@gmail.com>

Make sure you can check all these boxes before submitting your issue—Thank you!

 - [] The submitted code is available under the GNU GPL version 2 with the "or later" clause
 - [] You have certified that this is the case by including a "Signed-off-by" message in each commit
 - [] You used your real name and a working e-mail address in this message

[you can delete this text before submitting your issue]
