### PR TITLE
 uspace: get rid of runtime setuid use

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -376,7 +376,7 @@ static int init_board(hm2_eth_t *board, const char *board_ip) {
         return ret;
     }
 
-    ret = rtapi_do_as_root(ioctl_siocsarp, board);
+    ret = ioctl_siocsarp(board);
     if(ret < 0) {
         perror("ioctl SIOCSARP");
         board->req.arp_flags &= ~ATF_PERM;
@@ -399,7 +399,7 @@ static int close_board(hm2_eth_t *board) {
     if(use_iptables()) clear_iptables();
 
     if(board->req.arp_flags & ATF_PERM) {
-        int ret = rtapi_do_as_root(ioctl_siocdarp, board);
+        int ret = ioctl_siocdarp(board);
         if(ret < 0) perror("ioctl SIOCDARP");
     }
     int ret = shutdown(board->sockfd, SHUT_RDWR);

--- a/src/rtapi/rtapi.h
+++ b/src/rtapi/rtapi.h
@@ -826,8 +826,6 @@ int rtapi_spawnp_as_root(pid_t *pid, const char *path,
     const posix_spawn_file_actions_t *file_actions,
     const posix_spawnattr_t *attrp,
     char *const argv[], char *const envp[]);
-
-int rtapi_do_as_root(int (*fn)(void *), void *arg);
 #endif
 
 extern int rtapi_is_kernelspace(void);

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -85,14 +85,14 @@ int rtapi_shmem_new(int key, int module_id, unsigned long int size)
   int res = shmctl(shmem->id, IPC_STAT, &stat);
   if(res < 0) perror("shmctl IPC_STAT");
 
+#ifdef RTAPI
   /* ensure the segment is owned by user, not root */
-  if(geteuid() == 0 && getuid() != 0) {
-    stat.shm_perm.uid = getuid();
+  if(geteuid() == 0) {
+    stat.shm_perm.uid = ruid;
     res = shmctl(shmem->id, IPC_SET, &stat);
     if(res < 0) perror("shmctl IPC_SET");
   }
 
-#ifdef RTAPI
   if(rtapi_is_realtime())
   {
     /* ensure the segment is locked */

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -53,8 +53,6 @@
 #include "hal/hal_priv.h"
 #include "rtapi_uspace.hh"
 
-#include <sys/ipc.h>		/* IPC_* */
-#include <sys/shm.h>		/* shmget() */
 #include <string.h>
 #include <boost/lockfree/queue.hpp>
 

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -48,7 +48,6 @@
 #include "config.h"
 
 #include "rtapi.h"
-#include "rtapi/uspace_common.h"
 #include "hal.h"
 #include "hal/hal_priv.h"
 #include "rtapi_uspace.hh"
@@ -59,35 +58,17 @@
 std::atomic<int> WithRoot::level;
 static uid_t euid, ruid;
 
-static void priv_info(const char *m) {
-#ifdef RTAPI_DEBUG_PRIV
-    uid_t r, e, s;
-    if(getresuid(&r, &e, &s) < 0)
-        printf("%s: %s\n", m, strerror(errno));
-    else
-        printf("%s: ruid=%d euid=%d suid=%d\n", m, (int)r, (int)e, (int)s);
-#endif
-}
+#include "rtapi/uspace_common.h"
 
 WithRoot::WithRoot() {
     if(!level++) {
-        priv_info("before  WithRoot");
-        if(seteuid(euid) < 0) {
-            perror("seteuid (root)");
-            exit(1);
-        }
-        priv_info("after   WithRoot");
+        setfsuid(euid);
     }
 }
 
 WithRoot::~WithRoot() {
     if(!--level) {
-        priv_info("before ~WithRoot");
-        if(seteuid(ruid) < 0) {
-            perror("seteuid (user)");
-            exit(1);
-        }
-        priv_info("after  ~WithRoot");
+        setfsuid(ruid);
     }
 }
 
@@ -521,10 +502,8 @@ int main(int argc, char **argv) {
     }
     ruid = getuid();
     euid = geteuid();
-    if(seteuid(ruid) < 0) {
-        perror("setuid (user)");
-        exit(1);
-    } 
+    setresuid(euid, euid, ruid);
+    setfsuid(ruid);
     vector<string> args;
     for(int i=1; i<argc; i++) { args.push_back(string(argv[i])); }
 
@@ -1197,13 +1176,7 @@ int rtapi_spawn_as_root(pid_t *pid, const char *path,
     const posix_spawnattr_t *attrp,
     char *const argv[], char *const envp[])
 {
-    WITH_ROOT;
-    setreuid(euid, euid);
-    priv_info("before posix_spawn");
-    int r = posix_spawn(pid, path, file_actions, attrp, argv, envp);
-    setresuid(ruid, ruid, (pid_t)-1);
-    priv_info("after posix_spawnp");
-    return r;
+    return posix_spawn(pid, path, file_actions, attrp, argv, envp);
 }
 
 int rtapi_spawnp_as_root(pid_t *pid, const char *path,
@@ -1211,16 +1184,5 @@ int rtapi_spawnp_as_root(pid_t *pid, const char *path,
     const posix_spawnattr_t *attrp,
     char *const argv[], char *const envp[])
 {
-    WITH_ROOT;
-    setreuid(euid, euid);
-    priv_info("before posix_spawnp");
-    int r = posix_spawnp(pid, path, file_actions, attrp, argv, envp);
-    setresuid(ruid, ruid, (pid_t)-1);
-    priv_info("after posix_spawnp");
-    return r;
-}
-
-int rtapi_do_as_root(int (*fn)(void *), void *arg) {
-    WITH_ROOT;
-    return fn(arg);
+    return posix_spawnp(pid, path, file_actions, attrp, argv, envp);
 }


### PR DESCRIPTION
Now we return to something like the status quo ante in 2.7:
filesystem operations are done as the user, but the real and
effective user IDs are always root when running in realtime.

The rtapi_do_as_root API has been deleted, but it was never
documented and never in a released version.

This is unfortunate but necessary since calling setreuid() causes
loss of realtime on PREEMPT_RT and hard locks in RTAI.

I verified this to still work with PCI and ethernet hostmot2 cards
on Debian Jessie, which covers most of the in-tree places where
the "as root" functions were used.  Furthermore, I verified
(using a non-commited, interactive test) that rtapi_spawn_as_root
still spawns with EUID=RUID=0 even though they are now nothing
more than wrappers that directly call posix_spawn.

Finally, I verified that the RTAI hard locks were resolved.

I was uanble to duplicate the report of missed realtime deadlines
when starting halscope on preempt-rt after thread creation,
testing with 4.9.0-0.bpo.2-rt-amd64 on Debian Jessie.

Signed-off-by: Jeff Epler <jepler@unpythonic.net>