### PR TITLE
Remap default modalgroup

### DIFF
--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -515,10 +515,7 @@ int Interp::parse_remap(const char *inistring, int lineno)
 	break;
 
     case 'm':
-	if (sscanf(code + 1, "%d", &mcode) == 1) {
-	    _setup.remaps[code] = r;
-	    _setup.m_remapped[mcode] = &_setup.remaps[code];
-	} else {
+	if (sscanf(code + 1, "%d", &mcode) != 1) {
 	    Error("parsing M-code: expecting integer like 'M420', got '%s' : %d:REMAP = %s",
 		  code,lineno,inistring);
 	    goto fail;
@@ -533,6 +530,8 @@ int Interp::parse_remap(const char *inistring, int lineno)
 		  code,lineno,inistring);
 	    goto fail;
 	}
+        _setup.remaps[code] = r;
+        _setup.m_remapped[mcode] = &_setup.remaps[code];
 	break;
     case 'g':
 
@@ -554,7 +553,6 @@ int Interp::parse_remap(const char *inistring, int lineno)
 	    Error("warning: code '%s' : no modalgroup=<int> given, using default group %d : %d:REMAP = %s",
 		  code, GCODE_DEFAULT_MODAL_GROUP, lineno, inistring);
 	    r.modal_group = GCODE_DEFAULT_MODAL_GROUP;
-	    break;
 	}
 	if (!G_MODE_OK(r.modal_group)) {
 	    Error("error: code '%s' : %s modalgroup=<int> given  : %d:REMAP = %s",

--- a/tests/remap/sequencing/test.ini
+++ b/tests/remap/sequencing/test.ini
@@ -5,7 +5,7 @@ LOG_LEVEL=0
 [RS274NGC]
 SUBROUTINE_PATH = .
 
-REMAP=G88.1  modalgroup=1  ngc=rg881
+REMAP=G88.1 ngc=rg881
 
 # one M-code from each modal group
 REMAP=M405  modalgroup=5  ngc=rm405
@@ -13,4 +13,4 @@ REMAP=M406  modalgroup=6  ngc=rm406
 REMAP=M407  modalgroup=7  ngc=rm407
 REMAP=M408  modalgroup=8  ngc=rm408
 REMAP=M409  modalgroup=9  ngc=rm409
-REMAP=M410  modalgroup=10 ngc=rm410
+REMAP=M410  ngc=rm410


### PR DESCRIPTION
Andy reported via irc that there is a 'problem with a REMAP that lacks "modalgroup"'.  I didn't get a full problem report from him, but took a stab in the dark and found several problems.  These changes fix them, and make one of the existing tests look for the problem.