### PR TITLE
uspace: Find top online CPU

### DIFF
--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -899,7 +899,6 @@ int Posix::task_delete(int id)
   delete task;
   return 0;
 }
-
 int Posix::task_start(int task_id, unsigned long int period_nsec)
 {
   auto task = ::rtapi_get_task<PosixTask>(task_id);
@@ -913,10 +912,7 @@ int Posix::task_start(int task_id, unsigned long int period_nsec)
   memset(&param, 0, sizeof(param));
   param.sched_priority = task->prio;
 
-  cpu_set_t cpuset;
-  CPU_ZERO(&cpuset);
   int nprocs = sysconf( _SC_NPROCESSORS_ONLN );
-  CPU_SET(nprocs-1, &cpuset); // assumes processor numbers are contiguous
 
   pthread_attr_t attr;
   if(pthread_attr_init(&attr) < 0)
@@ -929,9 +925,47 @@ int Posix::task_start(int task_id, unsigned long int period_nsec)
       return -errno;
   if(pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED) < 0)
       return -errno;
-  if(nprocs > 1)
+  if(nprocs > 1) {
+
+      const static int rt_cpu_number = []() {
+        if(getenv("RTAPI_CPU_NUMBER")) return atoi(getenv("RTAPI_CPU_NUMBER"));
+
+        cpu_set_t cpuset_orig;
+        int r = sched_getaffinity(getpid(), sizeof(cpuset_orig), &cpuset_orig);
+        if(r < 0)
+            // if getaffinity fails, (it shouldn't be able to), just use CPU#0
+            return 0;
+
+        cpu_set_t cpuset;
+        for(int i=0; i<CPU_SETSIZE; i++) CPU_SET(i, &cpuset);
+
+        r = sched_setaffinity(getpid(), sizeof(cpuset), &cpuset);
+        if(r < 0)
+            // if setaffinity fails, (it shouldn't be able to), go on with
+            // whatever the default CPUs were.
+            perror("sched_setaffinity");
+
+        r = sched_getaffinity(getpid(), sizeof(cpuset), &cpuset);
+        if(r < 0) {
+            // if getaffinity fails, (it shouldn't be able to), copy the
+            // original affinity list in and use it
+            perror("sched_getaffinity");
+            CPU_AND(&cpuset, &cpuset_orig, &cpuset);
+        }
+
+        int top = -1;
+        for(int i=0; i<CPU_SETSIZE; i++) {
+            if(CPU_ISSET(i, &cpuset)) top = i;
+        }
+        return top;
+      }();
+
+      cpu_set_t cpuset;
+      CPU_ZERO(&cpuset);
+      CPU_SET(rt_cpu_number, &cpuset);
       if(pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset) < 0)
           return -errno;
+  }
   if(pthread_create(&task->thr, &attr, &wrapper, reinterpret_cast<void*>(task)) < 0)
       return -errno;
 


### PR DESCRIPTION
***NOTE*** This is PR relative to master branch, but we should consider whether to port it back to 2.7, because it affects that version.  (however, it is not a regression)

Before this change, uspace assumed that online CPU numbers were consecutive, and attempted to schedule the real time tasks on the highest numbered CPU.  For example, if _SC_NPROCESSORS_ONLN returns 8, then it is assumed that the online processors are 0-7, and processor number 7 is selected for real time tasks.

This is not always the case.  For example, on a D525 with HT turned off via BIOS, it is reported that _SC_NPROCESSORS_ONLN is 2 and the online processors are 0,2.  The old algorithm chooses processor number 1 for realtime, so no realtime thread is ever run.

While my HT system (i7-4790K) can turn off HT in the BIOS, it gets online processors 0-3 when this is done, so the buggy behavior is not provoked.  However, if I take a CPU offline which is not the highest numbered CPU, e.g., with
    $ sudo sh -c 'echo 0 > /sys/devices/system/cpu/cpu6/online'
I can provoke the reported behavior.  After this change, cpu number 7 is again selected (correctly) instead of cpu number 6 (incorrectly).

Closes: #294

Signed-off-by: Jeff Epler <jepler@unpythonic.net>