### PR TITLE
gcodemodule: Make interp really close part program

### DIFF
--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -741,6 +741,8 @@ static PyObject *parse_file(PyObject *self, PyObject *args) {
     }
 out_error:
     if(pinterp) pinterp->close();
+    if(pinterp) pinterp->open("");
+    if(pinterp) pinterp->close();
     if(interp_error) {
         if(!PyErr_Occurred()) {
             PyErr_Format(PyExc_RuntimeError,


### PR DESCRIPTION
For valid reasons (something to do with calling O-words from MDI),
the interpreter leaves the last file open even when close() is
called.  However, open() actually does close the old file before
opening a new one.

This three step process ensures the old file is closed,
no new file is opened, and the interpreter's internal state
is changed to "no file open"

@laurivosandi can you let me know if this fixes your issue?

Closes: #273