### PR TITLE
Consequently use "#!/usr/bin/env python".

### DIFF
--- a/scripts/update_ini
+++ b/scripts/update_ini
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 THIS_VERSION = "1.0"
 

--- a/src/emc/usr_intf/touchy/touchy.py
+++ b/src/emc/usr_intf/touchy/touchy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 
 # Touchy is Copyright (c) 2009  Chris Radek <chris@timeguy.com>

--- a/src/hal/user_comps/vismach/lineardelta.py
+++ b/src/hal/user_comps/vismach/lineardelta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #    Copyright 2013 Jeff Epler <jepler@unpythonic.net>
 #
 #    This program is free software; you can redistribute it and/or modify

--- a/src/hal/user_comps/vismach/rotarydelta.py
+++ b/src/hal/user_comps/vismach/rotarydelta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #    Copyright 2013 Jeff Epler <jepler@unpythonic.net>
 #
 #    This program is free software; you can redistribute it and/or modify

--- a/src/hal/user_comps/vismach/xyzac-trt-gui.py
+++ b/src/hal/user_comps/vismach/xyzac-trt-gui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #**************************************************************************
 # Copyright 2016 Rudy du Preez <rudy@asmsa.co.za>
 #

--- a/src/hal/user_comps/vismach/xyzbc-trt-gui.py
+++ b/src/hal/user_comps/vismach/xyzbc-trt-gui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #**************************************************************************
 # Copyright 2016 Rudy du Preez <rudy@asmsa.co.za>
 #

--- a/tests/mdi-while-queuebuster-waitflag/remap.py
+++ b/tests/mdi-while-queuebuster-waitflag/remap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import linuxcnc
 import emccanon
 import interpreter

--- a/tests/mdi-while-queuebuster-waitflag/toplevel.py
+++ b/tests/mdi-while-queuebuster-waitflag/toplevel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import remap
 
 def __init__(self):

--- a/tests/remap/remap-io/toplevel.py
+++ b/tests/remap/remap-io/toplevel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import remap
 
 def __init__(self):

--- a/tests/remap/remap-reentry/toplevel.py
+++ b/tests/remap/remap-reentry/toplevel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import remap
 
 def __init__(self):


### PR DESCRIPTION
This improves the situation on FreeBSD.

Signed-off-by: Edward Tomasz Napierala <trasz@FreeBSD.org>

