### PR TITLE
Apply show_tool rotations in original GEOMETRY order

### DIFF
--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -24,6 +24,7 @@ import linuxcnc
 import array
 import gcode
 import os
+import re
 
 def minmax(*args):
     return min(*args), max(*args)
@@ -1258,7 +1259,10 @@ class GlCanonDraw:
                 glPushMatrix()
                 glTranslatef(*pos)
                 sign = 1
-                for ch in self.get_geometry():
+                g = re.split(" *(-?[XYZABCUVW])", self.get_geometry())
+                g = "".join(reversed(g))
+
+                for ch in g: # Apply in orignal non-reversed GEOMETRY order
                     if ch == '-':
                         sign = -1
                     elif ch == 'A':


### PR DESCRIPTION
Impact is only for configs with more than one rotational axis.
Expectation is that rotations will be applied in the order of the GEOMETRY
attribute in the INI file. However when GEOMETRY is read in it is reversed.
This causes the tool rotations to be applied as -BA rather than A-B

Signed-off-by: Tom Schneider <cts@cs2corp.com>