### PR TITLE
glcanon signbug when show_tool if "-" on non-rotational axis

### DIFF
--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -1274,6 +1274,8 @@ class GlCanonDraw:
                     elif ch == 'C':
                         glRotatef(rz*sign, 0, 0, 1)
                         sign = 1
+                    else:
+                        sign = 1 # reset sign for non-rotational axis "XYZUVW"
                 glEnable(GL_BLEND)
                 glEnable(GL_CULL_FACE)
                 glBlendFunc(GL_ONE, GL_CONSTANT_ALPHA)


### PR DESCRIPTION
Show tool rotations could apply a negative rotation incorrectly

for example:
XY-ZA
would be processed as
XY-Z-A

when rendering the tool

Signed-off-by: Tom Schneider <cts@cs2corp.com>