### PR TITLE
axis.py: Dont try to convert unicode to unicode

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1321,8 +1321,10 @@ def jogspeed_listbox_change(dummy, value):
     iterator = iter(root_window.call(widgets.jogincr._w, "list", "get", "0", "end"))
     idx = 0
     cursel = -1
+    if isinstance(value, str): value = value.encode('utf-8', 'replace')
     for i in iterator:
-        if i == unicode(value, 'utf-8'):
+        if isinstance(i, str): i = i.encode('utf-8', 'replace')
+        if i == value:
             cursel= idx
             break
         idx += 1


### PR DESCRIPTION
I noticed when running in the ru_RU.UTF-8 locale that the message
  File "/home/jepler/src/linuxcnc/bin/axis", line 1419, in jogspeed_listbox_change
    if i == unicode(value, 'utf-8'):
TypeError: decoding Unicode is not supported
was displayed on the screen.  Almost certainly, the incremental
jog combobox would not behave properly when this error occurs.

Instead of making an assumption that 'i' is Unicode and 'value'
is 'bytes' (str), conditional reencode them based on their
runtime type.

Testing performed:
 * Test with LANG=C.UTF-8 and LANG=ru_RU.UTF_8
 * start axis, F1 F2
 * select continuous or incremental jog via keyboard
 * select continuous or incremental jog via mouse
 * with each selection, jogged X axis with arrow keys
No regressions detected.