### PR TITLE
Reenable translation of stepconf, pncconf

### DIFF
--- a/src/emc/usr_intf/pncconf/pncconf.py
+++ b/src/emc/usr_intf/pncconf/pncconf.py
@@ -1406,6 +1406,7 @@ class App:
         bar_size = 0
         # build the glade files
         self.builder = MultiFileBuilder()
+        self.builder.set_translation_domain(domain)
         self.builder.add_from_file(os.path.join(self._p.DATADIR,'main_page.glade'))
         self.builder.add_from_file(os.path.join(self._p.DATADIR,'dialogs.glade'))
         self.builder.add_from_file(os.path.join(self._p.DATADIR,'help.glade'))

--- a/src/emc/usr_intf/stepconf/stepconf.py
+++ b/src/emc/usr_intf/stepconf/stepconf.py
@@ -732,6 +732,7 @@ class StepconfApp:
 
         # build the glade files
         self.builder = MultiFileBuilder()
+        self.builder.set_translation_domain(domain)
         self.builder.add_from_file(os.path.join(datadir,'main_page.glade'))
         window = self.builder.get_object("window1")
         notebook1 = self.builder.get_object("notebook1")


### PR DESCRIPTION
Over in #319, @solitarily noted that translation of stepconf and pncconf wasn't working.  I looked into this, and it seems to affect 2.7 and master, probably due to some code that was lost when migrating to MultiFileBuilder.

Testing performed: start pncconf with LANG=en_US.UTF-8 and LANG=fr_FR.UTF-8

While many texts go untranslated due to out of date message catalogs, several of the standard buttons DO correctly translate after the change.

@SebKuzminsky OK for 2.7?

@solitarity can you verify that this fixes the ability to translate stepconf and pncconf for you?