### PR TITLE
homing: Added a requirement for immediate homing.

### DIFF
--- a/docs/src/config/ini-homing.txt
+++ b/docs/src/config/ini-homing.txt
@@ -269,6 +269,7 @@ the following ini entries for that axis are needed.
 . HOME_LATCH_VEL = 0
 . HOME_USE_INDEX = NO
 . HOME_SEQUENCE = 0
+. HOME equals to HOME_OFFSET
 
 === Inhibiting Homing (((Inhibiting Homing)))
 


### PR DESCRIPTION
I accidentally found that to achieve immediate homing, [AXIS_n]HOME should be equal to [AXIS_n]HOME_OFFSET. Otherwise, the machine would move a distance of (HOME - HOME_OFFSET) on the corresponding axis before changing current G53 coordinate to [AXIS_n]HOME, thus breaks "immediate homing".