### PR TITLE
all: update FSF address in GPL 2.0 notices

### DIFF
--- a/COPYING.more
+++ b/COPYING.more
@@ -19,8 +19,8 @@ NOT use LinuxCNC.
 		    GNU GENERAL PUBLIC LICENSE
 		       Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-     59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -323,7 +323,7 @@ the "copyright" line and a pointer to where the full notice is found.
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 Also add information on how to contact you by electronic and paper mail.

--- a/configs/apps/gladevcp/colored-label/coloredlabel.py
+++ b/configs/apps/gladevcp/colored-label/coloredlabel.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA''''''
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.''''''
 '''
     gladevcp colored label example
     Michael Haberler 2/2011

--- a/configs/apps/gladevcp/complex/complex.py
+++ b/configs/apps/gladevcp/complex/complex.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA''''''
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.''''''
 '''
     gladevcp complex demo example
     Michael Haberler 11/2010

--- a/configs/apps/gladevcp/templates/classhandler.py
+++ b/configs/apps/gladevcp/templates/classhandler.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 '''
     example gladevcp handler class to start your own
     no persistence support

--- a/configs/apps/gladevcp/templates/classhandler_persistent.py
+++ b/configs/apps/gladevcp/templates/classhandler_persistent.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 '''
     example gladevcp handler class with widget and attribute persistence support
 '''

--- a/configs/sim/axis/gladevcp/probe.py
+++ b/configs/sim/axis/gladevcp/probe.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA''''''
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.''''''
 '''
     gladevcp probe demo example
     Michael Haberler 11/2010

--- a/configs/sim/axis/lathe-fanucy/remap.py
+++ b/configs/sim/axis/lathe-fanucy/remap.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from stdglue import *
 

--- a/configs/sim/axis/lathe-fanucy/toplevel.py
+++ b/configs/sim/axis/lathe-fanucy/toplevel.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap
 

--- a/configs/sim/axis/ngcgui/fullscreen.py
+++ b/configs/sim/axis/ngcgui/fullscreen.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 
 

--- a/configs/sim/axis/orphans/iocontrol-removed/python/customtask.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/customtask.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import os
 import sys

--- a/configs/sim/axis/orphans/iocontrol-removed/python/embedding.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/embedding.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # a tour of accessing interpreter internals
 

--- a/configs/sim/axis/orphans/iocontrol-removed/python/nulluserfuncs.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/nulluserfuncs.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # empty extension object to make inheritance work
 

--- a/configs/sim/axis/orphans/iocontrol-removed/python/oword.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/oword.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import sys,os
 import interpreter

--- a/configs/sim/axis/orphans/iocontrol-removed/python/remap.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/remap.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from stdglue import *
 

--- a/configs/sim/axis/orphans/iocontrol-removed/python/sqltoolaccess.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/sqltoolaccess.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import os
 import re

--- a/configs/sim/axis/orphans/iocontrol-removed/python/task.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/task.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import sys
 import hal

--- a/configs/sim/axis/orphans/iocontrol-removed/python/tooltable.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/tooltable.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import os
 import re

--- a/configs/sim/axis/orphans/iocontrol-removed/python/toplevel.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/toplevel.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import os
 import interpreter

--- a/configs/sim/axis/orphans/iocontrol-removed/python/userfuncs.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/userfuncs.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import hal
 import emctask

--- a/configs/sim/axis/orphans/pysubs/customtask.py
+++ b/configs/sim/axis/orphans/pysubs/customtask.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import os
 import sys

--- a/configs/sim/axis/orphans/pysubs/nulluserfuncs.py
+++ b/configs/sim/axis/orphans/pysubs/nulluserfuncs.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # empty extension object to make inheritance work
 

--- a/configs/sim/axis/orphans/pysubs/oword.py
+++ b/configs/sim/axis/orphans/pysubs/oword.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import sys,os
 import interpreter

--- a/configs/sim/axis/orphans/pysubs/plugins.py
+++ b/configs/sim/axis/orphans/pysubs/plugins.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import os
 import interpreter

--- a/configs/sim/axis/orphans/pysubs/remap.py
+++ b/configs/sim/axis/orphans/pysubs/remap.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import os
 import signal

--- a/configs/sim/axis/orphans/pysubs/sqltoolaccess.py
+++ b/configs/sim/axis/orphans/pysubs/sqltoolaccess.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import os
 import re

--- a/configs/sim/axis/orphans/pysubs/task.py
+++ b/configs/sim/axis/orphans/pysubs/task.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import sys
 import hal

--- a/configs/sim/axis/orphans/pysubs/tooltable.py
+++ b/configs/sim/axis/orphans/pysubs/tooltable.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import os
 import re

--- a/configs/sim/axis/orphans/pysubs/userfuncs.py
+++ b/configs/sim/axis/orphans/pysubs/userfuncs.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import hal
 import emctask

--- a/configs/sim/axis/remap/cycle/python/remap.py
+++ b/configs/sim/axis/remap/cycle/python/remap.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from interpreter import *
 from emccanon import MESSAGE

--- a/configs/sim/axis/remap/cycle/python/toplevel.py
+++ b/configs/sim/axis/remap/cycle/python/toplevel.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap
 import os

--- a/configs/sim/axis/remap/extend-builtins/python/remap.py
+++ b/configs/sim/axis/remap/extend-builtins/python/remap.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from stdglue import *
 

--- a/configs/sim/axis/remap/extend-builtins/python/toplevel.py
+++ b/configs/sim/axis/remap/extend-builtins/python/toplevel.py
@@ -14,6 +14,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap

--- a/configs/sim/axis/remap/getting-started/python/oword.py
+++ b/configs/sim/axis/remap/getting-started/python/oword.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from util import call_pydevd
 

--- a/configs/sim/axis/remap/getting-started/python/remap.py
+++ b/configs/sim/axis/remap/getting-started/python/remap.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import sys
 import traceback

--- a/configs/sim/axis/remap/getting-started/python/toplevel.py
+++ b/configs/sim/axis/remap/getting-started/python/toplevel.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import oword
 import remap

--- a/configs/sim/axis/remap/getting-started/python/util.py
+++ b/configs/sim/axis/remap/getting-started/python/util.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import inspect
 import emccanon

--- a/configs/sim/axis/remap/manual-toolchange-with-tool-length-switch/python/remap.py
+++ b/configs/sim/axis/remap/manual-toolchange-with-tool-length-switch/python/remap.py
@@ -14,6 +14,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from stdglue import *

--- a/configs/sim/axis/remap/manual-toolchange-with-tool-length-switch/python/toplevel.py
+++ b/configs/sim/axis/remap/manual-toolchange-with-tool-length-switch/python/toplevel.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap
 

--- a/configs/sim/axis/remap/rack-toolchange/python/remap.py
+++ b/configs/sim/axis/remap/rack-toolchange/python/remap.py
@@ -14,6 +14,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from stdglue import *

--- a/configs/sim/axis/remap/rack-toolchange/python/toplevel.py
+++ b/configs/sim/axis/remap/rack-toolchange/python/toplevel.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap
 

--- a/configs/sim/axis/remap/stop-lookahead/python/remap.py
+++ b/configs/sim/axis/remap/stop-lookahead/python/remap.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import interpreter
 

--- a/configs/sim/axis/remap/stop-lookahead/python/toplevel.py
+++ b/configs/sim/axis/remap/stop-lookahead/python/toplevel.py
@@ -14,6 +14,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap

--- a/configs/sim/axis/vismach/VMC_toolchange/vmcgui
+++ b/configs/sim/axis/vismach/VMC_toolchange/vmcgui
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from vismach import *
 import hal

--- a/configs/sim/axis/vismach/puma/puma_link1.obj
+++ b/configs/sim/axis/vismach/puma/puma_link1.obj
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 ####
 # Object puma_link1.obj

--- a/configs/sim/axis/vismach/puma/puma_link2.obj
+++ b/configs/sim/axis/vismach/puma/puma_link2.obj
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 ####
 # Object puma_link2.obj

--- a/configs/sim/axis/vismach/puma/puma_link3.obj
+++ b/configs/sim/axis/vismach/puma/puma_link3.obj
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 ####
 # Object puma_link3.obj

--- a/configs/sim/axis/vismach/puma/puma_link4.obj
+++ b/configs/sim/axis/vismach/puma/puma_link4.obj
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 ####
 # Object puma_link4.obj

--- a/configs/sim/axis/vismach/puma/puma_link5.obj
+++ b/configs/sim/axis/vismach/puma/puma_link5.obj
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 ####
 # Object puma_link5.obj

--- a/configs/sim/axis/vismach/puma/puma_link6.obj
+++ b/configs/sim/axis/vismach/puma/puma_link6.obj
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 ####
 # Object puma_link6.obj

--- a/configs/sim/axis/vismach/puma/puma_link7.obj
+++ b/configs/sim/axis/vismach/puma/puma_link7.obj
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 ####
 # Object puma_link7.obj

--- a/configs/sim/axis/vismach/puma/puma_text.obj
+++ b/configs/sim/axis/vismach/puma/puma_text.obj
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 ####
 # Object puma_text.obj

--- a/configs/sim/gmoccapy/gmoccapy_plasma/plasma.py
+++ b/configs/sim/gmoccapy/gmoccapy_plasma/plasma.py
@@ -21,7 +21,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """
 

--- a/configs/sim/gmoccapy/gmoccapy_plasma/signals.py
+++ b/configs/sim/gmoccapy/gmoccapy_plasma/signals.py
@@ -24,7 +24,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """
 

--- a/configs/sim/gmoccapy/python/remap.py
+++ b/configs/sim/gmoccapy/python/remap.py
@@ -14,6 +14,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from stdglue import *

--- a/configs/sim/gmoccapy/python/stdglue.py
+++ b/configs/sim/gmoccapy/python/stdglue.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # gmoccapy - Remap of M6 for auto tool measurement
 

--- a/configs/sim/gmoccapy/python/toplevel.py
+++ b/configs/sim/gmoccapy/python/toplevel.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap
 

--- a/docs/html/gcode.html
+++ b/docs/html/gcode.html
@@ -15,7 +15,7 @@ Copyright (C) 2006, 2007 Jeff Epler
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -->
 <HTML>
 <HEAD>

--- a/docs/html/gcode_fr.html
+++ b/docs/html/gcode_fr.html
@@ -15,7 +15,7 @@ Copyright (C) 2006, 2007 Jeff Epler
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 -->
 <HTML>
 <HEAD>

--- a/docs/man/man1/axis-remote.1
+++ b/docs/man/man1/axis-remote.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/axis.1
+++ b/docs/man/man1/axis.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/gladevcp.1
+++ b/docs/man/man1/gladevcp.1
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH GLADEVCP "1"  "2010-12-20" "LinuxCNC Documentation" "The Enhanced Machine Controller"
 .SH NAME

--- a/docs/man/man1/gs2.1
+++ b/docs/man/man1/gs2.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/hal_manualtoolchange.1
+++ b/docs/man/man1/hal_manualtoolchange.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH hal_manualtoolchange 1 "04 APR 2017" "LinuxCNC Documentation" "HAL Userspace Component"
 .SH NAME

--- a/docs/man/man1/hal_parport.1
+++ b/docs/man/man1/hal_parport.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH hal_parport 1 "12 APR 2017" "LinuxCNC Documentation" "HAL Realtime Component"
 .SH NAME

--- a/docs/man/man1/halcmd.1
+++ b/docs/man/man1/halcmd.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/halcompile.1
+++ b/docs/man/man1/halcompile.1
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/halmeter.1
+++ b/docs/man/man1/halmeter.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/halrun.1
+++ b/docs/man/man1/halrun.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/halsampler.1
+++ b/docs/man/man1/halsampler.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/haltcl.1
+++ b/docs/man/man1/haltcl.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/halui.1
+++ b/docs/man/man1/halui.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/hy_vfd.1
+++ b/docs/man/man1/hy_vfd.1
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/mb2hal.1
+++ b/docs/man/man1/mb2hal.1
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/moveoff_gui.1
+++ b/docs/man/man1/moveoff_gui.1
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/pyvcp.1
+++ b/docs/man/man1/pyvcp.1
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH PYVCP "1"  "2007-04-01" "LinuxCNC Documentation" "The Enhanced Machine Controller"
 .SH NAME

--- a/docs/man/man1/sim_pin.1
+++ b/docs/man/man1/sim_pin.1
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/man/man1/vfdb_vfd.1
+++ b/docs/man/man1/vfdb_vfd.1
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\" $Id: vfdb_vfd.1,v 1.8 2009-09-19 13:49:34 mah Exp $

--- a/docs/man/man1/vfs11_vfd.1
+++ b/docs/man/man1/vfs11_vfd.1
@@ -19,7 +19,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\" $Id: vfs11_vfd.1,v 1.8 2009-09-19 13:49:34 mah Exp $

--- a/docs/man/man3/rtapi_bool.3rtapi
+++ b/docs/man/man3/rtapi_bool.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_byteorder.3rtapi
+++ b/docs/man/man3/rtapi_byteorder.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_device.3rtapi
+++ b/docs/man/man3/rtapi_device.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_firmware.3rtapi
+++ b/docs/man/man3/rtapi_firmware.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_gfp.3rtapi
+++ b/docs/man/man3/rtapi_gfp.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_io.3rtapi
+++ b/docs/man/man3/rtapi_io.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_is.3rtapi
+++ b/docs/man/man3/rtapi_is.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH rtapi_is "3rtapi" "2006-10-12" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_list.3rtapi
+++ b/docs/man/man3/rtapi_list.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_parport.3rtapi
+++ b/docs/man/man3/rtapi_parport.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH parport "3rtapi" "2006-10-12" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_pci.3rtapi
+++ b/docs/man/man3/rtapi_pci.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_slab.3rtapi
+++ b/docs/man/man3/rtapi_slab.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_stdint.3rtapi
+++ b/docs/man/man3/rtapi_stdint.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man3/rtapi_string.3rtapi
+++ b/docs/man/man3/rtapi_string.3rtapi
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH funct "3rtapi" "2014-06-28" "LinuxCNC Documentation" "RTAPI"
 .SH NAME

--- a/docs/man/man9/hm2_eth.9
+++ b/docs/man/man9/hm2_eth.9
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH HM2_ETH "9" "2008-05-13" "LinuxCNC Documentation" "HAL Component"
 .de TQ

--- a/docs/man/man9/hm2_rpspi.9
+++ b/docs/man/man9/hm2_rpspi.9
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH HM2_RPSPI "9" "2017-06-05" "LinuxCNC Documentation" "HAL Component"
 .de TQ

--- a/docs/man/man9/hm2_spi.9
+++ b/docs/man/man9/hm2_spi.9
@@ -17,7 +17,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .TH HM2_SPI "9" "2008-05-13" "LinuxCNC Documentation" "HAL Component"
 .de TQ

--- a/docs/man/man9/sampler.9
+++ b/docs/man/man9/sampler.9
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/docs/src/common/GPLD_Copyright_fr.txt
+++ b/docs/src/common/GPLD_Copyright_fr.txt
@@ -20,8 +20,8 @@ Free Documentation License".
 
 GNU Free Documentation License Version 1.1, March 2000
 
-Copyright (C) 2000 Free Software Foundation, Inc. 59 Temple Place,
-Suite 330, Boston, MA 02111-1307 USA Everyone is permitted to copy and
+Copyright (C) 2000 Free Software Foundation, Inc. 51 Franklin Street,
+Fifth Floor, Boston, MA 02110-1301 USA. Everyone is permitted to copy and
 distribute verbatim copies of this license document, but changing it is
 not allowed.
 

--- a/docs/src/common/gpld-copyright.txt
+++ b/docs/src/common/gpld-copyright.txt
@@ -16,8 +16,8 @@ Free Documentation License".
 
 GNU Free Documentation License Version 1.1, March 2000
 
-Copyright (C) 2000 Free Software Foundation, Inc. 59 Temple Place,
-Suite 330, Boston, MA 02111-1307 USA Everyone is permitted to copy and
+Copyright (C) 2000 Free Software Foundation, Inc. 51 Franklin Street,
+Fifth Floor, Boston, MA 02110-1301 USA. Everyone is permitted to copy and
 distribute verbatim copies of this license document, but changing it is
 not allowed.
 

--- a/docs/src/common/overleaf_fr.txt
+++ b/docs/src/common/overleaf_fr.txt
@@ -13,7 +13,7 @@ Permission is granted to copy, distribute and/or modify this document under
  license is included in the section entitled 
  "GNU Free Documentation License".. 
  If you do not find the license you may order a copy from Free Software 
- Foundation, Inc. 59 Temple Place, Suite 330 Boston, MA 02111-1307
+ Foundation, Inc. 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 LINUX® is the registered trademark of Linus Torvalds in the U.S. and other
 countries.  The registered trademark Linux® is used pursuant to a sublicense
@@ -27,7 +27,7 @@ toute version ultérieure publiée par la « Free Software Foundation »; sans
  couverture.  Une copie de la licence est incluse dans la section 
  intitulée « GNU Free Documentation License ». Si vous ne trouvez pas 
  la licence vous pouvez en commander un exemplaire chez Free Software 
- Foundation, Inc. 59 Temple Place, Suite 330 Boston, MA 02111-1307 
+ Foundation, Inc. 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
  (La version de langue anglaise fait foi)
 

--- a/docs/src/man/man1/linuxcnc.1.in
+++ b/docs/src/man/man1/linuxcnc.1.in
@@ -18,7 +18,7 @@
 .\"
 .\" You should have received a copy of the GNU General Public
 .\" License along with this manual; if not, write to the Free
-.\" Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111,
+.\" Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
 .\" USA.
 .\"
 .\"

--- a/lib/hallib/hookup_moveoff.tcl
+++ b/lib/hallib/hookup_moveoff.tcl
@@ -81,7 +81,7 @@ source [file join $::env(HALLIB_DIR) hal_procs_lib.tcl]
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 
 proc do_hal {args} {

--- a/lib/hallib/xhc-hb04.tcl
+++ b/lib/hallib/xhc-hb04.tcl
@@ -71,7 +71,7 @@ source [file join $::env(HALLIB_DIR) util_lib.tcl]
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 
 proc is_uniq {list_name} {

--- a/lib/python/bitfile.py
+++ b/lib/python/bitfile.py
@@ -12,7 +12,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #
 # Info about Xilinx bitfiles:

--- a/lib/python/bwidget.py
+++ b/lib/python/bwidget.py
@@ -12,7 +12,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """Wrapper for BWidget family of widgets"""
 

--- a/lib/python/gladevcp/hal_gremlin_plus.py
+++ b/lib/python/gladevcp/hal_gremlin_plus.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #------------------------------------------------------------------------------
 
 import sys

--- a/lib/python/gladevcp/hal_pyngcgui.py
+++ b/lib/python/gladevcp/hal_pyngcgui.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #------------------------------------------------------------------------------
 
 import os

--- a/lib/python/gladevcp/iconview.py
+++ b/lib/python/gladevcp/iconview.py
@@ -24,7 +24,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 '''
 

--- a/lib/python/gladevcp/makepins.py
+++ b/lib/python/gladevcp/makepins.py
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import sys
 import gtk
 import hal

--- a/lib/python/gladevcp/persistence.py
+++ b/lib/python/gladevcp/persistence.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA'''
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.'''
 '''
     persistence support for gladevcp widgets
     Michael Haberler 11/2010

--- a/lib/python/gremlin_view.py
+++ b/lib/python/gremlin_view.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #------------------------------------------------------------------------------
 
 """gremlin_view

--- a/lib/python/hershey.py
+++ b/lib/python/hershey.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from minigl import *
 

--- a/lib/python/linux_event.py
+++ b/lib/python/linux_event.py
@@ -12,7 +12,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import struct, fcntl, array, os, select, glob, fnmatch, time, re
 

--- a/lib/python/multifilebuilder.py
+++ b/lib/python/multifilebuilder.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import gtk
 
 __all__ = ['MultiFileBuilder']

--- a/lib/python/multifilebuilder_gtk3.py
+++ b/lib/python/multifilebuilder_gtk3.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 from gi.repository import Gtk
 
 __all__ = ['MultiFileBuilder']

--- a/lib/python/nf.py.in
+++ b/lib/python/nf.py.in
@@ -12,7 +12,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import os
 import Tkinter

--- a/lib/python/popupkeyboard.py
+++ b/lib/python/popupkeyboard.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #------------------------------------------------------------------------------
 
 """

--- a/lib/python/propertywindow.py
+++ b/lib/python/propertywindow.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import Tkinter
 

--- a/lib/python/pyngcgui.py
+++ b/lib/python/pyngcgui.py
@@ -33,7 +33,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #------------------------------------------------------------------------------
 """ python classes to implement an ngcgui-like application
 

--- a/lib/python/pyvcp_widgets.py
+++ b/lib/python/pyvcp_widgets.py
@@ -23,7 +23,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """ A widget library for pyVCP 
     

--- a/lib/python/rs274/__init__.py
+++ b/lib/python/rs274/__init__.py
@@ -13,6 +13,6 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from interpret import Translated, ArcsToSegmentsMixin

--- a/lib/python/rs274/author.py
+++ b/lib/python/rs274/author.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import sys, math
 

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from rs274 import Translated, ArcsToSegmentsMixin, OpenGLTk
 from minigl import *

--- a/lib/python/rs274/interpret.py
+++ b/lib/python/rs274/interpret.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import math, gcode
 
 class Translated:

--- a/lib/python/rs274/options.py
+++ b/lib/python/rs274/options.py
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import nf, os
 

--- a/lib/python/vcpparse.py
+++ b/lib/python/vcpparse.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """
     Parses a pyVCP XML file and creates widgets by calling pyvcp_widgets.py

--- a/lib/python/vismach.py
+++ b/lib/python/vismach.py
@@ -12,7 +12,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import rs274.OpenGLTk, Tkinter, signal, hal
 from minigl import *

--- a/nc_files/gcmc_lib/star.gcmc
+++ b/nc_files/gcmc_lib/star.gcmc
@@ -45,7 +45,7 @@ include("ensure_units.gcmc"); //avoid preamble conflict
  
   You should have received a copy of the GNU General Public License
   along with this program; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 

--- a/nc_files/gcmc_lib/wheels.gcmc
+++ b/nc_files/gcmc_lib/wheels.gcmc
@@ -45,7 +45,7 @@ include("ensure_units.gcmc"); //avoid preamble conflict
  
   You should have received a copy of the GNU General Public License
   along with this program; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 /********************************************************/

--- a/nc_files/ngcgui_lib/arc1.ngc
+++ b/nc_files/ngcgui_lib/arc1.ngc
@@ -29,7 +29,7 @@
 ;
 ; You should have received a copy of the GNU General Public License
 ; along with this program; if not, write to the Free Software
-; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ;----------------------------------------------------------------------
 
 o<arc1> sub

--- a/nc_files/ngcgui_lib/qpocket.ngc
+++ b/nc_files/ngcgui_lib/qpocket.ngc
@@ -52,7 +52,7 @@
 ;
 ; You should have received a copy of the GNU General Public License
 ; along with this program; if not, write to the Free Software
-; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ;----------------------------------------------------------------------
 
 o<qpocket>  sub

--- a/scripts/decode_dmesg
+++ b/scripts/decode_dmesg
@@ -44,4 +44,4 @@ for line in sys.stdin:
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/scripts/gladevcp_demo
+++ b/scripts/gladevcp_demo
@@ -21,7 +21,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 prog=$(basename $0)
 

--- a/scripts/hal-histogram
+++ b/scripts/hal-histogram
@@ -18,7 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 
 # library procs:

--- a/scripts/latency-histogram
+++ b/scripts/latency-histogram
@@ -20,7 +20,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 
 

--- a/scripts/latency-plot
+++ b/scripts/latency-plot
@@ -22,7 +22,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 package require Tk 8.5 ;# needed for clock milliseconds
 

--- a/scripts/linuxcnc_info
+++ b/scripts/linuxcnc_info
@@ -18,7 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 ofile=/tmp/linuxcnc.info
 # all output

--- a/scripts/linuxcnc_var.in
+++ b/scripts/linuxcnc_var.in
@@ -19,7 +19,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 function usage () {
   cat <<EOF
 

--- a/scripts/monitor-xhc-hb04
+++ b/scripts/monitor-xhc-hb04
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 
 set ::progname [file tail $::argv0]

--- a/scripts/moveoff_gui
+++ b/scripts/moveoff_gui
@@ -32,7 +32,7 @@ source [file join $hallib_dir util_lib.tcl]
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 proc wmposition {top} {
   set geo [wm geometry $top]

--- a/scripts/platform-is-supported
+++ b/scripts/platform-is-supported
@@ -19,7 +19,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import os
 import sys

--- a/scripts/pyvcp_demo
+++ b/scripts/pyvcp_demo
@@ -21,7 +21,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 prog=$(basename $0)
 
 function usage () {

--- a/scripts/rip-environment.in
+++ b/scripts/rip-environment.in
@@ -22,7 +22,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 case "$0" in
     rip-environment|*/rip-environment)

--- a/scripts/torture.py
+++ b/scripts/torture.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
 This program creates "torture test" ngc files.  These include arcs (helices)
 in any plane, straight feeds, and traverses all in a random order with

--- a/share/axis/tcl/accel.tcl
+++ b/share/axis/tcl/accel.tcl
@@ -13,7 +13,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # Each label, button, checkbutton, radiobutton, and menubutton can have
 # an underlined accelerator key.

--- a/share/axis/tcl/axis.tcl
+++ b/share/axis/tcl/axis.tcl
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 lappend auto_path $::linuxcnc::TCL_LIB_DIR
 

--- a/share/axis/tcl/dialog.tcl
+++ b/share/axis/tcl/dialog.tcl
@@ -13,7 +13,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # dialog.tcl --
 #

--- a/share/axis/tcl/sb.tcl
+++ b/share/axis/tcl/sb.tcl
@@ -13,7 +13,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 namespace eval ::sb {}
 

--- a/share/axis/tcl/support.tcl
+++ b/share/axis/tcl/support.tcl
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package require Img
 package require img::png

--- a/share/gscreen/skins/9_axis/9_axis_handler.py
+++ b/share/gscreen/skins/9_axis/9_axis_handler.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # This is a handler file for using Gscreen's infrastructure
 # to load a completely custom glade screen

--- a/share/gscreen/skins/gaxis/gaxis_handler.py
+++ b/share/gscreen/skins/gaxis/gaxis_handler.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import hal
 import gtk

--- a/share/gscreen/skins/gaxis_no_plot/gaxis_no_plot_handler.py
+++ b/share/gscreen/skins/gaxis_no_plot/gaxis_no_plot_handler.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import hal
 import gtk
 _X = 0;_Y = 1;_Z = 2;_A = 3;_B = 4;_C = 5;_U = 6;_V = 7;_W = 8

--- a/share/gscreen/skins/industrial/industrial_handler.py
+++ b/share/gscreen/skins/industrial/industrial_handler.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import hal
 import gtk

--- a/share/gscreen/skins/spartan/spartan_handler.py
+++ b/share/gscreen/skins/spartan/spartan_handler.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #############################################################################
 # This is a gscreen skin customized for a Bridgeport Interact Mill that used a

--- a/share/gtksourceview-2.0/language-specs/gcode.lang
+++ b/share/gtksourceview-2.0/language-specs/gcode.lang
@@ -16,7 +16,7 @@
 
  You should have received a copy of the GNU General Public License
  along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA	02111-1307	USA
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 -->
 <language id="gcode" _name="Gcode" version="2.0" _section="Others">

--- a/src/emc/ini/emcIniFile.cc
+++ b/src/emc/ini/emcIniFile.cc
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/emc/ini/emcIniFile.hh
+++ b/src/emc/ini/emcIniFile.hh
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/emc/ini/inihal.cc
+++ b/src/emc/ini/inihal.cc
@@ -16,7 +16,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ----------------------------------------------------------------------*/
 #include "rcs_print.hh"
 #include "emc.hh"

--- a/src/emc/ini/inihal.hh
+++ b/src/emc/ini/inihal.hh
@@ -15,7 +15,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ----------------------------------------------------------------------*/
 #ifndef INIHAL_H
 #define INIHAL_H

--- a/src/emc/kinematics/lineardeltakins-common.h
+++ b/src/emc/kinematics/lineardeltakins-common.h
@@ -14,7 +14,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /*
  * Kinematics for a rostock-style delta robot
  *

--- a/src/emc/kinematics/lineardeltakins.c
+++ b/src/emc/kinematics/lineardeltakins.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "hal.h"
 #include "kinematics.h"

--- a/src/emc/kinematics/lineardeltakins.cc
+++ b/src/emc/kinematics/lineardeltakins.cc
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <cmath>
 #define isnan(x) std::isnan(x)

--- a/src/emc/kinematics/rosekins.c
+++ b/src/emc/kinematics/rosekins.c
@@ -13,7 +13,7 @@
 
   You should have received a copy of the GNU General Public License
   along with this program; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 #include "kinematics.h"

--- a/src/emc/kinematics/rotarydeltakins-common.h
+++ b/src/emc/kinematics/rotarydeltakins-common.h
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 /*

--- a/src/emc/kinematics/rotarydeltakins.c
+++ b/src/emc/kinematics/rotarydeltakins.c
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "hal.h"
 #include "kinematics.h"

--- a/src/emc/kinematics/rotarydeltakins.cc
+++ b/src/emc/kinematics/rotarydeltakins.cc
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <cmath>
 #include "rotarydeltakins-common.h"

--- a/src/emc/kinematics/xyzac-trt-kins.c
+++ b/src/emc/kinematics/xyzac-trt-kins.c
@@ -13,7 +13,7 @@
 *
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 **************************************************************************/
 
 /********************************************************************

--- a/src/emc/kinematics/xyzbc-trt-kins.c
+++ b/src/emc/kinematics/xyzbc-trt-kins.c
@@ -13,7 +13,7 @@
 *
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 **************************************************************************/
 
 /********************************************************************

--- a/src/emc/motion/dbuf.c
+++ b/src/emc/motion/dbuf.c
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifdef RTAPI
 #else

--- a/src/emc/motion/dbuf.h
+++ b/src/emc/motion/dbuf.h
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef DBUF_H
 #define DBUF_H

--- a/src/emc/motion/stashf.c
+++ b/src/emc/motion/stashf.c
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include "stashf.h"
 #include "dbuf.h"

--- a/src/emc/motion/stashf.h
+++ b/src/emc/motion/stashf.h
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef STASHF_H
 #define STASHF_H

--- a/src/emc/motion/stashf_wrap.h
+++ b/src/emc/motion/stashf_wrap.h
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef EXTRA
 #define EXTRA

--- a/src/emc/nml_intf/debugflags.h
+++ b/src/emc/nml_intf/debugflags.h
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // factored out from emcglb.h so subsystems not requiring the
 // emcglb.h defines may include them as well

--- a/src/emc/nml_intf/emctool.h
+++ b/src/emc/nml_intf/emctool.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef EMCTOOL_H
 #define EMCTOOL_H

--- a/src/emc/nml_intf/motion_types.h
+++ b/src/emc/nml_intf/motion_types.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #define EMC_MOTION_TYPE_TRAVERSE 1
 #define EMC_MOTION_TYPE_FEED 2
 #define EMC_MOTION_TYPE_ARC 3

--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "python_plugin.hh"
 #include "inifile.hh"

--- a/src/emc/pythonplugin/python_plugin.hh
+++ b/src/emc/pythonplugin/python_plugin.hh
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #ifndef PYTHON_PLUGIN_HH
 #define PYTHON_PLUGIN_HH

--- a/src/emc/pythonplugin/testpp.cc
+++ b/src/emc/pythonplugin/testpp.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // test harness for python_plugin
 

--- a/src/emc/rs274ngc/canonmodule.cc
+++ b/src/emc/rs274ngc/canonmodule.cc
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include <boost/python/def.hpp>
 #include <boost/python/module.hpp>

--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -14,7 +14,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <Python.h>
 #include <structmember.h>

--- a/src/emc/rs274ngc/interp_array_types.hh
+++ b/src/emc/rs274ngc/interp_array_types.hh
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 typedef pp::array_1_t< int, ACTIVE_G_CODES> active_g_codes_array, (*active_g_codes_w)( Interp & );

--- a/src/emc/rs274ngc/interp_python.cc
+++ b/src/emc/rs274ngc/interp_python.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // Support for embedding Python in the RS274NGC interpreter
 // with access to Interp and Canon

--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include <string.h>
 #include "rs274ngc_interp.hh"

--- a/src/emc/rs274ngc/interpmodule.cc
+++ b/src/emc/rs274ngc/interpmodule.cc
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // Interpreter internals - Python bindings
 // Michael Haberler 7/2011

--- a/src/emc/rs274ngc/paramclass.hh
+++ b/src/emc/rs274ngc/paramclass.hh
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include <boost/python/list.hpp>
 

--- a/src/emc/rs274ngc/pyarrays.cc
+++ b/src/emc/rs274ngc/pyarrays.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // Interpreter internals - Python bindings
 // Michael Haberler 7/2011

--- a/src/emc/rs274ngc/pyblock.cc
+++ b/src/emc/rs274ngc/pyblock.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // Interpreter internals - Python bindings
 // Michael Haberler 7/2011

--- a/src/emc/rs274ngc/pyemctypes.cc
+++ b/src/emc/rs274ngc/pyemctypes.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // Interpreter internals - Python bindings
 // Michael Haberler 7/2011

--- a/src/emc/rs274ngc/pyinterp1.cc
+++ b/src/emc/rs274ngc/pyinterp1.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // Interpreter internals - Python bindings
 // Michael Haberler 7/2011

--- a/src/emc/rs274ngc/pyparamclass.cc
+++ b/src/emc/rs274ngc/pyparamclass.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // Interpreter internals - Python bindings
 // Michael Haberler 7/2011

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef RS274NGC_INTERP_H
 #define RS274NGC_INTERP_H

--- a/src/emc/rs274ngc/rs274ngc_return.hh
+++ b/src/emc/rs274ngc/rs274ngc_return.hh
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RS274NGC_RETURN_HH
 #define RS274NGC_RETURN_HH
 #include "interp_return.hh"

--- a/src/emc/rs274ngc/tool_parse.cc
+++ b/src/emc/rs274ngc/tool_parse.cc
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>

--- a/src/emc/rs274ngc/tool_parse.h
+++ b/src/emc/rs274ngc/tool_parse.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef TOOL_PARSE_H
 #define TOOL_PARSE_H
 

--- a/src/emc/sai/builtin_modules.cc
+++ b/src/emc/sai/builtin_modules.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #include "python_plugin.hh"
 

--- a/src/emc/sai/dummyemcstat.cc
+++ b/src/emc/sai/dummyemcstat.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // keep linker happy so TaskMod can be resolved
 

--- a/src/emc/task/backtrace.cc
+++ b/src/emc/task/backtrace.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // based on http://stackoverflow.com/questions/4636456/stack-trace-for-c-using-gcc/4732119#4732119
 #include <stdio.h>

--- a/src/emc/task/signalhandler.cc
+++ b/src/emc/task/signalhandler.cc
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // generate a backtrace from a signal handler,
 // or alternatively start gdb in a new window

--- a/src/emc/task/task.hh
+++ b/src/emc/task/task.hh
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef EMC_TASK_HH
 #define EMC_TASK_HH
 #include "taskclass.hh"

--- a/src/emc/task/taskclass.hh
+++ b/src/emc/task/taskclass.hh
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #ifndef TASKCLASS_HH
 #define TASKCLASS_HH

--- a/src/emc/task/taskmodule.cc
+++ b/src/emc/task/taskmodule.cc
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 // TODO: reuse interp converters
 

--- a/src/emc/usr_intf/axis/README
+++ b/src/emc/usr_intf/axis/README
@@ -39,7 +39,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 Portions of the program, located in the "thirdparty" subdirectory of the

--- a/src/emc/usr_intf/axis/extensions/_toglmodule.c
+++ b/src/emc/usr_intf/axis/extensions/_toglmodule.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <Python.h>
 #include <emc/usr_intf/axis/extensions/togl.c>
 static int first_time = 1;

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -14,7 +14,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #define __STDC_FORMAT_MACROS
 #include <Python.h>

--- a/src/emc/usr_intf/axis/extensions/minigl.c
+++ b/src/emc/usr_intf/axis/extensions/minigl.c
@@ -14,7 +14,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <Python.h>
 #define GL_GLEXT_PROTOTYPES

--- a/src/emc/usr_intf/axis/scripts/axis-remote.py
+++ b/src/emc/usr_intf/axis/scripts/axis-remote.py
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """\
 axis-remote: trigger commands in a running AXIS GUI

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 # import pdb

--- a/src/emc/usr_intf/axis/scripts/image-to-gcode.py
+++ b/src/emc/usr_intf/axis/scripts/image-to-gcode.py
@@ -8,8 +8,8 @@
 ## warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
 ## the GNU General Public License for more details.  You should have
 ## received a copy of the GNU General Public License along with image-to-gcode;
-## if not, write to the Free Software Foundation, Inc., 59 Temple Place,
-## Suite 330, Boston, MA 02111-1307 USA
+## if not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+## Fifth Floor, Boston, MA 02110-1301 USA.
 ## 
 ## image-to-gcode.py is Copyright (C) 2005 Chris Radek
 ## chris@timeguy.com

--- a/src/emc/usr_intf/axis/scripts/lintini.py
+++ b/src/emc/usr_intf/axis/scripts/lintini.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import sys, os
 import linuxcnc

--- a/src/emc/usr_intf/axis/scripts/linuxcnctop.py
+++ b/src/emc/usr_intf/axis/scripts/linuxcnctop.py
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import sys, os
 import linuxcnc, time

--- a/src/emc/usr_intf/axis/scripts/mdi.py
+++ b/src/emc/usr_intf/axis/scripts/mdi.py
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 '''Manual Data Input - issue a single line of g-code to the running system
 

--- a/src/emc/usr_intf/axis/scripts/teach-in.py
+++ b/src/emc/usr_intf/axis/scripts/teach-in.py
@@ -20,7 +20,7 @@ run-in-place.
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import linuxcnc
 import Tkinter

--- a/src/emc/usr_intf/gmoccapy/dialogs.py
+++ b/src/emc/usr_intf/gmoccapy/dialogs.py
@@ -19,7 +19,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 '''
 

--- a/src/emc/usr_intf/gmoccapy/getiniinfo.py
+++ b/src/emc/usr_intf/gmoccapy/getiniinfo.py
@@ -20,7 +20,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 '''
 

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -22,7 +22,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """
 

--- a/src/emc/usr_intf/gmoccapy/notification.py
+++ b/src/emc/usr_intf/gmoccapy/notification.py
@@ -18,7 +18,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 '''
 

--- a/src/emc/usr_intf/gmoccapy/player.py
+++ b/src/emc/usr_intf/gmoccapy/player.py
@@ -20,7 +20,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 '''
 import gobject

--- a/src/emc/usr_intf/gmoccapy/widgets.py
+++ b/src/emc/usr_intf/gmoccapy/widgets.py
@@ -20,7 +20,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 '''
 

--- a/src/emc/usr_intf/gremlin/gremlin.py
+++ b/src/emc/usr_intf/gremlin/gremlin.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #    2014 Steffen Noack
 #    add property 'mouse_btn_mode'

--- a/src/emc/usr_intf/gscreen/gscreen.py
+++ b/src/emc/usr_intf/gscreen/gscreen.py
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """
 # Gscreen is made for running linuxcnc CNC machines

--- a/src/emc/usr_intf/pncconf/build_HAL.py
+++ b/src/emc/usr_intf/pncconf/build_HAL.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #    This builds the HAL files from the collected data.
 #

--- a/src/emc/usr_intf/pncconf/pages.py
+++ b/src/emc/usr_intf/pncconf/pages.py
@@ -18,7 +18,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # This presents and collects the data from the GUI pages
 #

--- a/src/emc/usr_intf/pncconf/pncconf.py
+++ b/src/emc/usr_intf/pncconf/pncconf.py
@@ -17,7 +17,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import sys
 import os

--- a/src/emc/usr_intf/pncconf/private_data.py
+++ b/src/emc/usr_intf/pncconf/private_data.py
@@ -18,7 +18,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #
 

--- a/src/emc/usr_intf/pncconf/tests.py
+++ b/src/emc/usr_intf/pncconf/tests.py
@@ -17,7 +17,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USAimport os
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.import os
 import os
 import gtk
 import time

--- a/src/emc/usr_intf/stepconf/build_HAL.py
+++ b/src/emc/usr_intf/stepconf/build_HAL.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #    This builds the HAL files from the collected data.
 #

--- a/src/emc/usr_intf/stepconf/build_INI.py
+++ b/src/emc/usr_intf/stepconf/build_INI.py
@@ -17,7 +17,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #    This builds the INI file from the collected data.
 #

--- a/src/emc/usr_intf/stepconf/import_mach.py
+++ b/src/emc/usr_intf/stepconf/import_mach.py
@@ -17,7 +17,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
 from xml.dom.minidom import parseString

--- a/src/emc/usr_intf/stepconf/pages.py
+++ b/src/emc/usr_intf/stepconf/pages.py
@@ -17,7 +17,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # This presents and collects the data from the GUI pages
 #

--- a/src/emc/usr_intf/stepconf/stepconf.py
+++ b/src/emc/usr_intf/stepconf/stepconf.py
@@ -20,7 +20,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #import pygtk
 #pygtk.require("2.0")

--- a/src/hal/classicladder/arithm_eval.c
+++ b/src/hal/classicladder/arithm_eval.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #ifdef MODULE
 #include <linux/string.h>

--- a/src/hal/classicladder/arithm_eval.h
+++ b/src/hal/classicladder/arithm_eval.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #define arithmtype int
 

--- a/src/hal/classicladder/arrays.c
+++ b/src/hal/classicladder/arrays.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 // this code has been highly modified for EMC 2
 // EMC uses RTAPI realtime code to allocate shared memory / run calculations

--- a/src/hal/classicladder/calc.c
+++ b/src/hal/classicladder/calc.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #ifdef MODULE
 #include <linux/module.h>

--- a/src/hal/classicladder/calc.h
+++ b/src/hal/classicladder/calc.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 void InitRungs(void);
 void PrepareRungs(void);

--- a/src/hal/classicladder/calc_sequential.c
+++ b/src/hal/classicladder/calc_sequential.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #ifdef MODULE
 #include <linux/string.h>

--- a/src/hal/classicladder/calc_sequential.h
+++ b/src/hal/classicladder/calc_sequential.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void InitSequential( void );
 void PrepareSequential( void );
 void RefreshSequentialPage( int PageNbr );

--- a/src/hal/classicladder/classicladder.c
+++ b/src/hal/classicladder/classicladder.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 // This is an adaption of classicladder V7.124 For EMC
 // most of this file is very different from the original

--- a/src/hal/classicladder/classicladder.h
+++ b/src/hal/classicladder/classicladder.h
@@ -16,7 +16,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 /* if GTK not included before */
 #ifndef TRUE

--- a/src/hal/classicladder/classicladder_gtk.c
+++ b/src/hal/classicladder/classicladder_gtk.c
@@ -19,7 +19,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 // Chris Morley (EMC2) Jan 08
 
 #include <gtk/gtk.h>

--- a/src/hal/classicladder/classicladder_gtk.h
+++ b/src/hal/classicladder/classicladder_gtk.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void UpdateVScrollBar();
 void save_label_comment_edited();
 void refresh_label_comment( void );

--- a/src/hal/classicladder/config.c
+++ b/src/hal/classicladder/config.c
@@ -19,7 +19,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/hal/classicladder/config.h
+++ b/src/hal/classicladder/config.h
@@ -12,5 +12,5 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 int read_config (char * fname);

--- a/src/hal/classicladder/config_gtk.c
+++ b/src/hal/classicladder/config_gtk.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 //Chris Morley July 08
 
 #include <gtk/gtk.h>

--- a/src/hal/classicladder/config_gtk.h
+++ b/src/hal/classicladder/config_gtk.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void OpenConfigWindowGtk();
 void IntConfigWindowGtk();
 void destroyConfigWindow();

--- a/src/hal/classicladder/drawing.c
+++ b/src/hal/classicladder/drawing.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <gtk/gtk.h>
 #include <stdio.h>

--- a/src/hal/classicladder/drawing.h
+++ b/src/hal/classicladder/drawing.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #define DRAW_NORMAL 0
 #define DRAW_FOR_TOOLBAR 1
 #define DRAW_FOR_PRINT 2

--- a/src/hal/classicladder/drawing_sequential.c
+++ b/src/hal/classicladder/drawing_sequential.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <gtk/gtk.h>
 #include <stdio.h>

--- a/src/hal/classicladder/drawing_sequential.h
+++ b/src/hal/classicladder/drawing_sequential.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void DrawSeqStep(GdkPixmap * DrawPixmap,int x,int y,int Size,StrStep * pStep,char DrawingOption);
 void DrawSeqTransition(GdkPixmap * DrawPixmap,int x,int y,int Size,StrTransition * pTransi,char DrawingOption);
 

--- a/src/hal/classicladder/edit.c
+++ b/src/hal/classicladder/edit.c
@@ -21,7 +21,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 
 #include <gtk/gtk.h>

--- a/src/hal/classicladder/edit.h
+++ b/src/hal/classicladder/edit.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #define MODE_MODIFY 0
 #define MODE_ADD 1
 #define MODE_INSERT 2

--- a/src/hal/classicladder/edit_gtk.c
+++ b/src/hal/classicladder/edit_gtk.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <gtk/gtk.h>
 #include <stdio.h>

--- a/src/hal/classicladder/edit_gtk.h
+++ b/src/hal/classicladder/edit_gtk.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void EditorButtonsAccordingSectionType( );
 void ButtonCancelCurrentRung();
 void OpenEditWindow( void );

--- a/src/hal/classicladder/edit_sequential.c
+++ b/src/hal/classicladder/edit_sequential.c
@@ -21,7 +21,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 
 #include <gtk/gtk.h>

--- a/src/hal/classicladder/edit_sequential.h
+++ b/src/hal/classicladder/edit_sequential.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void SaveSeqElementProperties( void );
 void ModifyCurrentSeqPage(void);
 void CancelSeqPageEdited(void);

--- a/src/hal/classicladder/editproperties_gtk.c
+++ b/src/hal/classicladder/editproperties_gtk.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <gtk/gtk.h>
 #include <stdio.h>

--- a/src/hal/classicladder/editproperties_gtk.h
+++ b/src/hal/classicladder/editproperties_gtk.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void SetProperty(int NumParam,char * LblParam,char * ValParam);
 char * GetProperty(int NumParam);
 void ShowPropertiesWindow( int Visible );

--- a/src/hal/classicladder/emc_mods.c
+++ b/src/hal/classicladder/emc_mods.c
@@ -16,7 +16,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 
 #include "hal.h"

--- a/src/hal/classicladder/emc_mods.h
+++ b/src/hal/classicladder/emc_mods.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 char * ConvVarNameToHalSigName( char * VarNameParam );
 char * FirstVariableInArithm(char * Expr);
 void SymbolsAutoAssign (void);

--- a/src/hal/classicladder/files.c
+++ b/src/hal/classicladder/files.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <stdio.h>
 #include <string.h>

--- a/src/hal/classicladder/files.h
+++ b/src/hal/classicladder/files.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef S_LINE
 //#define S_LINE "<!--"
 //#define E_LINE "-->"

--- a/src/hal/classicladder/files_project.c
+++ b/src/hal/classicladder/files_project.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <stdio.h>
 #include <string.h>

--- a/src/hal/classicladder/files_project.h
+++ b/src/hal/classicladder/files_project.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 void VerifyDirectorySelected( char * NewDir );
 void InitTempDir( void );

--- a/src/hal/classicladder/files_sequential.c
+++ b/src/hal/classicladder/files_sequential.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <stdio.h>
 #include <string.h>

--- a/src/hal/classicladder/files_sequential.h
+++ b/src/hal/classicladder/files_sequential.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 char LoadSequential(char * FileName);
 char SaveSequential(char * FileName);

--- a/src/hal/classicladder/global.h
+++ b/src/hal/classicladder/global.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifdef MAT_CONNECTION
 #include "../../lib/plc.h"
 #define TYPE_FOR_BOOL_VAR plc_pt_t

--- a/src/hal/classicladder/manager.c
+++ b/src/hal/classicladder/manager.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 #ifdef HAL_SUPPORT
 #include "rtapi.h"
 #include "rtapi_string.h"

--- a/src/hal/classicladder/manager.h
+++ b/src/hal/classicladder/manager.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void InitSections( void );
 int SearchSubRoutineWithItsNumber( int SubRoutineNbrToFind );
 void SectionSelected( char * SectionName );

--- a/src/hal/classicladder/manager_gtk.c
+++ b/src/hal/classicladder/manager_gtk.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <gtk/gtk.h>
 #include <stdio.h>

--- a/src/hal/classicladder/manager_gtk.h
+++ b/src/hal/classicladder/manager_gtk.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void ManagerDisplaySections( );
 void ManagerInitGtk();
 void ToggleManagerWindow();

--- a/src/hal/classicladder/module_hal.c
+++ b/src/hal/classicladder/module_hal.c
@@ -21,7 +21,7 @@
 
    You should have received a copy of the GNU Lesser General Public
    License along with this library; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 #include "rtapi.h"

--- a/src/hal/classicladder/print_gnome.c
+++ b/src/hal/classicladder/print_gnome.c
@@ -19,7 +19,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/hal/classicladder/print_gnome.h
+++ b/src/hal/classicladder/print_gnome.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 void PrintGnome( void );
 void PrintPreviewGnome( void );

--- a/src/hal/classicladder/protocol_modbus_master.c
+++ b/src/hal/classicladder/protocol_modbus_master.c
@@ -23,7 +23,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/hal/classicladder/protocol_modbus_master.h
+++ b/src/hal/classicladder/protocol_modbus_master.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef _PROTOCOL_MODBUS_MASTER_H
 #define _PROTOCOL_MODBUS_MASTER_H

--- a/src/hal/classicladder/protocol_modbus_slave.c
+++ b/src/hal/classicladder/protocol_modbus_slave.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/hal/classicladder/protocol_modbus_slave.h
+++ b/src/hal/classicladder/protocol_modbus_slave.h
@@ -12,6 +12,6 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 int ModbusRequestToRespond( unsigned char * Question, int LgtQuestion, unsigned char * Response );

--- a/src/hal/classicladder/sequential.h
+++ b/src/hal/classicladder/sequential.h
@@ -16,7 +16,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 
 #define NBR_SEQUENTIAL_PAGES 5

--- a/src/hal/classicladder/serial_common.h
+++ b/src/hal/classicladder/serial_common.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 char SerialOpen( char * SerialPortName, int Speed );
 void SerialClose( );

--- a/src/hal/classicladder/serial_linux.c
+++ b/src/hal/classicladder/serial_linux.c
@@ -19,7 +19,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <termios.h>
 #include <stdio.h>

--- a/src/hal/classicladder/socket_modbus_master.c
+++ b/src/hal/classicladder/socket_modbus_master.c
@@ -21,7 +21,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 // Chris Morley July 08 (EMC)
 
 #include <stdio.h>

--- a/src/hal/classicladder/socket_modbus_master.h
+++ b/src/hal/classicladder/socket_modbus_master.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void InitSocketModbusMaster( void );
 void CloseSocketModbusMaster( void );
 void SocketModbusMasterLoop( void );

--- a/src/hal/classicladder/socket_server.c
+++ b/src/hal/classicladder/socket_server.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/hal/classicladder/socket_server.h
+++ b/src/hal/classicladder/socket_server.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 void InitSocketServer( int UseUdpMode, int PortNbr );

--- a/src/hal/classicladder/spy_vars_gtk.c
+++ b/src/hal/classicladder/spy_vars_gtk.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 // modified for EMC
 // Chris Morley Feb 08

--- a/src/hal/classicladder/spy_vars_gtk.h
+++ b/src/hal/classicladder/spy_vars_gtk.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 void RefreshAllBoolsVars( );
 void DisplayFreeVarSpy( );

--- a/src/hal/classicladder/symbols.c
+++ b/src/hal/classicladder/symbols.c
@@ -24,7 +24,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #ifndef MODULE
 #include <stdio.h>

--- a/src/hal/classicladder/symbols.h
+++ b/src/hal/classicladder/symbols.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 void InitSymbols( void );
 StrSymbol * ConvVarNameInSymbolPtr( char * tcVarNameVar );

--- a/src/hal/classicladder/symbols_gtk.c
+++ b/src/hal/classicladder/symbols_gtk.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <gtk/gtk.h>
 #include <stdio.h>

--- a/src/hal/classicladder/symbols_gtk.h
+++ b/src/hal/classicladder/symbols_gtk.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 void DisplaySymbols( );
 void OpenSymbolsWindow( );

--- a/src/hal/classicladder/vars_access.c
+++ b/src/hal/classicladder/vars_access.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #ifdef GTK_INTERFACE
 #include <gtk/gtk.h>

--- a/src/hal/classicladder/vars_access.h
+++ b/src/hal/classicladder/vars_access.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 void InitVars(void);
 int ReadVar(int TypeVar,int Offset);
 void WriteVar(int TypeVar,int NumVar,int Value);

--- a/src/hal/classicladder/vars_names.c
+++ b/src/hal/classicladder/vars_names.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 #include <stdio.h>
 #include <string.h>

--- a/src/hal/classicladder/vars_names.h
+++ b/src/hal/classicladder/vars_names.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 char * CreateVarName(int Type, int Offset);

--- a/src/hal/classicladder/vars_names_list.c
+++ b/src/hal/classicladder/vars_names_list.c
@@ -18,7 +18,7 @@
 
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
-/* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
+/* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
 
 
 

--- a/src/hal/components/abs.comp
+++ b/src/hal/components/abs.comp
@@ -12,7 +12,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component abs "Compute the absolute value and sign of the input signal";
 
 pin in float in "Analog input value" ;

--- a/src/hal/components/abs_s32.comp
+++ b/src/hal/components/abs_s32.comp
@@ -12,7 +12,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component abs_s32 "Compute the absolute value and sign of the input signal";
 
 pin in s32 in "input value" ;

--- a/src/hal/components/at_pid.c
+++ b/src/hal/components/at_pid.c
@@ -104,7 +104,7 @@
  *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/biquad.comp
+++ b/src/hal/components/biquad.comp
@@ -17,7 +17,7 @@
  *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/blend.comp
+++ b/src/hal/components/blend.comp
@@ -13,7 +13,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component blend "Perform linear interpolation between two values";
 

--- a/src/hal/components/boss_plc.c
+++ b/src/hal/components/boss_plc.c
@@ -98,7 +98,7 @@
  *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/charge_pump.comp
+++ b/src/hal/components/charge_pump.comp
@@ -13,7 +13,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component charge_pump "Create a square-wave for the 'charge pump' input of some controller boards";
 option singleton yes;

--- a/src/hal/components/ddt.comp
+++ b/src/hal/components/ddt.comp
@@ -13,7 +13,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component ddt "Compute the derivative of the input function";
 
 pin in float in;

--- a/src/hal/components/differential.comp
+++ b/src/hal/components/differential.comp
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component differential "kinematics for a differential transmission";
 

--- a/src/hal/components/edge.comp
+++ b/src/hal/components/edge.comp
@@ -13,7 +13,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component edge "Edge detector";
 
 pin in bit in;

--- a/src/hal/components/encoder.c
+++ b/src/hal/components/encoder.c
@@ -44,7 +44,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/encoder_ratio.c
+++ b/src/hal/components/encoder_ratio.c
@@ -77,7 +77,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/feedcomp.comp
+++ b/src/hal/components/feedcomp.comp
@@ -12,7 +12,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component feedcomp "Multiply the input by the ratio of current velocity to the feed rate";
 pin out float out "Proportionate output value";

--- a/src/hal/components/invert.comp
+++ b/src/hal/components/invert.comp
@@ -12,7 +12,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component invert """Compute the inverse of the input signal
 The output will be the mathematical inverse of the input, ie \\fBout\\fR = 1/\\fBin\\fR.
 The parameter \\fBdeadband\\fR can be used to control how close to 0 the denominator can be

--- a/src/hal/components/joyhandle.comp
+++ b/src/hal/components/joyhandle.comp
@@ -12,7 +12,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component joyhandle "sets nonlinear joypad movements, deadbands and scales";
 pin in float in;

--- a/src/hal/components/knob2float.comp
+++ b/src/hal/components/knob2float.comp
@@ -13,7 +13,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component knob2float "Convert counts (probably from an encoder) to a float value";
 

--- a/src/hal/components/maj3.comp
+++ b/src/hal/components/maj3.comp
@@ -13,7 +13,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component maj3 "Compute the majority of 3 inputs";
 

--- a/src/hal/components/message.comp
+++ b/src/hal/components/message.comp
@@ -19,7 +19,7 @@
  *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/moveoff.comp
+++ b/src/hal/components/moveoff.comp
@@ -113,7 +113,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 pin in  bit power_on      "Connect to motion.motion-enabled";

--- a/src/hal/components/multiclick.comp
+++ b/src/hal/components/multiclick.comp
@@ -17,7 +17,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 //
 
 component multiclick "Single-, double-, triple-, and quadruple-click detector";

--- a/src/hal/components/offset.comp
+++ b/src/hal/components/offset.comp
@@ -13,7 +13,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 component offset "Adds an offset to an input, and subtracts it from the feedback value";
 
 function update_output "Updated the output value by adding the offset to the input";

--- a/src/hal/components/oneshot.comp
+++ b/src/hal/components/oneshot.comp
@@ -13,7 +13,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component oneshot "one-shot pulse generator";
 

--- a/src/hal/components/panelui.c
+++ b/src/hal/components/panelui.c
@@ -56,7 +56,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/pid.c
+++ b/src/hal/components/pid.c
@@ -112,7 +112,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/pwmgen.c
+++ b/src/hal/components/pwmgen.c
@@ -50,7 +50,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/sampler.c
+++ b/src/hal/components/sampler.c
@@ -38,7 +38,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/sampler_usr.c
+++ b/src/hal/components/sampler_usr.c
@@ -44,7 +44,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/siggen.c
+++ b/src/hal/components/siggen.c
@@ -54,7 +54,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/sim_encoder.c
+++ b/src/hal/components/sim_encoder.c
@@ -43,7 +43,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/simple_tp.comp
+++ b/src/hal/components/simple_tp.comp
@@ -15,7 +15,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 component simple_tp """\
 This component is a single axis simple trajectory planner, same as used for jogging in linuxcnc.

--- a/src/hal/components/stepgen.c
+++ b/src/hal/components/stepgen.c
@@ -282,7 +282,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/streamer.c
+++ b/src/hal/components/streamer.c
@@ -38,7 +38,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/streamer_usr.c
+++ b/src/hal/components/streamer_usr.c
@@ -39,7 +39,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/supply.c
+++ b/src/hal/components/supply.c
@@ -29,7 +29,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/components/threads.c
+++ b/src/hal/components/threads.c
@@ -33,7 +33,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_ax5214h.c
+++ b/src/hal/drivers/hal_ax5214h.c
@@ -72,7 +72,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_evoreg.c
+++ b/src/hal/drivers/hal_evoreg.c
@@ -48,7 +48,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_motenc.c
+++ b/src/hal/drivers/hal_motenc.c
@@ -106,7 +106,7 @@
  *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_parport.c
+++ b/src/hal/drivers/hal_parport.c
@@ -80,7 +80,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_ppmc.c
+++ b/src/hal/drivers/hal_ppmc.c
@@ -56,7 +56,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_skeleton.c
+++ b/src/hal/drivers/hal_skeleton.c
@@ -60,7 +60,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_speaker.c
+++ b/src/hal/drivers/hal_speaker.c
@@ -45,7 +45,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_stg.c
+++ b/src/hal/drivers/hal_stg.c
@@ -120,7 +120,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_stg.h
+++ b/src/hal/drivers/hal_stg.h
@@ -21,7 +21,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_tiro.c
+++ b/src/hal/drivers/hal_tiro.c
@@ -42,7 +42,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_vti.c
+++ b/src/hal/drivers/hal_vti.c
@@ -137,7 +137,7 @@
 
 	You should have received a copy of the GNU General Public
 	License along with this library; if not, write to the Free Software
-	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 	THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
 	ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/hal_vti.h
+++ b/src/hal/drivers/hal_vti.h
@@ -32,7 +32,7 @@
 
 	You should have received a copy of the GNU General Public
 	License along with this library; if not, write to the Free Software
-	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 	THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
 	ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <sys/fcntl.h>

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.h
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.h
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #ifndef __INCLUDE_HM2_ETH_H

--- a/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 /* Without Source Tree */

--- a/src/hal/drivers/mesa-hostmot2/hm2_spi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_spi.c
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <ctype.h>

--- a/src/hal/drivers/mesa-hostmot2/lbp16.h
+++ b/src/hal/drivers/mesa-hostmot2/lbp16.h
@@ -14,7 +14,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #ifndef __LBP16_H

--- a/src/hal/drivers/mesa-hostmot2/spi_common_rpspi.h
+++ b/src/hal/drivers/mesa-hostmot2/spi_common_rpspi.h
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301-1307 USA
  */
 
 #ifndef HAL_RPSPI_H

--- a/src/hal/drivers/motenc.h
+++ b/src/hal/drivers/motenc.h
@@ -18,7 +18,7 @@
  *
  * You should have received a copy of the GNU General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  * ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/drivers/opto_ac5.h
+++ b/src/hal/drivers/opto_ac5.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /*************************************************************************
 
 Header for opto22 pci AC5  board driver

--- a/src/hal/drivers/pluto_servo_firmware/pluto_servo.qpf
+++ b/src/hal/drivers/pluto_servo_firmware/pluto_servo.qpf
@@ -14,7 +14,7 @@
 # 
 #     You should have received a copy of the GNU General Public License
 #     along with this program; if not, write to the Free Software
-#     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 QUARTUS_VERSION = "6.0"
 DATE = "09:23:55  December 23, 2006"

--- a/src/hal/drivers/pluto_servo_firmware/pluto_servo.qsf
+++ b/src/hal/drivers/pluto_servo_firmware/pluto_servo.qsf
@@ -14,7 +14,7 @@
 # 
 #     You should have received a copy of the GNU General Public License
 #     along with this program; if not, write to the Free Software
-#     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 set_global_assignment -name ALLOW_ANY_ROM_SIZE_FOR_RECOGNITION ON
 set_global_assignment -name ALLOW_ANY_SHIFT_REGISTER_SIZE_FOR_RECOGNITION ON

--- a/src/hal/drivers/pluto_servo_firmware/quad.v
+++ b/src/hal/drivers/pluto_servo_firmware/quad.v
@@ -14,7 +14,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1507  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 module quad(clk, A, B, Z, zr, out);
 parameter W=14;

--- a/src/hal/drivers/pluto_servo_firmware/servo.v
+++ b/src/hal/drivers/pluto_servo_firmware/servo.v
@@ -14,7 +14,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 module pluto_servo(clk, led, nConfig, epp_nReset, pport_data, nWrite, nWait, nDataStr,
 	nAddrStr, dout, din, quadA, quadB, quadZ, up, down);

--- a/src/hal/drivers/pluto_servo_firmware/wdt.v
+++ b/src/hal/drivers/pluto_servo_firmware/wdt.v
@@ -14,7 +14,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 module wdt(clk, ena, cnt, out);
 input clk, ena, cnt;

--- a/src/hal/drivers/pluto_step_firmware/main.v
+++ b/src/hal/drivers/pluto_step_firmware/main.v
@@ -14,7 +14,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 module main(clk, led, nConfig, epp_nReset, pport_data, nWrite, nWait, nDataStr,
 	nAddrStr, dout, din, step, dir);

--- a/src/hal/drivers/pluto_step_firmware/pluto_step.qpf
+++ b/src/hal/drivers/pluto_step_firmware/pluto_step.qpf
@@ -14,7 +14,7 @@
 # 
 #     You should have received a copy of the GNU General Public License
 #     along with this program; if not, write to the Free Software
-#     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 QUARTUS_VERSION = "6.0"
 DATE = "09:23:55  December 23, 2006"

--- a/src/hal/drivers/pluto_step_firmware/pluto_step.qsf
+++ b/src/hal/drivers/pluto_step_firmware/pluto_step.qsf
@@ -14,7 +14,7 @@ set_global_assignment -name ENABLE_DRC_SETTINGS OFF
 # 
 #     You should have received a copy of the GNU General Public License
 #     along with this program; if not, write to the Free Software
-#     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 set_global_assignment -name ALLOW_ANY_ROM_SIZE_FOR_RECOGNITION ON
 set_global_assignment -name ALLOW_ANY_SHIFT_REGISTER_SIZE_FOR_RECOGNITION ON

--- a/src/hal/drivers/pluto_step_firmware/stepgen.v
+++ b/src/hal/drivers/pluto_step_firmware/stepgen.v
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 module stepgen(clk, enable, position, velocity, dirtime, steptime, step, dir, tap);
 `define STATE_STEP 0

--- a/src/hal/drivers/pluto_step_firmware/test_stepgen.v
+++ b/src/hal/drivers/pluto_step_firmware/test_stepgen.v
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 // install ubuntu package "verilog" from universe
 // Compile with: iverilog -DTESTING test_stepgen.v stepgen.v

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -43,7 +43,7 @@
 
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -37,7 +37,7 @@
 
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -41,7 +41,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -14,7 +14,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <Python.h>
 #include <structmember.h>

--- a/src/hal/user_comps/gladevcp.py
+++ b/src/hal/user_comps/gladevcp.py
@@ -16,7 +16,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """ Python / GLADE based Virtual Control Panel for EMC
 

--- a/src/hal/user_comps/gs2_vfd.c
+++ b/src/hal/user_comps/gs2_vfd.c
@@ -18,7 +18,7 @@
 
     You should have received a copy of the GNU Lesser General Public
     License along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301-1307  USA.
 
 
     This is a userspace program that interfaces the Automation Direct

--- a/src/hal/user_comps/hal_input.py
+++ b/src/hal/user_comps/hal_input.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import linux_event, sys, os, fcntl, hal, select, time, glob, fnmatch, select
 from hal import *

--- a/src/hal/user_comps/hy_gt_vfd.c
+++ b/src/hal/user_comps/hy_gt_vfd.c
@@ -17,7 +17,7 @@
 
     You should have received a copy of the GNU Lesser General Public
     License along with this program; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301-1307 USA.
 */
 
 #include <errno.h>

--- a/src/hal/user_comps/mb2hal/LogBook.txt
+++ b/src/hal/user_comps/mb2hal/LogBook.txt
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301-1307
  * USA.
  */
 

--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -20,7 +20,7 @@
  *
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301-1307
  * USA.
  */
 

--- a/src/hal/user_comps/mitsub_vfd.py
+++ b/src/hal/user_comps/mitsub_vfd.py
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # user space component for controlling a misubishi inverter over the serial port using rs485 standard
 # specifcally the A500 F500 E500 A500 D700 E700 F700 series - others may work or need adjustment

--- a/src/hal/user_comps/pyvcp.py
+++ b/src/hal/user_comps/pyvcp.py
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 """ Python Virtual Control Panel for EMC

--- a/src/hal/user_comps/shuttle.c
+++ b/src/hal/user_comps/shuttle.c
@@ -17,7 +17,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301-1307 USA
 //
 
 

--- a/src/hal/user_comps/thermistor.comp
+++ b/src/hal/user_comps/thermistor.comp
@@ -14,7 +14,7 @@
 //
 //   You should have received a copy of the GNU General Public License
 //   along with this program; if not, write to the Free Software
-//   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 //
 
 component thermistor "compute temperature indicated by a thermistor";

--- a/src/hal/user_comps/vfdb_vfd/vfdb_vfd.c
+++ b/src/hal/user_comps/vfdb_vfd/vfdb_vfd.c
@@ -25,7 +25,7 @@
 
   You should have received a copy of the GNU Lesser General Public
   License along with this program; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301-1307  USA.
 
   see 'man vfdb_vfd' and the VFD-B section in the Drivers manual.
 

--- a/src/hal/user_comps/vfs11_vfd/vfs11_vfd.c
+++ b/src/hal/user_comps/vfs11_vfd/vfs11_vfd.c
@@ -23,7 +23,7 @@
 
   You should have received a copy of the GNU Lesser General Public
   License along with this program; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301-1307  USA.
 
   see 'man vfs11_vfd' and the VFS11 section in the Drivers manual.
 

--- a/src/hal/user_comps/vismach/5axisgui.py
+++ b/src/hal/user_comps/vismach/5axisgui.py
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 from vismach import *

--- a/src/hal/user_comps/vismach/hbmgui.py
+++ b/src/hal/user_comps/vismach/hbmgui.py
@@ -17,7 +17,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 from vismach import *

--- a/src/hal/user_comps/vismach/lineardelta.py
+++ b/src/hal/user_comps/vismach/lineardelta.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 from vismach import *
 import hal
 import lineardeltakins

--- a/src/hal/user_comps/vismach/maho600gui.py
+++ b/src/hal/user_comps/vismach/maho600gui.py
@@ -17,7 +17,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 from vismach import *

--- a/src/hal/user_comps/vismach/max5gui.py
+++ b/src/hal/user_comps/vismach/max5gui.py
@@ -17,7 +17,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 from vismach import *

--- a/src/hal/user_comps/vismach/puma560gui.py
+++ b/src/hal/user_comps/vismach/puma560gui.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # graphic model of a Unimate Puma 560
 # according to the dimensions from: http://www.juve.ro/blog/puma/

--- a/src/hal/user_comps/vismach/pumagui.py
+++ b/src/hal/user_comps/vismach/pumagui.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 from vismach import *

--- a/src/hal/user_comps/vismach/rotarydelta.py
+++ b/src/hal/user_comps/vismach/rotarydelta.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from vismach import *
 import hal

--- a/src/hal/user_comps/vismach/scaragui.py
+++ b/src/hal/user_comps/vismach/scaragui.py
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
 from vismach import *

--- a/src/hal/user_comps/vismach/xyzac-trt-gui.py
+++ b/src/hal/user_comps/vismach/xyzac-trt-gui.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #**************************************************************************
 
 #--------------------------------------------------------------------------

--- a/src/hal/user_comps/vismach/xyzbc-trt-gui.py
+++ b/src/hal/user_comps/vismach/xyzbc-trt-gui.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #**************************************************************************
 
 #--------------------------------------------------------------------------

--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -33,7 +33,7 @@ license "GPLv2 or greater";
 
   You should have received a copy of the GNU Lesser General Public
   License along with this program; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA.
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301-1307  USA.
 
   see 'man wj200_vfd' and the WJ200 section in the Drivers manual.
 */

--- a/src/hal/user_comps/xhc-hb04.cc
+++ b/src/hal/user_comps/xhc-hb04.cc
@@ -17,8 +17,8 @@
 
    You should have received a copy of the GNU Lesser General Public
    License along with the program; if not, write to the Free
-   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-   02111-1307 USA.
+   Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+   MA 02110-1301 USA.
  */
 
 #include <stdlib.h>

--- a/src/hal/utils/bitfile.c
+++ b/src/hal/utils/bitfile.c
@@ -17,7 +17,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
 ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/bitfile.h
+++ b/src/hal/utils/bitfile.h
@@ -19,7 +19,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
 ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/elbpcom.py
+++ b/src/hal/utils/elbpcom.py
@@ -15,7 +15,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import optparse
 import re

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -27,7 +27,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/halcmd.h
+++ b/src/hal/utils/halcmd.h
@@ -22,7 +22,7 @@
  *
  *  You should have received a copy of the GNU General Public
  *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  *  ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -22,7 +22,7 @@
  *
  *  You should have received a copy of the GNU General Public
  *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  *  ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/halcmd_commands.h
+++ b/src/hal/utils/halcmd_commands.h
@@ -22,7 +22,7 @@
  *
  *  You should have received a copy of the GNU General Public
  *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  *  ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/halcmd_completion.c
+++ b/src/hal/utils/halcmd_completion.c
@@ -22,7 +22,7 @@
  *
  *  You should have received a copy of the GNU General Public
  *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  *  ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/halcmd_completion.h
+++ b/src/hal/utils/halcmd_completion.h
@@ -22,7 +22,7 @@
  *
  *  You should have received a copy of the GNU General Public
  *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  *  ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -22,7 +22,7 @@
  *
  *  You should have received a copy of the GNU General Public
  *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *  THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
  *  ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -14,7 +14,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import os, sys, tempfile, shutil, getopt, time
 BASE = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))

--- a/src/hal/utils/halsh.c
+++ b/src/hal/utils/halsh.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/hal/utils/meter.c
+++ b/src/hal/utils/meter.c
@@ -29,7 +29,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/miscgtk.c
+++ b/src/hal/utils/miscgtk.c
@@ -23,7 +23,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/miscgtk.h
+++ b/src/hal/utils/miscgtk.h
@@ -26,7 +26,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/pci_read.c
+++ b/src/hal/utils/pci_read.c
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <errno.h>

--- a/src/hal/utils/pci_write.c
+++ b/src/hal/utils/pci_write.c
@@ -20,7 +20,7 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include <errno.h>

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -18,7 +18,7 @@ static char *license = \
 \n\
     You should have received a copy of the GNU General Public\n\
     License along with this library; if not, write to the Free Software\n\
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA\n\
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.\n\
 \n\
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR\n\
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE\n\

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -16,7 +16,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/scope_files.c
+++ b/src/hal/utils/scope_files.c
@@ -17,7 +17,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -17,7 +17,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/scope_rt.c
+++ b/src/hal/utils/scope_rt.c
@@ -17,7 +17,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/scope_rt.h
+++ b/src/hal/utils/scope_rt.h
@@ -21,7 +21,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/scope_shm.h
+++ b/src/hal/utils/scope_shm.h
@@ -22,7 +22,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -16,7 +16,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -21,7 +21,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -17,7 +17,7 @@
 
     You should have received a copy of the GNU General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/upci.c
+++ b/src/hal/utils/upci.c
@@ -17,7 +17,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
 ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/hal/utils/upci.h
+++ b/src/hal/utils/upci.h
@@ -28,7 +28,7 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public
 License along with this library; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
 ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/libnml/inifile/inifile.h
+++ b/src/libnml/inifile/inifile.h
@@ -13,7 +13,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef LINUXCNC_INIFILE_H
 #define LINUXCNC_INIFILE_H

--- a/src/libnml/nml/nml_mod.cc
+++ b/src/libnml/nml/nml_mod.cc
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 /*
    nml_mod.cc

--- a/src/libnml/nml/nml_mod.hh
+++ b/src/libnml/nml/nml_mod.hh
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef NML_MODULE_H
 #define NML_MODULE_H

--- a/src/libnml/nml/nml_type.hh
+++ b/src/libnml/nml/nml_type.hh
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #ifndef NMLTYPE_TYPEDEFED
 #define NMLTYPE_TYPEDEFED

--- a/src/module_helper/module_helper.c
+++ b/src/module_helper/module_helper.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 /*
 This module_helper program will be installed setuid and allows

--- a/src/move-if-change
+++ b/src/move-if-change
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 if
 test -r $2

--- a/src/rtapi/examples/extint/extint.c
+++ b/src/rtapi/examples/extint/extint.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /*
   extint.c
 

--- a/src/rtapi/examples/fifo/common.h
+++ b/src/rtapi/examples/fifo/common.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef COMMON_H
 #define COMMON_H
 

--- a/src/rtapi/examples/fifo/fifotask.c
+++ b/src/rtapi/examples/fifo/fifotask.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /*
   fifotask.c
 

--- a/src/rtapi/examples/fifo/fifousr.c
+++ b/src/rtapi/examples/fifo/fifousr.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /*
   fifousr.c - user-side FIFO code
 

--- a/src/rtapi/examples/semaphore/common.h
+++ b/src/rtapi/examples/semaphore/common.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef COMMON_H
 #define COMMON_H
 

--- a/src/rtapi/examples/semaphore/master.c
+++ b/src/rtapi/examples/semaphore/master.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /*
   master.c
 

--- a/src/rtapi/examples/semaphore/slave.c
+++ b/src/rtapi/examples/semaphore/slave.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /*
   slave.c
 

--- a/src/rtapi/examples/shmem/common.h
+++ b/src/rtapi/examples/shmem/common.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef COMMON_H
 #define COMMON_H
 

--- a/src/rtapi/examples/shmem/shmemtask.c
+++ b/src/rtapi/examples/shmem/shmemtask.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /*
   shmemtask.c
 

--- a/src/rtapi/examples/shmem/shmemusr.c
+++ b/src/rtapi/examples/shmem/shmemusr.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <stdio.h>
 #include <signal.h>		/* signal(), SIGINT */
 #include <unistd.h>		/* sleep() */

--- a/src/rtapi/examples/timer/timertask.c
+++ b/src/rtapi/examples/timer/timertask.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 /*
   timertask.c
 

--- a/src/rtapi/mathstubs.c
+++ b/src/rtapi/mathstubs.c
@@ -25,7 +25,7 @@
 *
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 #include <linux/types.h>	/* u_int16_t */

--- a/src/rtapi/procfs_macros.h
+++ b/src/rtapi/procfs_macros.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef PROCFS_MACROS_H
 #define PROCFS_MACROS_H
 /***********************************************************************

--- a/src/rtapi/rtai_rtapi.c
+++ b/src/rtapi/rtai_rtapi.c
@@ -43,7 +43,7 @@
 
    You should have received a copy of the GNU General Public License
    along with this library; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 /** THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR

--- a/src/rtapi/rtai_ulapi.c
+++ b/src/rtapi/rtai_ulapi.c
@@ -39,7 +39,7 @@
 
    You should have received a copy of the GNU General Lesser Public
    License along with this library; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 /** THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR

--- a/src/rtapi/rtapi.h
+++ b/src/rtapi/rtapi.h
@@ -44,7 +44,7 @@
 
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
     THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR
     ANY HARM OR LOSS RESULTING FROM ITS USE.  IT IS _EXTREMELY_ UNWISE

--- a/src/rtapi/rtapi_app.h
+++ b/src/rtapi/rtapi_app.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_APP_H
 #define RTAPI_APP_H
 

--- a/src/rtapi/rtapi_atomic.h
+++ b/src/rtapi/rtapi_atomic.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_ATOMIC_H
 #define RTAPI_ATOMIC_H
 

--- a/src/rtapi/rtapi_bitops.h
+++ b/src/rtapi/rtapi_bitops.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_BITOPS_H
 #define RTAPI_BITOPS_H
 #if defined(__KERNEL__)

--- a/src/rtapi/rtapi_bool.h
+++ b/src/rtapi/rtapi_bool.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_BOOL_H
 
 #if defined(__KERNEL__)

--- a/src/rtapi/rtapi_common.h
+++ b/src/rtapi/rtapi_common.h
@@ -46,7 +46,7 @@
 
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 /** THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR

--- a/src/rtapi/rtapi_ctype.h
+++ b/src/rtapi/rtapi_ctype.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifdef MODULE
 #include <linux/ctype.h>
 #else

--- a/src/rtapi/rtapi_device.h
+++ b/src/rtapi/rtapi_device.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_DEVICE_H
 #define RTAPI_DEVICE_H
 

--- a/src/rtapi/rtapi_errno.h
+++ b/src/rtapi/rtapi_errno.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifdef MODULE
 #include <linux/errno.h>
 #else

--- a/src/rtapi/rtapi_firmware.h
+++ b/src/rtapi/rtapi_firmware.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_FIRMWARE_H
 #define RTAPI_FIRMWARE_H
 

--- a/src/rtapi/rtapi_gfp.h
+++ b/src/rtapi/rtapi_gfp.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_GFP_H
 #define RTAPI_GFP_H
 

--- a/src/rtapi/rtapi_io.h
+++ b/src/rtapi/rtapi_io.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_IO_H
 #define RTAPI_IO_H
 

--- a/src/rtapi/rtapi_list.h
+++ b/src/rtapi/rtapi_list.h
@@ -17,7 +17,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_LIST_H
 #define RTAPI_LIST_H
 

--- a/src/rtapi/rtapi_math.h
+++ b/src/rtapi/rtapi_math.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_MATH_H
 #define RTAPI_MATH_H
 

--- a/src/rtapi/rtapi_mutex.h
+++ b/src/rtapi/rtapi_mutex.h
@@ -16,7 +16,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 /***********************************************************************
 *                  LIGHTWEIGHT MUTEX FUNCTIONS                         *

--- a/src/rtapi/rtapi_parport.h
+++ b/src/rtapi/rtapi_parport.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_PARPORT_H
 #define RTAPI_PARPORT_H
 

--- a/src/rtapi/rtapi_pci.h
+++ b/src/rtapi/rtapi_pci.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_PCI_H
 #define RTAPI_PCI_H
 

--- a/src/rtapi/rtapi_proc.h
+++ b/src/rtapi/rtapi_proc.h
@@ -49,7 +49,7 @@
 
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
-  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 /** THE AUTHORS OF THIS LIBRARY ACCEPT ABSOLUTELY NO LIABILITY FOR

--- a/src/rtapi/rtapi_rtai_shm_wrap.h
+++ b/src/rtapi/rtapi_rtai_shm_wrap.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_RTAI_SHM_WRAP_H
 #define RTAPI_RTAI_SHM_WRAP_H
 #pragma GCC system_header

--- a/src/rtapi/rtapi_slab.h
+++ b/src/rtapi/rtapi_slab.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_SLAB_H
 #define RTAPI_SLAB_H
 

--- a/src/rtapi/rtapi_stdint.h
+++ b/src/rtapi/rtapi_stdint.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_STDINT_H
 #define RTAPI_STDINT_H
 

--- a/src/rtapi/rtapi_string.h
+++ b/src/rtapi/rtapi_string.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #ifndef RTAPI_STRING_H
 #define RTAPI_STRING_H
 

--- a/src/rtapi/rtapi_uspace.hh
+++ b/src/rtapi/rtapi_uspace.hh
@@ -13,7 +13,7 @@
  *
  *    You should have received a copy of the GNU General Public License
  *    along with this program; if not, write to the Free Software
- *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 #ifndef RTAPI_USPACE_HH
 #define RTAPI_USPACE_HH

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <sys/time.h>
 #include <time.h>
 #include <stdio.h>

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -12,7 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
 #include "config.h"

--- a/src/rtapi/uspace_rtapi_parport.cc
+++ b/src/rtapi/uspace_rtapi_parport.cc
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/ppdev.h>

--- a/src/rtapi/uspace_rtapi_string.c
+++ b/src/rtapi/uspace_rtapi_string.c
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 //
 // This file contains some handy string parsing functions lifted from Linux

--- a/src/rtapi/vsnprintf.h
+++ b/src/rtapi/vsnprintf.h
@@ -31,7 +31,7 @@ values (or floating point).
 
    You should have received a copy of the GNU General Public License
    along with this library; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111 USA
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 #include <stdarg.h>

--- a/src/tests/mathtest.c
+++ b/src/tests/mathtest.c
@@ -24,7 +24,7 @@
 *
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
-* Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
 #define MODULE

--- a/tcl/linuxcnc.tcl.in
+++ b/tcl/linuxcnc.tcl.in
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 namespace eval linuxcnc {
     variable HOME @EMC2_HOME@

--- a/tcl/ngcgui.tcl
+++ b/tcl/ngcgui.tcl
@@ -53,7 +53,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 
 # ngcgui allows a user to write subroutine files that contain

--- a/tcl/ngcgui_app.tcl
+++ b/tcl/ngcgui_app.tcl
@@ -17,7 +17,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 
 proc ngcgui_app_init {} {

--- a/tcl/ngcgui_ttt.tcl
+++ b/tcl/ngcgui_ttt.tcl
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #-----------------------------------------------------------------------
 
 # $ truetype-tracer -?

--- a/tcl/show_errors.tcl
+++ b/tcl/show_errors.tcl
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program; if not, write to the Free Software
-#    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # Load the emc package, which defines variables for various useful paths
 package require Linuxcnc

--- a/tcl/tooledit.tcl
+++ b/tcl/tooledit.tcl
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #
 # As standalone tool table editor

--- a/tcl/twopass.tcl
+++ b/tcl/twopass.tcl
@@ -51,7 +51,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #--------------------------------------------------------------------------
 
 namespace eval ::tp {

--- a/tests/interp/compile/use-rs274.cc
+++ b/tests/interp/compile/use-rs274.cc
@@ -12,7 +12,7 @@
 //
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
-//    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <Python.h> // must be first header
 #include "rs274ngc.hh"

--- a/tests/interp/pymove/oword.py
+++ b/tests/interp/pymove/oword.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import emccanon
 import interpreter

--- a/tests/interp/pymove/subs.py
+++ b/tests/interp/pymove/subs.py
@@ -13,6 +13,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import oword

--- a/tests/interp/python-self/oword.py
+++ b/tests/interp/python-self/oword.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import interpreter 
 

--- a/tests/interp/python-self/subs.py
+++ b/tests/interp/python-self/subs.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import oword
 import interpreter

--- a/tests/interp/value-returned/oword.py
+++ b/tests/interp/value-returned/oword.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
 def nonereturned(self, *args):

--- a/tests/interp/value-returned/subs.py
+++ b/tests/interp/value-returned/subs.py
@@ -13,6 +13,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import oword

--- a/tests/remap/fail/body-py/remap.py
+++ b/tests/remap/fail/body-py/remap.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import interpreter
 

--- a/tests/remap/fail/body-py/subs.py
+++ b/tests/remap/fail/body-py/subs.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap
 

--- a/tests/remap/fail/epilog/remap.py
+++ b/tests/remap/fail/epilog/remap.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import emccanon
 import interpreter

--- a/tests/remap/fail/epilog/subs.py
+++ b/tests/remap/fail/epilog/subs.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap
 

--- a/tests/remap/fail/prolog/remap.py
+++ b/tests/remap/fail/prolog/remap.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import emccanon
 import interpreter

--- a/tests/remap/fail/prolog/subs.py
+++ b/tests/remap/fail/prolog/subs.py
@@ -13,6 +13,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap

--- a/tests/remap/introspect/oword.py
+++ b/tests/remap/introspect/oword.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import interpreter
 EMC_DEBUG_CONFIG            = 0x00000002

--- a/tests/remap/introspect/subs.py
+++ b/tests/remap/introspect/subs.py
@@ -13,6 +13,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import oword

--- a/tests/remap/oword-pycall/oword.py
+++ b/tests/remap/oword-pycall/oword.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Demo Python O-word subroutine - call as:
 # o<square> [5]

--- a/tests/remap/oword-pycall/subs.py
+++ b/tests/remap/oword-pycall/subs.py
@@ -13,6 +13,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import oword

--- a/tests/remap/predefined-named-params/namedparams.py
+++ b/tests/remap/predefined-named-params/namedparams.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # trivial example
 def _pi(self, *args):

--- a/tests/remap/predefined-named-params/subs.py
+++ b/tests/remap/predefined-named-params/subs.py
@@ -13,6 +13,6 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import namedparams

--- a/tests/remap/sequencing/permute.py
+++ b/tests/remap/sequencing/permute.py
@@ -14,7 +14,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 #http://stackoverflow.com/questions/361/generate-list-of-all-possible-permutations-of-a-string
 def nextPermutation(perm):

--- a/tests/remap/variable-injection/remap.py
+++ b/tests/remap/variable-injection/remap.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from interpreter import *
 

--- a/tests/remap/variable-injection/subs.py
+++ b/tests/remap/variable-injection/subs.py
@@ -13,7 +13,7 @@
 #
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
-#   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import remap
 


### PR DESCRIPTION
If you write to 59 Temple Place you're unlikely to get a response.
Let's realign the address with a more up-to-date one from [1].

  [1] https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt

This is purely a cosmetic change, doesn't affect the meaning of the
license. Done to make rpmlint happy.

Signed-off-by: Lubomir Rintel <lkundrak@v3.sk>