### PR TITLE
Specify the file character set as utf-8

### DIFF
--- a/src/emc/usr_intf/stepconf/build_INI.py
+++ b/src/emc/usr_intf/stepconf/build_INI.py
@@ -24,6 +24,9 @@
 
 import os
 import time
+import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 class INI:
     def __init__(self,app):

--- a/src/emc/usr_intf/stepconf/pages.py
+++ b/src/emc/usr_intf/stepconf/pages.py
@@ -33,6 +33,9 @@ import os
 from gi.repository import Gtk
 #import gobject
 from gi.repository import GObject
+import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 class Pages:
     def __init__(self, app):

--- a/src/emc/usr_intf/stepconf/stepconf.py
+++ b/src/emc/usr_intf/stepconf/stepconf.py
@@ -48,6 +48,8 @@ import hal
 import shutil
 import time
 from multifilebuilder_gtk3 import MultiFileBuilder
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 import traceback
 # otherwise, on hardy the user is shown spurious "[application] closed

--- a/src/po/gmoccapy/zh_CN.po
+++ b/src/po/gmoccapy/zh_CN.po
@@ -709,7 +709,7 @@ msgstr "<b>空程速率</b>"
 
 #: emc/usr_intf/gmoccapy/gmoccapy.glade.h:50
 msgid "<b>Feed Override</b>"
-msgstr "进给速率"
+msgstr "<b>进给速率</b>"
 
 #: gmoccapy.glade.h:26
 msgid "<b>Mouse Button mode</b>"


### PR DESCRIPTION
Specify the file character set as utf-8, Because there was an error when Setpconf wrote the configuration file in the Chinese locale.