### PR TITLE
Fix missed translation in recent large batch

### DIFF
--- a/src/po/gmoccapy/zh_CN.po
+++ b/src/po/gmoccapy/zh_CN.po
@@ -128,7 +128,7 @@ msgstr "**** GMOCCAPY 错误****"
 
 #: emc/usr_intf/gmoccapy/gmoccapy.py:926
 msgid "**** screen 2 GLADE ERROR: ****"
-msgstr "**** error con el archivo glade 2 ****"
+msgstr "**** 屏幕2 GLADE 错误 ****"
 
 #: emc/usr_intf/gmoccapy/gmoccapy.py:931
 msgid "**** No gmoccapy2.glade file present ****"


### PR DESCRIPTION
Out of curiosity, I clicked on the large batch.
Apparently the original .po source was Spanish.
The Spanish jumped out at me when I happened to see it.

I came up with a translation from the lines above, but
original poster Solitarily should approve first.

Thanks.

Signed-off-by: Kim Kirwan <Kim@KimKirwan.com>