### PR TITLE
Use Python's logging module instead of print

### DIFF
--- a/lib/python/qtvcp/lib/colored_formatter.py
+++ b/lib/python/qtvcp/lib/colored_formatter.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+
+#   Copyright (c) 2017 Kurt Jacobson
+
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+
+#  The above copyright notice and this permission notice shall be included in all
+#  copies or substantial portions of the Software.
+
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#  SOFTWARE.
+
+import re
+import time
+from copy import copy
+from logging import Formatter
+
+PREFIX = '\033['
+SUFFIX = '\033[0m'
+
+COLORS = {
+    'black'  : 30,
+    'red'    : 31,
+    'green'  : 32,
+    'yellow' : 33,
+    'blue'   : 34,
+    'magenta': 35,
+    'cyan'   : 36,
+    'white'  : 37,
+    'bgred'  : 41,
+    'bggrey' : 100
+    }
+
+MAPPING = {
+    'DEBUG'   : 'white',
+    'INFO'    : 'cyan',
+    'WARNING' : 'yellow',
+    'ERROR'   : 'red',
+    'CRITICAL': 'bgred',
+}
+
+
+# Returns `text` warped in ASCII escape codes to produce `color`
+def COLORIZE(text, color=None):
+    seq = COLORS.get(color, 37) # default to white
+    return '{0}{1}m{2}{3}'.format(PREFIX, seq, text, SUFFIX)
+
+
+# Matches only the first `color<text>` occurrence
+# ^(.*?)<([^)]+)> 
+
+# Matches all `color<text>` occurrences, both take the same number of steps
+# ([^<\s]+)<([^>]+)>
+# (\w+)<([^>]+)>
+
+RE = re.compile(r'(\w+)<([^>]+)>')
+
+
+class ColoredFormatter(Formatter):
+
+    def __init__(self, patern):
+        Formatter.__init__(self, patern)
+
+    # Override the Formatter's format method to add ASCII colors
+    # to the levelname and any marked words in the log message.
+    def format(self, record):
+        colored_record = copy(record)
+
+        # Add colors to levelname
+        levelname = colored_record.levelname
+        color = MAPPING.get(levelname, 'white')
+        colored_record.levelname = COLORIZE(levelname, color)
+
+        # Add colors to tagged message text
+        msg = colored_record.getMessage()
+        plain_msg, color_msg = self.color_words(msg)
+        record.msg = plain_msg
+        colored_record.msg = color_msg
+
+        return Formatter.format(self, colored_record)
+
+    # Replace `color<message>` in the log message with ASCII codes to colorize
+    # the word or phrase in the terminal log handler.  Also return a cleaned
+    # version of the message with the tags removed for use by the file handler.
+    def color_words(self, raw_msg):
+        plain_msg = color_msg = raw_msg
+        if '<' in raw_msg: # If no tag don't try to match
+            iterater = RE.finditer(raw_msg)
+            if iterater:
+                for match in iterater:
+                    group = match.group()
+                    color = match.group(1)
+                    word = match.group(2)
+
+                    # Could be optimized, but will rarely have more than one match
+                    color_msg = color_msg.replace(group, COLORIZE(word, color))
+                    plain_msg = plain_msg.replace(group, word)
+
+        return plain_msg, color_msg
+
+
+
+# ----------------------- E X A M P L E -----------------------
+
+if __name__ == '__main__':
+
+    import logging
+
+    # Create logger
+    log = logging.getLogger(__name__)
+    log.setLevel(logging.DEBUG)
+
+    # Add console handler
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    cf = ColoredFormatter("[%(name)s][%(levelname)s]  %(message)s (%(filename)s:%(lineno)d)")
+    ch.setFormatter(cf)
+    log.addHandler(ch)
+
+    # Add file handler
+    fh = logging.FileHandler('demo.log')
+    fh.setLevel(logging.DEBUG)
+    ff = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    fh.setFormatter(ff)
+    log.addHandler(fh)
+
+    # Log some stuff
+    log.debug("Logging demo has green<STARTED>")
+    log.info("Logging to yellow<demo.log> in the script dir")
+    log.warning("This is my last warning, red<take heed>")
+    log.error("This is an error")
+    log.critical("He's dead, Jim")
+
+    # Example exception logging
+    try:
+        print False + "True"
+    except Exception as e:
+        log.debug('That did not work!', exc_info=e)
+

--- a/lib/python/qtvcp/logger.py
+++ b/lib/python/qtvcp/logger.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+# QTVcp Logging Module
+# Provides a consistent and easy to use logging facility.  Log messages printed
+# to the terminal will be colorized for easy identification of log level.
+#
+# Copyright (c) 2017 Kurt Jacobson
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+
+import os
+import logging
+from linuxcnc import ini
+
+# For convenience import log levels so we don't need to import
+# logging to set the log level within other modules.
+from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
+
+# Our custom colorizing formatter for the terminal handler
+from lib.colored_formatter import ColoredFormatter
+
+
+# Global name of the base logger
+BASE_LOGGER_NAME = None
+
+# Define the log message formats
+TERM_FORMAT = '[%(name)s][%(levelname)s]  %(message)s (%(filename)s:%(lineno)d)'
+FILE_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+
+# Get logger for module based on module.__name__
+def getLogger(name):
+    if BASE_LOGGER_NAME is None:
+        initBaseLogger('QtDesigner')
+    name = '{0}.{1}'.format(BASE_LOGGER_NAME, name.upper())
+    return logging.getLogger(name)
+
+
+# Set global logging level
+def setGlobalLevel(level):
+    base_log.setLevel(level)
+    log.info('Base log level set to {}'.format(level))
+
+
+# Initialize the base logger
+def initBaseLogger(name, log_file=None, log_level=DEBUG):
+
+    global BASE_LOGGER_NAME
+    BASE_LOGGER_NAME = name
+
+    if not log_file:
+        log_file = getLogFile(name)
+
+    # Clear the previous sessions log file
+    with open(log_file, 'w') as fh:
+        pass
+
+    # Create base logger
+    base_log = logging.getLogger(BASE_LOGGER_NAME)
+    base_log.setLevel(log_level)
+
+    # Add console handler
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    cf = ColoredFormatter(TERM_FORMAT)
+    ch.setFormatter(cf)
+    base_log.addHandler(ch)
+
+    # Add file handler
+    fh = logging.FileHandler(log_file)
+    fh.setLevel(logging.DEBUG)
+    ff = logging.Formatter(FILE_FORMAT)
+    fh.setFormatter(ff)
+    base_log.addHandler(fh)
+
+    # Get logger for logger
+    log = getLogger(__name__)
+    base_log.info('Logging to "{}"'.format(log_file))
+
+    return base_log
+
+
+# Attempt to find the log file specified INI [DISPLAY] LOG_FILE,
+# failing that log to $HOME/<base_log_name>.log
+def getLogFile(name):
+
+    # Default log file to use if not specified in INI
+    log_file = os.path.expanduser('~/{}.log').format(name.lower())
+
+    # LinuxCNC may not be running, so use get() to avoid a KeyError
+    ini_file = os.environ.get('INI_FILE_NAME')
+    config_dir = os.environ.get('CONFIG_DIR')
+
+    if ini_file:
+        lcnc_ini = ini(ini_file)
+        path = lcnc_ini.find('DISPLAY', 'LOG_FILE')
+        if path:
+            if path.startswith('~'):
+                # Path is relative to $HOME
+                log_file = os.path.expanduser(path)
+            elif not os.path.isabs(path):
+                # Assume intended path is relative to the INI file
+                log_file = os.path.join(config_dir, path)
+            else:
+                # It must be an absolute path then
+                log_file = os.path.realpath(path)
+
+    return log_file

--- a/lib/python/qtvcp/qt_glib.py
+++ b/lib/python/qtvcp/qt_glib.py
@@ -11,6 +11,11 @@ from hal_glib import _GStat as GladeVcpStat
 from qtvcp.qt_istat import IStat
 INI = IStat()
 
+# Set up logging
+import logger
+log = logger.getLogger(__name__)
+# log.setLevel(logger.INFO) # One of DEBUG, INFO, WARNING, ERROR, CRITICAL
+
 class QPin(QObject, hal.Pin):
     value_changed = pyqtSignal([int], [float], [bool] )
 
@@ -39,10 +44,10 @@ class QPin(QObject, hal.Pin):
         for p in self.REGISTRY:
             try:
                 p.update()
-            except Exception, e:
+            except Exception as e:
                 kill.append(p)
-                print "Error updating pin %s; Removing" % p
-                print e
+                log.error("Error updating pin {}; Removing".format(p))
+                log.exception(e)
         for p in kill:
             self.REGISTRY.remove(p)
         return self.UPDATE
@@ -110,7 +115,7 @@ class Lcnc_Action():
             self.cmd.state(linuxcnc.STATE_OFF)
 
     def SET_MACHINE_HOMING(self, joint):
-        print 'Homing Joint:',joint
+        log.info('Homing Joint: {}'.format(joint))
         self.ensure_mode(linuxcnc.MODE_MANUAL)
         self.cmd.teleop_enable(False)
         self.cmd.home(joint)
@@ -163,7 +168,7 @@ class Lcnc_Action():
         if not self.gstat.stat.paused:
             self.cmd.auto(linuxcnc.AUTO_PAUSE)
         else:
-            print 'resume'
+            log.debug('resume')
             self.cmd.auto(linuxcnc.AUTO_RESUME)
 
     def SET_RAPID_RATE(self, rate):

--- a/lib/python/qtvcp/qt_istat.py
+++ b/lib/python/qtvcp/qt_istat.py
@@ -1,6 +1,11 @@
 import os
 import linuxcnc
 
+# Set up logging
+import logger
+log = logger.getLogger(__name__)
+# Set the log level for this module
+# log.setLevel(logger.INFO) # One of DEBUG, INFO, WARNING, ERROR, CRITICAL
 
 class IStat():
 
@@ -54,9 +59,10 @@ class IStat():
             self.MACHINE_UNIT_CONVERSION = 25.4
             self.MACHINE_UNIT_CONVERSION_9 = [25.4]*3+[1]*3+[25.4]*3
 
-        axes = (str(self.inifile.find("TRAJ", "COORDINATES"))).replace(" ", "")
-        print axes
-        if not axes == 'None':
+        axes = self.inifile.find("TRAJ", "COORDINATES")
+        if axes is not None: # i.e. LCNC is running, not just in Qt Desinger
+            axes = axes.replace(" ", "")
+            log.debug('TRAJ COORDINATES: {}'.format(axes))
             conversion = {"X":0, "Y":1, "Z":2, "A":3, "B":4, "C":5, "U":6, "V":7, "W":8}
             self.AVAILABLE_AXES = []
             self.AVAILABLE_AXES_INT = []

--- a/lib/python/qtvcp/qt_makepins.py
+++ b/lib/python/qtvcp/qt_makepins.py
@@ -22,6 +22,13 @@ import gobject
 from qtvcp.widgets.simple_widgets import _HalWidgetBase
 from qtvcp.qt_glib import QComponent
 from PyQt4.QtCore import QObject
+
+# Set up logging
+import logger
+log = logger.getLogger(__name__)
+# Set the log level for this module
+#log.setLevel(logger.INFO) # One of DEBUG, INFO, WARNING, ERROR, CRITICAL
+
 class QTPanel():
     def __init__(self,halcomp,xmlname,window,debug=False):
 
@@ -29,13 +36,11 @@ class QTPanel():
         self.widgets = {}
 
         # parse for HAL objects:
-        if debug:
-            print 'QTVCP: Parcing for hal widgets'
+        log.debug('QTVCP: Parcing for hal widgets')
         for widget in window.findChildren(QObject):
             idname = widget.objectName()
             if isinstance(widget, _HalWidgetBase):
-                if debug:
-                    print 'HAL-ified instance found:    %s'%(idname)
+                log.debug('HAL-ified instance found: {}'.format(idname))
                 widget.hal_init(self.hal, str(idname), widget, window)
                 self.widgets[idname] = widget
 

--- a/lib/python/qtvcp/qtvcp_handler.py
+++ b/lib/python/qtvcp/qtvcp_handler.py
@@ -1,5 +1,11 @@
 import linuxcnc
 
+# Set up logging
+import logger
+log = logger.getLogger(__name__)
+# Set the log level for this module
+#log.setLevel(logger.INFO) # One of DEBUG, INFO, WARNING, ERROR, CRITICAL
+
 class HandlerClass:
 
     # This will be pretty standard to gain access.
@@ -12,20 +18,20 @@ class HandlerClass:
         self.cmnd = linuxcnc.command()
 
     def initialized__(self):
-        print 'INIT qtvcp handler'
+        log.debug('INIT qtvcp handler')
 
     def halbuttonclicked(self):
-        print 'click'
+        log.debug('click')
 
     def estop_toggled(self,pressed):
-        print 'estop click',pressed
+        log.debug('estop click {}'.format(pressed))
         if pressed:
             self.cmnd.state(linuxcnc.STATE_ESTOP_RESET)
         else:
             self.cmnd.state(linuxcnc.STATE_ESTOP)
 
     def machineon_toggled(self,pressed):
-        print 'machine on click',pressed
+        log.debug('machine on click {}'.format(pressed))
         if pressed:
             self.cmnd.state(linuxcnc.STATE_ON)
         else:
@@ -33,7 +39,7 @@ class HandlerClass:
                 
 
     def home_clicked(self):
-        print 'home click'
+        log.debug('home click')
         self.cmnd.mode(linuxcnc.MODE_MANUAL)
         self.cmnd.home(-1)
 

--- a/lib/python/qtvcp/widgets/action_button.py
+++ b/lib/python/qtvcp/widgets/action_button.py
@@ -25,6 +25,10 @@ from qtvcp.qt_istat import IStat
 from qtvcp.lib.aux_program_loader import Aux_program_loader
 import linuxcnc
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
 # Instiniate the libraries with global reference
 # GSTAT gives us status messages from linuxcnc
 # ACTION gives commands to linuxcnc
@@ -167,7 +171,7 @@ class Lcnc_ActionButton(QtGui.QPushButton, _HalWidgetBase):
            if self.isCheckable():
                 ACTION.SET_MACHINE_STATE(state)
            else:
-                print 'gstat:',GSTAT.machine_is_on
+                log.debug('gstat machine is on: {}'.format(GSTAT.machine_is_on))
                 ACTION.SET_MACHINE_STATE(not GSTAT.machine_is_on())
         elif self.home:
            if self.isCheckable():
@@ -192,8 +196,8 @@ class Lcnc_ActionButton(QtGui.QPushButton, _HalWidgetBase):
             j = "XYZABCUVW"
             try:
                 axis = j[self.joint_number]
-            except:
-                print '''can't zero origin for specified jpint;''', self.joint_number
+            except IndexError:
+                log.error("can't zero origin for specified joint {}".format(self.joint_number))
             ACTION.SET_AXIS_ORIGIN(axis, 0)
         elif self.launch_halmeter:
             AUX_PRGM.load_halmeter()
@@ -209,7 +213,7 @@ class Lcnc_ActionButton(QtGui.QPushButton, _HalWidgetBase):
             ACTION.SET_MANUAL_MODE()
         # defult error case
         else:
-            print 'QTVCP: action button: * No action recognised *'
+            log.error('No action recognised')
 
     def jog_action(self,direction):
         if direction == 0 and GSTAT.current_jog_distance != 0: return

--- a/lib/python/qtvcp/widgets/container_widgets.py
+++ b/lib/python/qtvcp/widgets/container_widgets.py
@@ -6,6 +6,10 @@ from qtvcp.widgets.simple_widgets import _HalWidgetBase
 from qtvcp.qt_glib import GStat
 GSTAT = GStat()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
 class State_Enable_GridLayout(QWidget,_HalWidgetBase):
     def __init__(self, parent = None):
         QGridLayout.__init__(self, parent)

--- a/lib/python/qtvcp/widgets/dialog_widget.py
+++ b/lib/python/qtvcp/widgets/dialog_widget.py
@@ -23,6 +23,10 @@ from qtvcp.widgets.origin_offsetview import Lcnc_OriginOffsetView as OFFVIEW_WID
 from qtvcp.widgets.camview_widget import CamView
 from qtvcp.qt_glib import GStat, Lcnc_Action
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
 # Instiniate the libraries with global reference
 # GSTAT gives us status messages from linuxcnc
 # ACTION gives commands to linuxcnc
@@ -69,7 +73,7 @@ class Lcnc_Dialog(QMessageBox):
         self.buttonClicked.connect(self.msgbtn)
 
         retval = self.exec_()
-        print "value of pressed message box button:", retval
+        log.debug("Value of pressed button: {}".format(retval))
         if retval == QMessageBox.No:
             return False
         else:
@@ -82,8 +86,8 @@ class Lcnc_Dialog(QMessageBox):
         super(Lcnc_Dialog, self).showEvent(event)
 
     def msgbtn(self, i):
+        log.debug("Button pressed is: {}".format(i.text()))
         return
-        print "Button pressed is:",i.text()
 
     #**********************
     # Designer properties
@@ -163,7 +167,7 @@ class Lcnc_ToolDialog(Lcnc_Dialog, _HalWidgetBase):
                     self.changed.set(True)
                 else:
                     # TODO add abort command
-                    print 'cancelled should abort'
+                    log.debug('cancelled should abort')
         elif not change:
             self.changed.set(False)
 

--- a/lib/python/qtvcp/widgets/drowidget.py
+++ b/lib/python/qtvcp/widgets/drowidget.py
@@ -20,6 +20,10 @@ import linuxcnc
 from PyQt4 import QtCore, QtGui
 from qtvcp import qt_glib
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
 # we put this in a try so there is no error in the glade editor
 # linuxcnc is probably not running then 
 try:

--- a/lib/python/qtvcp/widgets/gcode_widget.py
+++ b/lib/python/qtvcp/widgets/gcode_widget.py
@@ -29,10 +29,15 @@
 import sys, os
 from PyQt4.QtCore import SIGNAL, pyqtProperty
 from PyQt4.QtGui import QFont, QFontMetrics, QColor
+
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
 try:
     from PyQt4.Qsci import QsciScintilla, QsciLexerCustom
-except:
-    print '**** QTVCP ERROR: Gcode widget can not import QsciScintilla - is package python-qscintilla2 installed?'
+except ImportError as e:
+    log.critical("Can't import QsciScintilla - is package python-qscintilla2 installed?", exc_info=e)
     sys.exit(1)
 from qtvcp.widgets.simple_widgets import _HalWidgetBase
 from qtvcp.qt_glib import GStat
@@ -292,7 +297,7 @@ class GcodeEditor(EditorBase, _HalWidgetBase):
         try:
             fp = os.path.expanduser(filename)
         except:
-            print 'error:',filename
+            log.error('File path is not valid: {}'.format(filename))
             self.setText('')
             return
 
@@ -304,7 +309,7 @@ class GcodeEditor(EditorBase, _HalWidgetBase):
     def highlight_line(self, w, line):
         if GSTAT.is_auto_running():
             if not GSTAT.old['file']  == self._last_filename:
-                print 'should reload the display'
+                log.debug('should reload the display')
                 self.load_text(GSTAT.old['file'])
         if 1==1:
             self.markerAdd(line, self.ARROW_MARKER_NUM)
@@ -319,7 +324,7 @@ class GcodeEditor(EditorBase, _HalWidgetBase):
         pass
 
     def line_changed(self, line, index):
-        print 'line changed',GSTAT.is_auto_mode()
+        log.debug('Line changed: {}'.format(GSTAT.is_auto_mode()))
         self.line_text = str(self.text(line)).strip()
         self.line = line
         if GSTAT.is_auto_running() == False:
@@ -327,13 +332,13 @@ class GcodeEditor(EditorBase, _HalWidgetBase):
 
     def select_lineup(self,w):
         line,col = self.getCursorPosition()
-        print line
+        log.debug(line)
         self.setCursorPosition(line-1,0)
         self.highlight_line(None,line-1)
 
     def select_linedown(self,w):
         line, col = self.getCursorPosition()
-        print line
+        log.debug(line)
         self.setCursorPosition(line+1,0)
         self.highlight_line(None,line+1)
 

--- a/lib/python/qtvcp/widgets/graphics.py
+++ b/lib/python/qtvcp/widgets/graphics.py
@@ -30,6 +30,11 @@ import rs274.glcanon
 
 gobject.threads_init()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 def run_gtk(self):
     try:
         gtk.gdk.threads_enter()
@@ -86,9 +91,9 @@ class modded_gremlin(gremlin.Gremlin):
         self._reload_filename=f
         try:
             self._load(f)
-        except AttributeError,detail:
+        except AttributeError as e:
                #AttributeError: 'NoneType' object has no attribute 'gl_end'
-            print 'hal_gremlin: continuing after',detail
+            log.exception('HAL Gremlin continuing after exception', exc_info=detail)
 
     @rs274.glcanon.with_context
     def _load(self, filename):
@@ -99,7 +104,7 @@ class modded_gremlin(gremlin.Gremlin):
         self.highlight_line = line
         if line == None:
             line = -1
-        print line
+        log.debug('Highlighting line in graphics: {}'.format(line))
         #self.emit('line-clicked', line)
 
     # This overrides glcannon.py method so we can change the DRO 
@@ -246,7 +251,7 @@ class Graphics(QX11EmbedContainer):
         self.setview('p')
 
     def embeddederror(self):
-        print 'embed error'
+        log.error('embed error')
 
     def sizeHint(self):
         return QSize(300, 300)

--- a/lib/python/qtvcp/widgets/gstat_bool_label.py
+++ b/lib/python/qtvcp/widgets/gstat_bool_label.py
@@ -6,6 +6,10 @@ from qtvcp.widgets.simple_widgets import _HalWidgetBase
 from qtvcp.qt_glib import GStat
 GSTAT = GStat()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
 class Lcnc_Gstat_Bool_Label(QtGui.QLabel, _HalWidgetBase):
     def __init__(self, parent=None):
         super(Lcnc_Gstat_Bool_Label, self).__init__(parent)
@@ -41,8 +45,8 @@ class Lcnc_Gstat_Bool_Label(QtGui.QLabel, _HalWidgetBase):
         self._true_textTemplate = data
         try:
             self._set_text(True)
-        except Exception, e:
-            print e,self._textTemplate,'data:',data
+        except Exception as e:
+            log.exception("textTemplate: {}, Data: {}".format(self._textTemplate, data), exc_info=e)
             self.setText('Error')
     def get_true_textTemplate(self):
         return self._true_textTemplate

--- a/lib/python/qtvcp/widgets/gstat_label.py
+++ b/lib/python/qtvcp/widgets/gstat_label.py
@@ -8,6 +8,10 @@ from qtvcp.qt_istat import IStat
 GSTAT = GStat()
 INI = IStat()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
 class Lcnc_Gstat_Label(QtGui.QLabel, _HalWidgetBase):
 
     def __init__(self, parent=None):
@@ -89,8 +93,8 @@ class Lcnc_Gstat_Label(QtGui.QLabel, _HalWidgetBase):
         self._textTemplate = data
         try:
             self._set_text(100.0)
-        except Exception, e:
-            print e,self._textTemplate,'data:',data
+        except Exception as e:
+            log.exception("textTemplate: {}, Data: {}".format(self._textTemplate, data), exc_info=e)
             self.setText('Error')
     def get_textTemplate(self):
         return self._textTemplate

--- a/lib/python/qtvcp/widgets/gstat_slider.py
+++ b/lib/python/qtvcp/widgets/gstat_slider.py
@@ -28,6 +28,11 @@ GSTAT = GStat()
 ACTION = Lcnc_Action()
 INI = IStat()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 class Gstat_Slider(QtGui.QSlider, _HalWidgetBase):
     def __init__(self, parent = None):
         QtGui.QSlider.__init__(self,parent)

--- a/lib/python/qtvcp/widgets/gstat_stacked.py
+++ b/lib/python/qtvcp/widgets/gstat_stacked.py
@@ -6,6 +6,11 @@ from qtvcp.widgets.simple_widgets import _HalWidgetBase
 from qtvcp.qt_glib import GStat
 GSTAT = GStat()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 class GstatStacked(QtGui.QStackedWidget, _HalWidgetBase):
     def __init__(self, parent=None):
         super(GstatStacked, self).__init__(parent)
@@ -15,7 +20,7 @@ class GstatStacked(QtGui.QStackedWidget, _HalWidgetBase):
 
     def _hal_init(self):
         def _switch( index):
-            print 'index',index
+            log.debug('index: {}'.format(index))
             self.setCurrentIndex(index)
         if self.auto:
             GSTAT.connect('mode-auto', lambda w: _switch(2))

--- a/lib/python/qtvcp/widgets/jog_increments.py
+++ b/lib/python/qtvcp/widgets/jog_increments.py
@@ -8,6 +8,11 @@ from qtvcp.qt_istat import IStat
 GSTAT = GStat()
 INI = IStat()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 class Lcnc_JogIncrements(QtGui.QComboBox, _HalWidgetBase):
     def __init__(self, parent=None):
         super(Lcnc_JogIncrements, self).__init__(parent)
@@ -20,11 +25,11 @@ class Lcnc_JogIncrements(QtGui.QComboBox, _HalWidgetBase):
 
     def selectionchange(self, i):
         text = str(self.currentText())
-        print "Current index",i,"selection changed ",text
+        log.debug("Current index: {}, selection changed {}".format(i, text))
         try:
             inc = self.parse_increment(text)
-        except  Exception, e:
-            #print e
+        except  Exception as e:
+            log.debug('Exception parsing increment', exc_info=e)
             inc = 0
         GSTAT.set_jog_increments(inc, text)
 

--- a/lib/python/qtvcp/widgets/led_state_widget.py
+++ b/lib/python/qtvcp/widgets/led_state_widget.py
@@ -5,6 +5,11 @@ from qtvcp.widgets.ledwidget import Lcnc_Led
 from qtvcp.qt_glib import GStat
 GSTAT = GStat()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 class Lcnc_State_Led(Lcnc_Led,):
 
     def __init__(self, parent=None):

--- a/lib/python/qtvcp/widgets/ledwidget.py
+++ b/lib/python/qtvcp/widgets/ledwidget.py
@@ -4,6 +4,11 @@ from PyQt4.QtCore import pyqtProperty, pyqtSlot, Qt, QTimer, QSize
 from PyQt4.QtGui import QWidget, QColor, QPainter, QBrush, QRadialGradient
 from qtvcp.widgets.simple_widgets import _HalWidgetBase, hal, hal_pin_changed_signal
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 class Lcnc_Led(QWidget, _HalWidgetBase):
 
     def __init__(self, parent=None):

--- a/lib/python/qtvcp/widgets/mdi_line.py
+++ b/lib/python/qtvcp/widgets/mdi_line.py
@@ -30,6 +30,11 @@ AUX_PRGM = Aux_program_loader()
 INI = IStat()
 ACTION = Lcnc_Action()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 class Lcnc_MDILine(QLineEdit):
     def __init__(self, parent = None):
         QLineEdit.__init__(self,parent)
@@ -70,7 +75,7 @@ class Lcnc_MDILine(QLineEdit):
 
     # Gcode widget can emit a signal to this
     def external_line_selected(self, w, text, filename):
-        print text, filename
+        log.debug('Ext line selected: {}, {}'.format(text, filename))
         if filename == INI.MDI_HISTORY_PATH:
             self.setText(text)
 
@@ -82,10 +87,10 @@ class Lcnc_MDILine(QLineEdit):
     def keyPressEvent(self, event):
         super(Lcnc_MDILine, self).keyPressEvent(event)
         if event.key() == Qt.Key_Up:
-            print 'up'
+            log.debug('up')
             GSTAT.emit('move-text-lineup')
         if event.key() == Qt.Key_Down:
-            print 'down'
+            log.debug('down')
             GSTAT.emit('move-text-linedown')
 
 # for testing without editor:

--- a/lib/python/qtvcp/widgets/origin_offsetview.py
+++ b/lib/python/qtvcp/widgets/origin_offsetview.py
@@ -2,9 +2,13 @@ import sys, os
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
 # localization
 import locale
-print sys.argv
+log.debug('sys.argv: {}'.format(sys.argv))
 #BASE = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
 #LOCALEDIR = os.path.join(BASE, "share", "locale")
 #locale.setlocale(locale.LC_ALL, '')
@@ -16,6 +20,7 @@ from qtvcp.qt_istat import IStat
 GSTAT = GStat()
 ACTION = Lcnc_Action()
 INI = IStat()
+
 
 class Lcnc_OriginOffsetView(QTableView, _HalWidgetBase):
     def __init__(self, parent=None):
@@ -104,7 +109,7 @@ class Lcnc_OriginOffsetView(QTableView, _HalWidgetBase):
     def showSelection(self, item):
         cellContent = item.data()
         text = cellContent.toPyObject()  # test
-        print text, item.row(), item.column()
+        log.debug('Text: {}, Row: {}, Column: {}'.format(text, item.row(), item.column()))
         sf = "You clicked on {}".format(text)
         # display in title bar for convenience
         self.setWindowTitle(sf)
@@ -179,7 +184,7 @@ class Lcnc_OriginOffsetView(QTableView, _HalWidgetBase):
             if self.filename == None:
                 return g54, g55, g56, g57, g58, g59, g59_1, g59_2, g59_3
             if not os.path.exists(self.filename):
-                print 'no file', self.filename
+                log.error('File does not exist: yellow<{}>'.format(self.filename))
                 return g54, g55, g56, g57, g58, g59, g59_1, g59_2, g59_3
             logfile = open(self.filename, "r").readlines()
             for line in logfile:
@@ -227,8 +232,8 @@ class Lcnc_OriginOffsetView(QTableView, _HalWidgetBase):
         try:
                 qualified = float(data)
                 #qualified = float(locale.atof(data))
-        except:
-            print 'error'
+        except Exception as e:
+            log.exception(e)
         # now update linuxcnc to the change
         try:
             if self.IS_RUNNING:
@@ -251,9 +256,8 @@ class Lcnc_OriginOffsetView(QTableView, _HalWidgetBase):
                 ACTION.RESTORE_RECORDED_MODE()
                 GSTAT.emit('reload-display')
                 self.reload_offsets()
-        except Exception, e:
-            print e
-            print "offsetpage widget error: MDI call error"
+        except Exception as e:
+            log.exception("offsetpage widget error: MDI call error", exc_info=e)
             self.reload_offsets()
 
     # only update every 10th time periodic calls
@@ -312,17 +316,17 @@ class MyTableModel(QAbstractTableModel):
     def setData(self, index, value, role):
         if not index.isValid():
             return False
-        print self.arraydata[index.row()][index.column()]
-        print(">>> setData() role = ", role)
-        print(">>> setData() index.column() = ", index.column())
+        log.debug(self.arraydata[index.row()][index.column()])
+        log.debug(">>> setData() role = {}".format(role))
+        log.debug(">>> setData() index.column() = {}".format(index.column()))
         if index.column() == 9:
             v=str(value.toPyObject())
         else:
             v=float(value.toPyObject())
-        print(">>> setData() value = ", v)
+        log.debug(">>> setData() value = ", v)
         # self.emit(SIGNAL("dataChanged(QModelIndex,QModelIndex)"), index, index)
-        print(">>> setData() index.row = ", index.row())
-        print(">>> setData() index.column = ", index.column())
+        log.debug(">>> setData() index.row = {}".format(index.row()))
+        log.debug(">>> setData() index.column = {}".format(index.column()))
         self.arraydata[index.row()][index.column()] = v
         self.dataChanged.emit(index, index)
         return True

--- a/lib/python/qtvcp/widgets/overlay_widget.py
+++ b/lib/python/qtvcp/widgets/overlay_widget.py
@@ -7,6 +7,11 @@ from qtvcp.widgets.simple_widgets import _HalWidgetBase
 from qtvcp.qt_glib import GStat
 GSTAT = GStat()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 class OverlayWidget(QWidget):
     def __init__(self, parent=None):
         self.last = None
@@ -24,7 +29,7 @@ class OverlayWidget(QWidget):
         if not self.parent: return
         self.parent = self.top_level
         if not self.last == None:
-            #print 'last removed:',self.last
+            log.debug('last removed: {}'.format(self.last))
             self.last.removeEventFilter(self)
         self.parent.installEventFilter(self)
         self.last = self.parent
@@ -239,7 +244,7 @@ def main():
 
     l = QLabel('Hello, world!',w)
     l.show()
-    print l
+    log.debug('Label: {}'.format(l))
 
     o = LoadingOverlay(l)
     o.setObjectName("overlay")

--- a/lib/python/qtvcp/widgets/qtvcp_icons.py
+++ b/lib/python/qtvcp/widgets/qtvcp_icons.py
@@ -1,11 +1,16 @@
 import os
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 class Icon:
     def __init__(self):
         self.ICONDIR = os.path.join(os.path.abspath(os.path.dirname(__file__)),'widget_icons')
         self.LCNC_ICON = os.path.join(self.ICONDIR,'linuxcnc-wizard.gif')
         if not os.path.isfile(self.LCNC_ICON):
-            print 'error no icon in: ',self.LCNC_ICON
+            log.error('error no icon in: {}'.format(self.LCNC_ICON))
 
     def get_path(self,widgetname):
         for i in ('.png','.gif','error'):
@@ -13,5 +18,5 @@ class Icon:
             if os.path.isfile(path):
                 return path
             elif i == 'error':
-                #print 'QTVCP WARNING: Missing icon for ',widgetname,' widget'
+                log.warning("Missing icon for '{}' widget".format(widgetname))
                 return self.LCNC_ICON 

--- a/lib/python/qtvcp/widgets/screenoptions.py
+++ b/lib/python/qtvcp/widgets/screenoptions.py
@@ -9,6 +9,11 @@ GSTAT = GStat()
 NOTE = Notify()
 MSG = Message()
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 class Lcnc_ScreenOptions(QtGui.QWidget, _HalWidgetBase):
     def __init__(self, parent = None):
         QtGui.QWidget.__init__(self, parent)

--- a/lib/python/qtvcp/widgets/simple_widgets.py
+++ b/lib/python/qtvcp/widgets/simple_widgets.py
@@ -6,6 +6,11 @@ import hal
 import gobject
 hal_pin_changed_signal = ('hal-pin-changed', (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, (gobject.TYPE_OBJECT,)))
 
+# Set up logging
+from qtvcp import logger
+log = logger.getLogger(__name__)
+
+
 ###########################
 """ Set of base classes """
 ###########################


### PR DESCRIPTION
print is not good for debugging/logging because unless you spend the time
to put a lot of detail into each print line, it does not give you enough
information.  Also since there is no way to silence debug prints so it is a
temptation to limit their use, or remove/comment them out, which can make
finding a problem later-on much more difficult.

This commit adds facilities for using Python's logging module to log to both
the terminal and a log file.  A subclass of `logging.Formatter` is used for the
terminal handler to produce colored log levels, and optionally allow tagging
text in the log message to colorize it as well.

Ex:
`log.debug('Spindle has green<STARTED>')` would print
`[QTSCREEN][MOD_NAME][DEBUG]  Spindle has STARTED (logged_file.py:13)`
with the the word `STARTED` highlighted in green.

Signed-off-by: Kurt Jacobson <kurtcjacobson@gmail.com>