### PR TITLE
Fixes #328. Preventing item assignment on tuple.

### DIFF
--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -1286,6 +1286,8 @@ class GlCanonDraw:
                 positions[0] = x * math.cos(t) - y * math.sin(t)
                 positions[1] = x * math.sin(t) + y * math.cos(t)
                 positions = [(i-j) for i, j in zip(positions, s.g92_offset)]
+            else:
+                positions = list(positions)
 
             if self.get_a_axis_wrapped():
                 positions[3] = math.fmod(positions[3], 360.0)


### PR DESCRIPTION
Trying to resolve #328, succeeded.
When one of rotary axis is wrapped, the code between line 1292 and 1302 will do item assignment in positions.
But if self.get_show_relative() returns false, positions is a tuple, item assignment will fail. So I added 2 lines of code to ensure positions is always a list.