### PR TITLE
doc: Correct default timeout.

### DIFF
--- a/docs/src/config/python-interface.txt
+++ b/docs/src/config/python-interface.txt
@@ -722,7 +722,9 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
 
 `wait_complete([float])`::
 	wait for completion of the last command sent. If timeout in
-	seconds not specified, default is 5 seconds.
+	seconds not specified, default is 5 seconds. Return -1 if
+	timed out, return RCS_DONE or RCS_ERROR according to command
+	execution status.
 
 
 == Reading the error channel

--- a/docs/src/config/python-interface.txt
+++ b/docs/src/config/python-interface.txt
@@ -722,7 +722,7 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
 
 `wait_complete([float])`::
 	wait for completion of the last command sent. If timeout in
-	seconds not specified, default is 1 second.
+	seconds not specified, default is 5 seconds.
 
 
 == Reading the error channel


### PR DESCRIPTION
I suppose the default timeout is 5 seconds? Because EMC_COMMAND_TIMEOUT is 5.0 here:

https://github.com/LinuxCNC/linuxcnc/blob/a966260822cfdd3c61d0db90ba086a30acc659a9/src/emc/usr_intf/axis/extensions/emcmodule.cc#L207