### PR TITLE
Update build_INI.py

### DIFF
--- a/src/emc/usr_intf/stepconf/build_INI.py
+++ b/src/emc/usr_intf/stepconf/build_INI.py
@@ -124,6 +124,7 @@ class INI:
         print >>file, "[FILTER]"
         print >>file, "PROGRAM_EXTENSION = .png,.gif,.jpg Greyscale Depth Image"
         print >>file, "PROGRAM_EXTENSION = .py Python Script"
+        print >>file, "PROGRAM_EXTENSION = .nc,.tap G-Code File"
         print >>file, "png = image-to-gcode"
         print >>file, "gif = image-to-gcode"
         print >>file, "jpg = image-to-gcode"


### PR DESCRIPTION
gmoccapy does not show the suffix .nc and .tap G code files when importing the program. I added these two suffixes to build_INI.py. You can write .nc and .tap to the ini configuration while running the wizard.