### PR TITLE
Reduce memory usage in compile by specifying BOOST_PYTHON_MAX_ARITY

### DIFF
--- a/src/emc/kinematics/lineardeltakins.cc
+++ b/src/emc/kinematics/lineardeltakins.cc
@@ -14,6 +14,7 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include <cmath>
 #include <boost/python.hpp>
 using namespace boost::python;

--- a/src/emc/kinematics/rotarydeltakins.cc
+++ b/src/emc/kinematics/rotarydeltakins.cc
@@ -14,6 +14,7 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include <cmath>
 #include "rotarydeltakins-common.h"
 #include <boost/python.hpp>

--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include <boost/python/exec.hpp>
 #include <boost/python/extract.hpp>
 #include <boost/python/import.hpp>

--- a/src/emc/pythonplugin/python_plugin.hh
+++ b/src/emc/pythonplugin/python_plugin.hh
@@ -19,6 +19,9 @@
 #ifndef PYTHON_PLUGIN_HH
 #define PYTHON_PLUGIN_HH
 
+#ifndef BOOST_PYTHON_MAX_ARITY
+#define BOOST_PYTHON_MAX_ARITY 4
+#endif
 #include <boost/python/object.hpp>
 
 #include <vector>

--- a/src/emc/rs274ngc/array1.hh
+++ b/src/emc/rs274ngc/array1.hh
@@ -6,6 +6,9 @@
 #ifndef __array_1_pyplusplus_hpp__
 #define __array_1_pyplusplus_hpp__
 
+#ifndef BOOST_PYTHON_MAX_ARITY
+#define BOOST_PYTHON_MAX_ARITY 4
+#endif
 #include <boost/python/iterator.hpp>
 #include <boost/python/enum.hpp>
 #include <boost/python/object.hpp>

--- a/src/emc/rs274ngc/canonmodule.cc
+++ b/src/emc/rs274ngc/canonmodule.cc
@@ -16,6 +16,7 @@
  *    along with this program; if not, write to the Free Software
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#define BOOST_PYTHON_MAX_ARITY 13
 #include <boost/python/def.hpp>
 #include <boost/python/module.hpp>
 #include <boost/python/scope.hpp>

--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -16,6 +16,7 @@
 #define _GNU_SOURCE
 #endif
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include "python_plugin.hh"
 #include <boost/python/dict.hpp>
 #include <boost/python/extract.hpp>

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -12,6 +12,7 @@
 *
 ********************************************************************/
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include <boost/python/list.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/dict.hpp>

--- a/src/emc/rs274ngc/interp_python.cc
+++ b/src/emc/rs274ngc/interp_python.cc
@@ -33,6 +33,7 @@
 // this is actually a bug in libgl1-mesa-dri and it looks
 // it has been fixed in mesa - 7.10.1-0ubuntu2
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include "python_plugin.hh"
 #include "interp_python.hh"
 #include <boost/python/extract.hpp>

--- a/src/emc/rs274ngc/interp_python.hh
+++ b/src/emc/rs274ngc/interp_python.hh
@@ -1,5 +1,8 @@
 #ifndef RS274NGC_INTERP_PYTHON
 #define RS274NGC_INTERP_PYTHON
+#ifndef BOOST_PYTHON_NAX_ARITY
+#define BOOST_PYTHON_MAX_ARITY 4
+#endif
 #include <boost/python/object.hpp>
 struct pycontext_impl {
     boost::python::object tupleargs; // the args tuple for Py functions

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -13,6 +13,7 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
+#define BOOST_PYTHON_MAX_ARITY 4
 #include "python_plugin.hh"
 #include "interp_python.hh"
 #include <boost/python/list.hpp>

--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -17,6 +17,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_PYTHON_NAX_ARITY
+#define BOOST_PYTHON_MAX_ARITY 4
+#endif
 #include <string.h>
 #include "rs274ngc_interp.hh"
 #include <boost/python/object.hpp>

--- a/src/emc/rs274ngc/interpmodule.cc
+++ b/src/emc/rs274ngc/interpmodule.cc
@@ -20,6 +20,7 @@
 // Michael Haberler 7/2011
 //
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/exception_translator.hpp>

--- a/src/emc/rs274ngc/paramclass.hh
+++ b/src/emc/rs274ngc/paramclass.hh
@@ -15,6 +15,9 @@
  *    along with this program; if not, write to the Free Software
  *    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+#ifndef BOOST_PYTHON_NAX_ARITY
+#define BOOST_PYTHON_MAX_ARITY 4
+#endif
 #include <boost/python/list.hpp>
 
 struct ParamClass {

--- a/src/emc/rs274ngc/pyarrays.cc
+++ b/src/emc/rs274ngc/pyarrays.cc
@@ -21,6 +21,7 @@
 // (at least in boost 1.55, return_internal_reference needs a definition
 // of boost::python::detail::get which comes from detail/caller.hpp.
 // At first sniff it's a boost bug but what can you do...)
+#define BOOST_PYTHON_MAX_ARITY 4
 #include <boost/python/detail/caller.hpp>
 #include <boost/python/return_internal_reference.hpp>
 namespace bp = boost::python;

--- a/src/emc/rs274ngc/pyblock.cc
+++ b/src/emc/rs274ngc/pyblock.cc
@@ -19,6 +19,7 @@
 // Michael Haberler 7/2011
 //
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include <boost/python/class.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <map>

--- a/src/emc/rs274ngc/pyemctypes.cc
+++ b/src/emc/rs274ngc/pyemctypes.cc
@@ -19,6 +19,7 @@
 // Michael Haberler 7/2011
 //
 
+#define BOOST_PYTHON_MAX_ARITY 9
 #include <boost/python/class.hpp>
 #include <boost/python/tuple.hpp>
 namespace bp = boost::python;

--- a/src/emc/rs274ngc/pyinterp1.cc
+++ b/src/emc/rs274ngc/pyinterp1.cc
@@ -19,6 +19,7 @@
 // Michael Haberler 7/2011
 //
 
+#define BOOST_PYTHON_MAX_ARITY 7
 #include <boost/python/object.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <map>

--- a/src/emc/rs274ngc/pyparamclass.cc
+++ b/src/emc/rs274ngc/pyparamclass.cc
@@ -19,6 +19,7 @@
 // Michael Haberler 7/2011
 //
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include <boost/python/extract.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <map>

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -65,6 +65,7 @@ suppression can produce more concise output. Future versions might
 include an option for suppressing superfluous commands.
 
 ****************************************************************************/
+#define BOOST_PYTHON_MAX_ARITY 4
 #include "python_plugin.hh"
 #include <boost/python/dict.hpp>
 #include <boost/python/extract.hpp>

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -36,6 +36,7 @@
 #include "python_plugin.hh"
 #include "taskclass.hh"
 
+#define BOOST_PYTHON_MAX_ARITY 4
 #include <boost/python/dict.hpp>
 #include <boost/python/extract.hpp>
 #include <boost/python/object.hpp>

--- a/src/emc/task/taskmodule.cc
+++ b/src/emc/task/taskmodule.cc
@@ -18,6 +18,7 @@
  */
 // TODO: reuse interp converters
 
+#define BOOST_PYTHON_MAX_ARITY 7
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 #include <boost/python/implicit.hpp>


### PR DESCRIPTION
This pull request reduces resource usage of a full LinuxCNC "make -j9"
 * peak memory usage by 14.4%
 * total task faults by 8.7%
 * CPU time by 8.4%

On one particular file directly benefiting from the change, `emc/rs274ngc/interpmodule.cc`, the improvement was a reduction of:
 * peak memory usage by 35.4%
 * total page faults by 33.0%
 * CPU time by 16.7%

It now takes (substantially) less than 512MB RAM to build this particular file on debian stretch amd64.

The cost of this change is that innocuous changes may require a higher BOOST_PYTHON_MAX_ARITY (the number of arguments that may be involved in certain boost python functions, like boost::python::make_tuple), and that might be non-obvious to a novice contributor.

I was prompted to make this PR due to @andypugh running into trouble compiling interpmodule.cc, which I surmised was due to inadequate RAM+swap.