### PR TITLE
fix vismach for puma sim configs.

### DIFF
--- a/configs/sim/axis/vismach/puma/puma560_postgui.hal
+++ b/configs/sim/axis/vismach/puma/puma560_postgui.hal
@@ -1,6 +1,6 @@
-net J0scaled pyvcp.joint0
-net J1scaled pyvcp.joint1
-net J2scaled pyvcp.joint2
-net J3scaled pyvcp.joint3
-net J4scaled pyvcp.joint4
-net J5scaled pyvcp.joint5
+net j0 pyvcp.joint0
+net j1 pyvcp.joint1
+net j2 pyvcp.joint2
+net j3 pyvcp.joint3
+net j4 pyvcp.joint4
+net j5 pyvcp.joint5

--- a/configs/sim/axis/vismach/puma/puma560_sim_6.hal
+++ b/configs/sim/axis/vismach/puma/puma560_sim_6.hal
@@ -55,33 +55,9 @@ setp genserkins.D-3 17.05
 setp genserkins.D-4 0 
 setp genserkins.D-5 2.2
 
-
-loadrt scale count=6
-
-addf scale.0 servo-thread
-addf scale.1 servo-thread
-addf scale.2 servo-thread
-addf scale.3 servo-thread
-addf scale.4 servo-thread
-addf scale.5 servo-thread
-
-net J0pos scale.0.in
-net J1pos scale.1.in
-net J2pos scale.2.in
-net J3pos scale.3.in
-net J4pos scale.4.in
-net J5pos scale.5.in
-
-setp scale.0.gain 1
-setp scale.1.gain 1
-setp scale.2.gain 1
-setp scale.3.gain 1
-setp scale.4.gain 1
-setp scale.5.gain 1
-
-net J0scaled scale.0.out puma560gui.joint1
-net J1scaled scale.1.out puma560gui.joint2
-net J2scaled scale.2.out puma560gui.joint3
-net J3scaled scale.3.out puma560gui.joint4
-net J4scaled scale.4.out puma560gui.joint5
-net J5scaled scale.5.out puma560gui.joint6
+net j0 joint.0.pos-fb puma560gui.joint1
+net j1 joint.1.pos-fb puma560gui.joint2
+net j2 joint.2.pos-fb puma560gui.joint3
+net j3 joint.3.pos-fb puma560gui.joint4
+net j4 joint.4.pos-fb puma560gui.joint5
+net j5 joint.5.pos-fb puma560gui.joint6

--- a/configs/sim/axis/vismach/puma/puma_postgui.hal
+++ b/configs/sim/axis/vismach/puma/puma_postgui.hal
@@ -1,6 +1,6 @@
-net J0scaled pyvcp.joint0
-net J1scaled pyvcp.joint1
-net J2scaled pyvcp.joint2
-net J3scaled pyvcp.joint3
-net J4scaled pyvcp.joint4
-net J5scaled pyvcp.joint5
+net j0 pyvcp.joint0
+net j1 pyvcp.joint1
+net j2 pyvcp.joint2
+net j3 pyvcp.joint3
+net j4 pyvcp.joint4
+net j5 pyvcp.joint5

--- a/configs/sim/axis/vismach/puma/puma_sim_6.hal
+++ b/configs/sim/axis/vismach/puma/puma_sim_6.hal
@@ -92,43 +92,12 @@ net cflt joint.5.amp-fault-in
 
 loadusr -W pumagui
 
-loadrt scale count=6
-
-addf scale.0 servo-thread
-addf scale.1 servo-thread
-addf scale.2 servo-thread
-addf scale.3 servo-thread
-addf scale.4 servo-thread
-addf scale.5 servo-thread
-
-net J0pos scale.0.in
-net J1pos scale.1.in
-net J2pos scale.2.in
-net J3pos scale.3.in
-net J4pos scale.4.in
-net J5pos scale.5.in
-
-setp scale.0.gain 1
-setp scale.1.gain 1
-setp scale.2.gain 1
-setp scale.3.gain 1
-setp scale.4.gain 1
-setp scale.5.gain 1
-
-net J0scaled scale.0.out pumagui.joint1
-net J1scaled scale.1.out pumagui.joint2
-net J2scaled scale.2.out pumagui.joint3
-net J3scaled scale.3.out pumagui.joint4
-net J4scaled scale.4.out pumagui.joint5
-net J5scaled scale.5.out pumagui.joint6
-
-#net j0 joint.0.pos-fb pumagui.joint1
-#net j1 joint.1.pos-fb pumagui.joint2
-#net j2 joint.2.pos-fb pumagui.joint3
-#net j3 joint.3.pos-fb pumagui.joint4
-#net j4 joint.4.pos-fb pumagui.joint5
-#net j5 joint.5.pos-fb pumagui.joint6
-#net j6 joint.6.pos-fb pumagui.grip
+net j0 joint.0.pos-fb pumagui.joint1
+net j1 joint.1.pos-fb pumagui.joint2
+net j2 joint.2.pos-fb pumagui.joint3
+net j3 joint.3.pos-fb pumagui.joint4
+net j4 joint.4.pos-fb pumagui.joint5
+net j5 joint.5.pos-fb pumagui.joint6
 
 setp pumakins.A2 400
 setp pumakins.A3 50


### PR DESCRIPTION
The puma sim uses immediate homing, so vismach needs to be connected to pos-fb instead of mot-pos-fb in order to work properly after homing again.

Signed-off-by: Rene Hopf <renehopf@mac.com>