### PR TITLE
Configure python3

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1562,7 +1562,7 @@ if test "$PYTHON" = "none"; then
 fi
 
 AC_MSG_CHECKING([python version])
-if ! $PYTHON -c 'import sys;raise SystemExit,sys.hexversion<0x2070000'
+if ! $PYTHON -c 'import sys;raise SystemExit(sys.hexversion<0x2070000)'
 then
     AC_MSG_ERROR(Python version too old (2.7 or newer required))
 fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1569,7 +1569,7 @@ fi
 AC_MSG_RESULT(OK)
 
 AC_MSG_CHECKING([version of python libraries])
-LIBPYTHON=`$PYTHON -c 'import distutils.sysconfig; print "python" + distutils.sysconfig.get_config_vars().get("VERSION")'`
+LIBPYTHON=`$PYTHON -c 'import distutils.sysconfig; print("python" + (distutils.sysconfig.get_config_vars().get("LDVERSION") or distutils.sysconfig.get_config_vars().get("VERSION")))'`
 AC_MSG_RESULT($LIBPYTHON)
 
 AC_MSG_CHECKING([match between tk and Tkinter versions])

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1574,8 +1574,8 @@ AC_MSG_RESULT($LIBPYTHON)
 
 AC_MSG_CHECKING([match between tk and Tkinter versions])
     
-PYTHON_TK_VERSION="`$PYTHON -c 'import _tkinter; print _tkinter.TK_VERSION'`"
-PYTHON_TCL_VERSION="`$PYTHON -c 'import _tkinter; print _tkinter.TCL_VERSION'`"
+PYTHON_TK_VERSION="`$PYTHON -c 'import _tkinter; print(_tkinter.TK_VERSION)'`"
+PYTHON_TCL_VERSION="`$PYTHON -c 'import _tkinter; print(_tkinter.TCL_VERSION)'`"
 
 if test "$PYTHON_TCL_VERSION" != "$TCL_VERSION"; then
     AC_MSG_RESULT([TCL mismatch: $TCL_VERSION vs $PYTHON_TCL_VERSION])
@@ -1589,7 +1589,7 @@ fi
 AC_MSG_RESULT([$PYTHON_TK_VERSION])
 
 AC_MSG_CHECKING(location of Python header files)
-INCLUDEPY=`$PYTHON -c 'import distutils.sysconfig; print distutils.sysconfig.get_config_vars().get("INCLUDEPY")'`
+INCLUDEPY=`$PYTHON -c 'import distutils.sysconfig; print(distutils.sysconfig.get_config_vars().get("INCLUDEPY"))'`
 AC_MSG_RESULT($INCLUDEPY)
 
 AC_MSG_CHECKING([for Python headers])
@@ -1619,7 +1619,7 @@ AC_CHECK_HEADER($INCLUDEPY/Python.h,[],
     [AC_MSG_ERROR([Required header Python.h missing.  Install it, or specify --disable-python to skip the parts of LinuxCNC that depend on Python])])
 
 AC_MSG_CHECKING(for site-package location)
-SITEPY=`$PYTHON -c 'import distutils.sysconfig; print distutils.sysconfig.get_python_lib()'`
+SITEPY=`$PYTHON -c 'import distutils.sysconfig; print(distutils.sysconfig.get_python_lib())'`
 AC_MSG_RESULT($SITEPY)
 
 AC_CHECK_HEADERS(GL/gl.h GL/glu.h,[],[AC_MSG_ERROR([Required OpenGL header missing.  Install it, or specify --disable-python to skip the parts of LinuxCNC that depend on Python])])


### PR DESCRIPTION
After this change, the following configure invocation works for me on debian stretch:
~~~~
$ ./configure --with-python=python3 --with-boost-python=boost_python-py35 --enable-non-distributable=yes
~~~~
(`--enable-non-distributable` is needed on my usual development system for reasons unrelated to python3)

However, as expected, actually building LinuxCNC after this `./configure` invocation fails for many reasons.