### PR TITLE
Make LinuxCNC testsuite clean under gcc -fsanitize=...

### DIFF
--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -355,7 +355,8 @@ int Interp::execute_return(setup_pointer settings, context_pointer current_frame
 
     block_pointer cblock = &CONTROLLING_BLOCK(*settings);
     block_pointer eblock = &EXECUTING_BLOCK(*settings);
-    context_pointer previous_frame = &settings->sub_context[settings->call_level - 1];
+    context_pointer previous_frame = settings->call_level > 0 ?
+        &settings->sub_context[settings->call_level - 1] : nullptr;
 
     // if level is not zero, in a call
     // otherwise in a defn

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -285,7 +285,7 @@ int hal_init(const char *name)
 
 int hal_exit(int comp_id)
 {
-    int *prev, next;
+    intptr_t *prev, next;
     hal_comp_t *comp;
     char name[HAL_NAME_LEN + 1];
 
@@ -605,7 +605,8 @@ int hal_pin_s32_newf(hal_pin_dir_t dir,
 int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     void **data_ptr_addr, int comp_id)
 {
-    int *prev, next, cmp;
+    intptr_t *prev, next;
+    int cmp;
     hal_pin_t *new, *ptr;
     hal_comp_t *comp;
 
@@ -724,7 +725,8 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
 
 int hal_pin_alias(const char *pin_name, const char *alias)
 {
-    int *prev, next, cmp;
+    intptr_t *prev, next;
+    int cmp;
     hal_pin_t *pin, *ptr;
     hal_oldname_t *oldname;
 
@@ -852,7 +854,8 @@ int hal_pin_alias(const char *pin_name, const char *alias)
 int hal_signal_new(const char *name, hal_type_t type)
 {
 
-    int *prev, next, cmp;
+    intptr_t *prev, next;
+    int cmp;
     hal_sig_t *new, *ptr;
     void *data_addr;
 
@@ -966,7 +969,7 @@ int hal_signal_new(const char *name, hal_type_t type)
 int hal_signal_delete(const char *name)
 {
     hal_sig_t *sig;
-    int *prev, next;
+    intptr_t *prev, next;
 
     if (hal_data == 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1287,7 +1290,8 @@ int hal_param_s32_newf(hal_param_dir_t dir, hal_s32_t * data_addr,
 int hal_param_new(const char *name, hal_type_t type, hal_param_dir_t dir, void *data_addr,
     int comp_id)
 {
-    int *prev, next, cmp;
+    intptr_t *prev, next;
+    int cmp;
     hal_param_t *new, *ptr;
     hal_comp_t *comp;
 
@@ -1495,7 +1499,8 @@ int hal_param_set(const char *name, hal_type_t type, void *value_addr)
 
 int hal_param_alias(const char *param_name, const char *alias)
 {
-    int *prev, next, cmp;
+    intptr_t *prev, next;
+    int cmp;
     hal_param_t *param, *ptr;
     hal_oldname_t *oldname;
 
@@ -1625,7 +1630,8 @@ int hal_param_alias(const char *param_name, const char *alias)
 int hal_export_funct(const char *name, void (*funct) (void *, long),
     void *arg, int uses_fp, int reentrant, int comp_id)
 {
-    int *prev, next, cmp;
+    intptr_t *prev, next;
+    int cmp;
     hal_funct_t *new, *fptr;
     hal_comp_t *comp;
     char buf[HAL_NAME_LEN + 1];
@@ -1922,7 +1928,7 @@ int hal_create_thread(const char *name, unsigned long period_nsec, int uses_fp)
 extern int hal_thread_delete(const char *name)
 {
     hal_thread_t *thread;
-    int *prev, next;
+    intptr_t *prev, next;
 
     if (hal_data == 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -3096,7 +3102,7 @@ static hal_thread_t *alloc_thread_struct(void)
 
 static void free_comp_struct(hal_comp_t * comp)
 {
-    int *prev, next;
+    intptr_t *prev, next;
 #ifdef RTAPI
     hal_funct_t *funct;
 #endif /* RTAPI */
@@ -3367,7 +3373,7 @@ static void free_thread_struct(hal_thread_t * thread)
     hal_list_t *list_root, *list_entry;
 /*! \todo Another #if 0 */
 #if 0
-    int *prev, next;
+    intptr_t *prev, next;
     char time[HAL_NAME_LEN + 1], tmax[HAL_NAME_LEN + 1];
     hal_param_t *param;
 #endif

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -141,8 +141,8 @@ typedef union {
     inside a larger structure.
 */
 typedef struct {
-    int next;			/* next element in list */
-    int prev;			/* previous element in list */
+    intptr_t next;			/* next element in list */
+    intptr_t prev;			/* previous element in list */
 } hal_list_t;
 
 /** HAL "oldname" data structure.

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -329,8 +329,8 @@ typedef struct {
 */
 
 #define HAL_KEY   0x48414C32	/* key used to open HAL shared memory */
-#define HAL_VER   0x0000000E	/* version code */
-#define HAL_SIZE  (75*4096)
+#define HAL_VER   0x0000000F	/* version code */
+#define HAL_SIZE  (85*4096)
 #define HAL_PSEUDO_COMP_PREFIX "__" /* prefix to identify a pseudo component */
 
 /* These pointers are set by hal_init() to point to the shmem block

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -150,7 +150,7 @@ typedef struct {
     store the original name.
 */
 typedef struct {
-    int next_ptr;		/* next struct (used for free list only) */
+    intptr_t next_ptr;		/* next struct (used for free list only) */
     char name[HAL_NAME_LEN + 1];	/* the original name */
 } hal_oldname_t;
 
@@ -172,24 +172,24 @@ typedef struct {
 			        /* prefix of name for new instance */
     char constructor_arg[HAL_NAME_LEN+1];
 			        /* prefix of name for new instance */
-    int shmem_bot;		/* bottom of free shmem (first free byte) */
-    int shmem_top;		/* top of free shmem (1 past last free) */
-    int comp_list_ptr;		/* root of linked list of components */
-    int pin_list_ptr;		/* root of linked list of pins */
-    int sig_list_ptr;		/* root of linked list of signals */
-    int param_list_ptr;		/* root of linked list of parameters */
-    int funct_list_ptr;		/* root of linked list of functions */
-    int thread_list_ptr;	/* root of linked list of threads */
+    intptr_t shmem_bot;		/* bottom of free shmem (first free byte) */
+    intptr_t shmem_top;		/* top of free shmem (1 past last free) */
+    intptr_t comp_list_ptr;		/* root of linked list of components */
+    intptr_t pin_list_ptr;		/* root of linked list of pins */
+    intptr_t sig_list_ptr;		/* root of linked list of signals */
+    intptr_t param_list_ptr;		/* root of linked list of parameters */
+    intptr_t funct_list_ptr;		/* root of linked list of functions */
+    intptr_t thread_list_ptr;	/* root of linked list of threads */
     long base_period;		/* timer period for realtime tasks */
     int threads_running;	/* non-zero if threads are started */
-    int oldname_free_ptr;	/* list of free oldname structs */
-    int comp_free_ptr;		/* list of free component structs */
-    int pin_free_ptr;		/* list of free pin structs */
-    int sig_free_ptr;		/* list of free signal structs */
-    int param_free_ptr;		/* list of free parameter structs */
-    int funct_free_ptr;		/* list of free function structs */
+    intptr_t oldname_free_ptr;	/* list of free oldname structs */
+    intptr_t comp_free_ptr;		/* list of free component structs */
+    intptr_t pin_free_ptr;		/* list of free pin structs */
+    intptr_t sig_free_ptr;		/* list of free signal structs */
+    intptr_t param_free_ptr;		/* list of free parameter structs */
+    intptr_t funct_free_ptr;		/* list of free function structs */
     hal_list_t funct_entry_free;	/* list of free funct entry structs */
-    int thread_free_ptr;	/* list of free thread structs */
+    intptr_t thread_free_ptr;	/* list of free thread structs */
     int exact_base_period;      /* if set, pretend that rtapi satisfied our
 				   period request exactly */
     unsigned char lock;         /* hal locking, can be one of the HAL_LOCK_* types */
@@ -201,7 +201,7 @@ typedef struct {
     component calls hal_init().
 */
 typedef struct {
-    int next_ptr;		/* next component in the list */
+    intptr_t next_ptr;		/* next component in the list */
     int comp_id;		/* component ID (RTAPI module id) */
     int mem_id;			/* RTAPI shmem ID used by this comp */
     int type;			/* 1 if realtime, 0 if not */
@@ -217,7 +217,7 @@ typedef struct {
     This structure contains information about a 'pin' object.
 */
 typedef struct {
-    int next_ptr;		/* next pin in linked list */
+    intptr_t next_ptr;		/* next pin in linked list */
     int data_ptr_addr;		/* address of pin data pointer */
     int owner_ptr;		/* component that owns this pin */
     int signal;			/* signal to which pin is linked */
@@ -232,7 +232,7 @@ typedef struct {
     This structure contains information about a 'signal' object.
 */
 typedef struct {
-    int next_ptr;		/* next signal in linked list */
+    intptr_t next_ptr;		/* next signal in linked list */
     int data_ptr;		/* offset of signal value */
     hal_type_t type;		/* data type */
     int readers;		/* number of input pins linked */
@@ -245,7 +245,7 @@ typedef struct {
     This structure contains information about a 'parameter' object.
 */
 typedef struct {
-    int next_ptr;		/* next parameter in linked list */
+    intptr_t next_ptr;		/* next parameter in linked list */
     int data_ptr;		/* offset of parameter value */
     int owner_ptr;		/* component that owns this signal */
     int oldname;		/* old name if aliased, else zero */
@@ -271,7 +271,7 @@ typedef struct {
 */
 
 typedef struct {
-    int next_ptr;		/* next function in linked list */
+    intptr_t next_ptr;		/* next function in linked list */
     int uses_fp;		/* floating point flag */
     int owner_ptr;		/* component that added this funct */
     int reentrant;		/* non-zero if function is re-entrant */
@@ -294,7 +294,7 @@ typedef struct {
 #define HAL_STACKSIZE 16384	/* realtime task stacksize */
 
 typedef struct {
-    int next_ptr;		/* next thread in linked list */
+    intptr_t next_ptr;		/* next thread in linked list */
     int uses_fp;		/* floating point flag */
     long int period;		/* period of the thread, in nsec */
     int priority;		/* priority of the thread */
@@ -329,7 +329,7 @@ typedef struct {
 */
 
 #define HAL_KEY   0x48414C32	/* key used to open HAL shared memory */
-#define HAL_VER   0x0000000D	/* version code */
+#define HAL_VER   0x0000000E	/* version code */
 #define HAL_SIZE  (75*4096)
 #define HAL_PSEUDO_COMP_PREFIX "__" /* prefix to identify a pseudo component */
 

--- a/src/libnml/inifile/inifile.cc
+++ b/src/libnml/inifile/inifile.cc
@@ -292,7 +292,7 @@ IniFile::Find(const char *_tag, const char *_section, int _num, int *lineno)
             line[newLinePos] = 0;        /* make the newline 0 */
         }
         // honor backslash (\) as line-end escape
-        if (line[newLinePos-1] == '\\') {
+        if (newLinePos > 0 && line[newLinePos-1] == '\\') {
            newLinePos = newLinePos-1;
            line[newLinePos] = 0;
            if (!extend_ct) {


### PR DESCRIPTION
I compiled LinuxCNC with
~~~~
./configure CC="gcc -fsanitize=undefined,bool,float-cast-overflow" CXX="g++ -fsanitize=undefined,bool,float-cast-overflow"
~~~~
built, ran the testsuite, and fixed what was broken.

For uninteresting reasons, `tests/build/ui` and `tests/overrun` fail here.  With `skip` files created in those directories, the testsuite passes without encountering any diagnostics from `-fsanitize`.

Compiler is `gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1)`.  Different compilers and versions may detect slightly different stuff.

The main concerning item for me is the one in interp: before my change, we could probably with a reasonable amount of blitheness access through the pointer in question and not crash.  Now, we're pretty much guaranteed by UNIX semantics to get a nice crash.  From the standpoint of bug hunting, though, this is a much better position to be in :wink: 

The other detail to consider is the somewhat increased HAL shared memory area usage, because every signal now allocates 8 bytes for its data, instead of sometimes allocating as little as 1 byte.  Investigation shows that memory usage typically increased by 8%, so I increased HAL shared memory area by 40KiB (13%).

The several UIs I tried also start and run without encountering `-fsanitize=` diagnostics.

Note: while actually fixing problems, it may be more useful to also specify `-fsanitize-recover=all`, since it allows the program to continue after a problem is encountered.