### PR TITLE
tram.c: Fix pointer arithmetic thinko

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/tram.c
+++ b/src/hal/drivers/mesa-hostmot2/tram.c
@@ -112,7 +112,7 @@ int hm2_allocate_tram_regions(hostmot2_t *hm2) {
         return -ENOMEM;
     }
     if(hm2->tram_read_size>old_tram_read_size)
-        memset(hm2->tram_read_buffer+old_tram_read_size, 0, hm2->tram_read_size-old_tram_read_size);
+        memset((char*)hm2->tram_read_buffer+old_tram_read_size, 0, hm2->tram_read_size-old_tram_read_size);
     
     hm2->tram_write_buffer = (rtapi_u32 *)rtapi_krealloc(hm2->tram_write_buffer, hm2->tram_write_size, RTAPI_GFP_KERNEL);
     if (hm2->tram_write_buffer == NULL) {
@@ -120,7 +120,7 @@ int hm2_allocate_tram_regions(hostmot2_t *hm2) {
         return -ENOMEM;
     }
     if(hm2->tram_write_size>old_tram_write_size)
-        memset(hm2->tram_write_buffer+old_tram_write_size, 0, hm2->tram_write_size-old_tram_write_size);
+        memset((char*)hm2->tram_write_buffer+old_tram_write_size, 0, hm2->tram_write_size-old_tram_write_size);
 
     HM2_DBG("buffer address %p\n", &hm2->tram_write_buffer);
     HM2_DBG("Translation RAM read buffer:\n");


### PR DESCRIPTION
Because the type of tram_read_buffer is uint32_t, it's not
appropriate to perform arithmetic on it with the old read size
which is in bytes.

This didn't usually affect hm2 EXCEPT FOR bspi, because bspi
is the only user of the code that reaches hm2_allocate_tram_regions
with the old_tran_read_size being nonzero.

(The analysis is just the same for the case of the write buffers)

For those following along at home, I added the bad code
in cf4f68997553422c40dea22ad916b82ff0254a7f and all 2.7 and master
branches are likely affected.

Closes: #451