### PR TITLE
Re-wording of LinuxCNC User Introduction doc

### DIFF
--- a/docs/src/user/user-intro.txt
+++ b/docs/src/user/user-intro.txt
@@ -4,180 +4,163 @@
 
 == How LinuxCNC Works
 
-When you start LinuxCNC from the CNC menu or by typing 'linuxcnc'
-in the terminal the LinuxCNC script starts the
-<<cha:starting-linuxcnc,Configuration Selector>>. When you pick a configuration
-LinuxCNC reads the <<cha:ini-configuration,INI file>> then loads the 
-<<cha:basic-hal-reference,HAL files>> in the order that they are listed in the
-INI file.
+LinuxCNC is a suite of highly-customisable applications for the control of a Computer Numerically
+Controlled (CNC) mills and lathes, 3D printers, robots, laser cutters, plasma cutters and other automated
+devices. It is capable of providing coordinated control of up to 9 axes of movement.
 
-When you create a configuration with the
-<<cha:stepconf-wizard,Stepper Configuration Wizard>> or
-<<cha:pncconf-wizard,Mesa Hardware Wizard>> or by picking a sample
-configuration from the <<cha:starting-linuxcnc,Configuration Selector>>
-LinuxCNC creates some directories and files in your user directory. In the
-following example the name of the configuration is 'My Lathe'.
+At its heart, LinuxCNC consists of several key components that are integrated together to form one
+complete system:
 
-* linuxcnc
-** configs
-*** My_Lathe
-**** My_Lathe.ini (this is read by the linuxcnc script)
-**** My_Lathe.hal (this hal file is loaded before the gui)
-**** post_gui.hal (this hal file is loaded after the gui)
-**** linuxcnc.var (stores the <<gcode:parameters,parameters>>)
-**** linuxcnc.var.bak (a backup parameter file)
-**** tool.tbl (the tool table file)
-** nc_files
-*** *.ngc (G code files)
+* a Graphical User Interface (GUI), which forms the basic interface between the operator, the software
+and the CNC machine itself;
+* the <<cha:hal-introduction,Hardware Abstraction Layer>> (HAL), which provides a method of linking all
+the various internal virtual signals generated and received by LinuxCNC with the outside world; and,
+* the high level controllers that coordinate the generation and execution of motion control of the CNC
+machine, namely the motion controller (EMCMOT), the discrete input/output controller (EMCIO) and the
+task executor (EMCTASK).
 
-There can be other directorys and files in a configuration but the above is
-usually the minimum files used.
-
-LinuxCNC can control machine tools, robots, or other automated devices. It can
-control servo motors, stepper motors, relays, and other devices related to
-motion control. LinuxCNC can control up to 9 axes in coordinated motion.
-
-There are five main components to the LinuxCNC software: 
-
-* a motion controller (EMCMOT)
-* a discrete I/O controller (EMCIO)
-* a task executor which coordinates them (EMCTASK)
-* a graphical user interface.
-* a hardware abstraction layer (HAL)
-
-.Simple LinuxCNC Controlled Machine
+The below illustration is a simple block diagram showing what a typical 3-axis, CNC mill with stepper
+motors might look like: 
 
 image::images/whatstep1.png[align="center", alt="Simple LinuxCNC Controlled Machine"]
 
-The above figure shows a simple block diagram showing
-what a typical 3-axis LinuxCNC system might look like. This diagram shows a
-stepper motor system. The PC, running Linux(((Linux))) as its operating
-system, is actually controlling the stepper motor drives by sending
-signals through the printer port. These signals (pulses) make the
-stepper drives move the stepper motors. The LinuxCNC system can also run servo
-motors via servo interface cards or by using an extended parallel port
-to connect with external control boards. As we examine each of the
-components that make up an LinuxCNC system we will remind the reader of
-this typical machine.
+A computer running LinuxCNC sends a sequence of pulses via the parallel port to the stepper drives, each of
+which has one stepper motor connected to it. Each drive receives two independent signals; one signal to
+command the drive to move its associated stepper motor in a clockwise or anti-clockwise direction, and a
+second signal that defines the speed at which that stepper motor rotates. 
+
+While a stepper motor system under parallel port control is illustrated, a LinuxCNC system can also control
+servo motors via servo interface cards, or dispense with the parallel port altogether and utilise dedicated
+interface cards by http://www.mesanet.com[Mesa Electronics] for increased speed and I/O capabilities.
+
+In most circumstances, users will create a configuration specific to their mill setup using either the
+<<cha:stepconf-wizard,Stepper Configuration Wizard>> (for CNC systems operating using the computers'
+parallel port) or the <<cha:pncconf-wizard,Mesa Hardware Wizard>> (for more advanced systems utilising a
+Mesa Anything I/O PCI card). Running either wizard will create several folders on the computers' hard drive
+containing a number of configuration files specific to that CNC machine, and an icon placed on the desktop
+to allow easy launching of LinuxCNC. 
+
+For example, if the Stepper Configuration Wizard was used to create a setup for the 3-axis CNC mill
+illustrated above entitled 'My_CNC', the folders created by the wizard would typically contain the
+following files:
+
+* Folder: My_CNC 
+** My_CNC.ini 
+*** The INI file contains all the basic hardware information regarding the operation of the CNC mill such
+as the number of steps each stepper motor must turn to complete one full revolution, the maximum rate at
+which each stepper may operate at, the limits of travel of each axis or the configuration and behaviour of
+limit switches on each axis. 
+** My_CNC.hal 
+*** This HAL file contains information that tells LinuxCNC how to link the internal virtual signals to
+physical connections beyond the computer. For example, specifying pin 4 on the parallel port to send out
+the Z axis step direction signal, or directing LinuxCNC to cease driving the X axis motor when a limit
+switch is triggered on parallel port pin 13.
+** custom.HAL
+*** Customisations to the mill configuration beyond the scope of the wizard may be performed by including
+further links to other virtual points within LinuxCNC in this HAL file. When starting a LinuxCNC session,
+this file is read and processed before the GUI is loaded. An example may include initiating Modbus
+communications to the spindle motor so that it is confirmed as operational before the GUI is displayed.
+** custom_postgui.hal 
+*** The custom_postgui HAL file allows further customisation of LinuxCNC, but differs from custom.HAL in
+that it is processed after the GUI is displayed. For example, after establishing Modbus communications to
+the spindle motor in custom.hal, LinuxCNC can use the custom_postgui file to link the spindle speed readout
+from the motor drive to a bargraph displayed on the GUI.
+** postgui_backup.hal 
+*** This is provided as a backup copy of the custom_postgui.hal file to allow the user to quickly restore a
+previously-working postgui HAL configuration. This is especially useful if the user wants to run the
+Configuration Wizard again under the same 'My_CNC' name in order to modify some parameters of the mill.
+Saving the mill configuration in the Wizard will overwrite the existing custom_postgui file while leaving
+the postgui_backup file untouched.
+** tool.tbl
+*** A tool table file contains a parameterised list of any cutting tools used by the mill. These parameters
+can include cutter diameter and length, and is used to provide a catalogue of data that tells LinuxCNC how
+to compensate its motion for different sized tools within a milling operation. 
+* Folder: nc_files 
+*** The nc_files folder is provided as a default location to store the G-code programs used to drive the
+mill. It also includes a number of subfolders with G-code examples.
 
 == Graphical User Interfaces
 
-A user interface is the part of the LinuxCNC that the machine tool
-operator interacts with. The LinuxCNC comes with several types of user
-interfaces:
+A graphical user interface is the part of the LinuxCNC that the machine tool operator interacts with.
+LinuxCNC comes with several types of user interfaces which may be chosen from by editing certain fields
+contained in the <<cha:ini-configuration,INI file>>:
 
-<<cha:axis-gui,'Axis'>>, the standard keyboard GUI interface.
+<<cha:axis-gui,'Axis'>>, the standard keyboard GUI interface. This is also the default GUI launched when a
+Configuration Wizard is used to create a desktop icon launcher:
 
 image::../gui/images/axis.png[align="center", alt="Axis, the standard keyboard GUI interface"]
 
-<<cha:touchy-gui,'Touchy'>>, a touch screen GUI.
+
+<<cha:touchy-gui,'Touchy'>>, a touch screen GUI:
 
 image::../gui/images/touchy.png[align="center", alt="Touchy, a touch screen GUI"]
 
-<<cha:gscreen,'Gscreen'>>, a configurable base touch screen GUI.
+<<cha:gscreen,'Gscreen'>>, a user-configurable touch screen GUI:
 
 image::../gui/images/gscreen-mill.png[align="center", alt="Gscreen, a configurable base touch screen GUI"]
 
-<<cha:gmoccapy,'gmoccapy'>>, a touch screen GUI based on Gscreen.
+<<cha:gmoccapy,'GMOCCAPY'>>, a touch screen GUI based on Gscreen. GMOCCAPY is also designed to work equally
+well in applications where a keyboard and mouse are the preferred methods of controlling the GUI:
 
-image::../gui/images/gmoccapy_3_axis.png[align="center", alt="gmoccapy, a touch screen GUI based on Gscreen"]
+image::../gui/images/gmoccapy_3_axis.png[align="center", alt="gmoccapy, a touch screen GUI based on
+Gscreen"]
 
-<<cha:ngcgui,'NGCGUI'>>, a subroutine GUI that provides 'fill in the blanks'
-   programming of G code. It also supports concatenation of subroutine files
-   to enable you to build a complete G code file without programming. The
-   following screen shot shows NGCGUI imbedded into Axis.
+<<cha:ngcgui,'NGCGUI'>>, a subroutine GUI that provides wizard-style programming of G code. NGCGUI may be
+run as a standalone program or embedded into another GUI as a series of tabs. The following screen shot
+shows NGCGUI embedded into Axis:
 
-image::../gui/images/ngcgui.png[align="center", alt="NGCGUI, a subroutine GUI that provides fill in the blanks programming of G code"]
-
-=== Additional Features
-
-* 'Xemc', an X-Windows program. A simulator configuration of Xemc can be 
-   ran from the configuration picker.
-
-* 'halui' - a HAL based user interface which allows to control LinuxCNC
-   using knobs and switches.
-   See the <<cha:hal-user-interface, HALUI chapter>> for more information.
-
-* 'linuxcncrsh' - a telnet based user interface which allows commands to
-   be sent to LinuxCNC from remote computers.
+image::../gui/images/ngcgui.png[align="center", alt="NGCGUI, a subroutine GUI that provides wizard-style
+programming of G code"]
 
 == Virtual Control Panels
 
-* 'PyVCP' a python based virtual control panel that can be added to the
-   Axis GUI or be stand alone.
+As mentioned above, many of LinuxCNC's GUIs may be customised by the user. This may be done to add
+indicators, readouts, switches or sliders to the basic appearance of one of the GUIs for increased
+flexibility or functionality. Two styles of Virtual Control Panel are offered in LinuxCNC:
 
-.PyVCP with Axis
+<<cha:pyvcp,'PyVCP'>>, a Python-based virtual control panel that can be added to the Axis GUI. PyVCP only
+utilises virtual signals contained within the Hardware Abstraction Layer, such as the spindle-at-speed
+indicator or the Emergency Stop output signal, and has a simple no-frills appearance. This makes it an
+excellent choice if the user wants to add a Virtual Control Panel with minimal fuss.
 
 image::../gui/images/axis-pyvcp.png[align="center", alt="PyVCP with Axis"]
 
-* 'GladeVCP' - a glade based virtual control panel that can be added to
-   the Axis GUI or be stand alone.
-
-.GladeVCP with Axis
+<<cha:glade-vcp,'GladeVCP'>>, a Glade-based virtual control panel that can be added to the Axis or Touchy
+GUIs. GladeVCP has the advantage over PyVCP in that it is not limited to the display or control of HAL
+virtual signals, but can include other external interfaces outside LinuxCNC such as window or network
+events. GladeVCP is also more flexible in how it may be configured to appear on the GUI:
 
 image::../gui/images/axis-gladevcp.png[align="center", alt="GladeVCP with Axis"]
 
-See the <<cha:pyvcp,PyVCP chapter>> and the<<cha:glade-vcp,GladeVCP chapter>> for more information on Virtual Control Panels.
-
 == Languages
 
-LinuxCNC uses translation files to translate LinuxCNC User Interfaces into many
-languages. You just need to log in with the language you intend to use
-and when you start up LinuxCNC it comes up in that language. If your
-language has not been translated contact a developer on the IRC or the
-mailing list if you can assist in the translation.
-
-== Thinking Like a Machine Operator
-
-This book will not even pretend that it can teach you to run a mill or
-a lathe. Becoming a machinist takes time and hard work. An author once
-said, "We learn from experience, if at all." Broken tools, gouged
-vices, and scars are the evidence of lessons taught. Good part finish,
-close tolerances, and careful work are the evidence of lessons learned.
-No machine, no computer program, can take the place of human
-experience.
-
-As you begin to work with the LinuxCNC program, you will need to place
-yourself in the position of operator. You need to think of yourself in
-the role of the one in charge of a machine. It is a machine that is
-either waiting for your command or executing the command that you have
-just given it. Throughout these pages we will give information that
-will help you become a good operator of the LinuxCNC system. You will need
-some information right up front here so that the following pages will
-make sense to you.
+LinuxCNC uses translation files to translate LinuxCNC User Interfaces into many languages including French,
+German, Italian, Finnish, Russian, Romanian, Portuguese and Chinese.  Assuming a translation has been
+created, LinuxCNC will automatically use whatever native language you log in with when starting the Linux
+operating system. If your language has not been translated, contact a developer on the IRC, the mailing
+list or the User Forum for assistance.
 
 == Modes of Operation
 
-When LinuxCNC is running, there are three different major modes used
-for inputting commands. These are 'Manual', 'Auto',
-and 'MDI'. Changing from one mode to another makes a big
-difference in the way that the LinuxCNC control behaves. There are specific things
-that can be done in one mode that cannot be done in another. An
-operator can home an axis in manual mode but not in auto or MDI modes.
-An operator can cause the machine to execute a whole file full of
-G-codes in the auto mode but not in manual or MDI.
+When LinuxCNC is running, there are three different major modes used for inputting commands. These are
+Manual, Auto, and Manual Data Input (MDI). Changing from one mode to another makes a big difference in the
+way that the LinuxCNC control behaves. There are specific things that can be done in one mode that cannot
+be done in another. An operator can home an axis in manual mode but not in auto or MDI modes. An operator
+can cause the machine to execute a whole file full of G-codes in the auto mode but not in manual or MDI.
 
-In manual mode, each command is entered separately. In human terms a
-manual command might be 'turn on coolant' or 'jog X at 25 inches per
-minute'. These are roughly equivalent to flipping a switch or turning
-the hand wheel for an axis. These commands are normally handled on one
-of the graphical interfaces by pressing a button with the mouse or
-holding down a key on the keyboard. In auto mode, a similar button or
-key press might be used to load or start the running of a whole program
-of G-code that is stored in a file. In the MDI mode the operator might
-type in a block of code and tell the machine to execute it by pressing
-the <return> or <enter> key on the keyboard.
+In manual mode, each command is entered separately. In human terms a manual command might be turn on
+coolant or jog X at 25 inches per minute. These are roughly equivalent to flipping a switch or turning the
+hand wheel for an axis. These commands are normally handled on one of the graphical interfaces by pressing
+a button with the mouse or holding down a key on the keyboard. In auto mode, a similar button or key press
+might be used to load or start the running of a whole program of G-code that is stored in a file. In the
+MDI mode the operator might type in a block of code and tell the machine to execute it by pressing the
+<return> or <enter> key on the keyboard.
 
-Some motion control commands are available and will cause the same
-changes in motion in all modes. These include 'abort',
-'estop', and 'feed rate override'.
-Commands like these should be self explanatory.
+Some motion control commands are available concurrently and will cause the same changes in motion in all
+modes. These include Abort, Emergency Stop, and Feed Rate Override. Commands like these should be self
+explanatory.
 
-The AXIS user interface hides some of the distinctions between Auto
-and the other modes by making Auto-commands available at most times. It
-also blurs the distinction between Manual and MDI because some Manual
-commands like Touch Off are actually implemented by sending MDI
-commands. It does this by automatically changing to the mode that is
-needed for the action the user has requested.
-
-
+The AXIS user interface hides some of the distinctions between Auto and the other modes by making
+Auto-commands available at most times. It also blurs the distinction between Manual and MDI because some
+Manual commands like Touch Off are actually implemented by sending MDI commands. It does this by
+automatically changing to the mode that is needed for the action the user has requested.

--- a/docs/src/user/user-intro.txt
+++ b/docs/src/user/user-intro.txt
@@ -29,9 +29,11 @@ which has one stepper motor connected to it. Each drive receives two independent
 command the drive to move its associated stepper motor in a clockwise or anti-clockwise direction, and a
 second signal that defines the speed at which that stepper motor rotates. 
 
-While a stepper motor system under parallel port control is illustrated, a LinuxCNC system can also control
-servo motors via servo interface cards, or dispense with the parallel port altogether and utilise dedicated
-interface cards by http://www.mesanet.com[Mesa Electronics] for increased speed and I/O capabilities.
+While a stepper motor system under parallel port control is illustrated, a LinuxCNC system can also take
+advantage of a wide variety of dedicated hardware motion control interfaces for increased speed and I/O 
+capabilities. A full list of interfaces supported by LinuxCNC can be found on the 
+http://http://wiki.linuxcnc.org/cgi-bin/wiki.pl?LinuxCNC_Supported_Hardware[Supported Hardware] page of the
+Wiki.
 
 In most circumstances, users will create a configuration specific to their mill setup using either the
 <<cha:stepconf-wizard,Stepper Configuration Wizard>> (for CNC systems operating using the computers'


### PR DESCRIPTION
Proposed re-wording of 'LinuxCNC User Introduction' documentation page as per Forum discussion here: https://forum.linuxcnc.org/32-documents/34802-linuxcnc-is-poorly-documented?start=100#113774

Hopefully I've got the formatting right in the asciidoc!

Feel free to spin/fold/mutilate as you deem necessary.

Quick and dirty print of the page as it should appear once uploaded for reference:
[LinuxCNC User Introduction - AC rewrite.pdf](https://github.com/LinuxCNC/linuxcnc/files/2186832/LinuxCNC.User.Introduction.-.AC.rewrite.pdf)

Cheers, Andrew.