### PR TITLE
pid: use command-deriv when supplied

### DIFF
--- a/src/hal/components/pid.c
+++ b/src/hal/components/pid.c
@@ -378,18 +378,9 @@ static void calc_pid(void *arg, long period)
 	    *(pid->error_d) = -*(pid->maxerror_d);
 	}
     }
-    /* calculate derivative of command */
     /* save old value for 2nd derivative calc later */
     tmp2 = *(pid->cmd_d);
-    if(!(pid->prev_ie && !*(pid->index_enable))) {
-        // not falling edge of index_enable: the normal case
-        *(pid->cmd_d) = (command - pid->prev_cmd) * periodrecip;
-    }
-    // else: leave cmd_d alone and use last period's.  prev_cmd
-    // shouldn't be trusted because index homing has caused us to have
-    // a step in position.  Using the previous period's derivative is
-    // probably a decent approximation since index search is usually a
-    // slow steady speed.
+    *(pid->cmd_d) = *(pid->commandv);
 
     // save ie for next time
     pid->prev_ie = *(pid->index_enable);


### PR DESCRIPTION
Due to an oversight, the command-deriv value was only being used when computing the contribution of Dgain, and not to FF1.  This corrects the problem.  Before this change, with IPD FF0 FF2 gains all 0 and FF1=1, pid.0.output was a (co)sine wave rather than a triangle, when its command was driven from a sine and its command-deriv from a triangle.

![image](https://user-images.githubusercontent.com/1517291/42915285-95054ae6-8ac4-11e8-93b1-805b13869677.png)

My `halrun -I` testing script:
```
loadrt threads 
loadrt pid num_chan=2 debug=1
loadrt siggen
addf siggen.0.update thread1
addf pid.0.do-pid-calcs thread1
addf pid.1.do-pid-calcs thread1
net cmd siggen.0.sine pid.0.command pid.1.command
net cmdderiv siggen.0.triangle pid.0.command-deriv
setp pid.0.FF1 1
setp pid.1.FF1 1
setp pid.0.Pgain 0 
setp pid.1.Pgain 0
setp pid.0.enable true
setp pid.1.enable true
start
#loadusr halscope
```

Closes: #466 