### PR TITLE
Dont crash on corrupt position.txt

### DIFF
--- a/src/emc/nml_intf/emc.hh
+++ b/src/emc/nml_intf/emc.hh
@@ -446,6 +446,8 @@ extern int emcMotionUpdate(EMC_MOTION_STAT * stat);
 
 extern int emcAbortCleanup(int reason,const char *message = "");
 
+int setup_inihal(void);
+
 // implementation functions for EMC_TOOL types
 
 extern int emcToolInit();

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -2977,6 +2977,11 @@ static int emctask_startup()
 	return -1;
     }
 
+    if (setup_inihal() != 0) {
+	rcs_print_error("%s: failed to setup inihal\n", __FUNCTION__);
+	return -1;
+    }
+
     end = RETRY_TIME;
     good = 0;
     do {

--- a/src/emc/task/taskintf.cc
+++ b/src/emc/task/taskintf.cc
@@ -1579,12 +1579,19 @@ int emcPositionLoad() {
     if(!f) return 0;
     for(int i=0; i<EMCMOT_MAX_JOINTS; i++) {
 	int r = fscanf(f, "%lf", &positions[i]);
-	if(r != 1) { fclose(f); return -1; }
+	if(r != 1) {
+            fclose(f);
+            rcs_print("%s: failed to load joint %d position from %s, ignoring\n", __FUNCTION__, i, posfile);
+            return -1;
+        }
     }
     fclose(f);
     int result = 0;
     for(int i=0; i<EMCMOT_MAX_JOINTS; i++) {
-	if(emcJointSetMotorOffset(i, -positions[i]) != 0) result = -1;;
+	if(emcJointSetMotorOffset(i, -positions[i]) != 0) {
+            rcs_print("%s: failed to set joint %d position (%.6f) from %s, ignoring\n", __FUNCTION__, i, positions[i], posfile);
+            result = -1;
+        }
     }
     return result;
 }


### PR DESCRIPTION
The local hackspace had a machine with a corrupt position.txt file: it existed, but was empty.  As a result, Task would segfault at startup, every time anyone launched LinuxCNC.

Investigation revealed two problems:
1. There was no error in the log complaining about the corrupted position.txt file.
2. Task's convoluted startup skipped inihal setup because of the failure of emcPositionLoad(), so Task would segfault later when trying to access the inihal data structures.

This PR adds the missing error logging to emcPositionLoad(), and fixes the initialization bug in Task that let it run without inihal set up.