### PR TITLE
use parameter 5400 for _current_tool

### DIFF
--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -653,7 +653,7 @@ int Interp::lookup_named_param(const char *nameBuf,
 	break;
 
     case NP_CURRENT_TOOL:
-	*value = _setup.tool_table[_setup.current_pocket].toolno;
+	*value = _setup.parameters[5400];
 	break;
 
     case NP_SELECTED_POCKET:


### PR DESCRIPTION
according to docs they are the same, but on startup their initial value is different. This way they are always the same, like it says in the docs.