### PR TITLE
configure.in:  require `intltool-extract` executable

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -872,6 +872,12 @@ fi
 # MANDB empty is handled in doc/Submakefile
 AC_PATH_PROG(MANDB, mandb, "")
 
+AC_PATH_PROG(INTLTOOL_EXTRACT, intltool-extract, "none", $SPATH)
+if test $INTLTOOL_EXTRACT = "none"
+then
+    AC_MSG_ERROR([intltool-extract not found])
+fi
+
 AC_ARG_WITH(rmmod,
     AS_HELP_STRING(
         [--with-rmmod=PATH],


### PR DESCRIPTION
Fixes part of #475, along with #477
