### PR TITLE
configure.in:  require `yaml2` executable

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -889,6 +889,12 @@ then
     AC_MSG_ERROR([fuser not found])
 fi
 
+AC_PATH_PROG(YAPPS, yapps, "none", $SPATH)
+if test $YAPPS = "none"
+then
+    AC_MSG_ERROR([yapps not found])
+fi
+
 # MANDB empty is handled in doc/Submakefile
 AC_PATH_PROG(MANDB, mandb, "")
 

--- a/src/hal/components/carousel.comp
+++ b/src/hal/components/carousel.comp
@@ -203,7 +203,7 @@ FUNCTION(_){
     case 'E': // index + position, both edges.
         p = current_position;
         if (homed){
-            if ( !old_index == sense(1) ){
+            if ( old_index != sense(1) ){
                 if (motor_fwd){
                     p += 1;
                     if (p > inst_pockets) p -= inst_pockets;
@@ -307,6 +307,7 @@ FUNCTION(_){
             motor_rev = hold_dc;
             active = 0;
             if (enable) ready = 1;
+            state = 4;
             break;
         }
     case 3:


### PR DESCRIPTION
Fixes #475; 2.7 counterpart for `inttool-extract` only in #476