### PR TITLE
docs: fix command for launching pyvcp example

### DIFF
--- a/docs/src/gui/pyvcp.txt
+++ b/docs/src/gui/pyvcp.txt
@@ -41,7 +41,7 @@ image::images/pyvcp_mypanel.png[]
 If you place this text in a file called tiny.xml, and run
 
 ----------------------------------------------
-halrun -I loadusr pyvcp -c mypanel tiny.xml
+halcmd loadusr pyvcp -c mypanel tiny.xml
 ----------------------------------------------
 
 PyVCP will create the panel for you, which includes two widgets, a


### PR DESCRIPTION
Jin^eLD reported on IRC that the command to launch the tiny.xml  PyVCP example did not work. If using halcmd instead of `halrun -I` it does work. `halrun` with the -I flag should be the same as `halcmd` (if I understand it correctly) but it does not seem to work. This may be a bug in `halrun` ...