### PR TITLE
 docs: add missing `rapidrate` method to linuxcnc.command docs, and convert tabs to spaces

### DIFF
--- a/docs/src/config/python-interface.txt
+++ b/docs/src/config/python-interface.txt
@@ -668,6 +668,9 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
 `program_open(string)`::
 	open an NGC file.
 
+`rapidrate()`::
+	set rapid override factor
+
 `reset_interpreter()`::
 	reset the RS274NGC interpreter
 

--- a/docs/src/config/python-interface.txt
+++ b/docs/src/config/python-interface.txt
@@ -61,14 +61,14 @@ linuxcnc is running for typical values):
 import sys
 import linuxcnc
 try:
-	s = linuxcnc.stat() # create a connection to the status channel
-	s.poll() # get current values 
+    s = linuxcnc.stat() # create a connection to the status channel
+    s.poll() # get current values 
 except linuxcnc.error, detail:
-	print "error", detail
-	sys.exit(1)
+    print "error", detail
+    sys.exit(1)
 for x in dir(s):
-	if not x.startswith("_"):
-		print x, getattr(s,x)
+    if not x.startswith("_"):
+        print x, getattr(s,x)
 ---------------------------------------------------------------------
 
 Linuxcnc uses the default compiled-in path to the NML configuration
@@ -388,9 +388,9 @@ s = linuxcnc.stat()
 s.poll()
 # to find the loaded tool information it is in tool table index 0
 if s.tool_table[0].id != 0: # a tool is loaded
-	print s.tool_table[0].zoffset
+    print s.tool_table[0].zoffset
 else:
-	print "no tool loaded"
+    print "no tool loaded"
 ----
 
 *velocity*:: '(returns float)' -
@@ -531,13 +531,13 @@ s = linuxcnc.stat()
 c = linuxcnc.command()
 
 def ok_for_mdi():
-	s.poll()
-	return not s.estop and s.enabled and s.homed and (s.interp_state == linuxcnc.INTERP_IDLE)
+    s.poll()
+    return not s.estop and s.enabled and s.homed and (s.interp_state == linuxcnc.INTERP_IDLE)
 
 if ok_for_mdi():
-	c.mode(linuxcnc.MODE_MDI)
-	c.wait_complete() # wait until mode switch executed
-	c.mdi("G0 X10 Y20 Z30")
+    c.mode(linuxcnc.MODE_MDI)
+    c.wait_complete() # wait until mode switch executed
+    c.mdi("G0 X10 Y20 Z30")
 ---------------------------------------------------------------------
 
 ==  Sending commands through `linuxcnc.command`
@@ -594,103 +594,103 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
 === `linuxcnc.command` attributes
 
 `serial`::
-	the current command serial number
+    the current command serial number
 
 === `linuxcnc.command` methods:
 
 `abort()`::
-	send EMC_TASK_ABORT message.
+    send EMC_TASK_ABORT message.
 
 `auto(int[, int])`:: 
-	run, step, pause or resume a program.
+    run, step, pause or resume a program.
 
 `brake(int)`::
-	engage or release spindle brake.
+    engage or release spindle brake.
         
 `debug(int)`::
-	set debug level via EMC_SET_DEBUG message.
+    set debug level via EMC_SET_DEBUG message.
 
 `feedrate(float)`::
-	set the feedrate.
+    set the feedrate.
 
 `flood(int)`::
-	turn on/off flooding. +
-	Syntax: +
-	flood(command) +
-	flood(linuxcnc.FLOOD_ON) +
-	flood(linuxcnc.FLOOD_OFF) +
-	Constants: +
-	FLOOD_ON +
-	FLOOD_OFF
+    turn on/off flooding. +
+    Syntax: +
+    flood(command) +
+    flood(linuxcnc.FLOOD_ON) +
+    flood(linuxcnc.FLOOD_OFF) +
+    Constants: +
+    FLOOD_ON +
+    FLOOD_OFF
 
 `home(int)`::
-	home a given joint.
+    home a given joint.
 
 `jog(command-constant, bool, int[, float[, float]])`::
-	Syntax: +
-	jog(command, joint-flag, axis-or-joint-number, velocity[, distance]]) +
-	jog(linuxcnc.JOG_STOP, joint-flag, axis-or-joint-number) +
-	jog(linuxcnc.JOG_CONTINUOUS, joint-flag, axis-or-joint-number, velocity) +
-	jog(linuxcnc.JOG_INCREMENT, joint-flag, axis-or-joint-number, velocity, distance)
-	Command Constants;;
-	JOG_STOP +
-	JOG_CONTINUOUS +
-	JOG_INCREMENT
+    Syntax: +
+    jog(command, joint-flag, axis-or-joint-number, velocity[, distance]]) +
+    jog(linuxcnc.JOG_STOP, joint-flag, axis-or-joint-number) +
+    jog(linuxcnc.JOG_CONTINUOUS, joint-flag, axis-or-joint-number, velocity) +
+    jog(linuxcnc.JOG_INCREMENT, joint-flag, axis-or-joint-number, velocity, distance)
+    Command Constants;;
+    JOG_STOP +
+    JOG_CONTINUOUS +
+    JOG_INCREMENT
         Joint flag;;
             True::: joint mode jog
             False::: axis (cartesian) mode jog
 
 `load_tool_table()`::
-	reload the tool table.
+    reload the tool table.
 
 `maxvel(float)`::
-	set maximum velocity
+    set maximum velocity
 
 `mdi(string)`::
-	send an MDI command. Maximum 255 chars.
+    send an MDI command. Maximum 255 chars.
 
 `mist(int)`:: turn on/off mist. +
-	Syntax: +
-	mist(command) +
-	mist(linuxcnc.MIST_ON) +
-	mist(linuxcnc.MIST_OFF) +
-	Constants: +
-	MIST_ON +
-	MIST_OFF
+    Syntax: +
+    mist(command) +
+    mist(linuxcnc.MIST_ON) +
+    mist(linuxcnc.MIST_OFF) +
+    Constants: +
+    MIST_ON +
+    MIST_OFF
 
 
 `mode(int)`::
-	set mode (MODE_MDI, MODE_MANUAL, MODE_AUTO).
+    set mode (MODE_MDI, MODE_MANUAL, MODE_AUTO).
 
 `override_limits()`::
-	set the override axis limits flag.
+    set the override axis limits flag.
 
 `program_open(string)`::
-	open an NGC file.
+    open an NGC file.
 
 `rapidrate()`::
-	set rapid override factor
+    set rapid override factor
 
 `reset_interpreter()`::
-	reset the RS274NGC interpreter
+    reset the RS274NGC interpreter
 
 `set_adaptive_feed(int)`::
-	set adaptive feed flag
+    set adaptive feed flag
 
 `set_analog_output(int, float)`::
-	set analog output pin to value
+    set analog output pin to value
 
 `set_block_delete(int)`::
-	set block delete flag
+    set block delete flag
 
 `set_digital_output(int, int)`::
-	set digital output pin to value
+    set digital output pin to value
 
 `set_feed_hold(int)`::
-	set feed hold on/off
+    set feed hold on/off
 
 `set_feed_override(int)`::
-	set feed override on/off
+    set feed override on/off
 
 `set_max_limit(int, float)`::
         set max position limit for a given axis
@@ -699,44 +699,44 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
         set min position limit for a given axis
 
 `set_optional_stop(int)`::
-	set optional stop on/off
+    set optional stop on/off
 
 `set_spindle_override(int)`::
-	set spindle override flag
+    set spindle override flag
 
 `spindle(int)`::
-	set spindle direction. Argument one of SPINDLE_FORWARD,
-	SPINDLE_REVERSE, SPINDLE_OFF, SPINDLE_INCREASE,
-	SPINDLE_DECREASE, or SPINDLE_CONSTANT.
+    set spindle direction. Argument one of SPINDLE_FORWARD,
+    SPINDLE_REVERSE, SPINDLE_OFF, SPINDLE_INCREASE,
+    SPINDLE_DECREASE, or SPINDLE_CONSTANT.
 
 `spindleoverride(float)`::
-	set spindle override factor
+    set spindle override factor
 
 `state(int)`::
-	set the machine state. Machine state should be STATE_ESTOP, STATE_ESTOP_RESET, STATE_ON, or STATE_OFF
+    set the machine state. Machine state should be STATE_ESTOP, STATE_ESTOP_RESET, STATE_ON, or STATE_OFF
 
 `task_plan_sync()`::
         on completion of this call, the var file on disk is updated with
         live values from the interpreter.
 
 `teleop_enable(int)`::
-	enable/disable teleop mode.
+    enable/disable teleop mode.
 
 `tool_offset(int, float, float, float, float, float, int)`::
         set the tool offset. See usage example above.
 
 `traj_mode(int)`::
-	set trajectory mode. Mode is one of MODE_FREE, MODE_COORD, or
-	MODE_TELEOP.
+    set trajectory mode. Mode is one of MODE_FREE, MODE_COORD, or
+    MODE_TELEOP.
 
 `unhome(int)`::
-	unhome a given joint.
+    unhome a given joint.
 
 `wait_complete([float])`::
-	wait for completion of the last command sent. If timeout in
-	seconds not specified, default is 5 seconds. Return -1 if
-	timed out, return RCS_DONE or RCS_ERROR according to command
-	execution status.
+    wait for completion of the last command sent. If timeout in
+    seconds not specified, default is 5 seconds. Return -1 if
+    timed out, return RCS_DONE or RCS_ERROR according to command
+    execution status.
 
 
 == Reading the error channel
@@ -762,12 +762,12 @@ e = linuxcnc.error_channel()
 error = e.poll()
 
 if error: 
-	kind, text = error
-	if kind in (linuxcnc.NML_ERROR, linuxcnc.OPERATOR_ERROR):
-		typus = "error"
-	else:
-		typus = "info"
-	print typus, text
+    kind, text = error
+    if kind in (linuxcnc.NML_ERROR, linuxcnc.OPERATOR_ERROR):
+        typus = "error"
+    else:
+        typus = "info"
+    print typus, text
 ---------------------------------------------------------------------
 
 
@@ -815,21 +815,21 @@ Some usage hints can be gleaned from
 === members
 
 `npts`::
-	number of points.
+    number of points.
 
 === methods
 `start(float)`::
-	start the position logger and run every ARG seconds
+    start the position logger and run every ARG seconds
 
 `clear()`::
-	clear the position logger
+    clear the position logger
 
 `stop()`::
-	stop the position logger
+    stop the position logger
 
 `call()`::
-	Plot the backplot now.
+    Plot the backplot now.
 
 `last([int])`::
-	Return the most recent point on the plot or None
+    Return the most recent point on the plot or None
 ,


### PR DESCRIPTION
The file had a significant number of tabs mixed in with the predominant space indentation style. I took the liberty to replace each tab with four spaces, which are preferred since they make more money than tabs. I would be happy to open a PR for just the addition of the `rapidrate` method if the tabs to spaces change is too invasive.

Thanks,
Kurt