### PR TITLE
mb2hal: add fnct_06_write_single_register

### DIFF
--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -195,6 +195,9 @@ void *link_loop_and_logic(void *thrd_link_num)
             case mbtx_04_READ_INPUT_REGISTERS:
                 ret = fnct_04_read_input_registers(this_mb_tx, this_mb_link);
                 break;
+            case mbtx_06_WRITE_SINGLE_REGISTER:
+                ret = fnct_06_write_single_register(this_mb_tx, this_mb_link);
+                break;
             case mbtx_15_WRITE_MULTIPLE_COILS:
                 ret = fnct_15_write_multiple_coils(this_mb_tx, this_mb_link);
                 break;
@@ -395,6 +398,7 @@ void set_init_gbl_params()
     gbl.mb_tx_fncts[mbtx_02_READ_DISCRETE_INPUTS]    = "fnct_02_read_discrete_inputs";
     gbl.mb_tx_fncts[mbtx_03_READ_HOLDING_REGISTERS]  = "fnct_03_read_holding_registers";
     gbl.mb_tx_fncts[mbtx_04_READ_INPUT_REGISTERS]    = "fnct_04_read_input_registers";
+    gbl.mb_tx_fncts[mbtx_06_WRITE_SINGLE_REGISTER]   = "fnct_06_write_single_register";
     gbl.mb_tx_fncts[mbtx_15_WRITE_MULTIPLE_COILS]    = "fnct_15_write_multiple_coils";
     gbl.mb_tx_fncts[mbtx_16_WRITE_MULTIPLE_REGISTERS]= "fnct_16_write_multiple_registers";
 

--- a/src/hal/user_comps/mb2hal/mb2hal.h
+++ b/src/hal/user_comps/mb2hal/mb2hal.h
@@ -26,6 +26,7 @@
 #define MB2HAL_MAX_FNCT03_ELEMENTS 100
 #define MB2HAL_MAX_FNCT04_ELEMENTS 100
 #define MB2HAL_MAX_FNCT05_ELEMENTS 100
+#define MB2HAL_MAX_FNCT06_ELEMENTS 1
 #define MB2HAL_MAX_FNCT15_ELEMENTS 100
 #define MB2HAL_MAX_FNCT16_ELEMENTS 100
 
@@ -43,6 +44,7 @@ typedef enum { mbtxERR,
                mbtx_02_READ_DISCRETE_INPUTS,
                mbtx_03_READ_HOLDING_REGISTERS,
                mbtx_04_READ_INPUT_REGISTERS,
+               mbtx_06_WRITE_SINGLE_REGISTER,
                mbtx_15_WRITE_MULTIPLE_COILS,
                mbtx_16_WRITE_MULTIPLE_REGISTERS,
                mbtxMAX
@@ -180,4 +182,5 @@ retCode fnct_15_write_multiple_coils(mb_tx_t *this_mb_tx, mb_link_t *this_mb_lin
 retCode fnct_02_read_discrete_inputs(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
 retCode fnct_04_read_input_registers(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
 retCode fnct_03_read_holding_registers(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
+retCode fnct_06_write_single_register(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
 retCode fnct_16_write_multiple_registers(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);

--- a/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
+++ b/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
@@ -98,6 +98,7 @@ PIN_NAMES=cycle_start,stop,feed_hold
 #    fnct_02_read_discrete_inputs     (02 = 0x02)
 #    fnct_03_read_holding_registers   (03 = 0x03)
 #    fnct_04_read_input_registers     (04 = 0x04)
+#    fnct_06_write_single_register    (06 = 0x06)
 #    fnct_15_write_multiple_coils     (15 = 0x0F)
 #    fnct_16_write_multiple_registers (16 = 0x10)
 
@@ -106,6 +107,8 @@ PIN_NAMES=cycle_start,stop,feed_hold
 #                           also creates a u32 output HAL pins.
 #fnct_04_read_input_registers: creates a floating point output HAL pins.
 #                         also creates a u32 output HAL pins.
+#fnct_06_write_single_register: creates a floating point input HAL pin.
+#	NELEMENTS needs to be 1 or PIN_NAMES must contain just one name
 #fnct_15_write_multiple_coils: creates boolean input HAL pins.
 #fnct_16_write_multiple_registers: creates a floating point input HAL pins.
 

--- a/src/hal/user_comps/mb2hal/mb2hal_hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_hal.c
@@ -58,6 +58,7 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
 
     case mbtx_03_READ_HOLDING_REGISTERS:
     case mbtx_04_READ_INPUT_REGISTERS:
+    case mbtx_06_WRITE_SINGLE_REGISTER:
     case mbtx_16_WRITE_MULTIPLE_REGISTERS:
         mb_tx->float_value= hal_malloc(sizeof(hal_float_t *) * mb_tx->mb_tx_nelem);
         mb_tx->int_value  = hal_malloc(sizeof(hal_s32_t *) * mb_tx->mb_tx_nelem);
@@ -138,6 +139,7 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
             //mb_tx->scale[pin_counter] = 1;
             //mb_tx->offset[pin_counter] = 0;
             break;
+        case mbtx_06_WRITE_SINGLE_REGISTER:
         case mbtx_16_WRITE_MULTIPLE_REGISTERS:
             if (0 != hal_pin_float_newf(HAL_IN, mb_tx->float_value + pin_counter, gbl.hal_mod_id,
                                         "%s", hal_pin_name)) {

--- a/src/hal/user_comps/mb2hal/mb2hal_modbus.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_modbus.c
@@ -114,6 +114,39 @@ retCode fnct_04_read_input_registers(mb_tx_t *this_mb_tx, mb_link_t *this_mb_lin
     return retOK;
 }
 
+retCode fnct_06_write_single_register(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link)
+{
+    char *fnct_name = "fnct_06_write_single_register";
+    int ret, data;
+
+    if (this_mb_tx == NULL || this_mb_link == NULL) {
+        return retERR;
+    }
+    if (this_mb_tx->mb_tx_nelem > MB2HAL_MAX_FNCT06_ELEMENTS) {
+        return retERR;
+    }
+
+    float val = *(this_mb_tx->float_value[0]);
+    data = (int) val;
+
+    DBG(this_mb_tx->cfg_debug, "mb_tx[%d] mb_links[%d] slave[%d] fd[%d] 1st_addr[%d] nelem[%d]",
+        this_mb_tx->mb_tx_num, this_mb_tx->mb_link_num, this_mb_tx->mb_tx_slave_id,
+        modbus_get_socket(this_mb_link->modbus), this_mb_tx->mb_tx_1st_addr, this_mb_tx->mb_tx_nelem);
+
+    ret = modbus_write_register(this_mb_link->modbus, this_mb_tx->mb_tx_1st_addr, data);
+    if (ret < 0) {
+        if (modbus_get_socket(this_mb_link->modbus) < 0) {
+            modbus_close(this_mb_link->modbus);
+        }
+        ERR(this_mb_tx->cfg_debug, "mb_tx[%d] mb_links[%d] slave[%d] = ret[%d] fd[%d]",
+            this_mb_tx->mb_tx_num, this_mb_tx->mb_link_num, this_mb_tx->mb_tx_slave_id, ret,
+            modbus_get_socket(this_mb_link->modbus));
+        return retERR;
+    }
+
+    return retOK;
+}
+
 retCode fnct_15_write_multiple_coils(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link)
 {
     char *fnct_name = "fnct_15_write_multiple_coils";


### PR DESCRIPTION
Add fnct_06_write_single_register function as not all devices (e.g. Parker AC10 VFD) support fnct_16_write_multiple_registers.