### PR TITLE
mb2hal: call modbus_flush() on transaction error

### DIFF
--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -225,6 +225,8 @@ void *link_loop_and_logic(void *thrd_link_num)
                 (**this_mb_tx->num_errors)++;
                 ERR(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] transaction failure, num_errors[%d]",
                     this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_link_num, modbus_get_socket(this_mb_link->modbus), **this_mb_tx->num_errors);
+                // Clear any unread data. Otherwise the link might get out of sync
+                modbus_flush(this_mb_link->modbus);
             }
             else { //transaction and link OK
                 OK(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] transaction OK, update_HZ[%0.03f]",


### PR DESCRIPTION
When a communication error happens and a transaction is just partially
read the modbus link can get out of sync. The next transaction gets the
unconsumed data from the transaction before and so on and the link may
not recover form this. modbus_flush() prevents this behaviour.