### PR TITLE
Provide a clearer error message when exceeding hal pin name length

### DIFF
--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -395,7 +395,9 @@ static PyObject * pyhal_create_pin(halobject *self, char *name, hal_type_t type,
 
     res = snprintf(pin_name, sizeof(pin_name), "%s.%s", self->prefix, name);
     if(res > HAL_NAME_LEN || res < 0) {
-        PyErr_Format(pyhal_error_type, "Invalid pin name length: max = %d characters",HAL_NAME_LEN);
+        PyErr_Format(pyhal_error_type,
+            "Invalid pin name length \"%s.%s\": max = %d characters",
+            self->prefix, name, HAL_NAME_LEN);
         return NULL;
     }
     res = hal_pin_new(pin_name, type, dir, (void**)pin.u, self->hal_id);


### PR DESCRIPTION
The maximum length of a pin name is calculated after an internal
construction of the string, which is not obvious to the user. The error
message will now print the constructed string, so that it becomes clear
why a "component_name.pin_name" combination, that is still shorter than the
maximum allowed size, fails.

Signed-off-by: Sergey 'Jin' Bostandzhyan <jin@mediatomb.cc>