### PR TITLE
WIP doc changes prior to making stretch release 'official'

### DIFF
--- a/docs/src/getting-started/getting-linuxcnc.txt
+++ b/docs/src/getting-started/getting-linuxcnc.txt
@@ -34,8 +34,11 @@ Image.
 
 Download the Live/Install image by clicking here:
 
-http://www.linuxcnc.org/linuxcnc-2.7-stretch.iso
+http://www.linuxcnc.org/stretch/linuxcnc-stretch-uspace-amd64.iso
 
+Or, if you are installing on a system which does not support 64 bit operating systems,
+
+http://www.linuxcnc.org/stretch/linuxcnc-stretch-uspace-i386.iso
 
 === Download using zsync
 
@@ -55,8 +58,12 @@ sudo apt-get install zsync
 . Then run this command to download the iso to your computer
 +
 ----
-zsync http://www.linuxcnc.org/linuxcnc-2.7-stretch.iso.zsync
+zsync http://www.linuxcnc.org/stretch/linuxcnc-stretch-uspace-amd64.iso.zsync
 ----
+
+Due to technical limitations, the downloaded file may have a revision number in
+the filename, so that the local file ends up being named e.g.,
+"linuxcnc-stretch-uspace-amd64-r12.iso".
 
 .zsync in Windows
 
@@ -103,7 +110,7 @@ a computer.  The image is too large to fit on a CD.
   then use this command:
 +
 -----
-dd if=linuxcnc-2.7-stretch.iso of=/dev/sde
+dd if=linuxcnc-stretch-uspace-amd64.iso of=/dev/sde
 -----
 
 The https://www.debian.org/CD/faq/#write-usb[Debian FAQ] provides more

--- a/docs/src/getting-started/getting-linuxcnc.txt
+++ b/docs/src/getting-started/getting-linuxcnc.txt
@@ -32,9 +32,9 @@ Image.
 
 === Normal Download
 
-Download the Live/Install CD by clicking here:
+Download the Live/Install image by clicking here:
 
-http://www.linuxcnc.org/linuxcnc-2.7-wheezy.iso
+http://www.linuxcnc.org/linuxcnc-2.7-stretch.iso
 
 
 === Download using zsync
@@ -55,7 +55,7 @@ sudo apt-get install zsync
 . Then run this command to download the iso to your computer
 +
 ----
-zsync http://www.linuxcnc.org/linuxcnc-2.7-wheezy.iso.zsync
+zsync http://www.linuxcnc.org/linuxcnc-2.7-stretch.iso.zsync
 ----
 
 .zsync in Windows
@@ -67,29 +67,21 @@ https://www.assembla.com/spaces/zsync-windows/documents
 
 === Verify the image
 
-(This step is unnecessary if you used zsync)
+Also download a "SUMS" file, "MD5SUMS" or "SHA256SUMS", from the same location
+where you downlooaded the iso image.  On a system with a working "md5sum"
+or "sha256sum" program, run a command similar to the following:
 
-. After downloading, verify the checksum of the image to ensure integrity.
-+
 ----
-md5sum linuxcnc-2.7-wheezy.iso
+$ sha256sum --ignore-missing --check SHA256SUMS
+linuxcnc-stretch-uspace-amd64.iso: OK
 ----
-+
-or
-+
-----
-sha256sum linuxcnc-2.7-wheezy.iso
-----
-. Then compare to these checksums
-+
------
-md5sum: 978ca074c51194e72f93e8c8d7110cfa
-sha256sum: a3c29850cbc44da7b1ecdbe584a915f158c0b84428acfbcf3271df85c24e34aa
------
+
+For each .iso file you downloaded, this process should print OK.
+If it prints nothing, prints "FAILED", or prints another message, then something is wrong.
 
 .Verify md5sum on Windows or Mac
 
-Windows and Mac OS X do not come with an md5sum program, but there are
+Windows and Mac OS X do not come with a md5sum program, but there are
 alternatives.  More information can be found at:
 https://help.ubuntu.com/community/HowToMD5SUM[How To MD5SUM]
 
@@ -111,8 +103,12 @@ a computer.  The image is too large to fit on a CD.
   then use this command:
 +
 -----
-dd if=linuxcnc-2.7-wheezy.iso of=/dev/sde
+dd if=linuxcnc-2.7-stretch.iso of=/dev/sde
 -----
+
+The https://www.debian.org/CD/faq/#write-usb[Debian FAQ] provides more
+information about how to work with USB media, including how to use
+win32diskimager to write the image to USB media on Microsoft Windows.
 
 .Writing the image to a DVD in Linux
 
@@ -129,7 +125,7 @@ dd if=linuxcnc-2.7-wheezy.iso of=/dev/sde
 
 . Download and install Infra Recorder, a free and open source image
   burning program: http://infrarecorder.org/
-. Insert a blank CD in the drive and select Do nothing or Cancel if an
+. Insert a blank DVD in the drive and select Do nothing or Cancel if an
   auto-run dialog pops up.
 . Open Infra Recorder, and select the 
  'Actions' menu, then 'Burn image'.
@@ -151,7 +147,7 @@ run the Latency Test as shown <<latency-test,here>>.
 
 == Installing LinuxCNC
 
-To install LinuxCNC from the LiveCD select 'Install (Graphical)' at bootup.
+To install LinuxCNC from the Live image select 'Install (Graphical)' at bootup.
 
 == Updates to LinuxCNC (((Updates to LinuxCNC)))
 
@@ -161,12 +157,12 @@ Linux knowledge needed.
 It is OK to upgrade everything except the operating system when asked to.
 
 [WARNING]
-Do not upgrade the operating system if prompted to do so.
+Do not upgrade the operating system even if prompted to do so.
 
 == Install Problems
 
 In rare cases you might have to reset the BIOS to default settings if
-during the Live CD install it cannot recognize the hard drive 
+during the Live image install it cannot recognize the hard drive 
 during the boot up.
 
 == Alternate Install Methods
@@ -182,6 +178,8 @@ kernel flavors, etc), new installs are supported on following platforms:
 [options="header"]
 |===================================================================
 | Distribution   | Architecture | kernel     | Typical use
+| Debian Stretch | amd64 & i386 | Preempt-RT | machine control & simulation
+| Debian Stretch | amd64 & i386 | Stock      | simulation only
 | Debian Jessie  | amd64 & i386 | Stock      | simulation only
 | Debian Wheezy  | i386         | RTAI       | machine control & simulation
 | Debian Wheezy  | amd64 & i386 | Preempt-RT | machine control & simulation
@@ -199,24 +197,21 @@ debian archive.  The apt source is:
 * Ubuntu Precise: `deb http://linuxcnc.org precise base`
 * Ubuntu Lucid: `deb http://linuxcnc.org lucid base`
 
-The Preempt-RT kernels are available for Debian Wheezy from the
+The Preempt-RT kernels are available for Debian Wheezy and Stretch from the
 regular debian.org archive.  The packages are called `linux-image-rt-amd64`
 and `linux-image-rt-686-pae`.
 
-=== Installing on Debian Wheezy (with Preempt-RT kernel)
+=== Installing on Debian Stretch (with Preempt-RT kernel)
 
-. Install Debian Wheezy (Debian version 7),
+. Install Debian Stretch (Debian version 9),
   either i386 or amd64.  You can download the installer here:
-  https://www.debian.org/releases/. One version that is tested is the net
-  install 'debian-7.9.0-i386-netinst.iso'. Be careful and don't download Debian
-  8.
+  https://www.debian.org/CD/http-ftp/#stable.
+  One version that is tested is the net install 'debian-9.5.0-amd64-netinst.iso '.
+  Be careful and make sure you download debian version 9.
 
-. After burning the iso and booting up if you don't want Gnome desktop select
-  'Advanced Options' > 'Alternative desktop environments' and pick the one you
-  like. Then select 'Install' or 'Graphical Install'.
+. During the installation you will be able to choose your preferred desktop environment, such as Xfce or Gnome.
 +
-WARNING: Do not enter a root password, if you do sudo is disabled and you won't
-be able to complete the following steps.
+NOTE: If you choose to enter a root password, then you must use "su" instead of "sudo" in all the following steps.
 
 . Run the following in a <<faq:terminal,terminal>> to bring the machine up to
   date with the latest packages.
@@ -234,8 +229,8 @@ or
 sudo apt-get install linux-image-rt-686-pae
 ----
 
-. Reboot, and select the Linux 3.2.0-4-rt-686-pae kernel. When you
-  log in, verify that `PREEMPT RT`is reported by the following command.
+. Reboot, and select the "-rt" kernel (such as 4.9.0-8-rt-amd64) from the GRUB menu.
+  When you log in, verify that `PREEMPT RT`is reported by the following command.
 +
 ----
 uname -v
@@ -254,7 +249,7 @@ sudo apt-key adv --keyserver hkp://keys.gnupg.net --recv-key 3cb9fd148f374fef
 . Add a the apt repository:
 +
 ----
-sudo add-apt-repository "deb http://linuxcnc.org/ wheezy base 2.7-uspace"
+sudo add-apt-repository "deb http://linuxcnc.org/ stretch base 2.7-uspace"
 ----
 
 . Update the package list from linuxcnc.org


### PR DESCRIPTION
@SebKuzminsky and I recently discussed that based on his experience running systems based on the stretch live images with preempt-rt, as well as feedback we've both seen on IRC, he is comfortable making it an official and recommended OS for 2.7.  This PR is a place for us to workshop the doc changes and figure out what's missing before we do this.  It's absolutely not ready to merge in its current state and before work is done on wlo and buildbot too.