### PR TITLE
docs: add missing status items to python interface docs

### DIFF
--- a/docs/src/config/python-interface.txt
+++ b/docs/src/config/python-interface.txt
@@ -99,12 +99,15 @@ machine angular units per deg, reflects [TRAJ]ANGULAR_UNITS ini value.
 *aout*:: '(returns tuple of floats)' -
 current value of the analog output pins.
 
-*joints*:: '(returns string)' -
-reflects [KINS]JOINTS ini value.
+*joints*:: '(returns integer)' -
+number of joints. Reflects [KINS]JOINTS ini value.
 
 *axis*:: '(returns tuple of dicts)' -
 reflecting current axis values. See
 <<sec:the-axis-dictionary,The axis dictionary>>.
+
+*axes*:: '(returns integer)' -
+number of axes. Derived from [TRAJ]COORDINATES ini value.
 
 *axis_mask*:: '(returns integer)' -
 mask of axis available as defined by [TRAJ]COORDINATES in the ini
@@ -333,6 +336,9 @@ sequence number, settings[1] = feed rate, settings[2] = speed.
 *spindle*:: ' (returns tuple of dicts) ' -
 returns the current spindle status
 see <sec:the-spindle-dictionary, The spindle dictionary>>
+
+*spindles*:: '(returns integer)' -
+number of spindles. Reflects [TRAJ]SPINDLES ini value.
 
 *state*:: '(returns integer)' -
 current command execution status. One of RCS_DONE,


### PR DESCRIPTION
Added missing `stat.axes` and `stat.spindles` entries, and fixed return type on the `stat.joints` entry.