### PR TITLE
fix #505: add optional spindle num argument to py interface `command.brake` method

### DIFF
--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -1022,17 +1022,20 @@ static PyObject *flood(pyCommandChannel *s, PyObject *o) {
 
 static PyObject *brake(pyCommandChannel *s, PyObject *o) {
     int dir;
-    if(!PyArg_ParseTuple(o, "i", &dir)) return NULL;
+    int spindle = 0;
+    if(!PyArg_ParseTuple(o, "i|i", &dir, &spindle)) return NULL;
     switch(dir) {
         case LOCAL_BRAKE_ENGAGE:
         {
             EMC_SPINDLE_BRAKE_ENGAGE m;
+            m.spindle = spindle;
             emcSendCommand(s, m);
         }
             break;
         case LOCAL_BRAKE_RELEASE:
         {
             EMC_SPINDLE_BRAKE_RELEASE m;
+            m.spindle = spindle;
             emcSendCommand(s, m);
         }
             break;


### PR DESCRIPTION
This makes it possible to engage/disengage the spindle brake for spindles other than the default spindle (spindle 0) by adding an optional spindle number argument to python interface `command.brake` method.