### PR TITLE
Create public header for hostmot2 public APIs

### DIFF
--- a/docs/man/man3/hm2_allocate_bspi_tram.3hm2
+++ b/docs/man/man3/hm2_allocate_bspi_tram.3hm2
@@ -7,6 +7,8 @@
 hm2_allocate_bspi_tram \- Allocate the TRAM regions for a BSPI channel
 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 hm2_allocate_bspi_tram(char* name)
 

--- a/docs/man/man3/hm2_bspi_set_read_function.3hm2
+++ b/docs/man/man3/hm2_bspi_set_read_function.3hm2
@@ -7,6 +7,8 @@
 hm2_bspi_set_read_function \- Register a function to handle the tram write phase
 of a hostmot2 buffered SPI driver. 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 int hm2_bspi_set_read_function(char *name, void *func, void *subdata)
 

--- a/docs/man/man3/hm2_bspi_set_write_function.3hm2
+++ b/docs/man/man3/hm2_bspi_set_write_function.3hm2
@@ -7,6 +7,8 @@
 hm2_bspi_set_write_function \- Register a function to handle the tram write phase
 of a hostmot2 buffered SPI driver. 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 int hm2_bspi_set_write_function(char *name, void *func, void *subdata)
 

--- a/docs/man/man3/hm2_bspi_setup_chan.3hm2
+++ b/docs/man/man3/hm2_bspi_setup_chan.3hm2
@@ -6,6 +6,8 @@
 hm2_bspi_setup_chan \- setup a Hostmot2 bspi channel
 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
 int delay, int cpol, int cpha, int noclear, int noecho)

--- a/docs/man/man3/hm2_bspi_write_chan.3hm2
+++ b/docs/man/man3/hm2_bspi_write_chan.3hm2
@@ -6,6 +6,8 @@
 hm2_bspi_write_chan \- write data to a Hostmot2 Buffered SPI channel
 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 hm2_bspi_write_chan(char* name, int chan, u32 val)
 

--- a/docs/man/man3/hm2_pktuart_read.3hm2
+++ b/docs/man/man3/hm2_pktuart_read.3hm2
@@ -6,6 +6,8 @@
 hm2_pktuart_read \- read data from a Hostmot2 UART buffer
 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 int hm2_pktuart_read(char *name,  unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 *max_frame_length, rtapi_u16 frame_sizes[])
 

--- a/docs/man/man3/hm2_pktuart_send.3hm2
+++ b/docs/man/man3/hm2_pktuart_send.3hm2
@@ -6,6 +6,8 @@
 hm2_pktuart_send \- write data to a Hostmot2 PktUART
 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 int hm2_uart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 frame_sizes[])
 

--- a/docs/man/man3/hm2_pktuart_setup.3hm2
+++ b/docs/man/man3/hm2_pktuart_setup.3hm2
@@ -5,6 +5,8 @@
 
 hm2_pktuart_setup \- setup a Hostmot2 PktUART instance
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 int hm2_pktuart_setup(char *name, int bitrate, rtapi_s32 tx_mode, rtapi_s32 rx_mode, int txclear, int rxclear)
 

--- a/docs/man/man3/hm2_tram_add_bspi_frame.3hm2
+++ b/docs/man/man3/hm2_tram_add_bspi_frame.3hm2
@@ -6,6 +6,8 @@
 hm2_tram_add_bspi_frame \- add a register-write to the Hostmot2 TRAM
 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 hm2_tram_add_bspi_frame(char *name, int chan, u32 **wbuff, u32 **rbuff)
 

--- a/docs/man/man3/hm2_uart_read.3hm2
+++ b/docs/man/man3/hm2_uart_read.3hm2
@@ -6,6 +6,8 @@
 hm2_uart_read \- read data from a Hostmot2 UART buffer
 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 int hm2_uart_read(char *name, unsigned char *data)
 

--- a/docs/man/man3/hm2_uart_send.3hm2
+++ b/docs/man/man3/hm2_uart_send.3hm2
@@ -6,6 +6,8 @@
 hm2_uart_send \- write data to a Hostmot2 UART
 
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 int hm2_uart_send(char* name,  unsigned char data[], int count)
 

--- a/docs/man/man3/hm2_uart_setup.3hm2
+++ b/docs/man/man3/hm2_uart_setup.3hm2
@@ -5,6 +5,8 @@
 
 hm2_uart_setup \- setup a Hostmot2 UART
 .SH SYNTAX
+.nf
+.B #include <hostmot2-serial.h>
 .HP
 int hm2_uart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode){
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -719,7 +719,7 @@ endif
 # "kbuild" system.  $(BASEPWD) is used here, instead of relative paths, because
 # that's what kbuild seems to require
 
-EXTRA_CFLAGS := $(filter-out -ffast-math,$(RTFLAGS)) -D__MODULE__ -I$(BASEPWD) -I$(BASEPWD)/libnml/linklist \
+EXTRA_CFLAGS := $(filter-out -ffast-math,$(RTFLAGS)) -D__MODULE__ -I$(BASEPWD)/../include -I$(BASEPWD) -I$(BASEPWD)/libnml/linklist \
 	-I$(BASEPWD)/libnml/cms -I$(BASEPWD)/libnml/rcs -I$(BASEPWD)/libnml/inifile \
 	-I$(BASEPWD)/libnml/os_intf -I$(BASEPWD)/libnml/nml -I$(BASEPWD)/libnml/buffer \
 	-I$(BASEPWD)/libnml/posemath -I$(BASEPWD)/rtapi -I$(BASEPWD)/hal \

--- a/src/Makefile
+++ b/src/Makefile
@@ -115,7 +115,8 @@ SUBDIRS := \
     rtapi/examples/timer rtapi/examples/semaphore rtapi/examples/shmem \
     rtapi/examples/extint rtapi/examples/fifo rtapi/examples rtapi \
     \
-    hal/components hal/drivers hal/user_comps/devices hal/user_comps/mb2hal \
+    hal/components hal/drivers hal/drivers/mesa-hostmot2 \
+    hal/user_comps/devices hal/user_comps/mb2hal \
     hal/user_comps hal/user_comps/vismach hal/user_comps/vfs11_vfd hal/classicladder hal/utils hal \
     hal/user_comps/vfdb_vfd hal/user_comps/wj200_vfd \
     hal/user_comps/huanyang-vfd \
@@ -305,6 +306,7 @@ HEADERS := \
     emc/rs274ngc/rs274ngc.hh \
     hal/hal.h \
     hal/hal_parport.h \
+    hal/drivers/mesa-hostmot2/hostmot2-serial.h \
     libnml/buffer/locmem.hh \
     libnml/buffer/memsem.hh \
     libnml/buffer/phantom.hh \
@@ -1006,7 +1008,8 @@ $(sort $(RTOBJS)) : objects/rt%.o : %.c
 	$(ECHO) Compiling realtime $<
 	@rm -f $@
 	@mkdir -p $(dir $@)
-	$(Q)$(CC) -c $(OPT) $(DEBUG) $(EXTRA_DEBUG) -DRTAPI $(EXTRA_CFLAGS) \
+	$(Q)$(CC) -c $(OPT) $(DEBUG) $(EXTRA_DEBUG) -DRTAPI -I../include \
+		$(EXTRA_CFLAGS) \
 		-MP -MD -MF "${@:.o=.d}" -MT "$@" \
 		$< -o $@
 endif

--- a/src/hal/drivers/mesa-hostmot2/Submakefile
+++ b/src/hal/drivers/mesa-hostmot2/Submakefile
@@ -1,0 +1,5 @@
+
+$(patsubst ./hal/drivers/mesa-hostmot2/%,../include/%,$(wildcard ./hal/drivers/mesa-hostmot2/*.h)): ../include/%.h: ./hal/drivers/mesa-hostmot2/%.h
+	cp $^ $@
+$(patsubst ./hal/drivers/mesa-hostmot2/%,../include/%,$(wildcard ./hal/drivers/mesa-hostmot2/*.hh)): ../include/%.hh: ./hal/drivers/mesa-hostmot2/%.hh
+	cp $^ $@

--- a/src/hal/drivers/mesa-hostmot2/hostmot2-serial.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2-serial.h
@@ -1,0 +1,45 @@
+//
+//    Copyright (C) 2007-2008 Sebastian Kuzminsky
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#ifndef __HOSTMOT2_UART_H
+#define __HOSTMOT2_UART_H
+
+#include <rtapi.h>
+
+RTAPI_BEGIN_DECLS
+
+int hm2_uart_setup(char *name, int bitrate, rtapi_s32 tx_mode, rtapi_s32 rx_mode);
+int hm2_uart_send(char *name, unsigned char data[], int count);
+int hm2_uart_read(char *name, unsigned char data[]);
+
+int hm2_pktuart_setup(char *name, int bitrate, rtapi_s32 tx_mode, rtapi_s32 rx_mode, int txclear, int rxclear);
+int hm2_pktuart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 frame_sizes[]);
+int hm2_pktuart_read(char *name, unsigned char data[],  rtapi_u8 *num_frames, rtapi_u16 *max_frame_length, rtapi_u16 frame_sizes[]);
+
+int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz, 
+                        int delay, int cpol, int cpha, int noclear, int noecho,
+                        int samplelate);
+int hm2_bspi_set_read_function(char *name, int (*func)(void *subdata), void *subdata);
+int hm2_bspi_set_write_function(char *name, int (*func)(void *subdata), void *subdata);
+int hm2_bspi_write_chan(char* name, int chan, rtapi_u32 val);
+int hm2_allocate_bspi_tram(char* name);
+int hm2_tram_add_bspi_frame(char *name, int chan, rtapi_u32 **wbuff, rtapi_u32 **rbuff);
+
+RTAPI_END_DECLS
+
+#endif

--- a/src/hal/drivers/mesa_7i65.comp
+++ b/src/hal/drivers/mesa_7i65.comp
@@ -43,7 +43,7 @@ variable unsigned *AD7329_read[8];
 license "GPL";
 author "Andy Pugh / Cliff Blackburn";
 
-include "../../../hal/drivers/mesa-hostmot2/hostmot2.h";
+include <hostmot2-serial.h>;
 ;;
 
 // to parse the modparam

--- a/src/hal/drivers/mesa_7i65.comp
+++ b/src/hal/drivers/mesa_7i65.comp
@@ -186,7 +186,8 @@ EXTRA_SETUP(){
     r += hm2_bspi_setup_chan(name, 9, 7, 8, 4, 0, 1, 1, 1, 1, 0);
 
     if (r < 0) {
-        HM2_ERR_NO_LL("There have been %i errors during channel setup, "
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                      "There have been %i errors during channel setup, "
                       "quitting\n", -r);
         return -EINVAL;
     }
@@ -200,7 +201,8 @@ EXTRA_SETUP(){
     r += hm2_bspi_write_chan(name, 3, 0x00009C18);
 
     if (r < 0) {
-        HM2_ERR_NO_LL("There have been %i errors during ADC setup, "
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                      "There have been %i errors during ADC setup, "
                       "quitting\n", -r);
         return -EINVAL;
     }
@@ -232,7 +234,8 @@ EXTRA_SETUP(){
     // r += hm2_bspi_set_write_function(name, &write, __comp_inst);
 
     if (r < 0) {
-        HM2_ERR_NO_LL("There have been %i errors during TRAM allocation setup, "
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                      "There have been %i errors during TRAM allocation setup, "
                       "quitting\n", -r);
         return -EINVAL;
     }

--- a/src/hal/drivers/mesa_uart.comp
+++ b/src/hal/drivers/mesa_uart.comp
@@ -36,8 +36,7 @@ http://www.linuxcnc.org/docview/html/hal/comp.html""";
 author "Andy Pugh andy@bodgesoc.org";
 license "GPL";
 
-// undocumented feature of comp, and when it is interpreted this file has moved
-include "../../../hal/drivers/mesa-hostmot2/hostmot2.h";
+include <hostmot2-serial.h>;
 
 pin in u32 tx-data-##[16] "Data to be transmitted";
 pin out u32 rx-data-##[16] "Data received";

--- a/tests/halcompile/relative-header/.gitignore
+++ b/tests/halcompile/relative-header/.gitignore
@@ -1,0 +1,2 @@
+relative_header.so
+relative_header.ko

--- a/tests/halcompile/relative-header/checkresult
+++ b/tests/halcompile/relative-header/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+[ -e "`dirname "$1"`/relative_header.so" -o "`dirname "$1"`/relative_header.ko" ]

--- a/tests/halcompile/relative-header/local.h
+++ b/tests/halcompile/relative-header/local.h
@@ -1,0 +1,1 @@
+#define X 1

--- a/tests/halcompile/relative-header/relative_header.comp
+++ b/tests/halcompile/relative-header/relative_header.comp
@@ -1,0 +1,7 @@
+component relative_header;
+pin out bit out;
+include "local.h";
+function _;
+license "GPL";
+;;
+out = X;

--- a/tests/halcompile/relative-header/test.sh
+++ b/tests/halcompile/relative-header/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+halcompile --compile relative_header.comp

--- a/tests/halcompile/serial-out-of-tree/.gitignore
+++ b/tests/halcompile/serial-out-of-tree/.gitignore
@@ -1,0 +1,2 @@
+mesa_uart.so
+mesa_uart.ko

--- a/tests/halcompile/serial-out-of-tree/checkresult
+++ b/tests/halcompile/serial-out-of-tree/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+[ -e "`dirname "$1"`/mesa_uart.so" -o "`dirname "$1"`/mesa_uart.ko" ]

--- a/tests/halcompile/serial-out-of-tree/mesa_uart.comp
+++ b/tests/halcompile/serial-out-of-tree/mesa_uart.comp
@@ -1,0 +1,1 @@
+../../../src/hal/drivers/mesa_uart.comp

--- a/tests/halcompile/serial-out-of-tree/test.sh
+++ b/tests/halcompile/serial-out-of-tree/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+halcompile --compile mesa_uart.comp


### PR DESCRIPTION
This is trying to address what I think is the actual problem underlying #515.  While I didn't test this with a package, I did test that with an RIP build "mesa_7i65.comp" can be copied out of the tree and built with `halcompile --compile`.  buildbot shows green for kernel-mode RTAI builds, and I tested locally with uspace builds on debian stretch.