### PR TITLE
halcompile: Add checks to generated code for array overflows

### DIFF
--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -399,8 +399,16 @@ static int comp_id;
         if personality:
             print("if(%s) {" % personality, file=f)
         if array:
-            if isinstance(array, tuple): array = array[1]
-            print("    for(j=0; j < (%s); j++) {" % array, file=f)
+            if isinstance(array, tuple):
+                lim, cnt = array
+                print("    if((%s) > (%s)) {" % (cnt, lim), file=f)
+                print('        rtapi_print_msg(RTAPI_MSG_ERR,' \
+                                '"Pin %s: Requested size %%d exceeds max size %%d\\n",'
+                                '(int)%s, (int)%s);' % (name, cnt, lim), file=f)
+                print("        return -ENOSPC;", file=f)
+                print("    }", file=f)
+            else: cnt = array
+            print("    for(j=0; j < (%s); j++) {" % cnt, file=f)
             print("        r = hal_pin_%s_newf(%s, &(inst->%s[j]), comp_id," % (
                 type, dirmap[dir], to_c(name)), file=f)
             print("            \"%%s%s\", prefix, j);" % to_hal("." + name), file=f)
@@ -422,8 +430,16 @@ static int comp_id;
         if personality:
             print("if(%s) {" % personality, file=f)
         if array:
-            if isinstance(array, tuple): array = array[1]
-            print("    for(j=0; j < %s; j++) {" % array, file=f)
+            if isinstance(array, tuple):
+                lim, cnt = array
+                print("    if((%s) > (%s)) {" % (cnt, lim), file=f)
+                print('        rtapi_print_msg(RTAPI_MSG_ERR,' \
+                                '"Parameter %s: Requested size %%d exceeds max size %%d\\n",'
+                                '(int)%s, (int)%s);' % (name, cnt, lim), file=f)
+                print("        return -ENOSPC;", file=f)
+                print("    }", file=f)
+            else: cnt = array
+            print("    for(j=0; j < (%s); j++) {" % cnt, file=f)
             print("        r = hal_param_%s_newf(%s, &(inst->%s[j]), comp_id," % (
                 type, dirmap[dir], to_c(name)), file=f)
             print("            \"%%s%s\", prefix, j);" % to_hal("." + name), file=f)
@@ -1115,7 +1131,7 @@ def main():
                 if outfile is not None: os.unlink(outfile)
             except: # os.error:
                 pass
-            raise e
+            raise
 if __name__ == '__main__':
     main()
 


### PR DESCRIPTION
This checks at 'loadrt' time that the dynamic array size fits within
the static maximum size.  This would detect problems like demux's
buggy "pin out bit out-## [1:personality]" which would allocate space
for at most 1 pin.  Now, this generates an error like

    halcmd: loadrt demux count=1 personality=32
    Note: Using POSIX non-realtime
    Pin out-##: Requested size 32 exceeds max size 1
    demux: rtapi_app_main: No space left on device (-28)

(This doesn't add any runtime checking of the accesses like out(i) = true)