### PR TITLE
Demux bugfixes

### DIFF
--- a/src/hal/components/demux.comp
+++ b/src/hal/components/demux.comp
@@ -28,8 +28,8 @@ function _;
 FUNCTION(_){
     int i, bit;
 
-    bit = sel_u32 + sel_bit(0) + sel_bit(1) << 1 + sel_bit(2) << 2
-          + sel_bit(3) << 3 + sel_bit(4) << 4;
+    bit = sel_u32 + sel_bit(0) + (sel_bit(1) << 1) + (sel_bit(2) << 2)
+          + (sel_bit(3) << 3) + (sel_bit(4) << 4);
     if (bit >= personality) bit = personality - 1;
     for (i = 0; i < personality ; i++) {
     out(i) = (bargraph) ? (bit > i) : (bit == i);

--- a/src/hal/components/demux.comp
+++ b/src/hal/components/demux.comp
@@ -13,7 +13,7 @@ set, as might be required for an LED bargraph display""";
 
 pin in bit sel-bit-## [5] "Binary-number bit selectors";
 pin in unsigned sel-u32 "Integer selection input";
-pin out bit out-## [1:personality] "The set of output bits";
+pin out bit out-## [32:personality] "The set of output bits";
 
 param rw bit bargraph = 0;
 

--- a/src/hal/components/demux.comp
+++ b/src/hal/components/demux.comp
@@ -32,6 +32,6 @@ FUNCTION(_){
           + (sel_bit(3) << 3) + (sel_bit(4) << 4);
     if (bit >= personality) bit = personality - 1;
     for (i = 0; i < personality ; i++) {
-    out(i) = (bargraph) ? (bit > i) : (bit == i);
+        out(i) = (bargraph) ? (bit > i) : (bit == i);
     }
 }

--- a/src/hal/components/demux.comp
+++ b/src/hal/components/demux.comp
@@ -15,6 +15,7 @@ pin in bit sel-bit-## [5] "Binary-number bit selectors";
 pin in unsigned sel-u32 "Integer selection input";
 pin out bit out-## [32:personality] "The set of output bits";
 
+option default_personality 32;
 param rw bit bargraph = 0;
 
 license "GPL 2+";


### PR DESCRIPTION
 - the default personality was 0, leading to a useless component
 - the maximum size was 1, meaning using a personality above 1 would lead to memory corruption
 - the calculation was incorrect, so when e.g., bit 02 was set a wrong bit number would be calculated