### PR TITLE
Issue159 2.7

### DIFF
--- a/docs/src/config/ini-config.txt
+++ b/docs/src/config/ini-config.txt
@@ -923,36 +923,60 @@ Typically (but not always):
     second squared.
 
 * 'BACKLASH = 0.0000' -
-    (((Backlash))) Backlash in machine units. Backlash compensation value
-    can be used to make up for small deficiencies in the hardware used to
-    drive an axis. If backlash is added to an axis and you are using
-    steppers the STEPGEN_MAXACCEL must be increased to 1.5 to 2 times the
-    MAX_ACCELERATION for the axis.
+    (((Backlash))) Backlash is in machine units. Backlash compensation can be
+    used to make up for small deficiencies in the hardware used to drive an
+    axis. If backlash is added to an axis and you are using steppers the
+    STEPGEN_MAXACCEL must be increased to 1.5 to 2 times the MAX_ACCELERATION
+    for the axis. Excessive backlash compensation can cause an axis to jerk as
+    it changes direction. If a COMP_FILE is specificed for an axis BACKLASH is
+    not used.
+
+// add a link to machine units
 
 * 'COMP_FILE = file.extension' -
-    (((Compensation))) A file holding compensation structure for the axis.
-    The file could be named xscrew.comp, for example, for the X axis. File
-    names are case sensitive and can contain letters and/or numbers. The
-    values are triplets per line separated by a space. The first value is
-    nominal (where it should be). The second and third values depend on the
-    setting of COMP_FILE_TYPE. Currently the limit inside LinuxCNC is for 256
-    triplets per axis. If COMP_FILE is specified, BACKLASH is ignored.
-    Compensation file values are in machine units.
+    (((Compensation))) The compensation file consists of map of position
+    information for the axis. Compensation file values are in machine units.
+    Each set of values are are on one line separated by a space. The first value
+    is the nominal value (the commanded position). The second and third values
+    depend on the setting of COMP_FILE_TYPE. Points in between nominal values
+    are interpolated between the two nominals. Compensation files must start
+    with the smallest nominal and be in ascending order to the largest value of
+    nominals. File names are case sensitive and can contain letters and/or
+    numbers. Currently the limit inside LinuxCNC is for 256 triplets per axis.
+    +
+    +
+    If COMP_FILE is specified for an axis, BACKLASH is not used. A 
+    'COMP_FILE_TYPE' must be specified for each 'COMP_FILE'.
 
-* 'COMP_FILE_TYPE = 0 or 1' -
-** 'If 0:' The second and third values specify
-    the forward position (where the axis is while traveling forward) and
-    the reverse position (where the axis is while traveling reverse),
-    positions which correspond to the nominal position.'
-** 'If 1:' The second and third values specify
-    the forward trim (how far from nominal while traveling forward) and
-    the reverse trim (how far from nominal while traveling in reverse),
-    positions which correspond to the nominal position.
+* 'COMP_FILE_TYPE = 0 or 1' - Specifies the type of compensation file. The
+   first value is the nominal (commanded) position for both types.
 
-    Example triplet with COMP_FILE_TYPE = 0: 1.00 1.01 0.99 +
-    Example triplet with COMP_FILE_TYPE = 1: 1.00 0.01 -0.01
+** 'Type 0:' The second value specifies the actual position as the axis is moving
+    in the positive direction (increasing value) and the third value specifies
+    the actual position as the axis is moving in the negative direction
+    (decreasing value).
+    +
+    +
+Type 0 Example
++
+----
+-1.000 -1.005 -0.995
+0.000 0.002 -0.003
+1.000 1.003 0.998
+----
 
-
+** 'Type 1:' The second value specifies positive offset from nominal while
+    traveling in the positive direction. The third value specifies the negitive
+    offset from nominal while traveling in a negitive direction.
+    +
+    +
+Type 1 Example
++
+----
+-1.000 0.005 -0.005
+0.000 0.002 -0.003
+1.000 0.003 -0.004
+----
 
 * 'MIN_LIMIT = -1000' - (((MIN LIMIT))) The minimum limit for axis motion, in
     machine units. When this limit is reached, the controller aborts axis

--- a/docs/src/gcode/m-code.txt
+++ b/docs/src/gcode/m-code.txt
@@ -40,16 +40,14 @@
 == M0, M1 Program Pause
 (((M0, M1 Program Pause)))
 
-* 'M0' - pause a running program temporarily. LinuxCNC remains
-         in the Auto Mode so MDI and other manual actions
-         are not enabled. Pressing the cycle start button
-         will restart the program at the following line.
+* 'M0' - pause a running program temporarily. LinuxCNC remains in the Auto Mode
+         so MDI and other manual actions are not enabled. Pressing the resume
+         button will restart the program at the following line.
 
-* 'M1' - pause a running program temporarily if the optional
-         stop switch is on. LinuxCNC remains in the Auto Mode
-         so MDI and other manual actions are not enabled.
-         Pressing the cycle start button
-         will restart the program at the following line.
+* 'M1' - pause a running program temporarily if the optional stop switch is on.
+         LinuxCNC remains in the Auto Mode so MDI and other manual actions are
+         not enabled. Pressing the resume button will restart the program at the
+         following line.
 
 [NOTE]
 It is OK to program 'M0' and 'M1' in MDI mode,
@@ -61,7 +59,7 @@ to stop after each line of input anyway.
 == M2, M30 Program End
 (((M2, M30 Program End)))
 
-* 'M2' - end the program. Pressing cycle start will
+* 'M2' - end the program. Pressing r will
          start the program at the beginning of the file.
          
 * 'M30' - exchange pallet shuttles and end the program.

--- a/src/emc/usr_intf/pncconf/pncconf.py
+++ b/src/emc/usr_intf/pncconf/pncconf.py
@@ -1638,7 +1638,7 @@ class App:
                 return True
             else:
                 return False
-        elif hal.is_rt and not hal.kernel_version == actual_kernel:
+        elif hal.is_kernelspace and hal.kernel_version != actual_kernel:
             self.warning_dialog(self._p.MESS_KERNEL_WRONG + '%s'%hal.kernel_version,True)
             if self.debugstate:
                 return True


### PR DESCRIPTION
Fix issue #159 for 2.7.  This is the same as #184, just cherry picked.  Noted by @andypugh in #500.j

Testing performed: Make selections in pncconf until it is possible to arrive at the "X Motor" screen with the "Test / Tune Axis" button.  Click it.

Before the change, the reported error occurs.

After the change, an error occurs when trying to load hm2_pci, which is expected since no such device is attached.
