### PR TITLE
pncconf: don't refer to kernel_version when not is_kernelspace

### DIFF
--- a/src/emc/usr_intf/pncconf/pncconf.py
+++ b/src/emc/usr_intf/pncconf/pncconf.py
@@ -1638,7 +1638,7 @@ class App:
                 return True
             else:
                 return False
-        elif hal.is_rt and not hal.kernel_version == actual_kernel:
+        elif hal.is_kernelspace and hal.kernel_version != actual_kernel:
             self.warning_dialog(self._p.MESS_KERNEL_WRONG + '%s'%hal.kernel_version,True)
             if self.debugstate:
                 return True


### PR DESCRIPTION
Fix issue #159 for 2.7.  This is the same as #184, just cherry picked.  Noted by @andypugh in #500.

Testing performed: Make selections in pncconf until it is possible to arrive at the "X Motor" screen with the "Test / Tune Axis" button.  Click it.

Before the change, the reported error occurs.

After the change, an error occurs when trying to load hm2_pci, which is expected since no such device is attached.
