### PR TITLE
Apply 'max velocity' to pure rotary motion

### DIFF
--- a/src/emc/ini/inihal.cc
+++ b/src/emc/ini/inihal.cc
@@ -134,6 +134,7 @@ int ini_hal_init(void)
 
     MAKE_FLOAT_PIN(traj_default_velocity,HAL_IN);
     MAKE_FLOAT_PIN(traj_max_velocity,HAL_IN);
+    MAKE_FLOAT_PIN(traj_max_angular_velocity,HAL_IN);
     MAKE_FLOAT_PIN(traj_default_acceleration,HAL_IN);
     MAKE_FLOAT_PIN(traj_max_acceleration,HAL_IN);
 
@@ -152,6 +153,7 @@ int ini_hal_init_pins()
 {
     INIT_PIN(traj_default_velocity);
     INIT_PIN(traj_max_velocity);
+    INIT_PIN(traj_max_angular_velocity);
     INIT_PIN(traj_default_acceleration);
     INIT_PIN(traj_max_acceleration);
 
@@ -192,23 +194,26 @@ int check_ini_hal_items()
     const value_inihal_data &new_inihal_data = new_inihal_data_mutable;
 
     if (CHANGED(traj_default_velocity)) {
-        if (debug) SHOW_CHANGE(traj_default_velocity)
+        if (debug) SHOW_CHANGE(traj_default_velocity);
         UPDATE(traj_default_velocity);
         if (0 != emcTrajSetVelocity(0, NEW(traj_default_velocity))) {
             rcs_print("check_ini_hal_items:bad return value from emcTrajSetVelocity\n");
         }
     }
-    if (CHANGED(traj_max_velocity)) {
-        if (debug) SHOW_CHANGE(traj_max_velocity)
+    if (CHANGED(traj_max_velocity) | CHANGED(traj_max_angular_velocity)) {
+        if (debug) SHOW_CHANGE(traj_max_velocity);
+	if (debug) SHOW_CHANGE(traj_max_angular_velocity);
         UPDATE(traj_max_velocity);
-        if (0 != emcTrajSetMaxVelocity(NEW(traj_max_velocity))) {
+        UPDATE(traj_max_angular_velocity);
+        if (0 != emcTrajSetMaxVelocity(NEW(traj_max_velocity),
+				       NEW(traj_max_angular_velocity))) {
             if (emc_debug & EMC_DEBUG_CONFIG) {
                 rcs_print("check_ini_hal_items:bad return value from emcTrajSetMaxVelocity\n");
             }
         }
     }
     if (CHANGED(traj_default_acceleration)) {
-        if (debug) SHOW_CHANGE(traj_default_acceleration)
+        if (debug) SHOW_CHANGE(traj_default_acceleration);
         UPDATE(traj_default_acceleration);
         if (0 != emcTrajSetAcceleration(NEW(traj_default_acceleration))) {
             if (emc_debug & EMC_DEBUG_CONFIG) {
@@ -217,7 +222,7 @@ int check_ini_hal_items()
         }
     }
     if (CHANGED(traj_max_acceleration)) {
-        if (debug) SHOW_CHANGE(traj_max_acceleration)
+        if (debug) SHOW_CHANGE(traj_max_acceleration);
         UPDATE(traj_max_acceleration);
         if (0 != emcTrajSetMaxAcceleration(NEW(traj_max_acceleration))) {
             if (emc_debug & EMC_DEBUG_CONFIG) {

--- a/src/emc/ini/inihal.hh
+++ b/src/emc/ini/inihal.hh
@@ -51,6 +51,7 @@ int ini_hal_init_pins(void);
 #define HAL_FIELDS \
     FIELD(hal_float_t,traj_default_velocity) \
     FIELD(hal_float_t,traj_max_velocity) \
+    FIELD(hal_float_t,traj_max_angular_velocity) \
     FIELD(hal_float_t,traj_default_acceleration) \
     FIELD(hal_float_t,traj_max_acceleration) \
 \

--- a/src/emc/ini/initraj.cc
+++ b/src/emc/ini/initraj.cc
@@ -51,7 +51,7 @@ extern value_inihal_data old_inihal_data;
   emcTrajSetCycleTime(double cycleTime);
   emcTrajSetVelocity(double vel);
   emcTrajSetAcceleration(double acc);
-  emcTrajSetMaxVelocity(double vel);
+  emcTrajSetMaxVelocity(double vel, double vela);
   emcTrajSetMaxAcceleration(double acc);
   emcTrajSetHome(EmcPose home);
   */
@@ -61,7 +61,7 @@ static int loadTraj(EmcIniFile *trajInifile)
     const char *inistring;
     EmcLinearUnits linearUnits;
     EmcAngularUnits angularUnits;
-    double vel;
+    double vel, vela;
     double acc;
     unsigned char coordinateMark[6] = { 1, 1, 1, 0, 0, 0 };
     int t;
@@ -127,14 +127,17 @@ static int loadTraj(EmcIniFile *trajInifile)
         }
 
         vel = 1e99; // by default, use AXIS limit
+        vela = 1e99;
         trajInifile->Find(&vel, "MAX_VELOCITY", "TRAJ");
+        trajInifile->Find(&vela, "MAX_ANGULAR_VELOCITY", "TRAJ");
 
         // set the corresponding global
         traj_max_velocity = vel;
         old_inihal_data.traj_max_velocity = vel;
+        old_inihal_data.traj_max_angular_velocity = vela;
 
         // and set dynamic value
-        if (0 != emcTrajSetMaxVelocity(vel)) {
+        if (0 != emcTrajSetMaxVelocity(vel, vela)) {
             if (emc_debug & EMC_DEBUG_CONFIG) {
                 rcs_print("bad return value from emcTrajSetMaxVelocity\n");
             }

--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -996,7 +996,9 @@ check_stuff ( "before command_handler()" );
 	    /* set the absolute max velocity for all subsequent moves */
 	    /* can do it at any time */
 	    emcmotConfig->limitVel = emcmotCommand->vel;
-	    tpSetVlimit(&emcmotDebug->tp, emcmotConfig->limitVel);
+	    emcmotConfig->limitVelAng = emcmotCommand->vela;
+	    tpSetVlimit(&emcmotDebug->tp,
+			emcmotConfig->limitVel, emcmotConfig->limitVelAng);
 	    break;
 
 	case EMCMOT_SET_JOINT_VEL_LIMIT:
@@ -1457,6 +1459,8 @@ check_stuff ( "before command_handler()" );
 		reportError
 		    (_("need to be enabled, in teleop mode for teleop move"));
 	    } else {
+		// FIXME how should this change for angular velocity
+		// in rotary-only moves?
 		double velmag;
 		emcmotDebug->teleop_data.desiredVel = emcmotCommand->pos;
 		pmCartMag(&emcmotDebug->teleop_data.desiredVel.tran, &velmag);

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -898,6 +898,7 @@ static int init_comm_buffers(void)
     ZERO_EMC_POSE(emcmotStatus->carte_pos_fb);
     emcmotStatus->vel = VELOCITY;
     emcmotConfig->limitVel = VELOCITY;
+    emcmotConfig->limitVelAng = VELOCITY;
     emcmotStatus->acc = ACCELERATION;
     emcmotStatus->feed_scale = 1.0;
     emcmotStatus->rapid_scale = 1.0;

--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -152,7 +152,8 @@ extern "C" {
 	EMCMOT_SET_MIN_FERROR,	/* minimum following error, input units */
 	EMCMOT_SET_MAX_FERROR,	/* maximum following error, input units */
 	EMCMOT_SET_VEL,		/* set the velocity for subsequent moves */
-	EMCMOT_SET_VEL_LIMIT,	/* set the max vel for all moves (tooltip) */
+	EMCMOT_SET_VEL_LIMIT,	/* set the max vel for all moves
+				   (linear and rotary-only) */
 	EMCMOT_SET_JOINT_VEL_LIMIT,	/* set the max joint vel */
 	EMCMOT_SET_JOINT_ACC_LIMIT,	/* set the max joint accel */
 	EMCMOT_SET_ACC,		/* set the max accel for moves (tooltip) */
@@ -212,7 +213,8 @@ extern "C" {
 	PmCartesian center;	/* center for circle */
 	PmCartesian normal;	/* normal vec for circle */
 	int turn;		/* turns for circle or which rotary to unlock for a line */
-	double vel;		/* max velocity */
+	double vel;		/* max linear velocity */
+	double vela;		/* max angular velocity */
         double ini_maxvel;      /* max velocity allowed by machine
                                    constraints (the ini file) */
         int motion_type;        /* this move is because of traverse, feed, arc, or toolchange */
@@ -739,7 +741,8 @@ Suggestion: Split this in to an Error and a Status flag register..
 	int interpolationRate;	/* grep control.c for an explanation....
 				   approx line 50 */
 
-	double limitVel;	/* scalar upper limit on vel */
+	double limitVel;	/* scalar upper limit on linear vel */
+	double limitVelAng;	/* scalar upper limit on angular vel */
 	KINEMATICS_TYPE kinematics_type;
 	int debug;		/* copy of DEBUG, from .ini file */
 	unsigned char tail;	/* flag count for mutex detect */

--- a/src/emc/nml_intf/emc.cc
+++ b/src/emc/nml_intf/emc.cc
@@ -2348,6 +2348,7 @@ void EMC_TRAJ_STAT::update(CMS * cms)
     cms->update(velocity);
     cms->update(acceleration);
     cms->update(maxVelocity);
+    cms->update(maxAngularVelocity);
     cms->update(maxAcceleration);
     EmcPose_update(cms, &probedPosition);
     cms->update(probe_tripped);
@@ -2599,6 +2600,7 @@ void EMC_TRAJ_SET_MAX_VELOCITY::update(CMS * cms)
 
     EMC_TRAJ_CMD_MSG::update(cms);
     cms->update(velocity);
+    cms->update(velocity_angular);
 
 }
 

--- a/src/emc/nml_intf/emc.hh
+++ b/src/emc/nml_intf/emc.hh
@@ -418,7 +418,7 @@ extern int emcTrajSetMode(int traj_mode);
 extern int emcTrajSetTeleopVector(EmcPose vel);
 extern int emcTrajSetVelocity(double vel, double ini_maxvel);
 extern int emcTrajSetAcceleration(double acc);
-extern int emcTrajSetMaxVelocity(double vel);
+extern int emcTrajSetMaxVelocity(double vel, double vela);
 extern int emcTrajSetMaxAcceleration(double acc);
 extern int emcTrajSetScale(double scale);
 extern int emcTrajSetRapidScale(double scale);

--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -582,6 +582,7 @@ class EMC_TRAJ_SET_MAX_VELOCITY:public EMC_TRAJ_CMD_MSG {
     void update(CMS * cms);
 
     double velocity;
+    double velocity_angular;
 };
 
 class EMC_TRAJ_SET_MAX_ACCELERATION:public EMC_TRAJ_CMD_MSG {
@@ -1003,6 +1004,7 @@ class EMC_TRAJ_STAT:public EMC_TRAJ_STAT_MSG {
     double acceleration;	// system acceleration, for subsequent
     // motions
     double maxVelocity;		// max system velocity
+    double maxAngularVelocity;	// max system angular velocity
     double maxAcceleration;	// system acceleration
 
     EmcPose probedPosition;	// last position where probe was tripped.

--- a/src/emc/nml_intf/emcops.cc
+++ b/src/emc/nml_intf/emcops.cc
@@ -71,6 +71,7 @@ EMC_TRAJ_STAT_MSG(EMC_TRAJ_STAT_TYPE, sizeof(EMC_TRAJ_STAT))
     velocity = 1.0;
     acceleration = 1.0;
     maxVelocity = 1.0;
+    maxAngularVelocity = 1.0;
     maxAcceleration = 1.0;
 
     ZERO_EMC_POSE(probedPosition);

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -1781,7 +1781,9 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 
     case EMC_TRAJ_SET_MAX_VELOCITY_TYPE:
 	emcTrajSetMaxVelocityMsg = (EMC_TRAJ_SET_MAX_VELOCITY *) cmd;
-	retval = emcTrajSetMaxVelocity(emcTrajSetMaxVelocityMsg->velocity);
+	retval = emcTrajSetMaxVelocity
+	    (emcTrajSetMaxVelocityMsg->velocity,
+	     emcTrajSetMaxVelocityMsg->velocity_angular);
 	break;
 
     case EMC_TRAJ_SET_SPINDLE_SCALE_TYPE:

--- a/src/emc/task/taskintf.cc
+++ b/src/emc/task/taskintf.cc
@@ -744,16 +744,20 @@ int emcTrajSetAcceleration(double acc)
   emcmot has no limits on max velocity, acceleration so we'll save them
   here and apply them in the functions above
   */
-int emcTrajSetMaxVelocity(double vel)
+int emcTrajSetMaxVelocity(double vel, double vela)
 {
     if (vel < 0.0) {
 	vel = 0.0;
+    }
+    if (vela < 0.0) {
+	vela = 0.0;
     }
 
     traj_max_velocity = vel;
 
     emcmotCommand.command = EMCMOT_SET_VEL_LIMIT;
     emcmotCommand.vel = vel;
+    emcmotCommand.vela = vela;
 
     return usrmotWriteEmcmotCommand(&emcmotCommand);
 }
@@ -1207,6 +1211,7 @@ int emcTrajUpdate(EMC_TRAJ_STAT * stat)
 	stat->cycleTime = emcmotConfig.trajCycleTime;
 	stat->kinematics_type = emcmotConfig.kinematics_type;
 	stat->maxVelocity = emcmotConfig.limitVel;
+	stat->maxAngularVelocity = emcmotConfig.limitVelAng;
     }
 
     return 0;

--- a/src/emc/task/taskmodule.cc
+++ b/src/emc/task/taskmodule.cc
@@ -343,6 +343,8 @@ BOOST_PYTHON_MODULE(emctask) {
 	.def_readwrite("velocity", &EMC_TRAJ_STAT::velocity )
 	.def_readwrite("acceleration", &EMC_TRAJ_STAT::acceleration)
 	.def_readwrite("maxVelocity", &EMC_TRAJ_STAT::maxVelocity )
+	.def_readwrite("maxAngularVelocity",
+		       &EMC_TRAJ_STAT::maxAngularVelocity )
 	.def_readwrite("maxAcceleration", &EMC_TRAJ_STAT::maxAcceleration )
 	.def_readwrite("probedPosition", &EMC_TRAJ_STAT::probedPosition )
 	.def_readwrite("probe_tripped", &EMC_TRAJ_STAT::probe_tripped )

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -273,9 +273,10 @@ STATIC inline double tpGetMaxTargetVel(TP_STRUCT const * const tp, TC_STRUCT con
      * computed in the TP, so it would disrupt position tracking to apply this
      * limit here.
      */
-    if (!tcPureRotaryCheck(tc) && (tc->synchronized != TC_SYNC_POSITION)){
+    if ((tc->synchronized != TC_SYNC_POSITION)){
         /*tc_debug_print("Cartesian velocity limit active\n");*/
-        v_max_target = fmin(v_max_target,tp->vLimit);
+        v_max_target = fmin(v_max_target,
+			    tcPureRotaryCheck(tc) ? tp->vLimitAng : tp->vLimit);
     }
 
     // Apply maximum segment velocity limit (must always be respected)
@@ -453,6 +454,7 @@ int tpInit(TP_STRUCT * const tp)
     tp->cycleTime = 0.0;
     //Velocity limits
     tp->vLimit = 0.0;
+    tp->vLimitAng = 0.0;
     tp->ini_maxvel = 0.0;
     //Accelerations
     tp->aLimit = 0.0;
@@ -513,12 +515,12 @@ int tpSetVmax(TP_STRUCT * const tp, double vMax, double ini_maxvel)
 }
 
 /**
- * (?) Set the tool tip maximum velocity.
+ * Set the maximum velocity for linear and rotary-only moves.
  * I think this is the [TRAJ] max velocity. This should be the max velocity of
  * const the TOOL TIP, not necessarily any particular axis. This applies to
  * subsequent moves until changed.
  */
-int tpSetVlimit(TP_STRUCT * const tp, double vLimit)
+int tpSetVlimit(TP_STRUCT * const tp, double vLimit, double vLimitAng)
 {
     if (!tp) return TP_ERR_FAIL;
 
@@ -526,6 +528,11 @@ int tpSetVlimit(TP_STRUCT * const tp, double vLimit)
         tp->vLimit = 0.;
     else
         tp->vLimit = vLimit;
+
+    if (vLimitAng < 0.)
+        tp->vLimitAng = 0.;
+    else
+        tp->vLimitAng = vLimitAng;
 
     return TP_ERR_OK;
 }

--- a/src/emc/tp/tp.h
+++ b/src/emc/tp/tp.h
@@ -25,7 +25,7 @@ int tpInit(TP_STRUCT * const tp);
 int tpClearDIOs(TP_STRUCT * const tp);
 int tpSetCycleTime(TP_STRUCT * const tp, double secs);
 int tpSetVmax(TP_STRUCT * const tp, double vmax, double ini_maxvel);
-int tpSetVlimit(TP_STRUCT * const tp, double vLimit);
+int tpSetVlimit(TP_STRUCT * const tp, double vLimit, double vLimitAng);
 int tpSetAmax(TP_STRUCT * const tp, double aMax);
 int tpSetId(TP_STRUCT * const tp, int id);
 int tpGetExecId(TP_STRUCT * const tp);

--- a/src/emc/tp/tp_types.h
+++ b/src/emc/tp/tp_types.h
@@ -101,7 +101,8 @@ typedef struct {
     double ini_maxvel;          /* max velocity allowed by machine
                                    constraints (ini file) for
                                    subsequent moves */
-    double vLimit;		/* absolute upper limit on all vels */
+    double vLimit;		/* absolute upper limit on all linear vels */
+    double vLimitAng;		/* absolute upper limit on all angular vels */
 
     double aMax;        /* max accel (unused) */
     //FIXME this shouldn't be a separate limit,

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -348,6 +348,8 @@ static PyMemberDef Stat_members[] = {
     {(char*)"velocity", T_DOUBLE, O(motion.traj.velocity), READONLY},
     {(char*)"acceleration", T_DOUBLE, O(motion.traj.acceleration), READONLY},
     {(char*)"max_velocity", T_DOUBLE, O(motion.traj.maxVelocity), READONLY},
+    {(char*)"max_angular_velocity", T_DOUBLE,
+     O(motion.traj.maxAngularVelocity), READONLY},
     {(char*)"max_acceleration", T_DOUBLE, O(motion.traj.maxAcceleration), READONLY},
     {(char*)"probe_tripped", T_BOOL, O(motion.traj.probe_tripped), READONLY},
     {(char*)"probing", T_BOOL, O(motion.traj.probing), READONLY},
@@ -784,7 +786,8 @@ static PyObject *mode(pyCommandChannel *s, PyObject *o) {
 
 static PyObject *maxvel(pyCommandChannel *s, PyObject *o) {
     EMC_TRAJ_SET_MAX_VELOCITY m;
-    if(!PyArg_ParseTuple(o, "d", &m.velocity)) return NULL;
+    if(!PyArg_ParseTuple(o, "dd", &m.velocity, &m.velocity_angular))
+	return NULL;
     emcSendCommand(s, m);
     Py_INCREF(Py_None);
     return Py_None;

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1843,10 +1843,16 @@ class TclCommands(nf.TclCommands):
 
     def set_maxvel(newval):
         newval = float(newval)
-        if vars.metric.get(): newval = newval / 25.4
+        max_maxvel = vars.max_maxvel.get()
+        max_maxavel = vars.max_aspeed.get()
+        newaval = newval/max_maxvel * max_maxavel
+        if vars.metric.get():
+            newval = newval / 25.4
+            newaval = newaval / 25.4
         newval = from_internal_linear_unit(newval)
+        newaval = from_internal_linear_unit(newaval)
         global maxvel_blackout
-        c.maxvel(newval / 60.)
+        c.maxvel(newval / 60., newaval / 60.)
         maxvel_blackout = time.time() + 1
 
     def copy_line(*args):

--- a/src/emc/usr_intf/shcom.hh
+++ b/src/emc/usr_intf/shcom.hh
@@ -123,7 +123,7 @@ extern int sendHome(int axis);
 extern int sendUnHome(int axis);
 extern int sendFeedOverride(double override);
 extern int sendRapidOverride(double override);
-extern int sendMaxVelocity(double velocity);
+extern int sendMaxVelocity(double velocity, double velocity_angular);
 extern int sendSpindleOverride(double override);
 extern int sendTaskPlanInit();
 extern int sendProgramOpen(char *program);

--- a/tests/motion/jogwheel/core_sim.hal
+++ b/tests/motion/jogwheel/core_sim.hal
@@ -30,6 +30,9 @@ addf hypot.1 servo-thread
 net Xpos axis.0.motor-pos-cmd => axis.0.motor-pos-fb ddt.0.in
 net Ypos axis.1.motor-pos-cmd => axis.1.motor-pos-fb ddt.2.in
 net Zpos axis.2.motor-pos-cmd => axis.2.motor-pos-fb ddt.4.in
+net Apos axis.3.motor-pos-cmd => axis.3.motor-pos-fb
+net Bpos axis.4.motor-pos-cmd => axis.4.motor-pos-fb
+net Cpos axis.5.motor-pos-cmd => axis.5.motor-pos-fb
 
 # send the position commands thru differentiators to
 # generate velocity and accel signals

--- a/tests/motion/max_velocity/.gitignore
+++ b/tests/motion/max_velocity/.gitignore
@@ -1,0 +1,2 @@
+sim.var
+sim.var.bak

--- a/tests/motion/max_velocity/README
+++ b/tests/motion/max_velocity/README
@@ -1,0 +1,2 @@
+This checks max velocity, both linear and angular, as set by e.g. the
+'max velocity' slider in the Axis GUI.

--- a/tests/motion/max_velocity/checkresult
+++ b/tests/motion/max_velocity/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh 
+exit 0 # test failure is indicated by test.sh exit value 

--- a/tests/motion/max_velocity/core_sim.hal
+++ b/tests/motion/max_velocity/core_sim.hal
@@ -1,0 +1,76 @@
+# core HAL config file for simulation
+
+# first load all the RT modules that will be needed
+# kinematics
+loadrt trivkins
+# motion controller, get name and thread periods from ini file
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[TRAJ]AXES
+# load 6 differentiators for velocity signals
+loadrt ddt count=6
+# load hypotenuse and minmax comps for capturing combined motion velocities
+loadrt hypot count=2
+loadrt minmax count=6
+
+# add motion controller functions to servo thread
+addf motion-command-handler servo-thread
+addf motion-controller servo-thread
+# link the differentiator functions into the code
+addf ddt.0 servo-thread
+addf ddt.1 servo-thread
+addf ddt.2 servo-thread
+addf ddt.3 servo-thread
+addf ddt.4 servo-thread
+addf ddt.5 servo-thread
+addf hypot.0 servo-thread
+addf hypot.1 servo-thread
+addf minmax.0 servo-thread
+addf minmax.1 servo-thread
+addf minmax.2 servo-thread
+addf minmax.3 servo-thread
+addf minmax.4 servo-thread
+addf minmax.5 servo-thread
+
+# create HAL signals for position commands from motion module loop
+# position commands back to motion module feedback, and into
+# differentiators to capture velocities
+net Xpos axis.0.motor-pos-cmd => axis.0.motor-pos-fb ddt.0.in
+net Ypos axis.1.motor-pos-cmd => axis.1.motor-pos-fb ddt.1.in
+net Zpos axis.2.motor-pos-cmd => axis.2.motor-pos-fb ddt.2.in
+net Apos axis.3.motor-pos-cmd => axis.3.motor-pos-fb ddt.3.in
+net Bpos axis.4.motor-pos-cmd => axis.4.motor-pos-fb ddt.4.in
+net Cpos axis.5.motor-pos-cmd => axis.5.motor-pos-fb ddt.5.in
+
+# joint velocities into joint vel minmax
+net Xvel ddt.0.out => minmax.0.in
+net Yvel ddt.1.out => minmax.1.in
+net Zvel ddt.2.out => minmax.2.in
+net Avel ddt.3.out => minmax.3.in
+net Bvel ddt.4.out => minmax.4.in
+net Cvel ddt.5.out => minmax.5.in
+
+# joint vel minmax reset
+net reset => minmax.0.reset
+net reset => minmax.1.reset
+net reset => minmax.2.reset
+net reset => minmax.3.reset
+net reset => minmax.4.reset
+net reset => minmax.5.reset
+
+# joint vel minmax to cartesian and angular 3-axis velocity minmax in
+net Xvelmax minmax.0.max => hypot.0.in0
+net Yvelmax minmax.1.max => hypot.0.in1
+net Zvelmax minmax.2.max => hypot.0.in2
+net Avelmax minmax.3.max => hypot.1.in0
+net Bvelmax minmax.4.max => hypot.1.in1
+net Cvelmax minmax.5.max => hypot.1.in2
+
+# combined cartesian and angular 3-axis velocity minmax out
+net XYZmax <= hypot.0.out
+net ABCmax <= hypot.1.out
+
+# estop loopback
+net estop-loop iocontrol.0.user-enable-out iocontrol.0.emc-enable-in
+
+# create signals for tool loading loopback
+net tool-prep-loop iocontrol.0.tool-prepare iocontrol.0.tool-prepared
+net tool-change-loop iocontrol.0.tool-change iocontrol.0.tool-changed

--- a/tests/motion/max_velocity/motion-test.ini
+++ b/tests/motion/max_velocity/motion-test.ini
@@ -34,14 +34,14 @@ ANGULAR_UNITS =         degree
 CYCLE_TIME =            0.010
 DEFAULT_VELOCITY =      1.2
 DEFAULT_ANGULAR_VELOCITY = 45.0
-MAX_LINEAR_VELOCITY =   4
-MAX_ANGULAR_VELOCITY =  80.0
+MAX_VELOCITY =   4.5
+MAX_ANGULAR_VELOCITY =  95.0
 
 [AXIS_0]
 TYPE =             LINEAR
 HOME =             0.000
-MAX_VELOCITY =     4
-MAX_ACCELERATION = 1000.0
+MAX_VELOCITY =     4.0
+MAX_ACCELERATION = 100000.0
 BACKLASH =         0.000
 INPUT_SCALE =      4000
 OUTPUT_SCALE =     1.000
@@ -53,8 +53,8 @@ MIN_FERROR =       0.010
 [AXIS_1]
 TYPE =             LINEAR
 HOME =             0.000
-MAX_VELOCITY =     4
-MAX_ACCELERATION = 1000.0
+MAX_VELOCITY =     4.1
+MAX_ACCELERATION = 100000.0
 BACKLASH =         0.000
 INPUT_SCALE =      4000
 OUTPUT_SCALE =     1.000
@@ -66,8 +66,8 @@ MIN_FERROR =       0.010
 [AXIS_2]
 TYPE =             LINEAR
 HOME =             0.0
-MAX_VELOCITY =     4
-MAX_ACCELERATION = 1000.0
+MAX_VELOCITY =     4.2
+MAX_ACCELERATION = 100000.0
 BACKLASH =         0.000
 INPUT_SCALE =      4000
 OUTPUT_SCALE =     1.000
@@ -80,8 +80,8 @@ MIN_FERROR =       0.010
 
 TYPE =                          ANGULAR
 HOME =                          0.0
-MAX_VELOCITY =                  90.0
-MAX_ACCELERATION =              1200.0
+MAX_VELOCITY =                  90.3
+MAX_ACCELERATION =              360000.0
 BACKLASH = 0.000
 INPUT_SCALE =                   40
 OUTPUT_SCALE = 1.000
@@ -98,8 +98,8 @@ HOME_SEQUENCE = 1
 
 TYPE =                          ANGULAR
 HOME =                          0.0
-MAX_VELOCITY =                  90.0
-MAX_ACCELERATION =              1200.0
+MAX_VELOCITY =                  90.4
+MAX_ACCELERATION =              360000.0
 BACKLASH = 0.000
 INPUT_SCALE =                   40
 OUTPUT_SCALE = 1.000
@@ -116,8 +116,8 @@ HOME_SEQUENCE = 1
 
 TYPE =                          ANGULAR
 HOME =                          0.0
-MAX_VELOCITY =                  90.0
-MAX_ACCELERATION =              1200.0
+MAX_VELOCITY =                  90.5
+MAX_ACCELERATION =              360000.0
 BACKLASH = 0.000
 INPUT_SCALE =                   40
 OUTPUT_SCALE = 1.000

--- a/tests/motion/max_velocity/postgui.hal
+++ b/tests/motion/max_velocity/postgui.hal
@@ -13,6 +13,7 @@ net joint-0-jog-scale <= test-ui.joint-0-jog-scale
 net joint-0-jog-scale => axis.0.jog-scale
 
 net Xpos => test-ui.joint-0-position
+net Xvelmax => test-ui.joint-0-velocity
 
 
 #
@@ -29,6 +30,7 @@ net joint-1-jog-scale <= test-ui.joint-1-jog-scale
 net joint-1-jog-scale => axis.1.jog-scale
 
 net Ypos => test-ui.joint-1-position
+net Yvelmax => test-ui.joint-1-velocity
 
 
 #
@@ -45,6 +47,7 @@ net joint-2-jog-scale <= test-ui.joint-2-jog-scale
 net joint-2-jog-scale => axis.2.jog-scale
 
 net Zpos => test-ui.joint-2-position
+net Zvelmax => test-ui.joint-2-velocity
 
 #
 # joint 3
@@ -60,6 +63,7 @@ net joint-3-jog-scale <= test-ui.joint-3-jog-scale
 net joint-3-jog-scale => axis.3.jog-scale
 
 net Apos => test-ui.joint-3-position
+net Avelmax => test-ui.joint-3-velocity
 
 #
 # joint 4
@@ -75,6 +79,7 @@ net joint-4-jog-scale <= test-ui.joint-4-jog-scale
 net joint-4-jog-scale => axis.4.jog-scale
 
 net Bpos => test-ui.joint-4-position
+net Bvelmax => test-ui.joint-4-velocity
 
 #
 # joint 5
@@ -90,4 +95,16 @@ net joint-5-jog-scale <= test-ui.joint-5-jog-scale
 net joint-5-jog-scale => axis.5.jog-scale
 
 net Cpos => test-ui.joint-5-position
+net Cvelmax => test-ui.joint-5-velocity
 
+#
+# XYZ and ABC max velocities
+#
+
+net XYZmax => test-ui.XYZmax
+net ABCmax => test-ui.ABCmax
+
+#
+# Reset minmax
+#
+net reset <= test-ui.minmax-reset

--- a/tests/motion/max_velocity/test.sh
+++ b/tests/motion/max_velocity/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+linuxcnc -r motion-test.ini
+exit $?
+


### PR DESCRIPTION
**NOTE:**  This commit addresses #523; I haven't checked to see whether GUIs need updates in order for this to work.

Add max angular velocity to UI parallel to max linear velocity, plumb
through task to motion, and in `tpGetMaxTargetVel()`, limit
pure-rotary motion.  UIs may then give user control of pure rotary
motion with a 'max velocity' slider.

- UI
  - `.ini` file:  `[TRAJ]MAX_ANGULAR_VELOCITY`
  - Python module
    - Add 2nd arg to `command.maxvel(vel_lin, vel_ang)`
    - Add `stat.max_angular_velocity` attribute
    - Update `axis.py` to compute angular velocity scale
      proportionately to linear velocity
  - `halui`: add `mav_*` pins in parallel to `mv_*` pins
  - `inihal`:  add `traj_max_angular_velocity` field
- NML
  - Add `velocity_angular` field to `EMC_TRAJ_SET_MAX_VELOCITY` message
  - Add `maxAngularVelocity` field to `EMC_TRAJ_STAT` message
- task
  - Add 2nd arg to `emcTrajSetMaxVelocity(maxvel_linear, maxvel_angular)`
- NML (previous commit)
- motion
  - Add `emcmot_config_t.limitVelAng` field
  - Add `emcmot_command_t.vela` field
- tp
  - Add 3rd arg to `tpSetVlimit()`

- Tests:
  - `motion/jogwheel`:  add ABC axes to test `halui`
  - `motion/max_velocity`:  add test for max velocity

Ugliness:

The [`.ini` docs][1] place `MAX_LINEAR_VELOCITY` and
`MAX_ANGULAR_VELOCITY` in the `[DISPLAY]` section; the former is the
maximum possible value on the max velocity slider.  The `MAX_VELOCITY`
param is in the `[TRAJ]` section, and is the set value on the slider.
This naming makes it hard to add the missing angular equivalent to
`[TRAJ]MAX_VELOCITY`.

[1]: http://linuxcnc.org/docs/2.7/html/config/ini-config.html