### PR TITLE
Fix locale string extraction error

### DIFF
--- a/src/emc/usr_intf/pncconf/Submakefile
+++ b/src/emc/usr_intf/pncconf/Submakefile
@@ -26,7 +26,7 @@ PYTARGETS += ../bin/pncconf  ../lib/python/pncconf/__init__.py $(patsubst %,../l
 	../share/linuxcnc/pncconf/dialogs.glade \
 	../share/linuxcnc/pncconf/finished.glade
 
-PYI18NSRCS += emc/usr_intf/pncconf/pncconf.py $(patsubst %,emc/usr_intf/pncconf/%.py,$(pncconf_MODULES)) \
+PYI18NSRCS += emc/usr_intf/pncconf/pncconf.py $(patsubst %,emc/usr_intf/pncconf/%.py,$(PNCCONF_MODULES)) \
 	emc/usr_intf/pncconf/main_page.glade \
 	emc/usr_intf/pncconf/help.glade \
 	emc/usr_intf/pncconf/mesa0.glade \


### PR DESCRIPTION
This is a bug that caused the string that “pncconf” needs to translate not to be extracted, now I fixed it.