### PR TITLE
Fix multi-language loading error for "tklinuxcnc" UI

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -702,7 +702,7 @@ else
     EMC2_ICON=linuxcncicon
     EMC2_TCL_DIR=${prefix}/lib/tcltk/linuxcnc
     EMC2_TCL_LIB_DIR=${prefix}/lib/tcltk/linuxcnc
-    EMC2_LANG_DIR=${prefix}/share/linuxcnc/tcl/msgs
+    EMC2_LANG_DIR=${prefix}/lib/tcltk/linuxcnc/msgs
     EMC2_PO_DIR=${prefix}/share/locale
     EMC2_HELP_DIR=${prefix}/share/doc/linuxcnc
     case $MODULE_DIR in

--- a/tcl/linuxcnc.tcl.in
+++ b/tcl/linuxcnc.tcl.in
@@ -76,7 +76,7 @@ proc hal {args} {
 # called *.msg, (e.g. en_US.msg).
 package require msgcat
 if {$linuxcnc::_langinit && [info exists env(LANG)]} {
-    msgcat::mclocale $env(LANG)
+    msgcat::mclocale
     msgcat::mcload $linuxcnc::LANG_DIR
     set linuxcnc::_langinit 0
 }

--- a/tcl/tklinuxcnc.tcl
+++ b/tcl/tklinuxcnc.tcl
@@ -58,7 +58,7 @@ set tkemc 1
 # called *.msg, (e.g. en_US.msg).
 package require msgcat
 if ([info exists env(LANG)]) {
-    msgcat::mclocale $env(LANG)
+    msgcat::mclocale
     msgcat::mcload $linuxcnc::LANG_DIR
 }
 


### PR DESCRIPTION
In the test "tklinuxcnc" UI found that other languages could not be loaded. First I found the language path definition in "/src/configure.ac" is wrong, I fixed it, but multi-language still can't work. Then I found that the sentence "msgcat::mclocale $env(LANG)" in "/tcl/tklinuxcnc.tcl" and "/tcl/linuxcnc.tcl.in" is the key to the problem. I looked in the relevant documentation and wrote: ("msgcat::mclocale?newLocale?" This function sets the locale to newLocale. If newLocale is omitted, the current locale is returned). So I deleted "$env(LANG)", which proved to be correct, and now multi-language loading works fine.

Document link:http://www.tcl.tk/man/tcl8.4/TclCmd/msgcat.htm#M8