### PR TITLE
add ~/.local/bin to PATH in linuxcnc start script

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -52,10 +52,11 @@ HALLIB_PATH=.:$HALLIB_DIR; export HALLIB_PATH
 
 # put ~.local/bin in PATH if missing. See:
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=839155
-if [[ "$PATH" != *".local/bin"* ]]; then
-	PATH=$HOME/.local/bin:$PATH
+if [ -d $HOME/.local/bin ]; then
+    if [[ "$PATH" != *".local/bin"* ]]; then
+        PATH=$HOME/.local/bin:$PATH
+    fi
 fi
-
 
 #put the LINUXCNC_BIN_DIR in PATH
 PATH=$LINUXCNC_BIN_DIR:$PATH

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -50,6 +50,13 @@ LINUXCNC_TCL_LIB_DIR=@EMC2_TCL_LIB_DIR@
 HALLIB_DIR=@HALLIB_DIR@; export HALLIB_DIR
 HALLIB_PATH=.:$HALLIB_DIR; export HALLIB_PATH
 
+# put ~.local/bin in PATH if missing. See:
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=839155
+if [[ "$PATH" != *".local/bin"* ]]; then
+	PATH=$HOME/.local/bin:$PATH
+fi
+
+
 #put the LINUXCNC_BIN_DIR in PATH
 PATH=$LINUXCNC_BIN_DIR:$PATH
 #ditto scripts if not RIP


### PR DESCRIPTION
There is a regression in bash shipped with Debian Stretch which results in `~/.local/bin` not being on the path. This is the location to which pip installs python entry points, so is needed for linuxcnc to be able to find and launch some python based displays distributed via pip .