### PR TITLE
Modify the Submakefile that extracts the POT file.

### DIFF
--- a/src/emc/usr_intf/gmoccapy/Submakefile
+++ b/src/emc/usr_intf/gmoccapy/Submakefile
@@ -3,8 +3,8 @@ GMOCCAPY_MODULES = dialogs getiniinfo notification player preferences widgets
 PYTARGETS += ../bin/gmoccapy ../lib/python/gmoccapy/__init__.py $(patsubst %,../lib/python/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
 	../share/gmoccapy/gmoccapy.glade 
 
-PYI18NSRCS += emc/usr_intf/gmoccapy/gmoccapy.py $(patsubst %,emc/usr_intf/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
-	emc/usr_intf/gmoccapy/gmoccapy.glade 
+#PYI18NSRCS += emc/usr_intf/gmoccapy/gmoccapy.py $(patsubst %,emc/usr_intf/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
+#	emc/usr_intf/gmoccapy/gmoccapy.glade 
 
 ../lib/python/gmoccapy/__init__.py:
 	@mkdir -p ../lib/python/gmoccapy

--- a/src/po/Submakefile
+++ b/src/po/Submakefile
@@ -54,6 +54,15 @@ TCLSRCS := \
 	../tcl/ngcgui_app.tcl \
 	../tcl/tooledit.tcl
 
+TOOLI18NSRCS := \
+    ../lib/python/gladevcp/iconview.py \
+    ../lib/python/gladevcp/hal_mdihistory.py \
+	../lib/python/gladevcp/offsetpage_widget.py \
+	../lib/python/gladevcp/tooledit_widget.py \
+    ../lib/python/gladevcp/gladevcp-test.glade \
+	../lib/python/gladevcp/offsetpage.glade \
+	../lib/python/gladevcp/tooledit_gtk.glade
+
 po/linuxcnc.pot:
 	$(ECHO) Localizing linuxcnc.pot
 	(cd ..; $(XGETTEXT) -k_ -o src/$@ `src/po/fixpaths.py -j src $^`)
@@ -108,25 +117,21 @@ po/linuxcnc.pot: emc/motion/control.c emc/motion/command.c emc/motion/motion.c e
 
 po/linuxcnc.pot: $(TCLSRCS)
 po/linuxcnc.pot: $(PYI18NSRCS)
+po/linuxcnc.pot: $(TOOLI18NSRCS)
 
 .PHONY: install-locale
 install-locale: $(addprefix $(DESTDIR)$(localedir)/, $(MO_FILES))
 install-kernel-indep: install-locale
 
-INTLTOOL_GLADE := \
-	emc/usr_intf/gmoccapy/gmoccapy.glade.h \
-	../lib/python/gladevcp/offsetpage.glade.h \
-	../lib/python/gladevcp/tooledit_gtk.glade.h
+GMOCCAPY_GLADE := \
+	emc/usr_intf/gmoccapy/gmoccapy.glade.h
 
-$(INTLTOOL_GLADE): %.glade.h: %.glade
+$(GMOCCAPY_GLADE): %.glade.h: %.glade
 	intltool-extract --type=gettext/glade $<
 GMOCCAPY_I18N_SRCS := \
 	$(patsubst %,emc/usr_intf/gmoccapy/%, \
 		gmoccapy.py dialogs.py getiniinfo.py notification.py player.py \
 		preferences.py widgets.py gmoccapy.glade.h) \
-	$(patsubst %,../lib/python/gladevcp/%, \
-		iconview.py offsetpage_widget.py tooledit_widget.py \
-		offsetpage.glade.h tooledit_gtk.glade.h)
 
 po/gmoccapy/gmoccapy.pot: $(GMOCCAPY_I18N_SRCS)
 	$(XGETTEXT) --from-code=UTF-8 --language=Python \
@@ -136,4 +141,4 @@ TARGETS += po/gmoccapy/gmoccapy.pot
 
 clean: gmoccapy_i18n_clean
 gmoccapy_i18n_clean:
-	@rm -f $(INTLTOOL_GLADE)
+	@rm -f $(GMOCCAPY_GLADE)


### PR DESCRIPTION
The translation of "gmoccapy" does not need to be included in "linuxcnc.pot". So I commented it out. The translation of "gladevcp" is not valid in "gmoccapy.pot". It should be included in "linuxcnc.pot".