### PR TITLE
Fix spindle override in halui.cc

### DIFF
--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -1755,7 +1755,7 @@ static void check_hal_changes()
 		counts = new_halui_data.so_counts[spindle];
 		if (counts != old_halui_data.so_counts[spindle]) {
 			if (new_halui_data.so_count_enable[spindle]) {
-				if (new_halui_data.so_direct_value) {
+				if (new_halui_data.so_direct_value[spindle]) {
 					sendSpindleOverride(spindle, counts * new_halui_data.so_scale[spindle]);
 				} else {
 					sendSpindleOverride(spindle, new_halui_data.so_value[spindle] + (counts - old_halui_data.so_counts[spindle]) *


### PR DESCRIPTION
I found this little issue well setting up my pendant and saw the spindle override was always resetting to 1% on first use of the wheel. looks like it was a simple miss when updating these for having multiple spindles.