### PR TITLE
bug: fix import of ImageTk so that it works with python-pil

### DIFF
--- a/src/emc/usr_intf/axis/scripts/image-to-gcode.py
+++ b/src/emc/usr_intf/axis/scripts/image-to-gcode.py
@@ -25,7 +25,7 @@ gettext.install("linuxcnc", localedir=os.path.join(BASE, "share", "locale"), uni
 
 try:
     from PIL import Image
-except:
+except ImportError:
     import Image
 
 import numpy.core
@@ -495,7 +495,12 @@ class ArcEntryCut:
 
 def ui(im, nim, im_name):
     import Tkinter
-    import ImageTk
+    
+    try:
+        from PIL import ImageTk
+    except ImportError:    
+        import ImageTk
+
     import pickle
     import nf
 


### PR DESCRIPTION
Someone has already updated the other Image imports so they work with both the python-imaging and python-pil packages (python-imaging is no longer available in some Ubuntu based distros), but this one was missed causing image-to-gcode to crash when loading a file.

This needs to be merged up to master.