### PR TITLE
Zultron/lcnc pr docker cleanup fixes

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -528,9 +528,9 @@ function KillTaskWithTimeout() {
 	if [ $WAIT -gt 0 ] ; then
 	    echo "Could not kill task $KILL_TASK, PID=$KILL_PID"
 	fi
-	KILL_PIDS=
-	KILL_TASK=
     done
+    KILL_PIDS=
+    KILL_TASK=
 }
 
 

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -27,6 +27,7 @@ LSMOD=@LSMOD@
 PIDOF="@PIDOF@ -x"
 PS=@PS@
 AWK=@AWK@
+GREP=@GREP@
 IPCS=@IPCS@
 KILL=@KILL@
 
@@ -280,7 +281,7 @@ function handle_includes () {
   hdr="# handle_includes():"
   inifile="$1"
   cd "$(dirname $inifile)" ;# for the function() subprocess only
-  grep "^#INCLUDE" "$inifile" >/dev/null
+  $GREP "^#INCLUDE" "$inifile" >/dev/null
   status=$?
   if [ $status -ne 0 ] ; then
     echo "$inifile" ;# just use the input

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -494,15 +494,20 @@ function KillTaskWithTimeout() {
 	echo "Could not find pid(s) for task $KILL_TASK"
 	return -1
     fi
+    local numprocs
     for KILL_PID in $KILL_PIDS ; do
-	echo "Killing task $KILL_TASK, PID=$KILL_PID" >>$PRINT_FILE
+        if $PS $KILL_PID -o comm= | $GREP -q '<defunct>'; then
+            echo "Skipping defunct task $KILL_TASK, PID=$KILL_PID" >>$PRINT_FILE
+            continue
+        fi
 	# first a "gentle" kill with signal TERM
 	$KILL $KILL_PID
 	WAIT=$KILL_TIMEOUT
 	# wait and see if it dissappears
 	while [ $WAIT -gt 1 ] ; do
 	    # see if it's still alive
-	    if $PS $KILL_PID >>$DEBUG_FILE ; then
+            numprocs=$($PS -o comm= $KILL_PID | $GREP -v '<defunct>' | wc -l)
+            if [ $numprocs -gt 0 ]; then
 		WAIT=$(($WAIT-1))
 		sleep .1
 	    else
@@ -517,7 +522,8 @@ function KillTaskWithTimeout() {
 	    # wait and see if it dissappears
 	    while [ $WAIT -gt 1 ] ; do
 		# see if it's still alive
-		if $PS $KILL_PID >>$DEBUG_FILE ; then
+                numprocs=$($PS -o comm= $KILL_PID | $GREP -v '<defunct>' | wc -l)
+                if [ $numprocs -gt 0 ]; then
 		    WAIT=$(($WAIT-1))
 		    sleep .1
 		else


### PR DESCRIPTION
Here are a few cleanups to the `scripts/linuxcnc.in` template.

The most significant update is ignoring defunct zombie processes when cleaning up on exit.  These hang around in Docker containers, and aren't a problem except where they trigger false positives in scripts like this.  More info [here][1].

The others are minor:  Use the autoconfigured `grep` executable, and fix a log message.

[1]: https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/