### PR TITLE
Zultron/lcnc pr docker cleanup fixes

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -528,9 +528,9 @@ function KillTaskWithTimeout() {
 	if [ $WAIT -gt 0 ] ; then
 	    echo "Could not kill task $KILL_TASK, PID=$KILL_PID"
 	fi
-	KILL_PIDS=
-	KILL_TASK=
     done
+    KILL_PIDS=
+    KILL_TASK=
 }
 
 

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -494,15 +494,20 @@ function KillTaskWithTimeout() {
 	echo "Could not find pid(s) for task $KILL_TASK"
 	return -1
     fi
+    local NPROCS
     for KILL_PID in $KILL_PIDS ; do
-	echo "Killing task $KILL_TASK, PID=$KILL_PID" >>$PRINT_FILE
+        if $PS -o comm= $KILL_PID | $GREP -q '<defunct>'; then
+            echo "Skipping defunct task $KILL_TASK, PID=$KILL_PID" >>$PRINT_FILE
+            continue
+        fi
 	# first a "gentle" kill with signal TERM
 	$KILL $KILL_PID
 	WAIT=$KILL_TIMEOUT
 	# wait and see if it dissappears
 	while [ $WAIT -gt 1 ] ; do
 	    # see if it's still alive
-	    if $PS $KILL_PID >>$DEBUG_FILE ; then
+            NPROCS=$($PS -o comm= $KILL_PID | $GREP -v '<defunct>' | wc -l)
+            if [ $NPROCS -gt 0 ]; then
 		WAIT=$(($WAIT-1))
 		sleep .1
 	    else
@@ -517,7 +522,8 @@ function KillTaskWithTimeout() {
 	    # wait and see if it dissappears
 	    while [ $WAIT -gt 1 ] ; do
 		# see if it's still alive
-		if $PS $KILL_PID >>$DEBUG_FILE ; then
+                NPROCS=$($PS -o comm= $KILL_PID | $GREP -v '<defunct>' | wc -l)
+                if [ $NPROCS -gt 0 ]; then
 		    WAIT=$(($WAIT-1))
 		    sleep .1
 		else

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -27,6 +27,7 @@ LSMOD=@LSMOD@
 PIDOF="@PIDOF@ -x"
 PS=@PS@
 AWK=@AWK@
+GREP=@GREP@
 IPCS=@IPCS@
 KILL=@KILL@
 
@@ -280,7 +281,7 @@ function handle_includes () {
   hdr="# handle_includes():"
   inifile="$1"
   cd "$(dirname $inifile)" ;# for the function() subprocess only
-  grep "^#INCLUDE" "$inifile" >/dev/null
+  $GREP "^#INCLUDE" "$inifile" >/dev/null
   status=$?
   if [ $status -ne 0 ] ; then
     echo "$inifile" ;# just use the input

--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -6,8 +6,8 @@
 
 export LANG=C
 
-PIDOF=@PIDOF@
 GREP=@GREP@
+PS=@PS@
 
 CheckKernel() {
     case "@KERNEL_VERS@" in
@@ -105,7 +105,7 @@ CheckConfig(){
 CheckStatus(){
     case $RTPREFIX in
     uspace)
-        if [ -z "$($PIDOF rtapi_app)" ]; then
+        if [ -z "$($PS -o comm= -C rtapi_app | $GREP -v '<defunct>')" ]; then
             exit 1
         else
             exit 0
@@ -187,13 +187,16 @@ Unload(){
 
         # wait 5 seconds for rtapi_app to die and be reaped by its parent
         START=$SECONDS
+        local NPROCS
         while [ 5 -gt $((SECONDS-START)) ]; do
-            if ! ps -C rtapi_app > /dev/null 2> /dev/null; then
+            NPROCS=$(ps -C rtapi_app -o comm= | $GREP -v '<defunct>' | wc -l)
+            if [ $NPROCS -eq 0 ]; then
                 break
             fi
             sleep 0.1
         done
-        if ps -C rtapi_app > /dev/null 2> /dev/null; then
+        NPROCS=$(ps -C rtapi_app -o comm= | $GREP -v '<defunct>' | wc -l)
+        if [ $NPROCS -gt 0 ]; then
             echo "ERROR: rtapi_app failed to die" 1>&2
         fi
 

--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -7,6 +7,7 @@
 export LANG=C
 
 PIDOF=@PIDOF@
+GREP=@GREP@
 
 CheckKernel() {
     case "@KERNEL_VERS@" in
@@ -113,7 +114,7 @@ CheckStatus(){
         # check loaded/unloaded status of modules
         unset NOTLOADED
         for MOD in $MODULES_UNLOAD ; do
-            if @LSMOD@ | awk '{print $1}' | grep -x $MOD >/dev/null ; then
+            if @LSMOD@ | awk '{print $1}' | $GREP -x $MOD >/dev/null ; then
                 echo "$MOD is loaded"
             else
                 echo "$MOD is not loaded"
@@ -212,7 +213,7 @@ CheckUnloaded(){
     STATUS=
     for module in $MODULES_UNLOAD ; do
 	# check to see if the module is installed
-	if @LSMOD@ | awk '{print $1}' | grep -x $module >/dev/null ; then
+	if @LSMOD@ | awk '{print $1}' | $GREP -x $module >/dev/null ; then
 	    echo "ERROR: Could not unload '$module'"
 	    STATUS=error
 	fi


### PR DESCRIPTION
Here are a few cleanups to the `scripts/linuxcnc.in` and `scripts/realtime.in` templates.

The most significant update is ignoring defunct zombie processes when cleaning up on exit.  These hang around in Docker containers, and aren't a problem except where they trigger false positives in scripts like these.  More info [here][1].

The others are minor:  Use the autoconfigured `grep` executable, and fix a log message.

[1]: https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/