### PR TITLE
fix importing of certain stls in vismach

### DIFF
--- a/lib/python/vismach.py
+++ b/lib/python/vismach.py
@@ -919,7 +919,7 @@ class AsciiSTL:
                         dx2 = t[2][0] - t[0][0]
                         dy2 = t[2][1] - t[0][1]
                         dz2 = t[2][2] - t[0][2]
-                        n = [y1*z2 - y2*z1, z1*x2 - z2*x1, y1*x2 - y2*x1]
+                        n = [dy1*dz2 - dy2*dz1, dz1*dx2 - dz2*dx1, dy1*dx2 - dy2*dx1]
                     d.append((n, t))
                     t = []
                     n = [0,0,0]


### PR DESCRIPTION
i'm trying to integrate a 6dof robot arm with linuxcnc, been having problems with kinematics so i thought i'de try and model in vismach. once in a while an stl would fail to import, with the small changes here the failed stl imports went away.

submitting for merge consideration in case it's helpful, if not please disregard.