### PR TITLE
Add yapps2 as optional yapps binary

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -889,7 +889,7 @@ then
     AC_MSG_ERROR([fuser not found])
 fi
 
-AC_PATH_PROG(YAPPS, yapps, "none", $SPATH)
+AC_PATH_PROGS(YAPPS, yapps yapps2, "none", $SPATH)
 if test $YAPPS = "none"
 then
     AC_MSG_ERROR([yapps not found])
@@ -1143,7 +1143,7 @@ fi
 # Checks for header files.
 
 ##############################################################################
-# Section 4.1 - Important headers, functions and gloabl defines.             #
+# Section 4.1 - Important headers, functions and global defines.             #
 #                                                                            #
 ##############################################################################
 


### PR DESCRIPTION
Fedora (and others) do not package YAPPS. When installing from pip the
binary is named yapps2. Modify the binary search to search for either
binary name.

Also fix a spelling mistake.

Signed-off-by: Alex Wigen <alex@wigen.net>