### PR TITLE
Use autoconf provided name for yapps

### DIFF
--- a/src/hal/utils/Submakefile
+++ b/src/hal/utils/Submakefile
@@ -99,4 +99,4 @@ endif
 TARGETS += ../bin/halcompile ../bin/elbpcom
 objects/%.py: %.g
 	@mkdir -p $(dir $@)
-	$(Q)yapps $< $@
+	$(Q)$(YAPPS) $< $@


### PR DESCRIPTION
While autoconf will correctly identify yapps or yapps2, the provided
variable should be used in the Makefile.

Signed-off-by: Alex Wigen <alex@wigen.net>