### PR TITLE
Enhanced Renes changes to the non-random tool changer so the tool id …

### DIFF
--- a/src/emc/nml_intf/canon.hh
+++ b/src/emc/nml_intf/canon.hh
@@ -475,7 +475,7 @@ extern void USE_SPINDLE_FORCE();
 extern void USE_NO_SPINDLE_FORCE();
 
 /* Tool Functions */
-extern void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diameter,
+extern void SET_TOOL_TABLE_ENTRY(int tool_index, int pocket, int toolno, EmcPose offset, double diameter,
                                  double frontangle, double backangle, int orientation);
 extern void USE_TOOL_LENGTH_OFFSET(EmcPose offset);
 

--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -377,7 +377,7 @@ void COMMENT(const char *comment) {
     Py_XDECREF(result);
 }
 
-void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diameter,
+void SET_TOOL_TABLE_ENTRY(int tool_index, int pocket, int toolno, EmcPose offset, double diameter,
                           double frontangle, double backangle, int orientation) {
 }
 

--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -665,13 +665,10 @@ int Interp::lookup_named_param(const char *nameBuf,
 	break;
 
     case NP_CURRENT_POCKET:
-    if(_setup.random_toolchanger){//random changers already report the real pocket number
-	    *value = _setup.current_pocket;
-    }
-    else{//non random get it from the tool table
-        *value = _setup.tool_table[_setup.current_pocket].pocketno;
-    }
-	break;
+		// No difference btw. random/!random
+		// current pocket is always the currently loaded tools original pocket it came from
+        *value = _setup.current_pocket;
+    break;
 
     case NP_SELECTED_TOOL:
 	*value = _setup.selected_tool;

--- a/src/emc/sai/saicanon.cc
+++ b/src/emc/sai/saicanon.cc
@@ -617,16 +617,16 @@ void USE_NO_SPINDLE_FORCE()
 {PRINT0("USE_NO_SPINDLE_FORCE()\n");}
 
 /* Tool Functions */
-void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diameter,
+void SET_TOOL_TABLE_ENTRY(int tool_index, int pocket, int toolno, EmcPose offset, double diameter,
                           double frontangle, double backangle, int orientation) {
-    _tools[pocket].toolno = toolno;
-    _tools[pocket].offset = offset;
-    _tools[pocket].diameter = diameter;
-    _tools[pocket].frontangle = frontangle;
-    _tools[pocket].backangle = backangle;
-    _tools[pocket].orientation = orientation;
+    _tools[tool_index].toolno = toolno;
+    _tools[tool_index].offset = offset;
+    _tools[tool_index].diameter = diameter;
+    _tools[tool_index].frontangle = frontangle;
+    _tools[tool_index].backangle = backangle;
+    _tools[tool_index].orientation = orientation;
     PRINT14("SET_TOOL_TABLE_ENTRY(%d, %d, %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f, %.4f, %.4f, %d)\n",
-            pocket, toolno,
+            tool_index, toolno,
             offset.tran.x, offset.tran.y, offset.tran.z, offset.a, offset.b, offset.c, offset.u, offset.v, offset.w,
             frontangle, backangle, orientation);
 }

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -1972,7 +1972,7 @@ void USE_NO_SPINDLE_FORCE(void)
 /* Tool Functions */
 
 /* this is called with distances in external (machine) units */
-void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diameter,
+void SET_TOOL_TABLE_ENTRY(int tool_index, int pocket, int toolno, EmcPose offset, double diameter,
                           double frontangle, double backangle, int orientation) {
     EMC_TOOL_SET_OFFSET o;
     flush_segments();
@@ -2951,11 +2951,11 @@ int GET_EXTERNAL_QUEUE_EMPTY(void)
 int GET_EXTERNAL_TOOL_SLOT()
 {
     int toolno = emcStatus->io.tool.toolInSpindle;
-    int pocket;
+    int index;
 
-    for (pocket = 1; pocket < CANON_POCKETS_MAX; pocket++) {
-        if (emcStatus->io.tool.toolTable[pocket].toolno == toolno) {
-            return pocket;
+    for (index = 1; index < CANON_POCKETS_MAX; index++) {
+        if (emcStatus->io.tool.toolTable[index].toolno == toolno) {
+            return emcStatus->io.tool.toolTable[index].pocketno;
         }
     }
 


### PR DESCRIPTION
…/ pockets are correct with internal as well as remapped m6. Non-random means:

Tool is loaded from and returned to the same pocket as given in the tool table
Tool 0 is special -> no tool.
Pocket 0 is special -> do not return to ATC but manual change instead (ToDo).
Current_Pocket -> original (tool table) pocket of the tool currently in spindle.

Signed-off-by: mydani <mydani@gmx.de>