### PR TITLE
num_sserials=N is not used in hostmot2.c

### DIFF
--- a/docs/man/man9/hostmot2.9
+++ b/docs/man/man9/hostmot2.9
@@ -119,7 +119,6 @@ The valid entries in the format string are:
  [num_3pwmgens=\fIN\fB]
  [num_stepgens=\fIN\fB]
  [stepgen_width=\fIN\fB]
- [num_sserials=\fIN\fB]
  [sserial_port_\fI0\fB=\fI00000000\fB]
  [num_leds=\fIN\fB]
  [num_ssrs=\fIN\fB]
@@ -198,11 +197,6 @@ Used to mask extra, unwanted, stepgen pins. Stepper drives typically require
 only two pins (step and dir) but the Hostmot2 stepgen can drive up to 8 output
 pins for specialised applications (depending on firmware). This parameter
 applies to all stepgen instances. Unused, masked pins will be available as GPIO.
-.TP
-\fBnum_sserials\fR [optional, default: -1]
-Only enable the first N of the Smart Serial modules on the FPGA board. If
-N is \-1, then all Smart Serial modules will be enabled. If N=0 then no
-Smart Serial modules will be enabled.
 .TP
 \fBsserial_port_N (N = 0 .. 3)\fR [optional, default: 00000000 for all ports]
 Up to 32 Smart Serial devices can be connected to a Mesa Anything IO board


### PR DESCRIPTION
num_sserials config parameter doesn't seemed to be used by the code, this PR removes it from the docs.