### PR TITLE
docs -  Correct the Python Interface example function ok_for_mdi

### DIFF
--- a/docs/src/config/python-interface.txt
+++ b/docs/src/config/python-interface.txt
@@ -509,7 +509,7 @@ c = linuxcnc.command()
 
 def ok_for_mdi():
 	s.poll()
-	return not s.estop and s.enabled and s.homed and (s.interp_state == linuxcnc.INTERP_IDLE)
+	return not s.estop and s.enabled and (s.homed.count(1) == s.axes) and (s.interp_state == linuxcnc.INTERP_IDLE)
 
 if ok_for_mdi():
 	c.mode(linuxcnc.MODE_MDI)


### PR DESCRIPTION
This PR corrects the logic in the ok_for_mdi() example function.  I will submit a separate request for 2.8.