### PR TITLE
fix bug in vismach stl import

### DIFF
--- a/lib/python/vismach.py
+++ b/lib/python/vismach.py
@@ -910,7 +910,7 @@ class AsciiSTL:
                         dx2 = t[2][0] - t[0][0]
                         dy2 = t[2][1] - t[0][1]
                         dz2 = t[2][2] - t[0][2]
-                        n = [y1*z2 - y2*z1, z1*x2 - z2*x1, y1*x2 - y2*x1]
+                        n = [dy1*dz2 - dy2*dz1, dz1*dx2 - dz2*dx1, dy1*dx2 - dy2*dx1]
                     d.append((n, t))
                     t = []
                     n = [0,0,0]


### PR DESCRIPTION
fix undefined variables causing some stl imports to fail in lib/python/vismach.py

resubmitting #583 against 2.7 per @andypugh 's suggestion