### PR TITLE
docs: Correct alphanumeric order of Python interface attributes/keys

### DIFF
--- a/docs/src/config/python-interface.txt
+++ b/docs/src/config/python-interface.txt
@@ -104,15 +104,12 @@ machine angular units per deg, reflects [TRAJ]ANGULAR_UNITS ini value.
 *aout*:: '(returns tuple of floats)' -
 current value of the analog output pins.
 
-*joints*:: '(returns integer)' -
-number of joints. Reflects [KINS]JOINTS ini value.
+*axes*:: '(returns integer)' -
+number of axes. Derived from [TRAJ]COORDINATES ini value.
 
 *axis*:: '(returns tuple of dicts)' -
 reflecting current axis values. See
 <<sec:the-axis-dictionary,The axis dictionary>>.
-
-*axes*:: '(returns integer)' -
-number of axes. Derived from [TRAJ]COORDINATES ini value.
 
 *axis_mask*:: '(returns integer)' -
 mask of axis available as defined by [TRAJ]COORDINATES in the ini
@@ -237,6 +234,9 @@ actual joint positions.
 
 *joint_position*:: '(returns tuple of floats)' -
 Desired joint positions.
+
+*joints*:: '(returns integer)' -
+number of joints. Reflects [KINS]JOINTS ini value.
 
 *kinematics_type*:: '(returns integer)' -
 The type of kinematics.  One of:
@@ -424,11 +424,6 @@ current velocity.
 
 For each joint, the following dictionary keys are available:
 
-*jointType*:: '(returns integer)' -
-type of axis configuration parameter, reflects
-[JOINT_n]TYPE. LINEAR=1, ANGULAR=2. See <<sec:axis-section, Joint
-ini configuration>> for details.
-
 *backlash*:: '(returns float)' -
 Backlash in machine units. configuration parameter, reflects [JOINT_n]BACKLASH.
 
@@ -455,6 +450,11 @@ non-zero means in position.
 
 *input*:: '(returns float)' -
 current input position.
+
+*jointType*:: '(returns integer)' -
+type of axis configuration parameter, reflects
+[JOINT_n]TYPE. LINEAR=1, ANGULAR=2. See <<sec:axis-section, Joint
+ini configuration>> for details.
 
 *max_ferror*:: '(returns float)' -
 maximum following error. configuration
@@ -508,8 +508,17 @@ rotational direction of the spindle. forward=1, reverse=-1.
 *enabled*:: '(returns integer)' -
 value of the spindle enabled flag.
 
+*homed*:: (not currently implemented)
+
 *increasing*:: '(returns integer)' -
 unclear.
+
+*orient_fault*:: '(returns integer)'
+
+*orient_state*:: '(returns integer)'
+
+*override*:: '(returns float)' -
+spindle speed override scale.
 
 *override_enabled*:: '(returns boolean)' -
 value of the spindle override enabled flag.
@@ -517,15 +526,6 @@ value of the spindle override enabled flag.
 *speed*:: '(returns float)' -
 spindle speed value, rpm, > 0: clockwise, < 0:
 counterclockwise.
-
-*override*:: '(returns float)' -
-spindle speed override scale.
-
-*homed*:: (not currently implemented)
-
-*orient_state*:: '(returns integer)'
-
-*orient_fault*:: '(returns integer)'
 
 ==  Preparing to send  commands
 


### PR DESCRIPTION
This change corrects the order of the listed Python interface attributes and dictionary keys.

For example the list of linuxcnc.stat attributes contains 82 items where 3 of them appear in a random order.  
The joint dictionary had 1 out of order item out of 22 items (see jointType).  Also corrected the spindle dictionary key ordering.