### PR TITLE
Added support for Devuan

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -156,16 +156,16 @@ PYTHON_IMAGING="python${PYTHON_VERSION}-imaging | python-imaging | python-pil"
 PYTHON_IMAGING_TK="python${PYTHON_VERSION}-imaging-tk | python-imaging-tk"
 
 case $DISTRIB_NAME in
-    Debian-10|Debian-10.*)
+    Debian-10|Debian-10.*|Devuan-3|Devuan3.*)
         DOC_DEPENDS="$DOC_DEPENDS, asciidoc-dblatex"
         PYTHON_GST=python-gst-1.0,gstreamer1.0-plugins-base
         EXTRA_BUILD=python-yapps
         ;;
-Debian-9.*|Debian-10|Debian-10.*|Raspbian-9.*|Debian-testing|LinuxMint-19.*|Ubuntu-18.*)
+Debian-9.*|Debian-10|Debian-10.*|Raspbian-9.*|Debian-testing|LinuxMint-19.*|Ubuntu-18.*|Devuan-2.*)
         DOC_DEPENDS="$DOC_DEPENDS, asciidoc-dblatex"
         PYTHON_GST=python-gst-1.0,gstreamer1.0-plugins-base
         ;;
-Debian-8.*|Raspbian-8.*) # Jessie
+Debian-8.*|Raspbian-8.*|Devuan-1.*) # Jessie
         ;;
 Debian-7.*|Raspbian-7) # Wheezy
         EXTRA_BUILD=libgnomeprintui2.2-dev

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -44,17 +44,9 @@ clean: debian/control
 	dh_testdir
 	dh_testroot
 	rm -f build-stamp
-
-	cd src && ./autogen.sh
-ifeq "$(kernel_version)" "uspace"
-	cd src && ./configure --prefix=/usr --sysconfdir=/etc --mandir=/usr/share/man --with-realtime=uspace --enable-build-documentation=pdf --disable-check-runtime-deps
-else
-	cd src && ./configure --prefix=/usr --sysconfdir=/etc --mandir=/usr/share/man --with-realtime=/usr/realtime-$(kernel_version) --enable-build-documentation=pdf --disable-check-runtime-deps
-endif
-	cd src && $(MAKE) clean -s
-	rm -f Makefile.inc
-	rm -f src/config.log src/config.status
-
+	-cd src && $(MAKE) clean -s
+	-rm -f Makefile.inc
+	-rm -f src/config.log src/config.status
 	dh_clean
 
 install: build


### PR DESCRIPTION
These commits:
1) adds support for detecting Devuan GNU/Linux versions into the debian/configure script
2) fixes the "clean" stage so it doesn't try to run autoconfig.sh  (breaks building with pbuilder because deps are resolved after the clean stage.
- this meant making some of the clean steps result be ignored because it tries to clean files that haven't yet been created.

