### PR TITLE
Adds PORT pin type to hal.

### DIFF
--- a/docs/man/man3/hal_pin_new.3hal
+++ b/docs/man/man3/hal_pin_new.3hal
@@ -18,6 +18,9 @@ hal_pin_new \- Create a HAL pin
  int hal_pin_s32_new(const char *\fIname\fR, hal_pin_dir_t \fIdir\fR, hal_s32_t ** \fIdata_ptr_addr\fR, int \fIcomp_id\fR)
 
 .HP
+ int hal_pin_port_new(const char *\fIname\fR, hal_pin_dir_t \fIdir\fR, hal_port_t ** \fIdata_ptr_addr\fR, int \fIcomp_id\fR)
+
+.HP
  int hal_pin_bit_newf(hal_pin_dir_t \fIdir\fR, hal_bit_t ** \fIdata_ptr_addr\fR, int \fIcomp_id\fR, const char *\fIfmt\fR, \fI...\fR)
 
 .HP
@@ -28,6 +31,9 @@ hal_pin_new \- Create a HAL pin
 
 .HP
  int hal_pin_s32_newf(hal_pin_dir_t \fIdir\fR, hal_s32_t ** \fIdata_ptr_addr\fR, int \fIcomp_id\fR, const char *\fIfmt\fR, \fI...\fR)
+
+.HP
+ int hal_pin_port_newf(hal_pin_dir_t \fIdir\fR, hal_port_t ** \fIdata_ptr_addr\fR, int \fIcomp_id\fR, const char *\fIfmt\fR, \fI...\fR)
 
 .HP
  int hal_pin_new(const char *\fIname\fR, hal_type_t \fItype\fR, hal_pin_dir_t \fIdir\fR, void **\fIdata_ptr_addr\fR, int \fIcomp_id\fR)

--- a/docs/man/man3/hal_pin_port_new.3hal
+++ b/docs/man/man3/hal_pin_port_new.3hal
@@ -1,0 +1,1 @@
+.so man3/hal_pin_new.3hal

--- a/docs/man/man3/hal_pin_port_newf.3hal
+++ b/docs/man/man3/hal_pin_port_newf.3hal
@@ -1,0 +1,1 @@
+.so man3/hal_pin_new.3hal

--- a/docs/man/man3/hal_port.3hal
+++ b/docs/man/man3/hal_port.3hal
@@ -1,0 +1,123 @@
+.TH hal_port "3hal" "2006-10-12" "LinuxCNC Documentation" "HAL"
+.de FU
+.sp
+.ti -4
+\\$*
+..
+.de FF
+.br
+.ti -4
+\\$*
+..
+.SH NAME
+
+hal_port \- a hal pin type that acts as an asyncronous one way byte stream
+
+.SH SYNOPSIS
+
+.FU .B #include <hal.h>
+.FU bool hal_port_read(hal_port_t port, char* dest, unsigned count);
+.FF bool hal_port_peek(hal_port_t port, char* dest, unsigned count);
+.FF bool hal_port_peek_commit(hal_port_t port, unsigned count);
+.FF unsigned hal_port_readable(hal_port_t port);
+.FF void hal_port_clear(hal_port_t port);
+
+.FU bool hal_port_write(hal_port_t port, const char* src, unsigned count);
+.FF unsigned hal_port_writable(hal_port_t port);
+
+.FU unsigned hal_port_buffer_size(hal_port_t port);
+
+.FU .B #ifdef ULAPI
+.FF void hal_port_wait_readable(hal_port_t **port, unsigned count, sig_atomic_t *stop);
+.FF void hal_port_wait_writable(hal_port_t **port, unsigned count, sig_atomic_t *stop);
+.FF .B #endif
+
+
+.SH DESCRIPTION
+A HAL port pin is a hal pin that acts as a one way byte oriented data stream in real time.
+An output port on any component may be connected to an input port on any other component via a signal. Data written on the output pin becomes accessible to the input pin.
+A HAL port signal may link only a single writer and a single reader.
+
+A port also buffers data. Users should determine the proper buffer size based upon their intented application.
+
+
+.SS \fBhal_port_read\fR
+Reads count bytes from the port into destination buffer dest. hal_port_read will read \fIcount\fR bytes if and ony if \fIcount\fR bytes are available for reading and otherwise it will leave the port unaffected.
+Returns true if count bytes were read and false otherwise.
+This function should only be called by the component that owns the IN PORT pin.
+
+
+.SS \fBhal_port_peek\fR
+Behaves the same as hal_port_read, however it does not consume bytes from the hal port.
+Repeated calls to hal_port_peek will return the same data.
+Returns true if count bytes were read and false otherwise.
+This function should only be called by the component that owns the IN PORT pin.
+
+
+.SS \fBhal_port_peek_commit\fR
+Advances the read position in the port buffer by count bytes. 
+A hal_port_peek followed by a hal_port_peek_commit would function equivalently to hal_port_read given the same count value. 
+Returns true if count readable bytes were skipped and are no longer accessible and false if no bytes wer skipped.
+This function should only be called by the component that owns the IN PORT pin.
+
+
+.SS \fBhal_port_readable\fR
+Returns the number of bytes available for reading from port. It is safe to call this function from any component.
+
+.SS \fBhal_port_clear\fR
+Emptys a given port of all data.
+hal_port_clear should only be called by the component that owns the IN PORT pin.
+
+.SS \fBhal_port_write\fR
+Writes count bytes from src into the port. 
+Returns true if count bytes were written and false otherwise.
+This function should only be called by the component that owns the OUT PORT pin.
+
+.SS \fBhal_port_writable\fR
+Returns the number of bytes that can be written into the port.
+It is safe to call this function from any component.
+
+.SS \fBhal_port_buffer_size\fR
+Returns the maximum number of bytes that a port can buffer.
+It is safe to call this function from any component.
+
+.SS \fBhal_port_wait_readable\fR
+Waits until the port has count bytes or more available for reading or the stop flag is set.
+
+.SS \fBhal_port_wait_writable\fR
+Waits until the port has count bytes or more available for writing or the stop flag is set.
+
+
+.SH ARGUMENTS
+.IP \fBhal_port_t\fR
+A handle to a port object. Created by hal_pin_new
+
+.IP \fBdest\fR
+An array of bytes that hal_port_read and hal_port_peek will copy data into. This must be allocated by the caller and be at least count bytes long. 
+
+.IP \fBcount\fR
+The number of bytes that hal_port_read, hal_port_peek, and hal_port_write will copy in to dest or out from src
+
+.IP \fBsrc\fR
+An array of bytes that hal_port_write will copy data from into the port buffer. This must be of size count bytes or larger.
+
+.IP \fBstop\fR
+A pointer to a value which is monitored while waiting.  If it is nonzero,
+the wait operation returns early.  This allows a wait call to be safely
+terminated in the case of a signal.
+
+.SH SAMPLE CODE
+In the source tree under
+ src/hal/components/raster.comp is a realtime component intended for laser control.
+ src/tests/raster is a test program that also programs the raster component from python.
+
+.SH REALTIME CONSIDERATIONS
+.BR hal_port_read ", " hal_port_peek ", " hal_port_peek_commit ", " hal_port_readable ", " hal_port_clear ", " hal_port_write ", " hal_port_writable ", " hal_port_buffer_size
+may be called from realtime code.
+
+.BR hal_port_wait_writable ", " hal_port_wait_readable
+may be called from ULAPI code.
+
+
+.SH SEE ALSO
+.BR raster (9),

--- a/docs/man/man3/hal_type_t.3hal
+++ b/docs/man/man3/hal_type_t.3hal
@@ -15,6 +15,9 @@ A volatile type which may have a value from \-2147483648 to 2147483647.
 typedef ... \fBhal_u32_t\fR;
 A volatile type which may have a value from 0 to 4294967295.
 .TP
+typedef ... \fBhal_port_t\fR;
+A volatile handle to a port object. Used with hal_port* functions.
+.TP
 typedef ... \fBhal_float_t\fR;
 A volatile floating-point type, which typically has the same precision and range
 as the C type \fBdouble\fR.
@@ -67,7 +70,10 @@ __u32
 
 .IP hal_float_t 16
 hal_real_t
-.RE
+
+.IP hal_port_t 16
+int
+.RE 
 
 Take care not to use the types \fBs32\fR and \fBu32\fR.  These will compile in
 kernel modules but not in userspace, and not for "realtime components" when

--- a/lib/python/pyhal.py
+++ b/lib/python/pyhal.py
@@ -1,0 +1,245 @@
+"""hal library python interface using ctypes ffi interface"""
+
+from ctypes import*
+
+
+lib = CDLL('liblinuxcnchal.so')
+lib.hal_malloc.restype = c_void_p
+lib.hal_malloc.argtype = [c_long]
+lib.hal_comp_name.restype = c_char_p
+
+lib.hal_pin_new.argtypes = [c_char_p, c_int, c_int, c_void_p, c_int]
+
+lib.hal_signal_new.argtypes = [c_char_p, c_int]
+
+lib.hal_link.argtypes = [c_char_p, c_char_p]
+
+lib.hal_port_read.argtypes = [c_int, c_char_p, c_uint]
+lib.hal_port_read.restype = c_bool
+
+lib.hal_port_peek.argtypes = [c_int, c_char_p, c_uint]
+lib.hal_port_peek.restype = c_bool
+
+lib.hal_port_peek_commit.argtypes = [c_int, c_char_p, c_uint]
+lib.hal_port_peek.restype = c_bool
+
+lib.hal_port_write.argtypes = [c_int, c_char_p, c_uint]
+lib.hal_port_write.restype = c_bool
+
+lib.hal_port_readable.argtypes = [c_int]
+lib.hal_port_readable.restype = c_uint
+
+lib.hal_port_writable.argtypes = [c_int]
+lib.hal_port_writable.restype = c_uint
+
+lib.hal_port_buffer_size.argtypes = [c_int]
+lib.hal_port_buffer_size.restype = c_uint
+
+lib.hal_port_clear.argtypes = [c_int]
+
+lib.hal_port_wait_readable.argtypes = [POINTER(POINTER(c_int)), c_uint, c_int]
+lib.hal_port_wait_writable.argtypes = [POINTER(POINTER(c_int)), c_uint, c_int]
+
+class HalException(Exception):
+    """An exception raised by hal library functions"""
+    pass
+
+
+class halType:
+    BIT = 1
+    FLOAT = 2
+    SIGNED = 3
+    UNSIGNED = 4
+    PORT = 5
+
+    values = [BIT, FLOAT, SIGNED, UNSIGNED, PORT ]
+
+    typeConversion = { BIT : c_bool,
+                       FLOAT : c_double,
+                       SIGNED : c_int32,
+                       UNSIGNED : c_uint32,
+                       PORT : c_int }
+
+class pinDir:
+    IN = 16
+    OUT = 32
+    IO = IN | OUT
+
+    values =  [IN, OUT, IO]
+
+
+class pin(object):
+    def __init__(self, component, name, type, dir, data_ptr):
+        self.comp = component
+        self.name = name
+        self.type = type
+        self.dir = dir
+        self.data_ptr = data_ptr
+
+    @property
+    def fullname(self):
+        return "{0}.{1}".format(self.comp.name, self.name)
+
+    @property
+    def value(self):
+        if self.type == halType.PORT:
+            raise HalException("cannot get value of PORT pin")
+        else:
+            return self.data_ptr.contents.contents.value
+
+    @value.setter
+    def value(self, val):
+        if self.type == halType.PORT:
+            raise HalException("cannot set value of PORT pin")
+        else:
+            self.data_ptr.contents.contents.value = val
+
+
+class port(pin):
+    def __init__(self, component, name, type, dir, data_ptr):
+        pin.__init__(self, component, name, type, dir, data_ptr)
+
+    @property
+    def __port(self):
+        return self.data_ptr.contents.contents.value
+
+    def read(self, count):
+        if self.dir != pinDir.IN:
+            raise HalException("cannot read output port")
+
+        buff = create_string_buffer(count)
+        if not lib.hal_port_read(self.__port, buff, count):
+            return ''
+        else:
+            return buff.raw
+
+    def peek(self, count):
+        if self.dir != pinDir.IN:
+            raise HalException("cannot peek output port")
+
+        buff = create_string_buffer(count)
+        if not lib.hal_port_peek(self.__port, buff, count):
+            return ''
+        else:
+            return buff.raw
+
+    def peek_commit(self, count):
+        if self.dir != pinDir.IN:
+            raise HalException("cannot peek commit output port")
+        return lib.hal_port_peek_commit(self.__port, count)
+
+    def write(self, buff):
+        if self.dir != pinDir.OUT:
+           raise HalException("cannot write input port")
+
+        return lib.hal_port_write(self.__port, buff, len(buff))
+
+    def readable(self):
+        if self.dir != pinDir.IN:
+            raise HalException("cannot read output port")
+
+        return lib.hal_port_readable(self.__port)
+
+    def writable(self):
+        if self.dir != pinDir.OUT:
+            raise HalException("cannot write input port")
+
+        return lib.hal_port_writable(self.__port)
+
+    def size(self):
+        return lib.hal_port_buffer_size(self.__port)
+
+    def clear(self):
+        if self.dir != pinDir.IN:
+            raise HalException("cannot clear output port")
+
+        lib.hal_port_clear(self.__port)
+
+    def waitReadable(self, count):
+        if self.dir != pinDir.IN:
+            raise HalException("cannot read ouput port")
+
+        lib.hal_port_wait_readable(self.data_ptr, count, 0)
+
+    def waitWritable(self, count):
+        if self.dir != pinDir.OUT:
+            raise HalException("cannot write input port")
+
+        lib.hal_port_wait_writable(self.data_ptr, count, 0)
+
+    
+
+class component:
+    def __init__(self, name):
+        self.id = lib.hal_init(name)
+        self.name = name
+        self.pins = {}
+        if self.id < 0:
+            raise HalException('failed to initialized component "{0}"'.format(name))
+            
+
+    def __del__(self):
+        self.exit()
+
+          
+    def exit(self):
+        if self.id > 0:
+            result = lib.hal_exit(self.id)
+            self.id = -1
+            if result < 0:
+                raise HalException('hal_exit failed with code {0}'.format(result))
+
+        
+    def ready(self):
+        result = lib.hal_ready(self.id)
+        if result < 0:
+            raise HalException('hal_ready failed with code {0}'.format(result))
+
+    def name(self):
+        return lib.hal_comp_name(self.id)
+
+
+    def pinNew(self, name, type, dir):
+        if not type in halType.typeConversion:
+            raise HalException('failed to create pin "{0}". Unknown type {1}'.format(name, type))
+
+        if not dir in pinDir.values:
+            raise HalException('failed to create pin "{0}". Unknown dir {1}'.format(name, dir))
+
+        ctype = halType.typeConversion[type]
+
+        ptr = self.halMalloc(sizeof(c_void_p))
+        result = lib.hal_pin_new("{0}.{1}".format(self.name, name), type, dir, ptr, self.id)
+        if result < 0:
+            raise HalException('failed to create pin "{0}" with code {1}'.format(name, result))
+
+        if type == halType.PORT:
+            self.pins[name] = port(self, name, type, dir,  cast(ptr, POINTER(POINTER(ctype))))
+        else:
+            self.pins[name] = pin(self, name, type, dir, cast(ptr, POINTER(POINTER(ctype))))
+
+        return self.pins[name]
+
+    def sigNew(self, name, type):
+        if not type in halType.values:
+            raise HalException('failed to create signal "{0}". Invalid type {1}'.format(name, type))
+
+        result = lib.hal_signal_new(name, type)
+
+        if result < 0:
+            raise HalException('failed to create signal "{0}" with code {1}'.format(name, result))
+
+    def sigLink(self, pin_name, sig_name):
+        result = lib.hal_link(pin_name, sig_name)
+        if result < 0:
+            raise HalException('failed to link sig "{0}" to pin "{1}" with result {2}'.format(sig_name, pin_name, result))
+
+
+    def halMalloc(self, count):
+        ptr = lib.hal_malloc(count)
+        memset(ptr, 0, count)
+        return ptr
+
+
+
+

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -149,7 +149,6 @@ RTAPI_BEGIN_DECLS
 
 #define HAL_LOCK_ALL      255   /* locks every action */
 
-
 /***********************************************************************
 *                   GENERAL PURPOSE FUNCTIONS                          *
 ************************************************************************/
@@ -260,7 +259,8 @@ typedef enum {
     HAL_BIT = 1,
     HAL_FLOAT = 2,
     HAL_S32 = 3,
-    HAL_U32 = 4
+    HAL_U32 = 4,
+    HAL_PORT = 5
 } hal_type_t;
 
 /** HAL pins have a direction attribute.  A pin may be an input to 
@@ -296,10 +296,12 @@ typedef enum {
 typedef volatile bool hal_bit_t;
 typedef volatile rtapi_u32 hal_u32_t;
 typedef volatile rtapi_s32 hal_s32_t;
+typedef volatile int hal_port_t;
 typedef double real_t __attribute__((aligned(8)));
 typedef rtapi_u64 ireal_t __attribute__((aligned(8))); // integral type as wide as real_t / hal_float_t
-#define hal_float_t volatile real_t
 
+#define hal_float_t volatile real_t
+       
 /***********************************************************************
 *                      "LOCKING" FUNCTIONS                             *
 ************************************************************************/
@@ -360,6 +362,9 @@ extern int hal_pin_u32_new(const char *name, hal_pin_dir_t dir,
     hal_u32_t ** data_ptr_addr, int comp_id);
 extern int hal_pin_s32_new(const char *name, hal_pin_dir_t dir,
     hal_s32_t ** data_ptr_addr, int comp_id);
+extern int hal_pin_port_new(const char *name, hal_pin_dir_t dir,
+    hal_port_t ** data_ptr_addr, int comp_id);
+
 
 /** The hal_pin_XXX_newf family of functions are similar to
     hal_pin_XXX_new except that they also do printf-style formatting to compute
@@ -378,6 +383,9 @@ extern int hal_pin_u32_newf(hal_pin_dir_t dir,
 	__attribute__((format(printf,4,5)));
 extern int hal_pin_s32_newf(hal_pin_dir_t dir,
     hal_s32_t ** data_ptr_addr, int comp_id, const char *fmt, ...)
+	__attribute__((format(printf,4,5)));
+extern int hal_pin_port_newf(hal_pin_dir_t dir,
+    hal_port_t** data_ptr_addr, int comp_id, const char *fmt, ...)
 	__attribute__((format(printf,4,5)));
 
 
@@ -725,6 +733,100 @@ typedef int(*constructor)(char *prefix, char *arg);
 /** hal_set_constructor() sets the constructor function for this component
 */
 extern int hal_set_constructor(int comp_id, constructor make);
+
+
+
+/******************************************************************************
+  A HAL port pin is an asyncronous one way byte stream
+  
+  A hal port should have only one reader and one writer. Both sides can
+  read or write respectivly at any time without interfering with the other
+ 
+  A component that exports a PORT pin does not own the port buffer.
+  The signal linking an input port to an output port owns the port buffer.
+  The buffer is allocated by issuing a 'halcmd sets port-sig size'
+  command.
+*/
+
+
+/** hal_port_read reads count bytes from the port into dest.
+    This function should only be called by the component that owns 
+    the IN PORT pin.
+    returns
+        true: count bytes were read into dest
+        false: no bytes were read into dest
+ */
+extern bool hal_port_read(hal_port_t port, char* dest, unsigned count);
+
+
+/** hal_port_peek operates the same as hal_port_read but no bytes are consumed
+    from the input port. Repeated calls to hal_port_peek will return the same data.
+    This function should only be called by the component that owns the IN PORT pin.
+    returns 
+        true: count bytes were read into dest
+        false: no bytes were read into dest
+*/
+extern bool hal_port_peek(hal_port_t port, char* dest, unsigned count);
+
+/** hal_port_peek_commit advances the read position in the port buffer
+    by count bytes. A hal_port_peek followed by a hal_port_peek_commit
+    with the same count value would function equivalently to 
+    hal_port_read given the same count value. This function should only
+    be called by the component that owns the IN PORT pin.
+    returns:
+       true: count readable bytes were skipped and are no longer accessible
+       false: no bytes wer skipped
+*/ 
+extern bool hal_port_peek_commit(hal_port_t port, unsigned count);
+
+/** hal_port_write writes count bytes from src into the port. 
+    This function should only be called by the component that owns
+    the OUT PORT pin.
+    returns:
+        true: count bytes were written
+        false: no bytes were written into dest
+    
+*/
+extern bool hal_port_write(hal_port_t port, const char* src, unsigned count);
+
+/** hal_port_readable returns the number of bytes available
+    for reading from the port.
+*/
+extern unsigned hal_port_readable(hal_port_t port);
+
+/** hal_port_writable returns the number of bytes that
+    can be written into the port
+*/
+extern unsigned hal_port_writable(hal_port_t port);
+
+/** hal_port_buffer_size returns the total number of bytes
+    that a port can buffer
+*/
+extern unsigned hal_port_buffer_size(hal_port_t port);
+
+/** hal_port_clear emptys a given port of all data
+    without consuming any of it.
+    hal_port_clear should only be called by a reader
+*/
+extern void hal_port_clear(hal_port_t port);
+
+
+#ifdef ULAPI
+/** hal_port_wait_readable spin waits on a port until it has at least 
+    count bytes available for reading, or *stop > 0
+ */
+extern void hal_port_wait_readable(hal_port_t** port, unsigned count, sig_atomic_t* stop);
+
+/** hal_port_wait_writable spin waits on a port until it has at least
+    count bytes available for writing or *stop > 0
+ */
+extern void hal_port_wait_writable(hal_port_t** port, unsigned count, sig_atomic_t* stop);
+#endif
+
+
+
+
+
 
 union hal_stream_data {
     real_t f;

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -540,6 +540,13 @@ int hal_pin_s32_new(const char *name, hal_pin_dir_t dir,
     return hal_pin_new(name, HAL_S32, dir, (void **) data_ptr_addr, comp_id);
 }
 
+int hal_pin_port_new(const char *name, hal_pin_dir_t dir,
+    hal_port_t ** data_ptr_addr, int comp_id)
+{
+    return hal_pin_new(name, HAL_PORT, dir, (void **)data_ptr_addr, comp_id);
+}
+
+
 static int hal_pin_newfv(hal_type_t type, hal_pin_dir_t dir,
     void ** data_ptr_addr, int comp_id, const char *fmt, va_list ap)
 {
@@ -599,6 +606,17 @@ int hal_pin_s32_newf(hal_pin_dir_t dir,
     return ret;
 }
 
+int hal_pin_port_newf(hal_pin_dir_t dir,
+    hal_port_t **data_ptr_addr, int comp_id, const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+    va_start(ap, fmt);
+    ret = hal_pin_newfv(HAL_PORT, dir, (void**)data_ptr_addr, comp_id, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
 
 /* this is a generic function that does the majority of the work. */
 
@@ -622,9 +640,9 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
             "HAL: ERROR: pin_new(%s) called with already-initialized memory\n",
             name);
     }
-    if (type != HAL_BIT && type != HAL_FLOAT && type != HAL_S32 && type != HAL_U32) {
+    if (type != HAL_BIT && type != HAL_FLOAT && type != HAL_S32 && type != HAL_U32 && type != HAL_PORT) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "HAL: ERROR: pin type not one of HAL_BIT, HAL_FLOAT, HAL_S32 or HAL_U32\n");
+	    "HAL: ERROR: pin type not one of HAL_BIT, HAL_FLOAT, HAL_S32, HAL_U32 or HAL_PORT\n");
 	return -EINVAL;
     }
     
@@ -632,6 +650,11 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "HAL: ERROR: pin direction not one of HAL_IN, HAL_OUT, or HAL_IO\n");
 	return -EINVAL;
+    }
+    if(type == HAL_PORT && dir == HAL_IO) {
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        "HAL: ERROR: pin direction must be one of HAL_IN or HAL_OUT for hal port\n");
+    return -EINVAL;
     }
     if (strlen(name) > HAL_NAME_LEN) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -902,8 +925,9 @@ with the C standard.
     case HAL_S32:
     case HAL_U32:
     case HAL_FLOAT:
+    case HAL_PORT:
         data_addr = shmalloc_up(sizeof(hal_data_u));
-	break;
+    break;
     default:
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -933,6 +957,9 @@ with the C standard.
         break;
     case HAL_FLOAT:
 	*((hal_float_t *) data_addr) = 0.0;
+	break;
+    case HAL_PORT:
+	*((int *) data_addr) = 0;
 	break;
     default:
 	break;
@@ -1096,6 +1123,13 @@ int hal_link(const char *pin_name, const char *sig_name)
 	    "HAL: ERROR: signal '%s' already has output or I/O pin(s)\n", sig_name);
 	return -EINVAL;
     }
+    /* linking bidir pin to sig that is a port?*/
+    if ((pin->dir == HAL_IO) && (pin->type == HAL_PORT)) {
+    rtapi_mutex_give(&(hal_data->mutex));
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        "HAL: ERROR: signal '%s' is a port and cannot have I/O pin(s)\n", sig_name);
+    return -EINVAL;
+    }
     /* linking bidir pin to sig that already has output pin? */
     if ((pin->dir == HAL_IO) && (sig->writers > 0)) {
 	/* yes, can't do that */
@@ -1104,13 +1138,26 @@ int hal_link(const char *pin_name, const char *sig_name)
 	    "HAL: ERROR: signal '%s' already has output pin\n", sig_name);
 	return -EINVAL;
     }
+
+    /* linking input pin to port sig that already has an input port? */
+    if ((pin->type == HAL_PORT) && (pin->dir == HAL_IN) && (sig->readers > 0)) {
+	/* ports can only have one reader */
+	rtapi_mutex_give(&(hal_data->mutex));
+	rtapi_print_msg(RTAPI_MSG_ERR,
+	    "HAL: ERROR: siganl '%s' can only have one input pin\n", sig_name);
+	return -EINVAL;
+    }
+    
     /* everything is OK, make the new link */
     data_ptr_addr = SHMPTR(pin->data_ptr_addr);
     comp = SHMPTR(pin->owner_ptr);
     data_addr = comp->shmem_base + sig->data_ptr;
     *data_ptr_addr = data_addr;
+
+    /* if the pin is a HAL_PORT the buffer belongs to the signal, port pins not linked
+      to a signal will always be empty (unreadable and unwritable)*/
     bool drive_pin_default_value_onto_signal =
-        ( pin->dir != HAL_IN || sig->readers == 0 )
+        (pin->type != HAL_PORT) && (pin->dir != HAL_IN || sig->readers == 0 )
             && ( sig->writers == 0 ) && ( sig->bidirs == 0 );
     if (drive_pin_default_value_onto_signal) {
 	/* this is the first pin for this signal, copy value from pin's "dummy" field */
@@ -3186,49 +3233,53 @@ static void unlink_pin(hal_pin_t * pin)
 
     /* is this pin linked to a signal? */
     if (pin->signal != 0) {
-	/* yes, need to unlink it */
-	sig = SHMPTR(pin->signal);
-	/* make pin's 'data_ptr' point to its dummy signal */
-	data_ptr_addr = SHMPTR(pin->data_ptr_addr);
-	comp = SHMPTR(pin->owner_ptr);
-	dummy_addr = comp->shmem_base + SHMOFF(&(pin->dummysig));
-	*data_ptr_addr = dummy_addr;
+    /* yes, need to unlink it */
+    sig = SHMPTR(pin->signal);
+    /* make pin's 'data_ptr' point to its dummy signal */
+    data_ptr_addr = SHMPTR(pin->data_ptr_addr);
+    comp = SHMPTR(pin->owner_ptr);
+    dummy_addr = comp->shmem_base + SHMOFF(&(pin->dummysig));
+    *data_ptr_addr = dummy_addr;
 
-	/* copy current signal value to dummy */
-	sig_data_addr = (hal_data_u *)(hal_shmem_base + sig->data_ptr);
-	dummy_addr = (hal_data_u *)(hal_shmem_base + SHMOFF(&(pin->dummysig)));
+    /* copy current signal value to dummy */
+    sig_data_addr = (hal_data_u *)(hal_shmem_base + sig->data_ptr);
+    dummy_addr = (hal_data_u *)(hal_shmem_base + SHMOFF(&(pin->dummysig)));
 
-	switch (pin->type) {
-	case HAL_BIT:
-	    dummy_addr->b = sig_data_addr->b;
-	    break;
-	case HAL_S32:
-	    dummy_addr->s = sig_data_addr->s;
-	    break;
-	case HAL_U32:
-	    dummy_addr->u = sig_data_addr->u;
-	    break;
-	case HAL_FLOAT:
-	    dummy_addr->f = sig_data_addr->f;
-	    break;
-	default:
-	    rtapi_print_msg(RTAPI_MSG_ERR,
-			  "HAL: BUG: pin '%s' has invalid type %d !!\n",
-			  pin->name, pin->type);
-	}
+    switch (pin->type) {
+    case HAL_BIT:
+        dummy_addr->b = sig_data_addr->b;
+        break;
+    case HAL_S32:
+        dummy_addr->s = sig_data_addr->s;
+        break;
+    case HAL_U32:
+        dummy_addr->u = sig_data_addr->u;
+        break;
+    case HAL_FLOAT:
+        dummy_addr->f = sig_data_addr->f;
+        break;
+    case HAL_PORT:
+	/*once a pin is unlinked from its signal, it gets set to the empty_port*/
+        dummy_addr->p = 0;
+        break;
+    default:
+        rtapi_print_msg(RTAPI_MSG_ERR,
+              "HAL: BUG: pin '%s' has invalid type %d !!\n",
+              pin->name, pin->type);
+    }
 
-	/* update the signal's reader/writer counts */
-	if ((pin->dir & HAL_IN) != 0) {
-	    sig->readers--;
-	}
-	if (pin->dir == HAL_OUT) {
-	    sig->writers--;
-	}
-	if (pin->dir == HAL_IO) {
-	    sig->bidirs--;
-	}
-	/* mark pin as unlinked */
-	pin->signal = 0;
+    /* update the signal's reader/writer counts */
+    if ((pin->dir & HAL_IN) != 0) {
+        sig->readers--;
+    }
+    if (pin->dir == HAL_OUT) {
+        sig->writers--;
+    }
+    if (pin->dir == HAL_IO) {
+        sig->bidirs--;
+    }
+    /* mark pin as unlinked */
+    pin->signal = 0;
     }
 }
 
@@ -3445,12 +3496,322 @@ static char *halpr_type_string(int type, char *buf, size_t nbuf) {
         case HAL_FLOAT: return "float";
         case HAL_S32: return "s32";
         case HAL_U32: return "u32";
+        case HAL_PORT: return "port";
         default:
             rtapi_snprintf(buf, nbuf, "UNK#%d", type);
             return buf;
     }
 }
 
+
+
+/******************************************************************************
+HAL PORT functions
+******************************************************************************/
+
+static void hal_port_atomic_load(hal_port_shm_t* port_shm, unsigned* read, unsigned* write)
+{
+    *read = atomic_load_explicit(&port_shm->read, memory_order_acquire);
+    *write = atomic_load_explicit(&port_shm->write, memory_order_acquire);
+}
+
+
+static void hal_port_atomic_store_read(hal_port_shm_t* port_shm, unsigned read)
+{
+    atomic_store_explicit(&port_shm->read, read, memory_order_release);
+}
+
+
+static void hal_port_atomic_store_write(hal_port_shm_t* port_shm, unsigned write)
+{
+    atomic_store_explicit(&port_shm->write, write, memory_order_release);
+}
+
+
+static unsigned hal_port_bytes_readable(unsigned read, unsigned write, unsigned size) {
+    if(size == 0) {
+        return 0;
+    } else if (read <= write) {
+        return write - read;
+    } else {
+        return size - read + write;
+    }
+}
+
+
+static unsigned hal_port_bytes_writable(unsigned read, unsigned write, unsigned size) {
+    if(size == 0) {
+        return 0;
+    } else if(write < read) {
+        return read - write - 1;
+    } else {
+        return size - write + read - 1;
+    }
+
+}
+
+
+static bool hal_port_compute_copy(unsigned read,
+                                  unsigned write,
+                                  unsigned size,
+                                  unsigned count, 
+                                  unsigned* end_bytes_to_read, 
+                                  unsigned* beg_bytes_to_read, 
+                                  unsigned* final_pos)
+{
+    unsigned  bytes_avail,
+              end_bytes_avail;
+
+    bytes_avail = hal_port_bytes_readable(read, write, size); 
+
+    if(count > bytes_avail) {
+        return false;
+    } else if(read <= write) {
+        //can read up to write position (no wraparound condition in buffer)
+        *end_bytes_to_read = count;
+        *beg_bytes_to_read = 0;
+        *final_pos = read + count;
+    } else {
+        end_bytes_avail = size - read;
+
+        if(count < end_bytes_avail) {
+            //still only reading from end of buffer
+            *end_bytes_to_read = count;
+            *beg_bytes_to_read = 0;
+            *final_pos = read + count;
+        } else {
+            //read porition of buffer with wrap around to beginnning of buffer
+            *end_bytes_to_read = end_bytes_avail;
+            *beg_bytes_to_read = count - end_bytes_avail;
+            *final_pos = *beg_bytes_to_read;
+        }
+    }
+    
+   return true;
+}
+
+
+hal_port_t hal_port_alloc(unsigned size) {
+    hal_port_shm_t* new_port = shmalloc_up(sizeof(hal_port_shm_t) + size);
+
+    memset(new_port, 0, sizeof(hal_port_shm_t));
+
+    new_port->size = size;
+
+    return SHMOFF(new_port);
+}
+
+
+bool hal_port_read(hal_port_t port, char* dest, unsigned count) {
+    unsigned read,
+             write,
+             end_bytes_to_read,   //number of bytes to read after read position and before end of buffer
+             beg_bytes_to_read,   //number of bytes to read at beginning of buffer
+             final_pos;           //final position after read
+    hal_port_shm_t* port_shm = SHMPTR(port);
+    
+
+    if(!port || !count) {
+        return false;
+    } else {
+        hal_port_atomic_load(port_shm, &read, &write);
+
+        if(hal_port_compute_copy(read, 
+                                 write, 
+                                 port_shm->size, 
+                                 count, 
+                                 &end_bytes_to_read, 
+                                 &beg_bytes_to_read, 
+                                 &final_pos)) {
+
+            memcpy(dest, port_shm->buff + read, end_bytes_to_read);
+            memcpy(dest+end_bytes_to_read, port_shm->buff, beg_bytes_to_read);
+            hal_port_atomic_store_read(port_shm, final_pos);
+            return true;
+        } else {
+            return false;
+        }
+    }
+}   
+
+
+bool hal_port_peek(hal_port_t port, char* dest, unsigned count) {
+    unsigned read,
+             write,
+             end_bytes_to_read,   //number of bytes to read after read position and before end of buffer
+             beg_bytes_to_read,   //number of bytes to read at beginning of buffer
+             final_pos;           //final position of read
+    hal_port_shm_t* port_shm = SHMPTR(port);
+
+    if(!port || !count) {
+        return false;
+    } else {
+        hal_port_atomic_load(port_shm, &read, &write);
+
+        if(hal_port_compute_copy(read, 
+                                 write, 
+                                 port_shm->size, 
+                                 count, 
+                                 &end_bytes_to_read, 
+                                 &beg_bytes_to_read, 
+                                 &final_pos)) {
+
+            memcpy(dest, port_shm->buff + read, end_bytes_to_read);
+            memcpy(dest+end_bytes_to_read, port_shm->buff, beg_bytes_to_read);
+            return true;
+        } else {
+            return false;
+        }      
+    }
+}
+
+
+bool hal_port_peek_commit(hal_port_t port, unsigned count) {
+    unsigned read,
+             write,
+             end_bytes_to_read,   //number of bytes to read after read position and before end of buffer
+             beg_bytes_to_read,   //number of bytes to read at beginning of buffer
+             final_pos;           //final position of read
+    hal_port_shm_t* port_shm = SHMPTR(port);
+
+    if(!port || !count) {
+        return false;
+    } else {
+        hal_port_atomic_load(port_shm, &read, &write);
+
+        if(hal_port_compute_copy(read,
+                                 write,
+                                 port_shm->size,
+                                 count,
+                                 &end_bytes_to_read,
+                                 &beg_bytes_to_read,
+                                 &final_pos)) {
+
+            hal_port_atomic_store_read(port_shm, final_pos);
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+
+
+bool hal_port_write(hal_port_t port, const char* src, unsigned count) {
+    unsigned read,
+             write,
+             bytes_avail,
+             end_bytes_avail,
+             end_bytes_to_write,
+             beg_bytes_to_write,
+             final_pos;
+   
+    hal_port_shm_t* port_shm = SHMPTR(port);
+ 
+    if(!port || !count) {
+	    return false;
+    } else {
+       hal_port_atomic_load(port_shm, &read, &write);
+       bytes_avail = hal_port_bytes_writable(read, write, port_shm->size);
+
+        if(count > bytes_avail) {
+            return false;
+        } else {
+            if (write < read) {
+                //we can write up to one byte behind read
+                end_bytes_to_write = count;
+                beg_bytes_to_write = 0;
+                final_pos = write + count;
+            } else {
+                if(read == 0) {
+                    end_bytes_avail = bytes_avail;
+                } else {
+                    end_bytes_avail = port_shm->size - write;
+                }
+
+                if (count < end_bytes_avail) {
+                    end_bytes_to_write = count;
+                    beg_bytes_to_write = 0;
+                    final_pos = write + count;
+                } else {
+                    end_bytes_to_write = end_bytes_avail;
+                    beg_bytes_to_write = count - end_bytes_to_write;
+                    final_pos = beg_bytes_to_write;
+                }
+            }
+     
+            memcpy(port_shm->buff+write, src, end_bytes_to_write);
+            memcpy(port_shm->buff, src+end_bytes_to_write, beg_bytes_to_write);
+
+            hal_port_atomic_store_write(port_shm, final_pos);
+            return true;
+        }
+    }
+}
+
+
+unsigned hal_port_readable(hal_port_t port) {
+    hal_port_shm_t* port_shm = SHMPTR(port);
+
+    if(!port) {
+        return 0;
+    } else {
+        return hal_port_bytes_readable(port_shm->read, port_shm->write, port_shm->size);
+    }
+}
+
+
+unsigned hal_port_writable(hal_port_t port) {
+    hal_port_shm_t* port_shm = SHMPTR(port);
+             
+    if(!port) {
+        return 0;
+    } else {
+        return hal_port_bytes_writable(port_shm->read, port_shm->write, port_shm->size);
+    }
+}
+
+
+unsigned hal_port_buffer_size(hal_port_t port) {
+    if(!port) {
+        return 0;
+    } else {
+        return ((hal_port_shm_t*)SHMPTR(port))->size;
+    }
+}
+
+
+void hal_port_clear(hal_port_t port) {
+    unsigned read,write;
+    hal_port_shm_t* port_shm = SHMPTR(port);
+
+    if(port) {
+        hal_port_atomic_load(port_shm, &read, &write);
+        hal_port_atomic_store_read(port_shm, write);
+    }
+}
+
+
+#ifdef ULAPI
+void hal_port_wait_readable(hal_port_t** port, unsigned count, sig_atomic_t* stop) {
+    while((hal_port_readable(**port) < count) && (!stop || !*stop)) {
+        rtapi_delay(10000000);
+    }
+}
+
+
+void hal_port_wait_writable(hal_port_t** port, unsigned count, sig_atomic_t* stop) {
+    while((hal_port_writable(**port) < count) && (!stop || !*stop)) {
+        rtapi_delay(10000000);
+    }
+}
+#endif
+
+
+
+
+/*
+hal stream implementation
+*/
 int halpr_parse_types(hal_type_t type[HAL_STREAM_MAX_PINS], const char *cfg)
 {
     const char *c;
@@ -3727,12 +4088,14 @@ EXPORT_SYMBOL(hal_pin_bit_new);
 EXPORT_SYMBOL(hal_pin_float_new);
 EXPORT_SYMBOL(hal_pin_u32_new);
 EXPORT_SYMBOL(hal_pin_s32_new);
+EXPORT_SYMBOL(hal_pin_port_new);
 EXPORT_SYMBOL(hal_pin_new);
 
 EXPORT_SYMBOL(hal_pin_bit_newf);
 EXPORT_SYMBOL(hal_pin_float_newf);
 EXPORT_SYMBOL(hal_pin_u32_newf);
 EXPORT_SYMBOL(hal_pin_s32_newf);
+EXPORT_SYMBOL(hal_pin_port_newf);
 
 
 EXPORT_SYMBOL(hal_signal_new);
@@ -3786,6 +4149,17 @@ EXPORT_SYMBOL(halpr_find_pin_by_sig);
 
 EXPORT_SYMBOL(hal_pin_alias);
 EXPORT_SYMBOL(hal_param_alias);
+
+EXPORT_SYMBOL(hal_port_alloc);
+EXPORT_SYMBOL(hal_port_read);
+EXPORT_SYMBOL(hal_port_peek);
+EXPORT_SYMBOL(hal_port_peek_commit);
+EXPORT_SYMBOL(hal_port_write);
+EXPORT_SYMBOL(hal_port_readable);
+EXPORT_SYMBOL(hal_port_writable);
+EXPORT_SYMBOL(hal_port_size);
+EXPORT_SYMBOL(hal_port_clear);
+
 EXPORT_SYMBOL_GPL(hal_stream_create);
 EXPORT_SYMBOL_GPL(hal_stream_destroy);
 EXPORT_SYMBOL_GPL(hal_stream_readable);

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -127,7 +127,15 @@ typedef union {
     hal_s32_t s;
     hal_u32_t u;
     hal_float_t f;
+    hal_port_t p;
 } hal_data_u;
+
+typedef struct {
+    volatile unsigned int read;  //offset into buff that outgoing data gets read from
+    volatile unsigned int write; //offset into buff that incoming data gets written to
+    unsigned int size;           //size of allocated buffer
+    char buff[];                 
+} hal_port_shm_t;
 
 /** HAL "list element" data structure.
     This structure is used to implement generic double linked circular
@@ -426,6 +434,15 @@ extern hal_funct_t *halpr_find_funct_by_owner(hal_comp_t * owner,
     the next matching pin.  If no match is found, it returns NULL
 */
 extern hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start);
+
+
+/** hal_port_alloc allocates a new empty hal_port having a buffer of size bytes. 
+    returns a negative value on failure or a hal_port_t which can be used with
+    all other hal_port functions.
+*/
+extern hal_port_t hal_port_alloc(unsigned size);
+
+
 
 #define HAL_STREAM_MAGIC_NUM		0x4649464F
 struct hal_stream_shm {

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -621,6 +621,8 @@ int do_newsig_cmd(char *name, char *type)
 	retval = hal_signal_new(name, HAL_U32);
     } else if (strcasecmp(type, "s32") == 0) {
 	retval = hal_signal_new(name, HAL_S32);
+    } else if (strcasecmp(type, "port") == 0) {
+	retval = hal_signal_new(name, HAL_PORT);
     } else {
 	halcmd_error("Unknown signal type '%s'\n", type);
 	retval = -EINVAL;
@@ -637,6 +639,7 @@ static int set_common(hal_type_t type, void *d_ptr, char *value) {
     double fval;
     long lval;
     unsigned long ulval;
+    unsigned uval;
     char *cp = value;
 
     switch (type) {
@@ -681,6 +684,20 @@ static int set_common(hal_type_t type, void *d_ptr, char *value) {
 	    *((hal_u32_t *) (d_ptr)) = ulval;
 	}
 	break;
+    case HAL_PORT:
+        uval = strtoul(value, &cp, 0);
+        if ((*cp != '\0') && (!isspace(*cp))) {
+            halcmd_error("value '%s' invalid for PORT\n", value);
+            retval = -EINVAL;
+        } else {
+            if((*((hal_port_t*)d_ptr) != 0) && (hal_port_buffer_size(*((hal_port_t*)d_ptr)) > 0)) {
+                halcmd_error("port is already allocated with %u bytes.\n", hal_port_buffer_size(*((hal_port_t*)d_ptr)));
+                retval = -EINVAL;
+        } else {
+            *((hal_port_t*) (d_ptr)) = hal_port_alloc(uval);
+        }
+    }
+    break;
     default:
 	/* Shouldn't get here, but just in case... */
 	halcmd_error("bad type %d\n", type);
@@ -849,8 +866,8 @@ int do_sets_cmd(char *name, char *value)
 	halcmd_error("signal '%s' not found\n", name);
 	return -EINVAL;
     }
-    /* found it - does it have a writer? */
-    if (sig->writers > 0) {
+    /* found it - it have a writer? if it is a port we can set its buffer size */
+    if ((sig->type != HAL_PORT) && (sig->writers > 0)) {
 	rtapi_mutex_give(&(hal_data->mutex));
 	halcmd_error("signal '%s' already has writer(s)\n", name);
 	return -EINVAL;
@@ -935,6 +952,7 @@ static int get_type(char ***patterns) {
     if(strcmp(typestr, "u32") == 0) return HAL_U32;
     if(strcmp(typestr, "signed") == 0) return HAL_S32;
     if(strcmp(typestr, "unsigned") == 0) return HAL_U32;
+    if(strcmp(typestr, "port") == 0) return HAL_PORT;
     return -1;
 }
 
@@ -2179,6 +2197,9 @@ static const char *data_type(int type)
     case HAL_U32:
 	type_str = "u32  ";
 	break;
+    case HAL_PORT:
+	type_str = "port ";
+	break;
     default:
 	/* Shouldn't get here, but just in case... */
 	type_str = "undef";
@@ -2202,6 +2223,9 @@ static const char *data_type2(int type)
 	break;
     case HAL_U32:
 	type_str = "u32";
+	break;
+    case HAL_PORT:
+	type_str = "port";
 	break;
     default:
 	/* Shouldn't get here, but just in case... */
@@ -2321,6 +2345,10 @@ static char *data_value(int type, void *valptr)
 	snprintf(buf, 14, "  0x%08lX", (unsigned long)*((hal_u32_t *) valptr));
 	value_str = buf;
 	break;
+    case HAL_PORT:
+	snprintf(buf, 14, "  %10u", hal_port_buffer_size(*((hal_port_t*) valptr)));
+	value_str = buf;
+	break;
     default:
 	/* Shouldn't get here, but just in case... */
 	value_str = "   undef    ";
@@ -2354,6 +2382,11 @@ static char *data_value2(int type, void *valptr)
 	snprintf(buf, 14, "%ld", (unsigned long)*((hal_u32_t *) valptr));
 	value_str = buf;
 	break;
+    case HAL_PORT:
+	snprintf(buf, 14, "%u", hal_port_buffer_size(*((hal_port_t*) valptr)));
+	value_str = buf;
+	break;
+
     default:
 	/* Shouldn't get here, but just in case... */
 	value_str = "unknown_type";
@@ -2802,7 +2835,7 @@ int do_help_cmd(char *command)
     } else if (strcmp(command, "newsig") == 0) {
 	printf("newsig signame type\n");
 	printf("  Creates a new signal called 'signame'.  Type\n");
-	printf("  is 'bit', 'float', 'u32', or 's32'.\n");
+	printf("  is 'bit', 'float', 'port', 'u32', or 's32'.\n");
     } else if (strcmp(command, "delsig") == 0) {
 	printf("delsig signame\n");
 	printf("  Deletes signal 'signame'.  If 'signame is 'all',\n");
@@ -2825,7 +2858,9 @@ int do_help_cmd(char *command)
 #endif
     } else if (strcmp(command, "sets") == 0) {
 	printf("sets signame value\n");
-	printf("  Sets signal 'signame' to 'value' (if signal has no writers).\n");
+	printf("  Sets a non-port signal 'signame' to 'value' (if signal has no writers).\n");
+    printf("  If 'signame' is a port signal (that has not previously been allocated),\n");
+    printf("  then 'value' is the new maximum size in bytes of that port.\n");
     } else if (strcmp(command, "getp") == 0) {
 	printf("getp paramname\n");
 	printf("getp pinname\n");
@@ -2837,6 +2872,7 @@ int do_help_cmd(char *command)
     } else if (strcmp(command, "gets") == 0) {
 	printf("gets signame\n");
 	printf("  Gets the value of signal 'signame'.\n");
+    printf("  If signal 'signame' is a port, returns the buffer size of that port.\n");
     } else if (strcmp(command, "stype") == 0) {
 	printf("stype signame\n");
 	printf("  Gets the type of signal 'signame'\n");

--- a/tests/pyhal/test
+++ b/tests/pyhal/test
@@ -1,0 +1,268 @@
+#!/usr/bin/env python
+from pyhal import *
+import os
+
+os.system('halrun -U')
+
+c = component("hello")
+
+port_in = c.pinNew("port-in", halType.PORT, pinDir.IN)
+port_out = c.pinNew("port-out", halType.PORT, pinDir.OUT)
+
+in_s = c.pinNew("in-s", halType.SIGNED, pinDir.IN)
+out_s = c.pinNew("out-s", halType.SIGNED, pinDir.OUT)
+
+in_u = c.pinNew("in-u", halType.UNSIGNED, pinDir.IN)
+out_u = c.pinNew("out-u", halType.UNSIGNED, pinDir.OUT)
+
+in_f = c.pinNew("in-f", halType.FLOAT, pinDir.IN)
+out_f = c.pinNew("out-f", halType.FLOAT, pinDir.OUT)
+
+
+in_io = c.pinNew("in-io", halType.BIT, pinDir.IO)
+out_io = c.pinNew("out-io", halType.BIT, pinDir.IO)
+
+
+c.ready()
+
+
+
+
+
+#test signed in/out pins 
+c.sigNew("testSig-S", halType.SIGNED)
+c.sigLink("hello.in-s", "testSig-S")
+c.sigLink("hello.out-s", "testSig-S")
+out_s.value = -100
+assert in_s.value == -100, "in_s.value should be -100. got {0}".format(in_s.value)
+out_s.value = 34435
+assert in_s.value == 34435, "in_s.value should be 34435. got {0}".format(in_s.value)
+
+
+#test unsigned in/out pins
+c.sigNew("testSig-U", halType.UNSIGNED)
+c.sigLink("hello.in-u", "testSig-U")
+c.sigLink("hello.out-u", "testSig-U")
+out_u.value = 65535
+assert in_u.value == out_u.value, "in_u.value should be {0}. got {0}".format(out_u.value, in_u.value)
+
+
+#test float pins
+c.sigNew("testSig-F", halType.FLOAT)
+c.sigLink("hello.in-f", "testSig-F")
+os.system("halcmd sets testSig-F -1000.0")
+
+assert in_f.value == -1000.0
+c.sigLink("hello.out-f", "testSig-F")
+
+out_f.value = 333.333
+assert in_f.value == 333.333
+
+#test io bool
+c.sigNew("testSig-IO", halType.BIT)
+c.sigLink("hello.in-io", "testSig-IO")
+c.sigLink("hello.out-io", "testSig-IO")
+
+out_io.value = False
+assert in_io.value == False
+out_io.value = True
+assert in_io.value == True
+
+in_io.value = False
+assert out_io.value == False
+
+
+
+#now test hal port
+c.sigNew("testSig-PORT", halType.PORT)
+c.sigLink("hello.port-in", "testSig-PORT")
+c.sigLink("hello.port-out", "testSig-PORT")
+
+assert port_in.size() == 0
+assert port_out.size() == 0
+
+#make sure to allocate a port on the signal
+os.system('halcmd sets testSig-PORT 9')
+
+assert port_in.size() == 9
+assert port_out.size() == 9
+
+
+assert port_out.writable() == 8
+assert port_in.readable() == 0
+
+
+port_out.waitWritable(8)
+assert port_out.write("hello")
+assert port_out.writable() == 3
+
+assert port_in.readable() == 5
+assert port_in.read(2) == "he"
+assert port_in.peek(10) == ""
+assert port_in.peek(3) == "llo"
+assert port_in.readable() == 3
+assert port_in.read(3) == "llo"
+
+assert port_in.readable() == 0
+assert port_out.write("hello")
+assert port_in.read(5) == "hello"
+
+assert port_in.readable() == 0
+assert port_in.read(5) == ''
+
+
+assert port_out.writable() == 8
+
+assert port_out.write("12345678")
+
+assert port_in.readable() == 8
+assert port_out.writable() == 0
+
+assert port_in.read(8) == "12345678"
+
+c.exit()
+os.system("halrun -U")
+exit(0)
+from pyhal import *
+
+
+c = component("hello")
+
+port_in = c.pinNew("port-in", halType.PORT, pinDir.IN)
+port_out = c.pinNew("port-out", halType.PORT, pinDir.OUT)
+
+in_s = c.pinNew("in-s", halType.SIGNED, pinDir.IN)
+out_s = c.pinNew("out-s", halType.SIGNED, pinDir.OUT)
+
+in_u = c.pinNew("in-u", halType.UNSIGNED, pinDir.IN)
+out_u = c.pinNew("out-u", halType.UNSIGNED, pinDir.OUT)
+
+in_f = c.pinNew("in-f", halType.FLOAT, pinDir.IN)
+out_f = c.pinNew("out-f", halType.FLOAT, pinDir.OUT)
+
+
+in_io = c.pinNew("in-io", halType.BIT, pinDir.IO)
+out_io = c.pinNew("out-io", halType.BIT, pinDir.IO)
+
+
+c.makeReady()
+
+import os
+
+
+
+#test signed in/out pins 
+c.sigNew("testSig-S", halType.SIGNED)
+c.sigLink("hello.in-s", "testSig-S")
+c.sigLink("hello.out-s", "testSig-S")
+out_s.value = -100
+assert in_s.value == -100, "in_s.value should be -100. got {0}".format(in_s.value)
+out_s.value = 34435
+assert in_s.value == 34435, "in_s.value should be 34435. got {0}".format(in_s.value)
+
+
+#test unsigned in/out pins
+c.sigNew("testSig-U", halType.UNSIGNED)
+c.sigLink("hello.in-u", "testSig-U")
+c.sigLink("hello.out-u", "testSig-U")
+out_u.value = 65535
+assert in_u.value == out_u.value, "in_u.value should be {0}. got {0}".format(out_u.value, in_u.value)
+
+
+#test float pins
+c.sigNew("testSig-F", halType.FLOAT)
+c.sigLink("hello.in-f", "testSig-F")
+os.system("halcmd sets testSig-F -1000.0")
+
+assert in_f.value == -1000.0
+c.sigLink("hello.out-f", "testSig-F")
+
+out_f.value = 333.333
+assert in_f.value == 333.333
+
+#test io bool
+c.sigNew("testSig-IO", halType.BIT)
+c.sigLink("hello.in-io", "testSig-IO")
+c.sigLink("hello.out-io", "testSig-IO")
+
+out_io.value = False
+assert in_io.value == False
+out_io.value = True
+assert in_io.value == True
+
+in_io.value = False
+assert out_io.value == False
+
+
+
+#now test hal port
+c.sigNew("testSig-PORT", halType.PORT)
+c.sigLink("hello.port-in", "testSig-PORT")
+c.sigLink("hello.port-out", "testSig-PORT")
+
+assert port_in.size() == 0
+assert port_out.size() == 0
+
+#make sure to allocate a port on the signal
+os.system('halcmd sets testSig-PORT 9')
+
+assert port_in.size() == 9
+assert port_out.size() == 9
+
+
+assert port_out.writable() == 8
+assert port_in.readable() == 0
+
+
+port_out.waitWritable(8)
+assert port_out.write("hello")
+
+
+assert port_in.readable() == 5
+assert port_in.read(2) == "he"
+assert port_in.peek(10) == ""
+assert port_in.readable() == 3
+assert port_in.read(3) == "llo"
+
+assert port_in.readable() == 0
+assert port_out.write("hello")
+assert port_in.read(5) == "hello"
+
+assert port_in.readable() == 0
+assert port_in.read(5) == ''
+
+
+assert port_out.writable() == 8
+
+
+assert port_out.write("12345678") == 8
+
+assert port_in.readable() == 8
+assert port_out.writable() == 0
+
+assert port_in.read(8) == "12345678"
+
+
+assert port_out.write("12345678")
+assert port_in.peek(4) == "1234"
+assert port_in.readable() == 8
+assert port_out.writable() == 0
+assert port_in.peek_commit(4)
+assert port_in.readable() == 4
+assert port_out.writable() == 4
+assert port_in.peek(4) == "5678"
+assert port_in.peek(4) == "5678"
+assert port_in.read() == "5678"
+assert port_in.readable() == 0
+assert port_out.writable() == 8
+
+
+assert port_out.write("12345")
+assert port_in.readable() == 5
+assert port_in.clear()
+assert port_in.readable() == 0
+
+
+c.exit()
+os.system("halrun -U")
+exit(0)


### PR DESCRIPTION
A HAL port pin is a hal pin that acts as a real time one way byte oriented data stream An output port on any component may be connected to an input port on any other component via a signal. Data written on the output pin becomes accessible to the input pin. A HAL port signal may link only a single writer and a single reader. A port buffers data with a user definable buffer size.

Includes:
	Documentation on how to use a port object.
	a ctypes wrapper for the hal api (pyhal.py)
	a test to exersice hal port code along with pyhal.py
	changes to allow halcmd to understand and manipulate ports.