### PR TITLE
Disable tooltips option in Gmoccapy

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -3137,6 +3137,23 @@
                                             <property name="position">4</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="chk_hide_tooltips">
+                                            <property name="label" translatable="yes">hide tooltips</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="use_action_appearance">False</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_chk_hide_tooltips_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="padding">10</property>
+                                            <property name="position">5</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                     </child>
                                   </object>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -331,6 +331,7 @@ class gmoccapy(object):
         self._init_gremlin()
         self._init_kinematics_type()
         self._init_hide_cursor()
+        self._init_hide_tooltips()
         self._init_offsetpage()
         self._init_keybindings()
         self._init_IconFileSelection()
@@ -1914,6 +1915,16 @@ class gmoccapy(object):
             self.widgets.window1.window.set_cursor(None)
             self.widgets.gremlin.set_property("use_default_controls", True)
 
+    # init the function to hide tooltips
+    def _init_hide_tooltips(self):
+        self.widgets_with_tooltips = []
+        for widget in self.widgets:
+            if hasattr(widget, "set_has_tooltip"):
+                self.widgets_with_tooltips.append(widget)
+        self.hide_tooltips = self.prefs.getpref('hide_tooltips', False, bool)
+        self.widgets.chk_hide_tooltips.set_active(self.hide_tooltips)
+        self._set_enable_tooltips(not self.hide_tooltips)
+
 # =============================================================
 # Onboard keybord handling Start
 
@@ -3307,6 +3318,10 @@ class gmoccapy(object):
             self.command.mdi("G43")
             self.command.wait_complete()
 
+    def _set_enable_tooltips(self, value):
+        for widget in self.widgets_with_tooltips:
+            widget.set_has_tooltip(value)
+
 # helpers functions end
 # =========================================================
 
@@ -4258,6 +4273,11 @@ class gmoccapy(object):
         self.dtg_color = self.prefs.getpref("dtg_color", "yellow", str)
         self.homed_color = self.prefs.getpref("homed_color", "green", str)
         self.unhomed_color = self.prefs.getpref("unhomed_color", "red", str)
+
+    def on_chk_hide_tooltips_toggled(self, widget, data=None):
+        self.hide_tooltips = widget.get_active()
+        self.prefs.putpref("hide_tooltips", self.hide_tooltips)
+        self._set_enable_tooltips(not self.hide_tooltips)
 
     def on_rel_colorbutton_color_set(self, widget):
         color = widget.get_color()

--- a/src/emc/usr_intf/gmoccapy/widgets.py
+++ b/src/emc/usr_intf/gmoccapy/widgets.py
@@ -42,3 +42,5 @@ class Widgets:
             raise IndexError, "No widget %s" % attr
         return widget
 
+    def __iter__(self):
+        return self._builder.get_objects().__iter__()


### PR DESCRIPTION
GTK tooltips are really annoying when being used with a touch screen. I added a checkbox in the settings to disable them.
I am not aware of any way to globally disable them in GTK, so this walks the widgets and individually enables or disables them.
If someone is aware of a way to do this globally at runtime, please let me know and I will update the code accordingly.