### PR TITLE
Added missing include required by recent versions of asm/uaccess.h

### DIFF
--- a/src/rtapi/rtai_rtapi.c
+++ b/src/rtapi/rtai_rtapi.c
@@ -64,6 +64,7 @@
 #include <linux/kernel.h>
 #include <linux/slab.h>		/* replaces malloc.h in recent kernels */
 #include <linux/ctype.h>	/* isdigit */
+#include <asm/traps.h>		/* current */
 #include <asm/uaccess.h>	/* copy_from_user() */
 #include <asm/msr.h>		/* rdtscll() */
 


### PR DESCRIPTION
This fixes a compile error with recent versions of the linux kernel, in my case 4.14.134:
`
./arch/x86/include/asm/uaccess.h:33:9: error: dereferencing pointer to incomplete type
  current->thread.addr_limit = fs;
`
I have not tested this against older versions of the kernel, but it seems safe to include traps.h as it has an include guard.
