### PR TITLE
Backport the RPi4 fixes and 7C80/7C81 board additions to the 2.8 branch

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
@@ -99,22 +99,136 @@ typedef struct hm2_rpspi_struct {
 	int		spiceid;	// The SPI CE id [012]
 } hm2_rpspi_t;
 
-typedef enum {
-	RPI_UNSUPPORTED,
-	RPI_1,		// Version 1
-	RPI_2		// Version 2 and 3
-} platform_t;
-
 static uint32_t *peripheralmem = (uint32_t *)MAP_FAILED;	// mmap'ed peripheral memory
 static size_t peripheralsize;					// Size of the mmap'ed block
 static bcm2835_gpio_t *gpio;					// GPIO peripheral structure in mmap'ed address space
 static bcm2835_spi_t *spi;					// SPI peripheral structure in mmap'ed address space
 static bcm2835_aux_t *aux;					// AUX peripheral structure in mmap'ed address space
 static uint32_t aux_enables;					// Previous state of SPI1 enable
-static platform_t platform;					// The RPI version
 
 static hm2_rpspi_t boards[RPSPI_MAX_BOARDS];	// Connected boards
 static int comp_id;				// Upstream assigned component ID
+
+static char *hm2_7c80_pin_names[] = {
+	"TB07-02/TB07-03",	/* Step/Dir/Misc 5V out */
+	"TB07-04/TB07-05",
+	"TB08-02/TB08-03",
+	"TB08-04/TB08-05",
+	"TB09-02/TB09-03",
+	"TB09-04/TB09-05",
+	"TB10-02/TB10-03",
+	"TB10-04/TB10-05",
+	"TB11-02/TB11-03",
+	"TB11-04/TB11-05",
+	"TB12-02/TB12-03",
+	"TB12-04/TB12-05",
+	"TB03-03/TB04-04",	/* RS-422/RS-485 interface */
+	"TB03-05/TB04-06",
+	"TB03-05/TB03-06",
+	"TB04-01/TB04-02",	/* Encoder */
+	"TB04-04/TB04-05",
+	"TB04-07/TB04-08",
+	"TB05-02",		/* Spindle */
+	"TB05-02",
+	"TB05-05/TB05-06",
+	"TB05-07/TB05-08",
+	"Internal InMux0",	/* InMux */
+	"Internal InMux1",
+	"Internal InMux2",
+	"Internal InMux3",
+	"Internal InMux4",
+
+	"Internal InMuxData",
+	"TB13-01/TB13-02",	/* SSR */
+	"TB13-03/TB13-04",
+	"TB13-05/TB13-06",
+	"TB13-07/TB13-08",
+	"TB14-01/TB14-02",
+	"TB14-03/TB14-04",
+	"TB14-05/TB14-06",
+	"TB14-07/TB14-08",
+	"Internal SSR",
+	"P1-01",		/* P1 parallel expansion */
+	"P1-02",
+	"P1-03",
+	"P1-04",
+	"P1-05",
+	"P1-06",
+	"P1-07",
+	"P1-08",
+	"P1-09",
+	"P1-11",
+	"P1-13",
+	"P1-15",
+	"P1-17",
+	"P1-19",
+	"P1-21",
+	"P1-23",
+	"P1-25"
+};
+
+static char *hm2_7c81_pin_names[] = {
+	"P1-01",
+	"P1-02",
+	"P1-03",
+	"P1-04",
+	"P1-05",
+	"P1-06",
+	"P1-07",
+	"P1-08",
+	"P1-09",
+	"P1-11",
+	"P1-13",
+	"P1-15",
+	"P1-17",
+	"P1-19",
+	"P1-21",
+	"P1-23",
+	"P1-25",
+	"J5-TX0",
+	"J6-TX1",
+
+	"P2-01",
+	"P2-02",
+	"P2-03",
+	"P2-04",
+	"P2-05",
+	"P2-06",
+	"P2-07",
+	"P2-08",
+	"P2-09",
+	"P2-11",
+	"P2-13",
+	"P2-15",
+	"P2-17",
+	"P2-19",
+	"P2-21",
+	"P2-23",
+	"P2-25",
+	"J5-TXEN0",
+	"J6-TXEN1",
+
+	"P7-01",
+	"P7-02",
+	"P7-03",
+	"P7-04",
+	"P7-05",
+	"P7-06",
+	"P7-07",
+	"P7-08",
+	"P7-09",
+	"P7-11",
+	"P7-13",
+	"P7-15",
+	"P7-17",
+	"P7-19",
+	"P7-21",
+	"P7-23",
+	"P7-25",
+	"P5-RX0",
+	"P6-RX1"
+};
+
 
 /*
  * Configuration parameters
@@ -866,6 +980,25 @@ static int probe_board(hm2_rpspi_t *board) {
 		board->llio.ioport_connector_name[2] = "P3";
 		board->llio.num_leds = 2;
 		board->llio.fpga_part_number = "xc6slx9tq144";
+	} else if(!memcmp(ident, "MESA7C80", 8)){
+		base = "hm2_7c80";
+		board->llio.num_ioport_connectors = 2;
+		board->llio.pins_per_connector = 27;
+		board->llio.ioport_connector_name[0] = "Embedded I/O";
+		board->llio.ioport_connector_name[1] = "Embedded I/O + P1 expansion";
+		board->llio.io_connector_pin_names = hm2_7c80_pin_names;
+		board->llio.num_leds = 4;
+		board->llio.fpga_part_number = "xc6slx9tq144";
+	} else if(!memcmp(ident, "MESA7C81", 8)){
+		base = "hm2_7c81";
+		board->llio.num_ioport_connectors = 3;
+		board->llio.pins_per_connector = 19;
+		board->llio.ioport_connector_name[0] = "P1";
+		board->llio.ioport_connector_name[1] = "P2";
+		board->llio.ioport_connector_name[2] = "P7";
+		board->llio.io_connector_pin_names = hm2_7c81_pin_names;
+		board->llio.num_leds = 4;
+		board->llio.fpga_part_number = "xc6slx9tq144";
 	} else {
 		int i;
 		for(i = 0; i < sizeof(ident) - 1; i++) {
@@ -885,34 +1018,12 @@ static int probe_board(hm2_rpspi_t *board) {
 }
 
 /*************************************************/
-static int peripheral_map(void)
+static int peripheral_map(uint32_t membase, uint32_t memsize)
 {
 	int fd;
 	int err;
-	uint32_t membase = BCM2835_GPIO_BASE;	// We know that the GPIO peripheral is first in the map
-	long pagesize = sysconf(_SC_PAGESIZE);	// Default mapped page size multiple
 
-	// error, zero or not power of two
-	if(-1 == pagesize || !pagesize || (pagesize & (pagesize-1))) {
-		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Pagesize is bad (%ld), assuming 4kByte\n", pagesize);
-		pagesize = 4096;	// We assume this is a 12-bit (4k) page system, pretty safe
-	}
-
-	// Size is independent of the Pi we are running on
-	peripheralsize = BCM2835_AUX_END - membase;	// We know that the AUX peripheral is last in the map
-	peripheralsize += pagesize - 1;			// Round up to next full page
-	peripheralsize &= ~(uint32_t)(pagesize - 1);	// Round up to next full page
-
-	switch(platform) {
-	case RPI_1:
-		break;
-	case RPI_2:	// for RPI 3 too
-		membase += BCM2709_OFFSET;
-		break;
-	default:
-		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Platform not supported\n");
-		return -1;
-	}
+	peripheralsize = memsize;
 
 	if((fd = rtapi_open_as_root("/dev/mem", O_RDWR | O_SYNC)) < 0) {
 		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: can't open /dev/mem\n");
@@ -920,7 +1031,7 @@ static int peripheral_map(void)
 	}
 
 	/* mmap BCM2835 GPIO and SPI peripherals */
-	peripheralmem = mmap(NULL, peripheralsize, PROT_READ|PROT_WRITE, MAP_SHARED, fd, membase);
+	peripheralmem = mmap(NULL, peripheralsize, PROT_READ|PROT_WRITE, MAP_SHARED, fd, (off_t)membase);
 	err = errno;
 	close(fd);
 
@@ -929,9 +1040,19 @@ static int peripheral_map(void)
 		return -err;
 	}
 
-	gpio = (bcm2835_gpio_t *)peripheralmem;
-	spi  = (bcm2835_spi_t *)(peripheralmem + (BCM2835_SPI_OFFSET - BCM2835_GPIO_OFFSET) / sizeof(*peripheralmem));
-	aux  = (bcm2835_aux_t *)(peripheralmem + (BCM2835_AUX_OFFSET - BCM2835_GPIO_OFFSET) / sizeof(*peripheralmem));
+	// The Right Way(TM) may be to extract the reg mappings for the
+	// specific devices at /dev/device-tree/soc/*. Then we'd need to
+	// inspect the gpio@... and spi@... device nodes, read the
+	// corresponding reg file and correct the address with respect to the
+	// virtual vs. physical mappings. Too much work... These are all
+	// compatible devices and nobody in their right mind (famous last
+	// words) will change that after the large quantity of devices out in
+	// the wild.
+	// Lets just say, when somebody decides to change the world, then we'll
+	// fix all this code too.
+	gpio = (bcm2835_gpio_t *)(peripheralmem + (BCM2835_GPIO_OFFSET / sizeof(*peripheralmem)));
+	spi  = (bcm2835_spi_t *)(peripheralmem + (BCM2835_SPI_OFFSET  / sizeof(*peripheralmem)));
+	aux  = (bcm2835_aux_t *)(peripheralmem + (BCM2835_AUX_OFFSET  / sizeof(*peripheralmem)));
 
 	rtapi_print_msg(RPSPI_INFO, "hm2_rpspi: Mapped peripherals from 0x%08x (size 0x%08x) to gpio:0x%p, spi:0x%p, aux:0x%p\n",
 			membase, (uint32_t)peripheralsize, gpio, spi, aux);
@@ -1088,65 +1209,49 @@ static void peripheral_restore(void)
 }
 
 /*************************************************/
-#define CPUINFO_BUFSIZE	(16*1024)	// Should be large enough for now
-static platform_t check_platform(void)
+static uint8_t *read_file(const char *fname, size_t maxsize, size_t minsize)
 {
 	FILE *fp;
-	char *buf;
-	size_t fsize;
-	platform_t rv = RPI_UNSUPPORTED;
+	struct stat sb;
+	uint8_t *buf;
+	size_t nn, fsize;
 
-	if(!(buf = rtapi_kmalloc(CPUINFO_BUFSIZE, RTAPI_GFP_KERNEL))) {
+	if(-1 == stat(fname, &sb)) {
+		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Cannot stat '%s'\n", fname);
+		return NULL;
+	}
+
+	if((size_t)sb.st_size < minsize) {
+		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Target file '%s' stat's less than minimum size of %zu bytes (st_size=%zu)\n", fname, minsize, (size_t)sb.st_size);
+		return NULL;
+	}
+
+	nn = sb.st_size > maxsize ? maxsize : sb.st_size;
+	if(!(buf = rtapi_kmalloc(nn+1, RTAPI_GFP_KERNEL))) {
 		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: No dynamic memory\n");
-		return RPI_UNSUPPORTED;
+		return NULL;
 	}
-	if(!(fp = fopen("/proc/cpuinfo", "r"))) {
-		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Failed to open /proc/cpuinfo\n");
-		goto check_exit;
+	memset(buf, 0, nn+1);
+	if(!(fp = fopen(fname, "r"))) {
+		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Cannot open '%s' for read\n", fname);
+		rtapi_kfree(buf);
+		return NULL;
 	}
-	fsize = fread(buf, 1, CPUINFO_BUFSIZE - 1, fp);
+
+	fsize = fread(buf, 1, nn, fp);
 	fclose(fp);
-
-	// we have truncated cpuinfo return unsupported
-	if(!fsize || fsize == CPUINFO_BUFSIZE - 1) {
-		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Platform detection memory buffer too small\n");
-		goto check_exit;
+	if(!fsize) {
+		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Nothing read from '%s' (errno=%d)\n", fname, errno);
+		rtapi_kfree(buf);
+		return NULL;
+	}
+	if(fsize < nn) {
+		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Short read from '%s'; read=%zu required>=%zu\n", fname, fsize, nn);
+		rtapi_kfree(buf);
+		return NULL;
 	}
 
-	/* NUL terminate the buffer */
-	buf[fsize] = '\0';
-
-	if(strstr(buf, "BCM2708")) {
-		rv = RPI_1;
-	} else if(strstr(buf, "BCM2709")) {
-		rv = RPI_2;	//for RPI 3 too
-	} else if(strstr(buf, "BCM2835")) {	// starting with 4.8 kernels revision tag has board details
-		char *rev_val = strstr(buf, "Revision");
-		if(rev_val) {
-			char *rev_start = strstr(rev_val, ": ");
-			unsigned long rev = strtol(rev_start + 2, NULL, 16);
-
-			if(rev <= 0xffff)
-				rv = RPI_1; // pre pi2 revision scheme
-			else {
-				switch((rev & 0xf000) >> 12) {
-				case 0: //bcm2835
-					rv = RPI_1;
-					break;
-				case 1: //bcm2836
-				case 2: //bcm2837
-					rv = RPI_2;	// peripheral base is same on pi2/3
-					break;
-				default:
-					break;
-				}
-			}
-		}
-	}
-
-check_exit:
-	rtapi_kfree(buf);
-	return rv;
+	return buf;
 }
 
 /*************************************************/
@@ -1164,17 +1269,81 @@ static int hm2_rpspi_setup(void)
 {
 	int i, j;
 	int retval = -1;
+	uint8_t *buf;
+	uint32_t pmembase;
+	uint32_t pmemsize;
 
 	// Set process-level message level if requested
 	if(spi_debug >= RTAPI_MSG_NONE && spi_debug <= RTAPI_MSG_ALL)
 		rtapi_set_msg_level(spi_debug);
 
-	platform = check_platform();
-
-	if(platform == RPI_UNSUPPORTED) {
-		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Unsupported Platform, only Raspberry1/2/3 supported.\n");
+	// Info about the hardware platform
+	// This should read something like: "Raspberry Pi X Model Y Rev A.B"
+	//
+	// A 4095(+1) byte maximum buffer size should be somewhat future proof
+	// for now, I guess. anyway, it is freed very fast again. Setting a
+	// maximum prevents run-away allocations.
+	if(!(buf = read_file("/proc/device-tree/model", 4095, 0))) {
+		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Unsupported Platform.\n");
 		return -1;
 	}
+	rtapi_print_msg(RPSPI_INFO, "hm2_rpspi: Platform: %s\n", *buf ? (const char *)buf : "<no data from /proc/device-tree/model>");
+	rtapi_kfree(buf);
+
+	// Extract the IO base and size
+	// The ranges file in the device-tree has the physical mappings of the
+	// IO space we need to map. There are several interesting values in big
+	// endian:
+	// RPi3 (BCM2836)
+	//	[0]: Real register file address
+	//	[1]: IO register file base address
+	//	[2]: IO register file size
+	//	...
+	// RPi4 (BCM2838)
+	//	[0]: Real register file address
+	//	[1]: 0x00000000
+	//	[2]: IO register file base address
+	//	[3]: IO register file size
+	//	...
+	//
+	// The definitions for the device-tree are in the (rpi) linux source
+	// tree to be found at arch/arm/boot/dts/bcm283[568]*.
+	//
+	// A 4095(+1) byte maximum buffer size should be somewhat future proof
+	// for now, I guess. anyway, it is freed very fast again. Setting a
+	// maximum prevents run-away allocations.
+	//
+	// We require the ranges file to contain at least three 32-bit words.
+	// These are required to be present for the RPi3 and RPi4 (and older
+	// versions).
+	if(!(buf = read_file("/proc/device-tree/soc/ranges", 4095, 12))) {
+		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Cannot determine IO base address and size.\n");
+		return -1;
+	}
+
+	pmembase = be32toh(((uint32_t *)buf)[1]);	// This should do the trick for RPi3
+	pmemsize = be32toh(((uint32_t *)buf)[2]);
+
+	if(!pmembase) {
+		// This is (probably) a RPi4 and the ranges file has a zero at
+		// the base address. Here we need to read four 32-bit words to
+		// get to the right values.
+		rtapi_kfree(buf);
+		if(!(buf = read_file("/proc/device-tree/soc/ranges", 4095, 16))) {
+			rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: Cannot determine IO base address and size.\n");
+			return -1;
+		}
+		pmembase = be32toh(((uint32_t *)buf)[2]);
+		pmemsize = be32toh(((uint32_t *)buf)[3]);
+	}
+	rtapi_kfree(buf);
+
+	if(!pmembase || !pmemsize) {
+		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: IO base address (0x%08x) or size (0x%08x) are zero.\n", pmembase, pmemsize);
+		return -1;
+	}
+	rtapi_print_msg(RPSPI_INFO, "hm2_rpspi: Base address 0x%08x size 0x%08x\n", pmembase, pmemsize);
+
 
 	if(-1 == spiclk_rate_rd)
 		spiclk_rate_rd = spiclk_rate;
@@ -1194,7 +1363,7 @@ static int hm2_rpspi_setup(void)
 		return -EINVAL;
 	}
 
-	if((retval = peripheral_map()) < 0) {
+	if((retval = peripheral_map(pmembase, pmemsize)) < 0) {
 		rtapi_print_msg(RPSPI_ERR, "hm2_rpspi: cannot map peripheral memory.\n");
 		return retval;
 	}

--- a/src/hal/drivers/mesa-hostmot2/spi_common_rpspi.h
+++ b/src/hal/drivers/mesa-hostmot2/spi_common_rpspi.h
@@ -32,19 +32,10 @@
  * - http://elinux.org/BCM2835_datasheet_errata
  */
 
-#define BCM2835_PERI_BASE	0x20000000
 #define BCM2835_GPIO_OFFSET	0x200000
 #define BCM2835_SPI_OFFSET	0x204000
 #define BCM2835_AUX_OFFSET	0x215000
 
-#define BCM2835_GPIO_BASE	(BCM2835_PERI_BASE + BCM2835_GPIO_OFFSET)	/* GPIO controller */
-#define BCM2835_SPI_BASE	(BCM2835_PERI_BASE + BCM2835_SPI_OFFSET)	/* SPI controller */
-#define BCM2835_AUX_BASE	(BCM2835_PERI_BASE + BCM2835_AUX_OFFSET)	/* AUX controller */
-#define BCM2835_GPIO_END	(BCM2835_GPIO_BASE + sizeof(bcm2835_gpio_t))
-#define BCM2835_SPI_END		(BCM2835_SPI_BASE + sizeof(bcm2835_spi_t))
-#define BCM2835_AUX_END		(BCM2835_AUX_BASE + sizeof(bcm2835_aux_t))
-
-#define BCM2709_OFFSET		0x1F000000	// For RPI 2 and 3
 
 #if !defined(__I) && !defined(__O) && !defined(__IO)
 #ifdef __cplusplus


### PR DESCRIPTION
This is the same as PR #649, but specific for the 2.8 branch. There are no code differences, other than the branch it targets. Two separate PRs should make it easy to do the merge automatically for each target branch.