### PR TITLE
added support for task PLL functions

### DIFF
--- a/src/rtapi/rtapi.h
+++ b/src/rtapi/rtapi.h
@@ -419,6 +419,26 @@ RTAPI_BEGIN_DECLS
 */
     extern int rtapi_task_self(void);
 
+#if defined(RTAPI_USPACE) || defined(USPACE)
+
+#define RTAPI_TASK_PLL_SUPPORT
+
+/** 'rtapi_task_pll_get_reference()' gets the reference timestamp
+    for the start of the current cycle.
+    Returns 0 if not called from within task context or on
+    platforms that do not support this.
+*/
+    extern long long rtapi_task_pll_get_reference(void);
+
+/** 'rtapi_task_pll_set_correction()' sets the correction value for
+    the next scheduling cycle of the current task. This could be
+    used to synchronize the task cycle to external sources.
+    Returns -EINVAL if not called from within task context or on
+    platforms that do not support this.
+*/
+    extern int rtapi_task_pll_set_correction(long value);
+#endif /* USPACE */
+
 #endif /* RTAPI */
 
 /***********************************************************************

--- a/src/rtapi/rtapi_uspace.hh
+++ b/src/rtapi/rtapi_uspace.hh
@@ -60,6 +60,8 @@ struct rtapi_task {
   long period;
   struct timespec nextstart;
   unsigned ratio;
+  long pll_correction;
+  long pll_correction_limit;
   void *arg;
   void (*taskcode) (void*);	/* pointer to task function */
 };
@@ -85,6 +87,8 @@ struct RtapiApp
     virtual int task_pause(int task_id) = 0;
     virtual int task_resume(int task_id) = 0;
     virtual int task_self() = 0;
+    virtual long long task_pll_get_reference(void) = 0;
+    virtual int task_pll_set_correction(long value) = 0;
     virtual void wait() = 0;
     virtual unsigned char do_inb(unsigned int port) = 0;
     virtual void do_outb(unsigned char value, unsigned int port) = 0;

--- a/src/rtapi/uspace_rtai.cc
+++ b/src/rtapi/uspace_rtai.cc
@@ -57,6 +57,9 @@ struct RtaiApp : RtapiApp {
         memset(&param, 0, sizeof(param));
         param.sched_priority = task->prio;
 
+        // PLL functions not supported
+        task->pll_correction_limit = 0;
+        task->pll_correction = 0;
 
         pthread_attr_t attr;
         if(pthread_attr_init(&attr) < 0)
@@ -104,6 +107,16 @@ struct RtaiApp : RtapiApp {
         auto task = ::get_task<RtaiTask>(task_id);
         if(!task) return -EINVAL;
         return rt_task_resume(task->rt_task);
+    }
+
+    long long task_pll_get_reference(void) {
+        // PLL functions not supported
+        return 0;
+    }
+
+    int task_pll_set_correction(long value) {
+        // PLL functions not supported
+        return -EINVAL;
     }
 
     void wait() {

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -608,6 +608,8 @@ struct Posix : RtapiApp
     int task_pause(int task_id);
     int task_resume(int task_id);
     int task_self();
+    long long task_pll_get_reference(void);
+    int task_pll_set_correction(long value);
     void wait();
     struct rtapi_task *do_task_new() {
         return new PosixTask;
@@ -979,6 +981,10 @@ int Posix::task_start(int task_id, unsigned long int period_nsec)
   task->period = period_nsec;
   task->ratio = period_nsec / period;
 
+  // limit PLL correction values to +/-1% of cycle time
+  task->pll_correction_limit = period_nsec / 100;
+  task->pll_correction = 0;
+
   struct sched_param param;
   memset(&param, 0, sizeof(param));
   param.sched_priority = task->prio;
@@ -1042,13 +1048,28 @@ void *Posix::wrapper(void *arg)
 
   struct timespec now;
   clock_gettime(RTAPI_CLOCK, &now);
-  rtapi_timespec_advance(task->nextstart, now, task->period);
+  rtapi_timespec_advance(task->nextstart, now, task->period + task->pll_correction);
 
   /* call the task function with the task argument */
   (task->taskcode) (task->arg);
 
   rtapi_print("ERROR: reached end of wrapper for task %d\n", task->id);
   return NULL;
+}
+
+long long Posix::task_pll_get_reference(void) {
+    struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
+    if(!task) return 0;
+    return task->nextstart.tv_sec * 1000000000LL + task->nextstart.tv_nsec;
+}
+
+int Posix::task_pll_set_correction(long value) {
+    struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
+    if(!task) return -EINVAL;
+    if (value > task->pll_correction_limit) value = task->pll_correction_limit;
+    if (value < -(task->pll_correction_limit)) value = -(task->pll_correction_limit);
+    task->pll_correction = value;
+    return 0;
 }
 
 int Posix::task_pause(int) {
@@ -1070,7 +1091,7 @@ void Posix::wait() {
         pthread_mutex_unlock(&thread_lock);
     pthread_testcancel();
     struct rtapi_task *task = reinterpret_cast<rtapi_task*>(pthread_getspecific(key));
-    rtapi_timespec_advance(task->nextstart, task->nextstart, task->period);
+    rtapi_timespec_advance(task->nextstart, task->nextstart, task->period + task->pll_correction);
     struct timespec now;
     clock_gettime(RTAPI_CLOCK, &now);
     if(rtapi_timespec_less(task->nextstart, now))
@@ -1171,6 +1192,16 @@ int rtapi_task_resume(int task_id)
 int rtapi_task_self()
 {
     return App().task_self();
+}
+
+long long rtapi_task_pll_get_reference(void)
+{
+    return App().task_pll_get_reference();
+}
+
+int rtapi_task_pll_set_correction(long value)
+{
+    return App().task_pll_set_correction(value);
 }
 
 void rtapi_wait(void)

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -981,13 +981,13 @@ int Posix::task_start(int task_id, unsigned long int period_nsec)
   task->period = period_nsec;
   task->ratio = period_nsec / period;
 
-  // limit PLL correction values to +/-1% of cycle time
-  task->pll_correction_limit = period_nsec / 100;
-  task->pll_correction = 0;
-
   struct sched_param param;
   memset(&param, 0, sizeof(param));
   param.sched_priority = task->prio;
+
+  // limit PLL correction values to +/-1% of cycle time
+  task->pll_correction_limit = period_nsec / 100;
+  task->pll_correction = 0;
 
   int nprocs = sysconf( _SC_NPROCESSORS_ONLN );
 


### PR DESCRIPTION
This functions could be used to sync a RT task to external time sources. It is originally intended to sync the servo thread to the ethercat master clock but might also be useful for other applications.