### PR TITLE
lsb_release on Buster currently reports "10" as the release

### DIFF
--- a/scripts/platform-is-supported
+++ b/scripts/platform-is-supported
@@ -67,7 +67,11 @@ if os == 'linux':
     cpu = subprocess.check_output(['dpkg-architecture', '-qDEB_HOST_ARCH_CPU']).strip()
     distributor = subprocess.check_output(['lsb_release', '--id', '--short']).strip()
     release = subprocess.check_output(['lsb_release', '--release', '--short']).strip()
-    major, minor = re.split('\.', release)
+    try:
+        major, minor = re.split('\.', release)
+    except ValueError as e:
+        major = release
+        minor = "0"
     release_major = int(major)
     release_minor = int(minor)
 


### PR DESCRIPTION
This teaches the buildbot that it's ok to build, test, and package 2.8 on Debian Buster.