### PR TITLE
axis: allow pyvcp panel at bottom of windows

### DIFF
--- a/configs/sim/pyvcp_demo/pyvcp_bottom_panel.hal
+++ b/configs/sim/pyvcp_demo/pyvcp_bottom_panel.hal
@@ -1,0 +1,9 @@
+# #########################################
+# Example hal file showing some linkages
+# of pyvcp_widgets
+
+# second row of dials and scales
+net dial2scale0 pyvcp.scale.0.param_pin <= pyvcp.dial0
+net dial2scale1 pyvcp.scale.1.param_pin <= pyvcp.dial1
+net dial2scale2 pyvcp.scale.2.param_pin <= pyvcp.dial2
+net dial2scale3 pyvcp.scale.3.param_pin <= pyvcp.dial3

--- a/configs/sim/pyvcp_demo/pyvcp_bottom_panel.ini
+++ b/configs/sim/pyvcp_demo/pyvcp_bottom_panel.ini
@@ -1,0 +1,235 @@
+# EMC controller parameters for a simulated machine.
+
+# General note: Comments can either be preceded with a # or ; - either is
+# acceptable, although # is in keeping with most linux config files.
+
+# General section -------------------------------------------------------------
+[EMC]
+# Version of this INI file
+VERSION = 1.1
+
+# Name of machine, for use with display, etc.
+MACHINE =               Pyvcp_demo1
+
+# Name of NML file to use, default is emc.nml
+#NML_FILE =              emc.nml
+
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+# DEBUG =               0x7FFFFFFF
+DEBUG = 0
+
+# Sections for display options ------------------------------------------------
+[DISPLAY]
+
+DISPLAY =             axis
+
+PYVCP = pyvcp_bottom_panel.xml
+
+# places the pyvcp panel at the bottom of the Axis window
+PYVCP_POSITION = BOTTOM
+
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.100
+
+# Path to help file
+HELP_FILE =             doc/help.txt
+
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.2
+MAX_SPINDLE_OVERRIDE =  1.0
+# Prefix to be used
+PROGRAM_PREFIX = /media/imac/linuxcnc/nc_files
+
+# Introductory graphic
+INTRO_GRAPHIC = linuxcnc.gif
+INTRO_TIME = 5
+
+#EDITOR = gedit
+
+INCREMENTS = 5mm 1mm .5mm .1mm .05mm .01mm
+#INCREMENTS = 1 mm, .01 in, .1mm, 1 mil, .1 mil, 1/8000 in
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+PROGRAM_EXTENSION = .nc, .NC
+
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+dxf = image-to-gcode
+py = python
+nc = /usr/bin/axis
+
+# Task controller section -----------------------------------------------------
+[RS274NGC]
+
+# File containing interpreter variables
+PARAMETER_FILE =        sim_mm.var
+
+# Motion control section ------------------------------------------------------
+[EMCMOT]
+
+EMCMOT =              motmod
+
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+
+# BASE_PERIOD is unused in this configuration but specified in core_sim.hal
+BASE_PERIOD  =               0
+# Servo task period, in nano-seconds
+SERVO_PERIOD =               1000000
+
+# Hardware Abstraction Layer section --------------------------------------------------
+[TASK]
+
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.001
+
+# Part program interpreter section --------------------------------------------
+[HAL]
+
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+#
+
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+HALFILE =                    core_sim.hal
+HALFILE =		     axis_manualtoolchange.hal
+HALFILE = simulated_home.hal
+#HALFILE = gamepad.hal
+
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =                    save neta
+
+# Single file that is executed after the GUI has started.  Only supported by
+# AXIS at this time (only AXIS creates a HAL component of its own)
+POSTGUI_HALFILE = pyvcp_bottom_panel.hal
+
+HALUI = halui
+
+[HALUI]
+# add halui MDI commands here (max 64)
+
+# Trajectory planner section --------------------------------------------------
+[TRAJ]
+COORDINATES =           X Y Z
+LINEAR_UNITS =          mm
+ANGULAR_UNITS =         degree
+DEFAULT_LINEAR_VELOCITY = 30.48
+MAX_LINEAR_VELOCITY = 53.34
+DEFAULT_LINEAR_ACCELERATION = 508
+MAX_LINEAR_ACCELERATION = 508
+POSITION_FILE = position_mm.txt
+
+# Axes sections ---------------------------------------------------------------
+
+# First axis
+[EMCIO]
+
+# Name of IO controller program, e.g., io
+EMCIO = 		io
+
+# cycle time, in seconds
+CYCLE_TIME =    0.100
+
+# tool table file
+TOOL_TABLE =    sim_mm.tbl
+TOOL_CHANGE_POSITION = 0 0 50.8
+#RANDOM_TOOLCHANGER = 1
+
+[KINS]
+KINEMATICS = trivkins
+JOINTS = 3
+
+[AXIS_X]
+MIN_LIMIT = -254
+MAX_LIMIT = 254
+MAX_VELOCITY = 30.48
+MAX_ACCELERATION = 508
+
+[JOINT_0]
+TYPE =                          LINEAR
+HOME =                          0.000
+MAX_VELOCITY =                  30.48
+MAX_ACCELERATION =              508
+BACKLASH = 0.000
+INPUT_SCALE =                   157.48
+OUTPUT_SCALE = 1.000
+MIN_LIMIT =                     -254
+MAX_LIMIT =                     254
+FERROR = 1.27
+MIN_FERROR = .254
+HOME_OFFSET =                    0.0
+HOME_SEARCH_VEL =                0
+HOME_LATCH_VEL =                 0
+HOME_USE_INDEX =                 NO
+#HOME_IGNORE_LIMITS =             YES
+HOME_SEQUENCE = 0
+#HOME_IS_SHARED = 1
+
+# Second axis
+[AXIS_Y]
+MIN_LIMIT = -254
+MAX_LIMIT = 254
+MAX_VELOCITY = 30.48
+MAX_ACCELERATION = 508
+
+[JOINT_1]
+TYPE =                          LINEAR
+HOME =                          0.000
+MAX_VELOCITY =                  30.48
+MAX_ACCELERATION =              508
+BACKLASH = 0.000
+INPUT_SCALE =                   157.48
+OUTPUT_SCALE = 1.000
+MIN_LIMIT =                     -254
+MAX_LIMIT =                     254
+FERROR = 1.27
+MIN_FERROR = .254
+HOME_OFFSET =                    0.0
+HOME_SEARCH_VEL =                0
+HOME_LATCH_VEL =                 0
+#HOME_USE_INDEX =                 NO
+#HOME_IGNORE_LIMITS =             NO
+HOME_SEQUENCE = 0
+
+# Third axis
+[AXIS_Z]
+MIN_LIMIT = -150
+MAX_LIMIT = 101.6
+MAX_VELOCITY = 30.48
+MAX_ACCELERATION = 508
+
+[JOINT_2]
+TYPE =                          LINEAR
+HOME =                          0.0
+MAX_VELOCITY =                  30.48
+MAX_ACCELERATION =              508
+BACKLASH = 0.000
+INPUT_SCALE =                   157.48
+OUTPUT_SCALE = 1.000
+MIN_LIMIT =                     -150
+MAX_LIMIT =                     101.6
+FERROR = 1.27
+MIN_FERROR = .254
+HOME_OFFSET =                    0
+HOME_SEARCH_VEL =                0
+HOME_LATCH_VEL =                 0
+#HOME_USE_INDEX =                 NO
+#HOME_IGNORE_LIMITS =             NO
+HOME_SEQUENCE = 0
+#HOME_IS_SHARED = 1
+
+# section for main IO controller parameters -----------------------------------

--- a/configs/sim/pyvcp_demo/pyvcp_bottom_panel.xml
+++ b/configs/sim/pyvcp_demo/pyvcp_bottom_panel.xml
@@ -1,0 +1,136 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<pyvcp>
+    <hbox>
+        <labelframe>
+            <bd>2</bd>
+            <relief>RAISED</relief> 
+            <hbox>
+                <dial>
+                    <size>100</size>
+                    <cpr>100</cpr>
+                    <min_>0</min_>
+                    <max_>100</max_>
+                    <text>"Dial 0"</text>
+                    <initval>5</initval>
+                    <resolution>1</resolution>
+                    <halpin>"dial0"</halpin>
+                    <dialcolor>"yellow"</dialcolor>
+                    <edgecolor>"green"</edgecolor>
+                    <dotcolor>"black"</dotcolor>
+                    <param_pin>1</param_pin>
+                </dial>
+                <scale>
+                    <width>"15"</width>
+                    <halpin>"scale0"</halpin>
+                    <resolution>1</resolution>
+                    <orient>VERTICAL</orient>
+                    <initval>20</initval>
+                    <min_>0</min_>
+                    <max_>100</max_>
+                    <param_pin>1</param_pin>
+                </scale>
+                </hbox>
+        </labelframe>
+        <label>
+            <text>"   "</text>
+        </label>
+        <labelframe>
+            <bd>2</bd>
+            <relief>RAISED</relief> 
+            <hbox>
+                <dial>
+                    <size>100</size>
+                    <cpr>100</cpr>
+                    <min_>0</min_>
+                    <max_>100</max_>
+                    <text>"Dial 1"</text>
+                    <initval>10</initval>
+                    <resolution>0.1</resolution>
+                    <halpin>"dial1"</halpin>
+                    <dialcolor>"green"</dialcolor>
+                    <edgecolor>"red"</edgecolor>
+                    <dotcolor>"black"</dotcolor>
+                    <param_pin>1</param_pin>
+                </dial>
+                <scale>
+                    <width>"15"</width>
+                    <halpin>"scale1"</halpin>            
+                    <resolution>0.1</resolution>
+                    <orient>VERTICAL</orient>
+                    <initval>10</initval>
+                    <min_>0</min_>
+                    <max_>100</max_>
+                    <param_pin>1</param_pin>
+                </scale>
+            </hbox>
+        </labelframe>
+        <label>
+            <text>"   "</text>
+        </label>
+        <labelframe>
+            <bd>2</bd>
+            <relief>RAISED</relief> 
+            <hbox>
+                <dial>
+                    <size>100</size>
+                    <cpr>100</cpr>
+                    <min_>0</min_>
+                    <max_>100</max_>
+                    <text>"Dial 2"</text>
+                    <initval>15</initval>
+                    <resolution>0.01</resolution>
+                    <halpin>"dial2"</halpin>
+                    <dialcolor>"yellow"</dialcolor>
+                    <edgecolor>"green"</edgecolor>
+                    <dotcolor>"black"</dotcolor>
+                    <param_pin>1</param_pin>
+                </dial>
+                <scale>
+                    <width>"15"</width>
+                    <halpin>"scale2"</halpin>
+                    <resolution>0.01</resolution>
+                    <orient>VERTICAL</orient>
+                    <initval>1</initval>
+                    <min_>0</min_>
+                    <max_>100</max_>
+                    <param_pin>1</param_pin>
+                </scale>
+            </hbox>
+        </labelframe>
+        <label>
+            <text>"   "</text>
+        </label>
+        <labelframe>
+            <bd>2</bd>
+            <relief>RAISED</relief> 
+            <hbox>
+                <dial>
+                    <size>100</size>
+                    <cpr>100</cpr>
+                    <min_>0</min_>
+                    <max_>100</max_>
+                    <text>"Dial 3"</text>
+                    <initval>20</initval>
+                    <resolution>0.001</resolution>
+                    <halpin>"dial3"</halpin>
+                    <dialcolor>"green"</dialcolor>
+                    <edgecolor>"red"</edgecolor>
+                    <dotcolor>"black"</dotcolor>
+                    <param_pin>1</param_pin>
+                </dial>
+                <scale>
+                    <width>"15"</width>
+                    <halpin>"scale3"</halpin>            
+                    <resolution>0.001</resolution>
+                    <orient>VERTICAL</orient>
+                    <initval>10</initval>
+                    <min_>0</min_>
+                    <max_>100</max_>
+                    <param_pin>1</param_pin>
+                </scale>
+            </hbox>
+        </labelframe>
+    </hbox>
+</pyvcp>
+
+

--- a/docs/src/config/ini-config.txt
+++ b/docs/src/config/ini-config.txt
@@ -346,7 +346,7 @@ Many of them are used also from gmoccapy, see the
 
 * 'OPEN_FILE = /full/path/to/file.ngc' - The file to show in the preview plot when AXIS starts. Use
    a blank string "" and no file will be loaded at start up. gmoccapy will not use this setting, as it
-   offers a coresponding entry on its settings page.
+   offers a corresponding entry on its settings page.
 
 * 'EDITOR = gedit' - The editor to use when selecting File > Edit to edit the G code 
     from the AXIS menu. This must be configured for this menu item to
@@ -360,6 +360,10 @@ Many of them are used also from gmoccapy, see the
 
 * 'PYVCP = /filename.xml' - The PyVCP panel description file. See the 
     <<cha:pyvcp,PyVCP Chapter>> for more information.
+
+* 'PYVCP_POSITION = BOTTOM' - The placement of the PyVCP panel in the AXIS user interface.
+    If this variable is omitted the panel will default to the right side. The only valid
+    alternative is BOTTOM. See the <<cha:pyvcp,PyVCP Chapter>> for more information.
 
 * 'LATHE = 1' - Any non-empty value (including "0") causes axis to use "lathe mode" with a top view and with Radius and Diameter on the DRO.
 

--- a/docs/src/gui/pyvcp.txt
+++ b/docs/src/gui/pyvcp.txt
@@ -76,8 +76,8 @@ source that you trust.
 == AXIS
 
 Since AXIS uses the same GUI toolkit (Tkinter) as PyVCP, it is
-possible to include a PyVCP panel on the right side of the normal AXIS
-user interface. A typical example is explained below.
+possible to include a PyVCP panel at either the right side or the bottom
+of the AXIS user interface. A typical example is explained below.
 
 Place your PyVCP XML file describing the panel in the same directory
 where your .ini file is. Say we we want to display the current spindle
@@ -107,6 +107,17 @@ up, we need to specify the following in the [DISPLAY] section of the
 -----------------------------
 PYVCP = spindle.xml
 -----------------------------
+
+If the panel should appear at the bottom of the AXIS user interface
+then we need to specify the following in the [DISPLAY] section of the
+.ini file:
+
+-----------------------------
+PYVCP_POSITION = BOTTOM
+-----------------------------
+
+Anything other than BOTTOM or omitting this variable will place the
+PYVCP panel at the right.
 
 To make our widget actually display the spindle-speed it needs to be
 hooked up to the appropriate HAL signal. A .hal file that will be run

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -3813,7 +3813,10 @@ if hal_present == 1 :
         import vcpparse
         comp.setprefix("pyvcp")
         f = Tkinter.Frame(root_window)
-        f.grid(row=0, column=4, rowspan=6, sticky="nw", padx=4, pady=4)
+        if inifile.find("DISPLAY", "PYVCP_POSITION") == "BOTTOM":
+            f.grid(row=4, column=0, columnspan=6, sticky="nw", padx=4, pady=4)
+        else:
+            f.grid(row=0, column=4, rowspan=6, sticky="nw", padx=4, pady=4)
         vcpparse.filename = vcp
         vcpparse.create_vcp(f, comp)
         vcp_frame = f


### PR DESCRIPTION
Allows a PyVCP panel to be at the bottom of the AXIS user interface as an alternative to being at the right side. 