### PR TITLE
Halcompile: fix user_comp builds on RTAI platforms

### DIFF
--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -783,7 +783,7 @@ def build_usr(tempdir, filename, mode, origfilename):
     makefile = os.path.join(tempdir, "Makefile")
     f = open(makefile, "w")
     print("%s: %s" % (binname, filename), file=f)
-    print("\t$(CC) $(EXTRA_CFLAGS) -URTAPI -U__MODULE__ -DULAPI -Os %s -o $@ $< -Wl,-rpath,$(LIBDIR) -L$(LIBDIR) -llinuxcnchal %s" % (
+    print("\t$(CC) -I$(EMC2_HOME)/include -I/usr/include/linuxcnc -URTAPI -U__MODULE__ -DULAPI -Os %s -o $@ $< -Wl,-rpath,$(LIBDIR) -L$(LIBDIR) -llinuxcnchal %s" % (
         options.get("extra_compile_args", ""),
         options.get("extra_link_args", "")), file=f)
     print("include %s" % find_modinc(), file=f)


### PR DESCRIPTION
Halcompile inserts $(EXTRA_CFLAGS) when compiling userspace components:
https://github.com/LinuxCNC/linuxcnc/blob/master/src/hal/utils/halcompile.g#L792
EXTRA_CFLAGS gets RTFLAGS if the realtime system is RTAI:
https://github.com/LinuxCNC/linuxcnc/blob/master/src/Makefile.modinc.in#L76
And RTFLAGS with current RTAI includes -nostdinc and other options that prevent relocation.
-fPIC is suggested by the compiler, but that doesn't work with some other options. 
https://github.com/NTULINUX/RTAI/blob/master/configure.ac#L748

My feeling is that all that the userspace comps get from EXTRA_CFLAGS is some useful library paths. 

This commit makes those paths explicit (and that can't be the right thing to do) and passes runtests on a RIP install. It also appears to fix halcompile on an installed Buster RTAI. 
