### PR TITLE
Update kernel version PREEMPT_RT check

### DIFF
--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -331,6 +331,9 @@ static int detect_preempt_rt() {
     uname(&u);
     crit1 = strcasestr (u.version, "PREEMPT RT") != 0;
 
+    //"PREEMPT_RT" is used in the version string instead of "PREEMPT RT" starting with kernel version 5.4
+    crit1 = crit1 || (strcasestr(u.version, "PREEMPT_RT") != 0);
+
     if ((fd = fopen("/sys/kernel/realtime","r")) != NULL) {
         int flag;
         crit2 = ((fscanf(fd, "%d", &flag) == 1) && (flag == 1));


### PR DESCRIPTION
When trying out the in development 5.4-rt kernel, I found that the version string changed and LinuxCNC was unable to detect the patched kernel. This PR adds a check for the new version string and lets LinuxCNC detect the patched kernel.