### PR TITLE
Fix ERROR: ambiguous python shebang

### DIFF
--- a/configs/by_machine/plasmac/M190
+++ b/configs/by_machine/plasmac/M190
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 M190

--- a/configs/by_machine/plasmac/configurator.py
+++ b/configs/by_machine/plasmac/configurator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 configurator.py

--- a/configs/by_machine/plasmac/materialverter.py
+++ b/configs/by_machine/plasmac/materialverter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 materialverter.py

--- a/configs/by_machine/plasmac/plasmac_gcode.py
+++ b/configs/by_machine/plasmac/plasmac_gcode.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#!/usr/bin/python2
 
 '''
 plasmac_gcode.py

--- a/configs/by_machine/plasmac/pmx485.py
+++ b/configs/by_machine/plasmac/pmx485.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 pmx485.py

--- a/configs/by_machine/plasmac/pmx_test.py
+++ b/configs/by_machine/plasmac/pmx_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 '''
 pmx_test.py

--- a/configs/by_machine/plasmac/test/plasmac_test.py
+++ b/configs/by_machine/plasmac/test/plasmac_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 '''
 plasmac_test.py.

--- a/configs/sim/axis/vismach/3axis-tutorial/3axis-tutorial
+++ b/configs/sim/axis/vismach/3axis-tutorial/3axis-tutorial
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Rolf Redford, Nov 2018
 

--- a/configs/sim/axis/vismach/VMC_toolchange/vmcgui
+++ b/configs/sim/axis/vismach/VMC_toolchange/vmcgui
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #    Copyright 2009 Alex Joni
 #
 #    This program is free software; you can redistribute it and/or modify

--- a/configs/sim/axis/vismach/rolfmill/rolfmill
+++ b/configs/sim/axis/vismach/rolfmill/rolfmill
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #import libraries
 from vismach import *

--- a/configs/sim/gmoccapy/lathe_configs/lathehandler.py
+++ b/configs/sim/gmoccapy/lathe_configs/lathehandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: sts=4 sw=4 et
 #    This is a component of EMC
 #    savestate.py copyright 2013 Andy Pugh

--- a/scripts/update_ini
+++ b/scripts/update_ini
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 THIS_VERSION = "1.1"
 


### PR DESCRIPTION
Fixes the following shebang errors:
*** ERROR: ambiguous python shebang in
 /usr/bin/update_ini:
 #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/by_machine/plasmac/plasmac_gcode.py:
 #!/usr/bin/python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/by_machine/plasmac/test/plasmac_test.py:
 #!/usr/bin/python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/by_machine/plasmac/configurator.py:
 #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/by_machine/plasmac/M190:
 #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/by_machine/plasmac/pmx485.py:
 #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/by_machine/plasmac/pmx_test.py:
 #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/by_machine/plasmac/materialverter.py:
 #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/sim/gmoccapy/lathe_configs/lathehandler.py:
 #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/sim/axis/vismach/VMC_toolchange/vmcgui:
 #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/sim/axis/vismach/rolfmill/rolfmill:
 #!/usr/bin/python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in
 /usr/share/doc/linuxcnc/examples/sample-configs/sim/axis/vismach/3axis-tutorial/3axis-tutorial:
 #!/usr/bin/python. Change it to python3 (or python2) explicitly.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>