### PR TITLE
Switch to use mktemp(1) instead of tempfile(1)

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1080,7 +1080,7 @@ if ( test "$BUILD_DOCS" = "yes" ) ; then
     fi
 
     AC_MSG_CHECKING([whether to specify latex.encoding])
-    temp_asciidoc=`tempfile --suffix=.txt`
+    temp_asciidoc=`mktemp --suffix=.txt`
     cat > $temp_asciidoc <<EOF
 :lang: fr
 :ascii-ids:


### PR DESCRIPTION
tempfile(1) is not available at all on Fedora while mktemp(1) is
part of the coreutils package available virtually on all Linux
distributions.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>