### PR TITLE
Fix python errors in image-wildcart

### DIFF
--- a/docs/src/image-wildcard
+++ b/docs/src/image-wildcard
@@ -9,7 +9,7 @@ except:
 	    """Return a relative version of a path"""
 
 	    if not path:
-		raise ValueError("no path specified")
+	        raise ValueError("no path specified")
 
 	    start_list = os.path.abspath(start).split(os.path.sep)
 	    path_list = os.path.abspath(path).split(os.path.sep)
@@ -19,7 +19,7 @@ except:
 
 	    rel_list = [os.path.pardir] * (len(start_list)-i) + path_list[i:]
 	    if not rel_list:
-		return os.path.curdir
+	        return os.path.curdir
 	    return os.path.join(*rel_list)
 
 if len(sys.argv) > 1:
@@ -55,4 +55,4 @@ def lookup(image):
 i = lookup(image)
 if not i:
 	i = image
-print relpath(i, docpath)
+print(relpath(i, docpath))


### PR DESCRIPTION
Fixes the following issues:

 - TabError: inconsistent use of tabs and spaces in indentation
   -- File "image-wildcard", line 12
   -- File "image-wildcard", line 22

 - SyntaxError: invalid syntax
   -- File "./image-wildcard", line 58
   Above happens as the image-wildcard uses default python interpreter and
   on my system it's python 3.x:
   $ /usr/bin/env python --version
   Python 3.7.6

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>