### PR TITLE
Fix build for legacy RTAI kernels

### DIFF
--- a/src/rtapi/rtai_rtapi.c
+++ b/src/rtapi/rtai_rtapi.c
@@ -65,6 +65,7 @@
 #include <linux/slab.h>		/* replaces malloc.h in recent kernels */
 #include <linux/ctype.h>	/* isdigit */
 #include <linux/uaccess.h>	/* copy_from_user() */
+#include <linux/version.h>	/* LINUX_VERSION_CODE */
 #include <asm/msr.h>		/* rdtsc_ordered() */
 
 /* get inb(), outb(), ioperm() */
@@ -536,8 +537,12 @@ long long int rtapi_get_clocks(void)
 {
     long long int retval;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
     retval = rdtsc_ordered();
-    return retval;    
+#else
+    rdtscll(retval);
+#endif
+    return retval;
 }
 
 void rtapi_delay(long int nsec)


### PR DESCRIPTION
Signed-off-by: Alec Ari <neotheuser@ymail.com>

The build failure was committed to 2.8 but the fix only to master.  This cherry-picks it back.