### PR TITLE
halcompile: allow "?:" ternary operations in array size calculations

### DIFF
--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -34,7 +34,7 @@ parser Hal:
     token NUMBER: "0x[0-9a-fA-F]+|[+-]?[0-9]+"
     token STRING: "\"(\\.|[^\\\"])*\""
     token HEADER: "<.*?>"
-    token POP: "[-()+*/]|&&|\\|\\||personality|==|&|!=|<<|<|<=|>>|>|>="
+    token POP: "[-()+*/:?]|&&|\\|\\||personality|==|&|!=|<<|<|<=|>>|>|>="
     token TSTRING: "r?\"\"\"(\\.|\\\n|[^\\\"]|\"(?!\"\")|\n)*\"\"\""
 
     rule File: ComponentDeclaration Declaration* "$" {{ return True }}


### PR DESCRIPTION
This old commit was found in one of my source trees.  Apparently it would enable the size of an array of pins to have a "?:" ternary operator in its size, probably something like `arr[4 : personality & 1 ? 4 : 3]`, making an array be size 3 or 4 depending on specific needs.

I don't know anymore why I thought it would be useful.