### PR TITLE
Fix readline v5 GPL-2 license compatiblity checking

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1542,6 +1542,7 @@ fi
 
 AC_MSG_CHECKING([whether readline license is compatible with GPL-2])
 AC_TRY_COMPILE([
+        #include <stdio.h>
         #include <readline/readline.h>
     ],[
         #if RL_VERSION_MAJOR > 5


### PR DESCRIPTION
On gcc 9.3 the readline test reports false positive failure:

  checking whether readline license is compatible with GPL-2... no

due to the following compilation error:

In file included from /usr/include/readline5/readline/readline.h:36,
                 from conftest.c:51:
/usr/include/readline5/readline/rltypedefs.h:65:28: error: unknown type name 'FILE'
   65 | typedef int rl_getc_func_t PARAMS((FILE *));
      |                            ^~~~~~
In file included from /usr/include/readline5/readline/readline.h:37,
                 from conftest.c:51:
/usr/include/readline5/readline/rltypedefs.h:1:1:
  note: 'FILE' is defined in header '<stdio.h>'; did you forget to '#include <stdio.h>'?

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>