### PR TITLE
Fix compiling strsep() for uspace

### DIFF
--- a/src/rtapi/vsnprintf.h
+++ b/src/rtapi/vsnprintf.h
@@ -470,6 +470,7 @@ int rtapi_vsnprintf(char *buf, unsigned long size, const char *fmt, va_list args
     return str - buf;
 }
 
+#ifdef MODULE
 /**
  * strsep - Split a string into tokens
  * @s: The string to be searched
@@ -496,3 +497,4 @@ char *strsep(char **s, const char *ct)
 
     return sbegin;
 }
+#endif


### PR DESCRIPTION
Adds a missing #ifdef guard to avoid a clash
with strsep() from <string.h>.

Fixes the following error:
Compiling rtapi/test_rtapi_vsnprintf.c
                 from rtapi/rtapi_string.h:41,
                 from rtapi/vsnprintf.h:41,
                 from rtapi/test_rtapi_vsnprintf.c:19:
rtapi/vsnprintf.h:485:7: error: expected identifier or ‘(’ before ‘__extension__’
 char *strsep(char **s, const char *ct)
       ^
rtapi/vsnprintf.h:485:7: error: expected identifier or ‘(’ before ‘)’ token
 char *strsep(char **s, const char *ct)
       ^
make: *** [objects/rtapi/test_rtapi_vsnprintf.o] Error 1

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>