### PR TITLE
Fix threads.0 test

### DIFF
--- a/tests/threads.0/checkresult
+++ b/tests/threads.0/checkresult
@@ -3,8 +3,8 @@ import sys
 
 l = [int(line.strip()) for line in open(sys.argv[1])]
 if len(l) != 3500:
-    print "result contained %d lines, not the expected 3500 lines!" % (len(l))
-    raise SystemExit, 1 # failure
+    print("result contained %d lines, not the expected 3500 lines!" % (len(l)))
+    raise SystemExit(1) # failure
 
 lineno = 1
 
@@ -19,17 +19,17 @@ for i in l:
 
     if i != expected:
         if expected == 1: 
-            print "line %d: got %d, expected %d" % (lineno, i, expected)
+            print("line %d: got %d, expected %d" % (lineno, i, expected))
         else:
-            print "line %d: got %d, expected %d or 1" % (lineno, i, expected)
-        raise SystemExit, 1 # failure
+            print("line %d: got %d, expected %d or 1" % (lineno, i, expected))
+        raise SystemExit(1) # failure
 
     expected = i + 1
     lineno = lineno + 1
 
 if got_reset:
-    raise SystemExit, 0 # success
+    raise SystemExit(0) # success
 
-print "no reset in %d lines!" % (lineno-1)
-raise SystemExit, 1 # failure
+print("no reset in %d lines!" % (lineno-1))
+raise SystemExit(1) # failure
 


### PR DESCRIPTION
Fixes errors when the unversioned python
interpreter defaults to python3.

Fixes the following errors:
  File "/home/sw/projects/machinekit/linuxcnc/tests/threads.0/checkresult", line 6
    print "result contained %d lines, not the expected 3500 lines!" % (len(l))
                                                                  ^
SyntaxError: invalid syntax
*** /home/sw/projects/machinekit/linuxcnc/tests/threads.0: FAIL: checkresult exited with 1

  File "tests/threads.0/checkresult", line 7
    raise SystemExit, 1 # failure
                    ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>