### PR TITLE
Fix tests/abort/feed-rate

### DIFF
--- a/tests/abort/feed-rate/test-ui.py
+++ b/tests/abort/feed-rate/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc
 import hal
@@ -42,7 +42,7 @@ def wait_for_linuxcnc_startup(status, timeout=10.0):
             return
 
     # timeout, throw an exception
-    raise RuntimeError
+    raise RuntimeError("Timeout")
 
 
 c = linuxcnc.command()
@@ -66,7 +66,7 @@ c.wait_complete()
 c.abort()
 c.wait_complete()
 s.poll()
-print "feed rate:", s.settings[1]
+print("feed rate:{}".format(s.settings[1]))
 assert(math.fabs(s.settings[1] - feed_rate) < 0.0000001)
 
 feed_rate = 345.6
@@ -76,7 +76,7 @@ c.wait_complete()
 c.abort()
 c.wait_complete()
 s.poll()
-print "feed rate:", s.settings[1]
+print("feed rate:{}".format(s.settings[1]))
 assert(math.fabs(s.settings[1] - feed_rate) < 0.0000001)
 
 sys.exit(0)


### PR DESCRIPTION
Fixes the following errors:

  File "./test-ui.py", line 69
    print "feed rate:", s.settings[1]
                     ^
SyntaxError: Missing parentheses in call to 'print'.
Did you mean print("feed rate:", s.settings[1])?

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>