### PR TITLE
Fix running travis-install-build-deps.sh

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -30,6 +30,7 @@ Build-Depends: debhelper (>= 6),
     psmisc,
     desktop-file-utils,
     yapps2,
+    libtirpc-dev,
 Standards-Version: 3.9.2
 Vcs-Browser: https://github.com/LinuxCNC/linuxcnc
 Vcs-Git: git://github.com/linuxcnc/linuxcnc.git

--- a/scripts/travis-install-build-deps.sh
+++ b/scripts/travis-install-build-deps.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 sudo sh -c 'echo deb-src http://us.archive.ubuntu.com/ubuntu/ xenial main universe >> /etc/apt/sources.list'
-grep . /etc/apt/sources.list /etc/apt/sources.list.d/*
+grep . /etc/apt/sources.list /etc/apt/sources.list.d/* || true
 sudo apt-get update -qq
 sudo apt-get install -y devscripts equivs build-essential --no-install-recommends
 sudo apt-get remove -f libreadline6-dev || true


### PR DESCRIPTION
Fixes error:
    grep: /etc/apt/sources.list.d/*: No such file or directory
 which happens when you run:
    $sudo scripts/travis-install-build-deps.sh
in an official ubuntu:16.04 docker image.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>