### PR TITLE
Fix tests/halmodule.1

### DIFF
--- a/tests/halmodule.1/stream_reader.py
+++ b/tests/halmodule.1/stream_reader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import hal
 import time
 c = hal.component("stream_reader")
@@ -11,7 +11,7 @@ for i in range(9):
 assert reader.read() is None
 assert reader.num_underruns == 1
 c.ready()
-print "pass"
+print("pass")
 
 try:
     while 1: time.sleep(1)

--- a/tests/halmodule.1/stream_test.py
+++ b/tests/halmodule.1/stream_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 os.system("halcmd unload all")
 import hal
@@ -33,4 +33,4 @@ for i in range(9):
 assert reader.read() is None
 assert reader.num_underruns == 1
 
-print "pass"
+print("pass")

--- a/tests/halmodule.1/stream_writer.py
+++ b/tests/halmodule.1/stream_writer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import hal
 import time
 c = hal.component("stream_writer")


### PR DESCRIPTION
Fixes python errors, e.g;
 File "/home/sw/projects/machinekit/linuxcnc-rip/lib/python/hal.py", line 30, in <module>
    import _hal
ImportError: /home/sw/projects/machinekit/linuxcnc-rip/lib/python/_hal.so: undefined symbol: _Py_ZeroStruct

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>