### PR TITLE
Fix tests/ccomp/early-exit

### DIFF
--- a/tests/ccomp/early-exit/test-ui.py
+++ b/tests/ccomp/early-exit/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc
 import hal
@@ -67,7 +67,7 @@ c.mdi('g0 x0.9  ; surprise motion on Y and Z, to 0!!')
 c.wait_complete()
 
 s.poll()
-print "position:", s.position
+print("position: {}".format(s.position))
 assert(math.fabs(s.position[0] - 0.9) < 0.0000001)
 assert(math.fabs(s.position[1] - 0.2) < 0.0000001)
 assert(math.fabs(s.position[2] - 0.3) < 0.0000001)


### PR DESCRIPTION
Fixes the following error:
  File "test-ui.py", line 70
    print "position:", s.position
                    ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("position:", s.position)?

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>