### PR TITLE
Fix tests/interp/bad

### DIFF
--- a/tests/interp/bad/test
+++ b/tests/interp/bad/test
@@ -3,7 +3,7 @@ import glob, os, sys
 
 fail = 0
 for t in sorted(glob.glob('*.ngc')):
-    print >>sys.stderr, "#", t
+    sys.stderr.write("# {}".format(t))
     error = open(t).readline()
     if error.startswith(';'): expected = error[1:-1]
     elif error.startswith('('): expected = error[1:-2]
@@ -11,21 +11,21 @@ for t in sorted(glob.glob('*.ngc')):
     p = os.popen("rs274 -g %s 2>&1 > /dev/null" % t)
     output = p.readlines()
     r = p.close()
-    print "# ->", r
+    print("# -> {}".format(r))
     if not r:
-	print "%s: Interpreter accepted bad gcode" % t
-	fail += 1
-	continue
+        print("%s: Interpreter accepted bad gcode" % t)
+        fail += 1
+        continue
 
     if len(output) < 2:
-	print "%s: Unexpected interpreter output: %r" % output
-	fail += 1
-	continue
+        print("%s: Unexpected interpreter output: %r" % output)
+        fail += 1
+        continue
 
     err = output[-2].strip()
     if err != expected:
-	print "%s: Expected %r, got %r instead" % (t, expected, err)
-	fail += 1
+        print("%s: Expected %r, got %r instead" % (t, expected, err))
+        fail += 1
 
 if fail:
-    raise SystemExit, "%d failures" % fail
+    raise SystemExit("%d failures" % fail)


### PR DESCRIPTION
Fixes the following errors:
  File "test", line 6
    print("#", t, file=sys.stderr)
                      ^
SyntaxError: invalid syntax
  File "test", line 6
    print("# {}".format(t), file=sys.stderr)
                                ^
SyntaxError: invalid syntax

Sorry: TabError: inconsistent use of tabs and spaces in indentation (test, line 16)

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>