### PR TITLE
Fix tests/interp/m98m99/12-M99-endless-main-program

### DIFF
--- a/tests/interp/m98m99/12-M99-endless-main-program/test-ui.py
+++ b/tests/interp/m98m99/12-M99-endless-main-program/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc
 import hal


### PR DESCRIPTION
Traceback (most recent call last):
  File "./test-ui.py", line 3, in <module>
    import linuxcnc
ImportError: /home/sw/projects/machinekit/linuxcnc/lib/python/linuxcnc.so: undefined symbol: PyString_FromString

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>