### PR TITLE
Fix tests/interp/oword-mdi-sub-update

### DIFF
--- a/tests/interp/oword-mdi-sub-update/test-ui.py
+++ b/tests/interp/oword-mdi-sub-update/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc
 import hal


### PR DESCRIPTION
Fixes:
   File "./test-ui.py", line 3, in <module>
    import linuxcnc
ImportError: /home/sw/projects/machinekit/linuxcnc/lib/python/linuxcnc.so: undefined symbol: PyString_FromString
link (updating variable file): No such file or directory

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>