### PR TITLE
Fix tests/interp/python/error

### DIFF
--- a/tests/interp/python/error/canon.py
+++ b/tests/interp/python/error/canon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import tempfile
 import gcode
 import sys
@@ -13,8 +13,8 @@ class Canon:
         its args and return None"""
 
         def inner(*args):
-            args = map(float_fmt, args)
-            print "%-17s %s" % (attr, " ".join(args))
+            args = list(map(float_fmt, args))
+            print("%-17s %s" % (attr, " ".join(args)))
         return inner
 
     # this is just noisy
@@ -32,4 +32,4 @@ parameter = tempfile.NamedTemporaryFile()
 canon = Canon()
 canon.parameter_file = parameter.name
 result, seq = gcode.parse(sys.argv[1], canon, '', '', '')
-if result > gcode.MIN_ERROR: raise SystemExit, gcode.strerror(result)
+if result > gcode.MIN_ERROR: raise SystemExit(gcode.strerror(result))

--- a/tests/interp/python/error/test.sh
+++ b/tests/interp/python/error/test.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-! python -mcanon error.ngc 2>&1
+! python2 -mcanon error.ngc 2>&1


### PR DESCRIPTION
Fixes:
 File "canon.py", line 17
    print "%-17s %s" % (attr, " ".join(args))
                   ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>