### PR TITLE
Fix tests/io-startup/nonrandom/no-tool-in-P0

### DIFF
--- a/tests/io-startup/test-ui.py
+++ b/tests/io-startup/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc_util
 import hal
@@ -20,9 +20,9 @@ def wait_for_pin_value(pin_name, value, timeout=5.0):
     while (time.time() - start_time) < timeout:
         time.sleep(0.1)
         if h[pin_name] == value:
-            print "pin '%s' reached target value '%s' after %f seconds" % (pin_name, value, time.time() - start_time)
+            print("pin '%s' reached target value '%s' after %f seconds" % (pin_name, value, time.time() - start_time))
             return
-    print "Error: pin '%s' didn't reach value '%s' within timeout of %f seconds (it's %s instead)" % (pin_name, value, timeout, h[pin_name])
+    print("Error: pin '%s' didn't reach value '%s' within timeout of %f seconds (it's %s instead)" % (pin_name, value, timeout, h[pin_name]))
     sys.exit(1)
 
 
@@ -30,7 +30,7 @@ f = open('expected-startup-tool-number', 'r')
 contents = f.read()
 f.close()
 expected_startup_tool_number = int(contents)
-print "expecting tool number %d" % expected_startup_tool_number
+print("expecting tool number %d" % expected_startup_tool_number)
 
 #
 # set up pins


### PR DESCRIPTION
Fixes:
  File "../../test-ui.py", line 23
    print "pin '%s' reached target value '%s' after %f seconds" % (pin_name, value, time.time() - start_time)
                                                              ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>