### PR TITLE
Fix tests/motion-logger/startup-gcode-abort

### DIFF
--- a/tests/motion-logger/startup-gcode-abort/test-ui.py
+++ b/tests/motion-logger/startup-gcode-abort/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc
 import sys
@@ -20,12 +20,12 @@ e = linuxcnc.error_channel()
 
 time.sleep(1)
 
-print "UI abort"
+print("UI abort")
 sys.stdout.flush()
 
 c.abort()
 c.wait_complete()
 
-print "UI done with abort"
+print("UI done with abort")
 sys.stdout.flush()
 


### PR DESCRIPTION
Fixes:
Traceback (most recent call last):
  File "./test-ui.py", line 3, in <module>
    import linuxcnc
ImportError: /home/sw/projects/machinekit/linuxcnc/lib/python/linuxcnc.so: undefined symbol: PyString_FromString

  File "./test-ui.py", line 23
    print "UI abort"
                   ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("UI abort")?

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>