### PR TITLE
Fix tests/motion/jogwheel-axis

### DIFF
--- a/tests/motion/jogwheel-axis/test-ui.py
+++ b/tests/motion/jogwheel-axis/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc
 import linuxcnc_util
@@ -33,18 +33,18 @@ def jog_axis(axis_letter, counts=1, scale=0.001):
 
     h['axis-%c-jog-enable' % axis_letter] = 0
 
-    print "axis %c jogged from %.6f to %.6f (%d counts at scale %.6f)" % (axis_letter, start_pos[axis_letter], h['axis-%c-position' % axis_letter], counts, scale)
+    print("axis %c jogged from %.6f to %.6f (%d counts at scale %.6f)" % (axis_letter, start_pos[axis_letter], h['axis-%c-position' % axis_letter], counts, scale))
 
     success = True
     for a in 'xyz':
         pin_name = 'axis-%c-position' % a
         if a == axis_letter:
             if not close_enough(h[pin_name], target):
-                print "axis %c didn't get to target (start=%.6f, target=%.6f, got to %.6f)" % (axis_letter, start_pos[axis_letter], target, h['axis-%c-position' % axis_letter])
+                print("axis %c didn't get to target (start=%.6f, target=%.6f, got to %.6f)" % (axis_letter, start_pos[axis_letter], target, h['axis-%c-position' % axis_letter]))
                 success = False
         else:
             if h[pin_name] != start_pos[a]:
-                print "axis %c moved from %.6f to %.6f but shouldnt have!" % (a, start_pos[a], h[pin_name])
+                print("axis %c moved from %.6f to %.6f but shouldnt have!" % (a, start_pos[a], h[pin_name]))
                 success = False
 
     l.wait_for_axis_to_stop(axis_letter)


### PR DESCRIPTION
Fixes:
  File "test-ui.py", line 36
    print "axis %c jogged from %.6f to %.6f (%d counts at scale %.6f)" % (axis_letter, start_pos[axis_letter], h['axis-%c-position' % axis_letter], counts, scale)
                                                                     ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>