### PR TITLE
Fix tests/pyhal

### DIFF
--- a/tests/pyhal/test
+++ b/tests/pyhal/test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from pyhal import *
 import os
 


### PR DESCRIPTION
Fixes:
Traceback (most recent call last):
  File "./test", line 9, in <module>
    port_in = c.pinNew("port-in", halType.PORT, pinDir.IN)
  File "/home/sw/projects/machinekit/linuxcnc/lib/python/pyhal.py", line 212, in pinNew
    result = lib.hal_pin_new("{0}.{1}".format(self.name, name), type, dir, ptr, self.id)
ctypes.ArgumentError: argument 1: <class 'TypeError'>: wrong type

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>