### PR TITLE
Fix tests/remap/remap-io

### DIFF
--- a/tests/remap/remap-io/test-ui.py
+++ b/tests/remap/remap-io/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc, hal
 import sys, os


### PR DESCRIPTION
Fixes:
  File "./test-ui.py", line 3, in <module>
    import linuxcnc, hal
ImportError: /home/sw/projects/machinekit/linuxcnc/lib/python/linuxcnc.so: undefined symbol: PyString_FromString

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>