### PR TITLE
Fix tests/rs274ngc-startup

### DIFF
--- a/tests/rs274ngc-startup/test-ui.py
+++ b/tests/rs274ngc-startup/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc
 import linuxcnc_util
@@ -26,12 +26,12 @@ l.wait_for_linuxcnc_startup()
 s.poll()
 
 if s.g5x_index != 1:
-    print "Expected g5x_index=1 (startup in G54), got %d instead" % s.g5x_index
+    print("Expected g5x_index=1 (startup in G54), got %d instead" % s.g5x_index)
     retval = 1
 
 if math.fabs(s.tool_offset[2] - 0.1234) > 0.000001:
-    print "Expected tool offset of 0.1234 via startup gcode not detected"
-    print "Got %f instead." % s.tool_offset[2]
+    print("Expected tool offset of 0.1234 via startup gcode not detected")
+    print("Got %f instead." % s.tool_offset[2])
     retval = 1
 
 sys.exit(retval)


### PR DESCRIPTION
Fixes:
  File "./test-ui.py", line 29
    print "Expected g5x_index=1 (startup in G54), got %d instead" % s.g5x_index
                                                                ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>