### PR TITLE
Fix tests/toolchanger/reload-tool/non-random

### DIFF
--- a/tests/toolchanger/reload-tool/non-random/test-ui.py
+++ b/tests/toolchanger/reload-tool/non-random/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc
 import linuxcnc_util


### PR DESCRIPTION
Fixes:
Traceback (most recent call last):
  File "./test-ui.py", line 3, in <module>
    import linuxcnc
ImportError: /home/sw/projects/machinekit/linuxcnc/lib/python/linuxcnc.so: undefined symbol: PyString_FromString

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>