### PR TITLE
Fix tests/limit3

### DIFF
--- a/tests/limit3/checkresult
+++ b/tests/limit3/checkresult
@@ -32,8 +32,8 @@ def must_decel_to_avoid_pos_violation(sample, out, vel):
 
     # r = r0 + v0t + 1/2 at^2
     pos_at_stop = next_out + (vel * seconds_to_stop) + (accel_sign * 0.5 * params['maxa'] * math.pow(seconds_to_stop, 2))
-    print "sample=%d, next_out=%.6f, vel=%.6f, seconds_to_stop=%.6f, pos_at_stop=%.6f, min=%.6f, max=%.6f" % \
-            (sample, next_out, vel, seconds_to_stop, pos_at_stop, params['min'], params['max'])
+    print("sample=%d, next_out=%.6f, vel=%.6f, seconds_to_stop=%.6f, pos_at_stop=%.6f, min=%.6f, max=%.6f" % \
+            (sample, next_out, vel, seconds_to_stop, pos_at_stop, params['min'], params['max']))
     if pos_at_stop > (params['max'] * 1.01) or pos_at_stop < (params['min'] * 1.01):
         return True
 
@@ -71,23 +71,23 @@ for line in result_file.readlines():
     #
 
     if float(out) > params['max']:
-        print "max=%.3f, in=%.3f, out=%.3f, max violation on sample %s" % \
-            (params['max'], float(in_val), out, sample)
+        print("max=%.3f, in=%.3f, out=%.3f, max violation on sample %s" % \
+            (params['max'], float(in_val), out, sample))
         retval = 1
 
     if float(out) < params['min']:
-        print "min=%.3f, in=%.3f, out=%.3f, min violation on sample %s" % \
-            (params['min'], float(in_val), out, sample)
+        print("min=%.3f, in=%.3f, out=%.3f, min violation on sample %s" % \
+            (params['min'], float(in_val), out, sample))
         retval = 1
 
     if abs(vel) > params['maxv']:
-        print "maxv=%.3f, vel=%.3f, velocity violation on sample %s" % \
-            (params['maxv'], vel, sample)
+        print("maxv=%.3f, vel=%.3f, velocity violation on sample %s" % \
+            (params['maxv'], vel, sample))
         retval = 1
 
     if abs(acc) > params['maxa']:
-        print "maxa=%.3f, acc=%.3f, acceleration violation on sample %s" % \
-            (params['maxa'], acc, sample)
+        print("maxa=%.3f, acc=%.3f, acceleration violation on sample %s" % \
+            (params['maxa'], acc, sample))
         retval = 1
 
 
@@ -108,8 +108,8 @@ for line in result_file.readlines():
             pass
         else:
             # We have no good reason for not accelerating hard, so fail this test.
-            print "maxa=%.3f, acc=%.3f, sluggish acceleration on sample %s" % \
-                (params['maxa'], acc, sample)
+            print("maxa=%.3f, acc=%.3f, sluggish acceleration on sample %s" % \
+                (params['maxa'], acc, sample))
             retval = 1
 
 
@@ -133,8 +133,8 @@ for line in result_file.readlines():
             pass
         else:
             # We have no good reason for not going fast, so fail this test.
-            print "maxv=%.3f, vel=%.3f, sluggish velocity on sample %s" % \
-                (params['maxv'], vel, sample)
+            print("maxv=%.3f, vel=%.3f, sluggish velocity on sample %s" % \
+                (params['maxv'], vel, sample))
             retval = 1
 
 sys.exit(retval)

--- a/tests/limit3/sunny-day/checkresult
+++ b/tests/limit3/sunny-day/checkresult
@@ -29,19 +29,19 @@ for line in result_file.readlines():
     #
 
     if out_value > max_value:
-        print "max=%.3f, out=%.3f, position violation on line %s" % (max_value, out_value, line)
+        print(("max=%.3f, out=%.3f, position violation on line %s" % (max_value, out_value, line)))
         retval = 1
 
     if out_value < min_value:
-        print "min=%.3f, out=%.3f, position violation on line %s" % (min_value, out_value, line)
+        print(("min=%.3f, out=%.3f, position violation on line %s" % (min_value, out_value, line)))
         retval = 1
 
     if math.fabs(out_vel) > max_vel:
-        print "max_vel=%.3f, out_vel=%.3f, velocity violation on line %s" % (max_vel, out_vel, line)
+        print(("max_vel=%.3f, out_vel=%.3f, velocity violation on line %s" % (max_vel, out_vel, line)))
         retval = 1
 
     if math.fabs(out_accel) > max_accel:
-        print "max_accel=%.3f, out_accel=%.3f, acceleration violation on line %s" % (max_accel, out_accel, line)
+        print(("max_accel=%.3f, out_accel=%.3f, acceleration violation on line %s" % (max_accel, out_accel, line)))
         retval = 1
 
 
@@ -51,7 +51,7 @@ for line in result_file.readlines():
 
     error = math.fabs(in_value - out_value)
     if error > 0.0:
-        print "input=%.6f, output=%.6f, error=%.6f, threshold=%.6f, following failure on line %s" % (in_value, out_value, error, threshold, line)
+        print(("input=%.6f, output=%.6f, error=%.6f, threshold=%.6f, following failure on line %s" % (in_value, out_value, error, threshold, line)))
         retval = 1
 
 sys.exit(retval)


### PR DESCRIPTION
Fixes:
    print "sample=%d, next_out=%.6f, vel=%.6f, seconds_to_stop=%.6f, pos_at_stop=%.6f, min=%.6f, max=%.6f" % \
                                                                                                         ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("sample=%d, next_out=%.6f, vel=%.6f, seconds_to_stop=%.6f, pos_at_stop=%.6f, min=%.6f, max=%.6f" % \)?

    print "max=%.3f, out=%.3f, position violation on line %s" % (max_value, out_value, line)
                                                            ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>