### PR TITLE
Fix tests/remap

### DIFF
--- a/tests/remap/introspect/oword.py
+++ b/tests/remap/introspect/oword.py
@@ -16,6 +16,7 @@
 #   along with this program; if not, write to the Free Software
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+from __future__ import print_function
 import interpreter
 EMC_DEBUG_CONFIG            = 0x00000002
 EMC_DEBUG_VERSIONS          = 0x00000008
@@ -34,47 +35,47 @@ EMC_DEBUG_GDBONSIGNAL       = 0x00020000
 
 
 def introspect(self,*args):
-    print "debug: ", self.debugmask,"logging:",self.loggingLevel
-    print "call_level=",self.call_level
-    print "argc=", len(args)
-    print "args=(",
+    print("debug: ", self.debugmask,"logging:",self.loggingLevel)
+    print("call_level=",self.call_level)
+    print("argc=", len(args))
+    print("args=(", end=' ')
     for arg in args:
         if type(arg) == float:
-            print "%0.5f" % arg,
+            print("%0.5f" % arg, end=' ')
         else:
-            print arg,
-    print ")"
+            print(arg, end=' ')
+    print(")")
 
     # the low-level access within the block
     for n in range(len(args)):
-        print "param #",n ,"=", self.blocks[0].params[n]
+        print("param #",n ,"=", self.blocks[0].params[n])
 
     # this is a low-level interface.
     for x in self.sub_context[1].named_params:
-        print "name:",x.key(),"value=",x.data().value, "attr=",x.data().attr
+        print("name:",x.key(),"value=",x.data().value, "attr=",x.data().attr)
 
     #for r in self.remaps:
     #    print r.key(), str(r.data())
 
-    print "current oword subname=", self.blocks[0].o_name
-    print "m_modes[0]=", self.blocks[0].m_modes[0]
-    print "g_modes[0]=", self.blocks[0].g_modes[0]
+    print("current oword subname=", self.blocks[0].o_name)
+    print("m_modes[0]=", self.blocks[0].m_modes[0])
+    print("g_modes[0]=", self.blocks[0].g_modes[0])
 
     # this is the high level named & numbered parameter interface
-    print "current tool=",self.params[5400],self.params["_current_tool"]
+    print("current tool=",self.params[5400],self.params["_current_tool"])
 
-    print "feed=",self.params['_feed']
-    print "speed=",self.params['_rpm']
+    print("feed=",self.params['_feed'])
+    print("speed=",self.params['_rpm'])
 
-    print "global parameter set in test.ngc:",self.params['_a_global_set_in_test_dot_ngc']
-    print "parameter set via test.ini:",self.params['_ini[example]variable']
+    print("global parameter set in test.ngc:",self.params['_a_global_set_in_test_dot_ngc'])
+    print("parameter set via test.ini:",self.params['_ini[example]variable'])
     assert self.params['_ini[example]variable'] == args[3]
 
     self.params["a_new_local"] = 321.0
     self.params["_a_new_global"] = 456.0
 
-    print "locals: ",self.params.locals()
-    print "globals: ",self.params.globals()
-    print "params(): ",self.params()
+    print("locals: ",self.params.locals())
+    print("globals: ",self.params.globals())
+    print("params(): ",self.params())
     return 2.71828
 

--- a/tests/remap/oword-pycall/oword.py
+++ b/tests/remap/oword-pycall/oword.py
@@ -31,9 +31,10 @@ def square(self,x):
 # (debug, #<_value>)
 
 import operator
+from functools import reduce
 
 # you'd be better of doing it this way:
 def multiply(self, *args):
-    print "multiply: number of arguments=", len(args)
+    print("multiply: number of arguments= {}".format(len(args)))
     return reduce(operator.mul, args)
 

--- a/tests/remap/sequencing/permute.py
+++ b/tests/remap/sequencing/permute.py
@@ -38,11 +38,11 @@ def nextPermutation(perm):
 perm=["g88.1x1", "m405","m406","m407","m408"]
 
 while perm:
-    print perm
+    print(perm)
     perm = nextPermutation(perm)
 
 perm=["g88.1x1", "m407","m408","m409","m410"]
 
 while perm:
-    print perm
+    print(perm)
     perm = nextPermutation(perm)


### PR DESCRIPTION
Fixes:
  File "./remap/sequencing/permute.py", line 41
    print perm
             ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(perm)?

  File "./remap/introspect/oword.py", line 37
    print "debug: ", self.debugmask,"logging:",self.loggingLevel
                  ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("debug: ", self.debugmask,"logging:",self.loggingLevel)?

 File "./remap/oword-pycall/oword.py", line 37
    print "multiply: number of arguments=", len(args)
                                         ^
SyntaxError: invalid syntax

 File "./oremap/introspec/tword.py", line 41
    print("args=(", end=' ')
                       ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>