### PR TITLE
Fix tests/mdi-while-queuebuster-waitflag

### DIFF
--- a/tests/mdi-while-queuebuster-waitflag/remap.py
+++ b/tests/mdi-while-queuebuster-waitflag/remap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import linuxcnc
 import emccanon
 import interpreter
@@ -10,10 +10,10 @@ def M400(self,**words):
 
     self.execute("M66 E0 L0")
     # self.execute("M66 P0 L1 Q1")
-    print "self.input_flag pre = %s" % self.input_flag
+    print("self.input_flag pre = %s" % self.input_flag)
     yield interpreter.INTERP_EXECUTE_FINISH
 
-    print "self.input_flag post = %s" % self.input_flag
+    print("self.input_flag post = %s" % self.input_flag)
     # optionally,
     # yield interpreter.INTERP_OK
 


### PR DESCRIPTION
Fixes:
 File "mdi-while-queuebuster-waitflag/remap.py", line 13
    print "self.input_flag pre = %s" % self.input_flag
                                   ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("self.input_flag pre = %s" % self.input_flag)?

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>