### PR TITLE
Fix tests/trajectory-planner

### DIFF
--- a/tests/trajectory-planner/circular-arcs/linuxcnc_control.py
+++ b/tests/trajectory-planner/circular-arcs/linuxcnc_control.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''Copied from m61-test'''
 
 import linuxcnc
@@ -122,7 +122,7 @@ class LinuxcncControl:
                     pass
                 return True
             except KeyboardInterrupt:
-                print "interrupted by keyboard in c.wait_complete(self.timeout)"
+                print("interrupted by keyboard in c.wait_complete(self.timeout)")
                 return False
 
         self.error = self.e.poll()
@@ -132,9 +132,9 @@ class LinuxcncControl:
                 if self.g_raise_except:
                     raise LinuxcncError(text)
                 else:
-                    print ("error " + text)
+                    print(("error " + text))
             else:
-                print ("info " + text)
+                print(("info " + text))
         return False
 
     def get_current_tool(self):
@@ -185,7 +185,7 @@ class LinuxcncControl:
             if self.s.task_state != linuxcnc.STATE_ON:
                 return False
             if self.check_rcs_error():
-                print "Found RCS error while waiting, running again"
+                print("Found RCS error while waiting, running again")
                 self.run_full_program()
 
         return True
@@ -193,7 +193,7 @@ class LinuxcncControl:
     def check_rcs_error(self):
         self.s.poll()
         if self.s.state == linuxcnc.RCS_ERROR:
-            print "detected RCS error"
+            print("detected RCS error")
             return True
         return False
 

--- a/tests/trajectory-planner/circular-arcs/machine_setup.py
+++ b/tests/trajectory-planner/circular-arcs/machine_setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''Copied from m61-test'''
 
 import linuxcnc
@@ -36,6 +36,6 @@ if len(sys.argv)>1:
     e.wait_on_program()
 
 else:
-    print "No G code specified, setup complete"
+    print("No G code specified, setup complete")
 
 

--- a/tests/trajectory-planner/circular-arcs/run_all_tests.py
+++ b/tests/trajectory-planner/circular-arcs/run_all_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 '''Copied from m61-test'''
 
 import linuxcnc
@@ -11,7 +11,7 @@ from time import sleep
 from os import listdir
 from os.path import isfile, join
 import re
-import Tkinter, os
+import tkinter, os
 
 def query_yes_no(question, default="yes"):
     """Ask a yes/no question via raw_input() and return their answer.
@@ -36,7 +36,7 @@ def query_yes_no(question, default="yes"):
 
     while True:
         sys.stdout.write(question + prompt)
-        choice = raw_input().lower()
+        choice = input().lower()
         if default is not None and choice == '':
             return valid[default]
         elif choice in valid:
@@ -48,20 +48,20 @@ def query_yes_no(question, default="yes"):
 def find_test_nc_files(testpath='nc_files', show=False):
     files = [ testpath + '/' + f for f in listdir(testpath) if isfile(join(testpath,f)) and re.search('.ngc$',f) is not None ]
     if show:
-        print "In folder {0}, found {1} files:".format(testpath,len(files))
+        print("In folder {0}, found {1} files:".format(testpath,len(files)))
         for f in files:
-            print f
+            print(f)
     return files
 
 def axis_open_program(t,f):
     return t.tk.call("send", "axis", ("remote","open_file_name", os.path.abspath(f)))
 
-t = Tkinter.Tk()
+t = tkinter.Tk()
 t.wm_withdraw()
 
 """Run the test"""
 
-raw_input("Press any key when the LinuxCNC GUI has loaded")
+input("Press any key when the LinuxCNC GUI has loaded")
 
 import glob
 #KLUDGE this lists all subfolders in the auto-test directory
@@ -99,7 +99,7 @@ e.set_mode(linuxcnc.MODE_AUTO)
 sleep(1)
 for f in test_files:
     if re.search('\.ngc$',f) is not None:
-        print "Loading program {0}".format(f)
+        print("Loading program {0}".format(f))
         e.set_mode(linuxcnc.MODE_AUTO)
         sleep(1)
         axis_open_program(t,f)
@@ -109,7 +109,7 @@ for f in test_files:
             sleep(.5)
         res = e.wait_on_program()
         if res == False:
-            print "Program {0} failed to complete!".format(f)
+            print("Program {0} failed to complete!".format(f))
             sys.exit(1)
 
-print "All tests completed!"
+print("All tests completed!")


### PR DESCRIPTION
Fixes:
  File "./trajectory-planner/circular-arcs/run_all_tests.py", line 51
    print "In folder {0}, found {1} files:".format(testpath,len(files))
                                          ^
SyntaxError: invalid syntax

 File "./trajectory-planner/circular-arcs/run_all_tests.py", line 51
    print "In folder {0}, found {1} files:".format(testpath,len(files))
                                          ^
SyntaxError: invalid syntax

  File "./trajectory-planner/circular-arcs/machine_setup.py", line 39
    print "No G code specified, setup complete"
                                              ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("No G code specified, setup complete")?

  File "./trajectory-planner/circular-arcs/linuxcnc_control.py", line 125
    print "interrupted by keyboard in c.wait_complete(self.timeout)"
                                                                   ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>