### PR TITLE
Fix tests/interp/python-self

### DIFF
--- a/tests/interp/python-self/oword.py
+++ b/tests/interp/python-self/oword.py
@@ -22,13 +22,13 @@ def retainparam1(self,x):
 
 def checkparam1_retained(self):
     if hasattr(self,'param1'):
-        print "param1 was retained, value = ", self.param1
+        print("param1 was retained, value =  {}".format(self.param1))
     else:
         return "param1 was not retained across invocations"
 
     # test object identity
     if hasattr(interpreter,'this'):
-	print "this is self:", self is interpreter.this
+        print("this is self: {}".format(self is interpreter.this))
     else:
-        print "module interpreter: no 'this' attribute"
+        print("module interpreter: no 'this' attribute")
         

--- a/tests/interp/python-self/subs.py
+++ b/tests/interp/python-self/subs.py
@@ -21,7 +21,7 @@ import interpreter
 def __init__(self):
     if hasattr(interpreter,'this'):
         if self is not interpreter.this:
-            print "__init__: self not is this"
+            print("__init__: self not is this")
     else:
-        print "__init__: no 'this' attribute"
+        print("__init__: no 'this' attribute")
         


### PR DESCRIPTION
Fixes:
 File "./interp/python-self/subs.py", line 24
    print "__init__: self not is this"
                                     ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("__init__: self not is this")?

 File "./interp/python-self/oword.py", line 25
    print "param1 was retained, value = ", self.param1
                                        ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("param1 was retained, value = ", self.param1)?

Sorry: TabError: inconsistent use of tabs and spaces in indentation (oword.py, line 31)

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>