### PR TITLE
Fix tests/mdi-queue-length

### DIFF
--- a/tests/mdi-queue-length/test-ui.py
+++ b/tests/mdi-queue-length/test-ui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import linuxcnc
 import hal
@@ -52,7 +52,7 @@ def wait_for_mdi_queue(queue_len, timeout=10):
         if s.queued_mdi_commands == queue_len:
             return
         time.sleep(0.1)
-    print "queued_mdi_commands at %d after %.3f seconds" % (s.queued_mdi_commands, timeout)
+    print("queued_mdi_commands at %d after %.3f seconds" % (s.queued_mdi_commands, timeout))
     sys.exit(1)
 
 


### PR DESCRIPTION
Fixes:
  File "./mdi-queue-length/test-ui.py", line 55
    print "queued_mdi_commands at %d after %.3f seconds" % (s.queued_mdi_commands, timeout)
                                                       ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>