### PR TITLE
Add pycheck (Python check) Makefile target

### DIFF
--- a/scripts/travis-build-test.sh
+++ b/scripts/travis-build-test.sh
@@ -2,5 +2,5 @@
 cd src
 ./autogen.sh
 ./configure --with-realtime=uspace --disable-check-runtime-deps --enable-build-documentation
-make -O -j$(nproc) V=1
+make -O -j$(getconf _NPROCESSORS_ONLN) default pycheck V=1
 ../scripts/rip-environment runtests

--- a/scripts/travis-build-test.sh
+++ b/scripts/travis-build-test.sh
@@ -1,6 +1,6 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 cd src
 ./autogen.sh
 ./configure --with-realtime=uspace --disable-check-runtime-deps --enable-build-documentation
-make -O -j$(nproc)
+make -O -j$(nproc) V=1
 ../scripts/rip-environment runtests

--- a/scripts/travis-install-build-deps.sh
+++ b/scripts/travis-install-build-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/sh -ex
 sudo sh -c 'echo deb-src http://us.archive.ubuntu.com/ubuntu/ xenial main universe >> /etc/apt/sources.list'
 grep . /etc/apt/sources.list /etc/apt/sources.list.d/*
 sudo apt-get update -qq

--- a/src/Makefile
+++ b/src/Makefile
@@ -501,6 +501,28 @@ clean: depclean modclean
 	-rm -f ../rtlib/*.$(MODULE_EXT)
 	-rm -f hal/components/conv_*.comp
 
+pycheck-python-files:
+	@echo 'Checking *.py files for python2 and python3 compatibility...'
+	@for d in ./hal; do \
+		filelist=$(shell mktemp) && \
+		find $$d -name '*.py' -type f > $$filelist && \
+		cat $$filelist | xargs /usr/bin/env python2 -m py_compile && \
+		cat $$filelist | xargs /usr/bin/env python3 -m py_compile && \
+		rm -f $$filelist; \
+	done
+
+pycheck-python-script:
+	@echo 'Checking "text/x-python" (by MIME type) files for python2 and python3 compatibility...'
+	@for d in ../tests; do \
+		filelist=$(shell mktemp) && \
+		find $$d -type f -exec file -F ':' -i {} \; | grep 'text/x-python' | awk -F ':' '{print $$1}' > $$filelist && \
+		cat $$filelist | xargs /usr/bin/env python2 -m py_compile && \
+		cat $$filelist | xargs /usr/bin/env python3 -m py_compile && \
+		rm -f $$filelist; \
+	done
+
+pycheck: pycheck-python-files pycheck-python-script
+
 # So that nothing is built as root, this rule does not depend on the touched
 # files (Note that files in depends/ might be rebuilt, and there's little that
 # can be done about it)


### PR DESCRIPTION
    It is designed to be used for checking compatibility of python
    scripts (currently only from the 'tests' subdirectory) with
    both python2 and python3 interpreters.
    
    Usage:
      $ make pycheck
    
    Successfull output:
      $ make pycheck
      Reading 200/200 dependency files
      Done reading dependencies
      Reading 212/212 realtime dependency files
      Done reading realtime dependencies
      Checking *.py files for python2 and python3 compatibility...
      Checking "Python scripts" (by MIME type) files for python2 and python3 compatibility...    

    Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
