### PR TITLE
Fix linking error on gcc10

### DIFF
--- a/src/hal/classicladder/files.c
+++ b/src/hal/classicladder/files.c
@@ -1300,7 +1300,7 @@ void DeleteTheDefaultSection( )
 	SectionArray[ 0 ].Used = FALSE;
 }
 
-char FileName[500];
+static char FileName[500];
 void LoadAllLadderDatas(char * DatasDirectory)
 {
 	ClassicLadder_InitAllDatas( );

--- a/src/hal/classicladder/files_project.c
+++ b/src/hal/classicladder/files_project.c
@@ -160,7 +160,7 @@ char LoadProjectFiles( char * FileProject )
 	return Result;
 }
 
-char FileName[500];
+static char FileName[500];
 char LoadGeneralParamsOnlyFromProject( char * FileProject )
 {
 	char Result = FALSE;


### PR DESCRIPTION
Fixes the following linking error:
 /usr/bin/ld: objects/hal/classicladder/files_project.o:
 /home/sw/projects/rpmbuild/BUILD/linuxcnc-bb2a4cc21a7fed9574059d46eb4507c40ba3bf55 \
 /src/hal/classicladder/files_project.c:163: multiple definition of `FileName'; \
 objects/hal/classicladder/files.o:/home/sw/projects/rpmbuild/BUILD/ \
 linuxcnc-bb2a4cc21a7fed9574059d46eb4507c40ba3bf55/src/hal/classicladder/files.c:1303: \
 first defined here

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>