### PR TITLE
Fix invalid syntax for python3

### DIFF
--- a/lib/python/pyngcgui.py
+++ b/lib/python/pyngcgui.py
@@ -93,7 +93,7 @@ gettext.install("linuxcnc", localedir=LOCALEDIR, unicode=True)
 try:
     import pygtk
     pygtk.require('2.0')
-except ImportError,msg:
+except ImportError as msg:
     print('import pygtk failed: %s',msg)
     pass
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes:
$ python3 -m py_compile pyngcgui.py
  File "pyngcgui.py", line 96
    except ImportError,msg:
                      ^
SyntaxError: invalid syntax

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>