### PR TITLE
Fix SyntaxWarning: "is" with a literal - pyngcgui.py

### DIFF
--- a/lib/python/pyngcgui.py
+++ b/lib/python/pyngcgui.py
@@ -1421,7 +1421,7 @@ class SubFile():
                 dvalue = ''
 
             if name:
-                if comment is '':
+                if comment == '':
                     comment = name
                 pnum += 1
                 self.ndict[pnum] = (name,dvalue,comment)


### PR DESCRIPTION
Fixes the following warning when compiling for python3.8:

 linuxcnc/lib/python/pyngcgui.py:1424: SyntaxWarning: "is" with a literal. Did you mean "=="?
   if comment is '':

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>