### PR TITLE
Remove relying on unversioned python

### DIFF
--- a/src/po/Submakefile
+++ b/src/po/Submakefile
@@ -56,7 +56,7 @@ TCLSRCS := \
 
 po/linuxcnc.pot:
 	$(ECHO) Localizing linuxcnc.pot
-	(cd ..; $(XGETTEXT) -k_ -o src/$@ `src/po/fixpaths.py -j src $^`)
+	(cd ..; $(XGETTEXT) -k_ -o src/$@ `$(PYTHON) src/po/fixpaths.py -j src $^`)
 	touch $@
 TARGETS += po/linuxcnc.pot
 


### PR DESCRIPTION
Fixes the following error:

 /usr/bin/env: ‘python’: No such file or directory
 /usr/bin/xgettext: no input file given
 Try '/usr/bin/xgettext --help' for more information.
 make: *** [po/Submakefile:59: po/linuxcnc.pot] Error 1
 make: *** Waiting for unfinished jobs....

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>