### PR TITLE
Fix configure "integer expression expected" error

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1108,8 +1108,9 @@ EOF
     AC_MSG_CHECKING([dblatex version])
     set -- `dblatex --version`; DBLATEX_VER=$3
     set -- `echo $DBLATEX_VER | sed 's/[[.-]]/ /g'`
+    micro=`echo $3 | sed 's/\([[0-9]]*\).*/\1/g'`
 
-    if test $1 -eq 0 -a \( $2 -lt 2 -o \( $2 -eq 2 -a ${3:-0} -lt 12 \) \); then
+    if test $1 -eq 0 -a \( $2 -lt 2 -o \( $2 -eq 2 -a ${micro:-0} -lt 12 \) \); then
         AC_MSG_ERROR([dblatex version $DBLATEX_VER less than 0.2.12.
 Documentation cannot be built.])
     fi


### PR DESCRIPTION
Fixes error when micro version part contains non-digits characters.

Specifically for:

 $ dblatex --version
 dblatex version 0.3.11py3

which is available on Fedora the configure script produces:

 checking dblatex version... ./configure: line 7138: \
   test: 11py3: integer expression expected

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>