### PR TITLE
apply G54-G59.3 rotation to halui.axis.x.pos-relative and halui.axis.y.pos-relative

### DIFF
--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -2219,7 +2219,7 @@ static void modify_hal_pins()
       *(halui_data->axis_pos_feedback[0]) = emcStatus->motion.traj.actualPosition.tran.x;
       double x = emcStatus->motion.traj.actualPosition.tran.x - emcStatus->task.g5x_offset.tran.x - emcStatus->task.toolOffset.tran.x;
       double y = emcStatus->motion.traj.actualPosition.tran.y - emcStatus->task.g5x_offset.tran.y - emcStatus->task.toolOffset.tran.y;
-      x = x * cos(-emcStatus->task.rotation_xy * (M_PI / 180.0)) - y * sin(-emcStatus->task.rotation_xy * (M_PI / 180.0));
+      x = x * cos(-emcStatus->task.rotation_xy * TO_RAD) - y * sin(-emcStatus->task.rotation_xy * TO_RAD);
       *(halui_data->axis_pos_relative[0]) = x - emcStatus->task.g92_offset.tran.x;
     }
 
@@ -2228,7 +2228,7 @@ static void modify_hal_pins()
       *(halui_data->axis_pos_feedback[1]) = emcStatus->motion.traj.actualPosition.tran.y;
       double x = emcStatus->motion.traj.actualPosition.tran.x - emcStatus->task.g5x_offset.tran.x - emcStatus->task.toolOffset.tran.x;
       double y = emcStatus->motion.traj.actualPosition.tran.y - emcStatus->task.g5x_offset.tran.y - emcStatus->task.toolOffset.tran.y;
-      y = y * cos(-emcStatus->task.rotation_xy * (M_PI / 180.0)) + x * sin(-emcStatus->task.rotation_xy * (M_PI / 180.0));
+      y = y * cos(-emcStatus->task.rotation_xy * TO_RAD) + x * sin(-emcStatus->task.rotation_xy * TO_RAD);
       *(halui_data->axis_pos_relative[1]) = y - emcStatus->task.g92_offset.tran.y;
     }
 

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -2215,15 +2215,21 @@ static void modify_hal_pins()
     }
 
     if (axis_mask & 0x0001) {
-      *(halui_data->axis_pos_commanded[0]) = emcStatus->motion.traj.position.tran.x;	
-      *(halui_data->axis_pos_feedback[0]) = emcStatus->motion.traj.actualPosition.tran.x;	
-      *(halui_data->axis_pos_relative[0]) = emcStatus->motion.traj.actualPosition.tran.x - emcStatus->task.g5x_offset.tran.x - emcStatus->task.g92_offset.tran.x - emcStatus->task.toolOffset.tran.x;
+      *(halui_data->axis_pos_commanded[0]) = emcStatus->motion.traj.position.tran.x;
+      *(halui_data->axis_pos_feedback[0]) = emcStatus->motion.traj.actualPosition.tran.x;
+      double x = emcStatus->motion.traj.actualPosition.tran.x - emcStatus->task.g5x_offset.tran.x - emcStatus->task.toolOffset.tran.x;
+      double y = emcStatus->motion.traj.actualPosition.tran.y - emcStatus->task.g5x_offset.tran.y - emcStatus->task.toolOffset.tran.y;
+      x = x * cos(-emcStatus->task.rotation_xy * (M_PI / 180.0)) - y * sin(-emcStatus->task.rotation_xy * (M_PI / 180.0));
+      *(halui_data->axis_pos_relative[0]) = x - emcStatus->task.g92_offset.tran.x;
     }
 
     if (axis_mask & 0x0002) {
-      *(halui_data->axis_pos_commanded[1]) = emcStatus->motion.traj.position.tran.y;	
-      *(halui_data->axis_pos_feedback[1]) = emcStatus->motion.traj.actualPosition.tran.y;	
-      *(halui_data->axis_pos_relative[1]) = emcStatus->motion.traj.actualPosition.tran.y - emcStatus->task.g5x_offset.tran.y - emcStatus->task.g92_offset.tran.y - emcStatus->task.toolOffset.tran.y;
+      *(halui_data->axis_pos_commanded[1]) = emcStatus->motion.traj.position.tran.y;
+      *(halui_data->axis_pos_feedback[1]) = emcStatus->motion.traj.actualPosition.tran.y;
+      double x = emcStatus->motion.traj.actualPosition.tran.x - emcStatus->task.g5x_offset.tran.x - emcStatus->task.toolOffset.tran.x;
+      double y = emcStatus->motion.traj.actualPosition.tran.y - emcStatus->task.g5x_offset.tran.y - emcStatus->task.toolOffset.tran.y;
+      y = y * cos(-emcStatus->task.rotation_xy * (M_PI / 180.0)) + x * sin(-emcStatus->task.rotation_xy * (M_PI / 180.0));
+      *(halui_data->axis_pos_relative[1]) = y - emcStatus->task.g92_offset.tran.y;
     }
 
     if (axis_mask & 0x0004) {


### PR DESCRIPTION
When using coordinate system rotation, the value reported by halui.axis.x.pos-relative and halui.axis.y.pos-relative are incorrect and do not match the value reported by the axis DRO. This change applies the rotation to these values.