### PR TITLE
Fix using dumpfullversion for old compilers and clang

### DIFF
--- a/src/hal/user_comps/xhc-whb04b-6/Submakefile
+++ b/src/hal/user_comps/xhc-whb04b-6/Submakefile
@@ -1,4 +1,4 @@
-GCC_GTEQ_470 := $(shell expr `gcc -dumpfullversion | awk -F '.' '{print $$1*10000+$$2*100+$$3}'` \>= 40700)
+GCC_GTEQ_470 := $(shell $(CC) --version | head -n1 | grep gcc >/dev/null && (expr `($(CC) -dumpfullversion 2>/dev/null || $(CC) -dumpversion) | awk -F '.' '{print $$1*10000+$$2*100+$$3}'` \>= 40700 || true) || echo 1)
 ifeq "$(GCC_GTEQ_470)" "1"
 ifdef HAVE_LIBUSB10
 
@@ -26,5 +26,5 @@ TARGETS += ../bin/xhc-whb04b-6
 endif # HAVE_LIBUSB10
 
 else
-$(info gcc version $(GCC_VERSION) too old: skipping hal/user_comps/xhc-whb04b-6)
+$(info Compiler version: "$(shell $(CC) --version | head -n1)" is too old: skipping hal/user_comps/xhc-whb04b-6)
 endif # GCC VERSION CHECK


### PR DESCRIPTION
Fixes (non-fatal) error:
 gcc: fatal error: no input files
produced by compilers which does not support -dumpfullversion
(includes old gcc and all clang).

It also uses $(CC) instead of hardcoded 'gcc' value.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>