### PR TITLE
Fix desktop files

### DIFF
--- a/debian/extras/usr/share/applications/linuxcnc-documentation.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-documentation.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Exec=/usr/bin/see /usr/share/doc/linuxcnc/LinuxCNC_Documentation.pdf
+Exec=xdg-open /usr/share/doc/linuxcnc/LinuxCNC_Documentation.pdf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Name=Documentation
 Comment=LinuxCNC Documentation
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-gcoderef-fr.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-gcoderef-fr.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Exec=/usr/bin/x-www-browser /usr/share/doc/linuxcnc/gcode_fr.html
+Exec=xdg-open /usr/share/doc/linuxcnc/gcode_fr.html
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Name=French G-Code Quick Reference
 Comment=Quick reference for G, M and O codes in LinuxCNC
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-gcoderef-vi.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-gcoderef-vi.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Exec=/usr/bin/x-www-browser /usr/share/doc/linuxcnc/gcode_vi.html
+Exec=xdg-open /usr/share/doc/linuxcnc/gcode_vi.html
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Name=Vietnamese G-Code Quick Reference
 Comment=Quick reference for G, M and O codes in LinuxCNC
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-gcoderef.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-gcoderef.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Exec=/usr/bin/x-www-browser /usr/share/doc/linuxcnc/gcode.html
+Exec=xdg-open /usr/share/doc/linuxcnc/gcode.html
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Name=G-Code Quick Reference
 Comment=Quick reference for G, M, and O codes in LinuxCNC
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-gettingstarted-fr.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-gettingstarted-fr.desktop
@@ -2,11 +2,11 @@
 Version=1.0
 Name=French Getting Started Guide
 Type=Application
-Exec=/usr/bin/see /usr/share/doc/linuxcnc/LinuxCNC_Getting_Started_fr.pdf
+Exec=xdg-open /usr/share/doc/linuxcnc/LinuxCNC_Getting_Started_fr.pdf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Comment=Information on how to download and install LinuxCNC
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-gettingstarted.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-gettingstarted.desktop
@@ -2,11 +2,11 @@
 Version=1.0
 Name=Getting Started Guide
 Type=Application
-Exec=/usr/bin/see /usr/share/doc/linuxcnc/LinuxCNC_Getting_Started.pdf
+Exec=xdg-open /usr/share/doc/linuxcnc/LinuxCNC_Getting_Started.pdf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Comment=Information on how to download and install LinuxCNC
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-halmanual-fr.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-halmanual-fr.desktop
@@ -2,11 +2,11 @@
 Version=1.0
 Name=French HAL Manual
 Type=Application
-Exec=/usr/bin/see /usr/share/doc/linuxcnc/LinuxCNC_HAL_User_Manual_fr.pdf
+Exec=xdg-open /usr/share/doc/linuxcnc/LinuxCNC_HAL_User_Manual_fr.pdf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Comment=Details about the Hardware Abstract Layer.
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-integratorinfo.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-integratorinfo.desktop
@@ -2,12 +2,11 @@
 Version=1.0
 Name=Integrator Information
 Type=Application
-Exec=/usr/bin/see /usr/share/doc/linuxcnc/LinuxCNC_Integrator.pdf
+Exec=xdg-open /usr/share/doc/linuxcnc/LinuxCNC_Integrator.pdf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
-Comment=Integrator Information
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;
 Name[en_US]=Integrator Info

--- a/debian/extras/usr/share/applications/linuxcnc-integratormanual-fr.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-integratormanual-fr.desktop
@@ -2,11 +2,11 @@
 Version=1.0
 Name=French Integrator Manual
 Type=Application
-Exec=/usr/bin/see /usr/share/doc/linuxcnc/LinuxCNC_Integrator_Manual_fr.pdf
+Exec=xdg-open /usr/share/doc/linuxcnc/LinuxCNC_Integrator_Manual_fr.pdf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Comment=Installation and Configuration Manual (French)
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-latency.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-latency.desktop
@@ -8,5 +8,5 @@ Terminal=false
 Name=Latency Test
 Comment=Test your computers's latency
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-manualpages.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-manualpages.desktop
@@ -2,12 +2,12 @@
 Version=1.0
 Name=Manual Pages
 Type=Application
-Exec=/usr/bin/see /usr/share/doc/linuxcnc/LinuxCNC_Manual_Pages.pdf
+Exec=xdg-open /usr/share/doc/linuxcnc/LinuxCNC_Manual_Pages.pdf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Comment=Integrator Information
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;
 Name[en_US]=Manual Pages

--- a/debian/extras/usr/share/applications/linuxcnc-pncconf.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-pncconf.desktop
@@ -7,6 +7,6 @@ X-GNOME-DocPath=
 Terminal=false
 Comment=Configuration Wizard For Mesa I/O Cards
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Name=Pncconf Wizard
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-stepconf.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-stepconf.desktop
@@ -8,5 +8,5 @@ Terminal=false
 Name=Stepconf Wizard
 Comment=Stepper Configuration Wizard
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc-usermanual-fr.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-usermanual-fr.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Exec=/usr/bin/see /usr/share/doc/linuxcnc/LinuxCNC_User_Manual_fr.pdf
+Exec=xdg-open /usr/share/doc/linuxcnc/LinuxCNC_User_Manual_fr.pdf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
 Name=French User Manual
 Comment=The LinuxCNC User Manual
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;

--- a/debian/extras/usr/share/applications/linuxcnc.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc.desktop
@@ -8,5 +8,5 @@ Terminal=false
 Name=LinuxCNC
 Comment=Configuration Launcher
 StartupNotify=false
-Categories=X-CNC;
+Categories=Utility;Engineering;X-CNC;
 Keywords=cnc;linuxcnc;


### PR DESCRIPTION
Fixes various issues with desktop files:

$ desktop-file-validate  *.desktop
linuxcnc.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-documentation.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-gcoderef.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-gcoderef-fr.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-gcoderef-vi.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-gettingstarted.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-gettingstarted-fr.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-halmanual-fr.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-integratorinfo.desktop: warning: value "Integrator Information" for key "Comment" in group "Desktop Entry" looks redundant with value "Integrator Information" of key "Name"
linuxcnc-integratorinfo.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-integratormanual-fr.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-latency.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-manualpages.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-pncconf.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-stepconf.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
linuxcnc-usermanual-fr.desktop: hint: value "X-CNC;" for key "Categories" in group "Desktop Entry" does not contain a registered main category; application might only show up in a "catch-all" section of the application menu
$ echo $?
1

Switch to use xdg-open(1) for opening URL in the user's preferred application.

[1]https://portland.freedesktop.org/doc/xdg-open.html

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>