### PR TITLE
Build system tweaks

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1107,7 +1107,7 @@ $(sort $(RTOBJS)) : objects/rt%.o : %.c
 	$(ECHO) Compiling realtime $<
 	@rm -f $@
 	@mkdir -p $(dir $@)
-	$(Q)$(CC) -c $(OPT) $(DEBUG) $(EXTRA_DEBUG) -DRTAPI -I../include \
+	$(Q)$(CC) -c $(OPT) $(DEBUG) $(EXTRA_DEBUG) -DRTAPI \
 		$(EXTRA_CFLAGS) \
 		-MP -MD -MF "${@:.o=.d}" -MT "$@" \
 		$< -o $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -96,7 +96,7 @@ $(error Makefile.inc must specify RTPREFIX and other variables)
 endif
 
 cc-option = $(shell if $(CC) $(CFLAGS) $(1) -S -o /dev/null -xc /dev/null \
-	     > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi ;)
+	     > /dev/null 2>&1; then echo "$(1)"; fi ;)
 cxx-option = $(shell if $(CXX) $(CXXFLAGS) $(1) -S -o /dev/null -xc++ /dev/null \
             > /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi ;)
 

--- a/src/Makefile.inc.in
+++ b/src/Makefile.inc.in
@@ -1,3 +1,4 @@
+#                                                     -*-makefile-gmake-*-
 #
 # @configure_input@ 
 # on @DATE@

--- a/src/Makefile.modinc.in
+++ b/src/Makefile.modinc.in
@@ -1,3 +1,4 @@
+#                                                     -*-makefile-gmake-*-
 # Makefile.modinc includes rules for building HAL realtime modules outside
 # the LinuxCNC source tree.  It has three useful targets:
 #

--- a/src/emc/task/Submakefile
+++ b/src/emc/task/Submakefile
@@ -5,7 +5,7 @@ USERSRCS += $(EMCSVRSRCS)
 
 ../bin/linuxcncsvr: $(call TOOBJS, $(EMCSVRSRCS)) ../lib/liblinuxcnchal.so.0 ../lib/liblinuxcnc.a ../lib/libnml.so.0 ../lib/liblinuxcncini.so.0
 	$(ECHO) Linking $(notdir $@)
-	@$(CXX) $(LDFLAGS) -o $@ $^
+	$(Q)$(CXX) $(LDFLAGS) -o $@ $^
 TARGETS += ../bin/linuxcncsvr
 
 # disabled:	emc/task/iotaskintf.cc

--- a/src/po/Submakefile
+++ b/src/po/Submakefile
@@ -56,8 +56,8 @@ TCLSRCS := \
 
 po/linuxcnc.pot:
 	$(ECHO) Localizing linuxcnc.pot
-	(cd ..; $(XGETTEXT) -k_ -o src/$@ `$(PYTHON) src/po/fixpaths.py -j src $^`)
-	touch $@
+	$(Q)(cd ..; $(XGETTEXT) -k_ -o src/$@ `$(PYTHON) src/po/fixpaths.py -j src $^`)
+	$(Q)touch $@
 TARGETS += po/linuxcnc.pot
 
 pofiles: po/linuxcnc.pot


### PR DESCRIPTION
This PR contains a few tweaks to the build system:

- Tweak build console output
- Add mode settings to `Makefile.*.in` for us emacs users
- Remove a redundant `gcc -I../include` arg
- Silence warning from the make macro `cc-option`
