### PR TITLE
Move HAL private functions out of interp

### DIFF
--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -44,7 +44,6 @@ namespace bp = boost::python;
 
 // for HAL pin variables
 #include "hal.h"
-#include "hal/hal_priv.h"
 
 enum predefined_named_parameters {
     NP_LINE,
@@ -232,8 +231,9 @@ int Interp::fetch_hal_param( const char *nameBuf, int *status, double *value)
 {
     static int comp_id;
     int retval;
-    int type = 0;
+    hal_type_t type = HAL_TYPE_UNINITIALIZED;
     hal_data_u* ptr;
+    bool conn;
     char hal_name[LINELEN];
 
     *status = 0;
@@ -250,9 +250,6 @@ int Interp::fetch_hal_param( const char *nameBuf, int *status, double *value)
 	((s = (char *) strchr(&nameBuf[5],']')) != NULL)) {
 
 	int closeBracket = s - nameBuf;
-	hal_pin_t *pin;
-	hal_sig_t *sig;
-	hal_param_t *param;
 
 	strncpy(hal_name, &nameBuf[5], closeBracket);
 	hal_name[closeBracket - 5] = '\0';
@@ -268,29 +265,17 @@ int Interp::fetch_hal_param( const char *nameBuf, int *status, double *value)
 	// rtapi_mutex_get(&(hal_data->mutex)); 
         // rtapi_mutex_give(&(hal_data->mutex));
 
-	if ((pin = halpr_find_pin_by_name(hal_name)) != NULL) {
-            if (pin && !pin->signal) {
+        if (hal_get_pin_value_by_name(hal_name, &type, &ptr, &conn) == 0) {
+            if (!conn)
 		logOword("%s: no signal connected", hal_name);
-	    } 
-	    type = pin->type;
-	    if (pin->signal != 0) {
-		sig = (hal_sig_t *) SHMPTR(pin->signal);
-		ptr = (hal_data_u *) SHMPTR(sig->data_ptr);
-	    } else {
-		ptr = (hal_data_u *) &(pin->dummysig);
-	    }
 	    goto assign;
 	}
-	if ((sig = halpr_find_sig_by_name(hal_name)) != NULL) {
-	    if (!sig->writers) 
+        if (hal_get_signal_value_by_name(hal_name, &type, &ptr, &conn) == 0) {
+	    if (!conn)
 		logOword("%s: signal has no writer", hal_name);
-	    type = sig->type;
-	    ptr = (hal_data_u *) SHMPTR(sig->data_ptr);
 	    goto assign;
 	}
-	if ((param = halpr_find_param_by_name(hal_name)) != NULL) {
-	    type = param->type;
-	    ptr = (hal_data_u *) SHMPTR(param->data_ptr);
+        if (hal_get_param_value_by_name(hal_name, &type, &ptr) == 0) {
 	    goto assign;
 	}
 	*status = 0;
@@ -304,6 +289,7 @@ int Interp::fetch_hal_param( const char *nameBuf, int *status, double *value)
     case HAL_U32: *value = (double) (ptr->u); break;
     case HAL_S32: *value = (double) (ptr->s); break;
     case HAL_FLOAT: *value = (double) (ptr->f); break;
+    default: return -1;
     }
     logOword("%s: value=%f", hal_name, *value);
     *status = 1;

--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -234,11 +234,11 @@ int Interp::fetch_hal_param( const char *nameBuf, int *status, double *value)
     hal_type_t type = HAL_TYPE_UNINITIALIZED;
     hal_data_u* ptr;
     bool conn;
-    char hal_name[LINELEN];
+    char hal_name[HAL_NAME_LEN];
 
     *status = 0;
     if (!comp_id) {
-	char hal_comp[LINELEN];
+	char hal_comp[HAL_NAME_LEN];
 	snprintf(hal_comp, sizeof(hal_comp),"interp%d",getpid());
 	comp_id = hal_init(hal_comp); // manpage says: NULL ok - which fails miserably
 	CHKS(comp_id < 0,_("fetch_hal_param: hal_init(%s): %d"), hal_comp,comp_id);

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -256,6 +256,7 @@ extern char* hal_comp_name(int comp_id);
 */
 typedef enum {
     HAL_TYPE_UNSPECIFIED = -1,
+    HAL_TYPE_UNINITIALIZED = 0,
     HAL_BIT = 1,
     HAL_FLOAT = 2,
     HAL_S32 = 3,
@@ -302,6 +303,24 @@ typedef rtapi_u64 ireal_t __attribute__((aligned(8))); // integral type as wide 
 
 #define hal_float_t volatile real_t
        
+/** HAL "data union" structure
+ ** This structure may hold any type of hal data
+*/
+typedef union {
+    hal_bit_t b;
+    hal_s32_t s;
+    hal_u32_t u;
+    hal_float_t f;
+    hal_port_t p;
+} hal_data_u;
+
+typedef struct {
+    volatile unsigned int read;  //offset into buff that outgoing data gets read from
+    volatile unsigned int write; //offset into buff that incoming data gets written to
+    unsigned int size;           //size of allocated buffer
+    char buff[];
+} hal_port_shm_t;
+
 /***********************************************************************
 *                      "LOCKING" FUNCTIONS                             *
 ************************************************************************/
@@ -596,6 +615,42 @@ extern int hal_param_alias(const char *pin_name, const char *alias);
     it returns a negative error code.
 */
 extern int hal_param_set(const char *name, hal_type_t type, void *value_addr);
+
+/***********************************************************************
+*                 PIN/SIG/PARAM GETTER FUNCTIONS                       *
+************************************************************************/
+
+/** 'hal_get_pin_value_by_name()' gets the value of any arbitrary HAL pin by
+ * pin name.
+ *
+ * The 'type' and 'data' args are pointers to the returned values.  The function
+ * returns 0 if successful, or -1 on error.  If 'connected' is non-NULL, its
+ * value will be true if a signal is connected.
+ */
+
+extern int hal_get_pin_value_by_name(
+    const char *name, hal_type_t *type, hal_data_u **data, bool *connected);
+
+/** 'hal_get_signal_value_by_name()' returns the value of any arbitrary HAL
+ * signal by signal name.
+ *
+ * The 'type' and 'data' args are pointers to the returned values.  The function
+ * returns 0 if successful, or -1 on error.  If 'has_writers' is non-NULL, its
+ * value will be true if the signal has writers.
+ */
+
+extern int hal_get_signal_value_by_name(
+    const char *name, hal_type_t *type, hal_data_u **data, bool *has_writers);
+
+/** 'hal_get_param_value_by_name()' returns the value of any arbitrary HAL
+ * parameter by parameter name.
+ *
+ * The 'type' and 'data' args are pointers to the returned values.  The function
+ * returns 0 if successful, or -1 on error.
+ */
+
+extern int hal_get_param_value_by_name(
+    const char *name, hal_type_t *type, hal_data_u **data);
 
 /***********************************************************************
 *                   EXECUTION RELATED FUNCTIONS                        *

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -1673,6 +1673,57 @@ int hal_param_alias(const char *param_name, const char *alias)
 }
 
 /***********************************************************************
+*                 PIN/SIG/PARAM GETTER FUNCTIONS                       *
+************************************************************************/
+
+int hal_get_pin_value_by_name(
+    const char *hal_name, hal_type_t *type, hal_data_u **data, bool *connected)
+{
+    hal_pin_t *pin;
+    hal_sig_t *sig;
+    if ((pin = halpr_find_pin_by_name(hal_name)) == NULL)
+        return -1;
+
+    if (connected != NULL)
+        *connected = pin && pin->signal;
+    *type = pin->type;
+    if (pin->signal != 0) {
+        sig = (hal_sig_t *) SHMPTR(pin->signal);
+        *data = (hal_data_u *) SHMPTR(sig->data_ptr);
+    } else {
+        *data = (hal_data_u *) &(pin->dummysig);
+    }
+    return 0;
+}
+
+int hal_get_signal_value_by_name(
+    const char *hal_name, hal_type_t *type, hal_data_u **data, bool *has_writers)
+{
+    hal_sig_t *sig;
+    if ((sig = halpr_find_sig_by_name(hal_name)) == NULL)
+        return -1;
+
+    if (has_writers != NULL)
+        *has_writers = !!sig->writers;
+    *type = sig->type;
+    *data = (hal_data_u *) SHMPTR(sig->data_ptr);
+    return 0;
+}
+
+int hal_get_param_value_by_name(
+    const char *hal_name, hal_type_t *type, hal_data_u **data)
+{
+    hal_param_t *param;
+    if ((param = halpr_find_param_by_name(hal_name)) == NULL)
+        return -1;
+
+    *type = param->type;
+    *data = (hal_data_u *) SHMPTR(param->data_ptr);
+    return 0;
+}
+
+
+/***********************************************************************
 *                   EXECUTION RELATED FUNCTIONS                        *
 ************************************************************************/
 

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -119,24 +119,6 @@ RTAPI_BEGIN_DECLS
 *            PRIVATE HAL DATA STRUCTURES AND DECLARATIONS              *
 ************************************************************************/
 
-/** HAL "data union" structure
- ** This structure may hold any type of hal data
-*/
-typedef union {
-    hal_bit_t b;
-    hal_s32_t s;
-    hal_u32_t u;
-    hal_float_t f;
-    hal_port_t p;
-} hal_data_u;
-
-typedef struct {
-    volatile unsigned int read;  //offset into buff that outgoing data gets read from
-    volatile unsigned int write; //offset into buff that incoming data gets written to
-    unsigned int size;           //size of allocated buffer
-    char buff[];                 
-} hal_port_shm_t;
-
 /** HAL "list element" data structure.
     This structure is used to implement generic double linked circular
     lists.  Such lists have the following characteristics:

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -323,6 +323,7 @@ static PyObject *pyhal_read_common(halitem *item) {
             case HAL_FLOAT: return to_python(*(item->u->pin.f));
             case HAL_PORT: // HAL_PORT is currently not supported
             case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
+            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
         }
     } else {
         switch(item->type) {
@@ -332,6 +333,7 @@ static PyObject *pyhal_read_common(halitem *item) {
             case HAL_FLOAT: return to_python(item->u->param.f);
             case HAL_PORT: // HAL_PORT is currently not supported
             case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
+            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
         }
     }
     PyErr_Format(pyhal_error_type, "Invalid item type %d", item->type);
@@ -1010,6 +1012,7 @@ PyObject *get_value(PyObject *self, PyObject *args) {
             case HAL_FLOAT: return Py_BuildValue("f",  (double)*(hal_float_t *)d_ptr);
             case HAL_PORT: // HAL_PORT is currently not supported
             case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
+            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
         }
     }
     /* not found, search pin list for name */
@@ -1033,6 +1036,7 @@ PyObject *get_value(PyObject *self, PyObject *args) {
             case HAL_FLOAT: return Py_BuildValue("f",  (double)*(hal_float_t *)d_ptr);
             case HAL_PORT: // HAL_PORT is currently not supported
             case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
+            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
         }
     }
     sig = halpr_find_sig_by_name(name);
@@ -1049,6 +1053,7 @@ PyObject *get_value(PyObject *self, PyObject *args) {
             case HAL_FLOAT: return Py_BuildValue("f",  (double)*(hal_float_t *)d_ptr);
             case HAL_PORT: // HAL_PORT is currently not supported
             case HAL_TYPE_UNSPECIFIED: /* fallthrough */ ;
+            case HAL_TYPE_UNINITIALIZED: /* fallthrough */ ;
         }
     }
     /* error if here */

--- a/src/libnml/inifile/inifile.cc
+++ b/src/libnml/inifile/inifile.cc
@@ -204,7 +204,7 @@ IniFile::Find(const char *_tag, const char *_section, int _num, int *lineno)
 
     char  eline [(LINELEN + 2) * (MAX_EXTEND_LINES + 1)];
     char* elineptr;
-    char* elinenext;
+    char* elinenext = eline;
     int   extend_ct = 0;
 
     // For exceptions.


### PR DESCRIPTION
Interp should only connect to HAL through public APIs.  This patch
introduces pin, signal and param getter functions to the public HAL
API and replaces interp calls to private functions with these.

Also, use the standard `HAL_NAME_LEN` for a couple of buffers
used to store HAL names.

Also, silence a compiler warning in `libnml/inifile/inifile.cc`.