### PR TITLE
Axis GUI: add missing '[]' parentheses around touch-off expression

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -2436,7 +2436,8 @@ class TclCommands(nf.TclCommands):
         if linear_axis and 210 in s.gcodes:
             scale *= 25.4
 
-        offset_command = "G10 L20 %s %c[%s*%.12f]" % (system.split()[0], vars.current_axis.get(), new_axis_value, scale)
+        offset_command = "G10 L20 %s %c[[%s]*%.12f]" % (system.split()[0], vars.current_axis.get(), new_axis_value, scale)
+
         c.mdi(offset_command)
         c.wait_complete()
 
@@ -2475,7 +2476,7 @@ class TclCommands(nf.TclCommands):
             scale *= 25.4
 
         lnum = 10 + vars.tto_g11.get()
-        offset_command = "G10 L%d P%d %c[%s*%.12f]" % (lnum, s.tool_in_spindle, vars.current_axis.get(), new_axis_value, scale)
+        offset_command = "G10 L%d P%d %c[[%s]*%.12f]" % (lnum, s.tool_in_spindle, vars.current_axis.get(), new_axis_value, scale)
         c.mdi(offset_command)
         c.wait_complete()
         c.mdi("G43")


### PR DESCRIPTION
This makes touch-off expressions work when the internal scale is not
1.0, ie when Axis is in metric view mode.  Before this commit, the scale
would be applied only to the last token in the expression.

This fixes #867, and fixes a similar unreported bug for tool-length
touch-off.