### PR TITLE
G33.1 Fix for #639 & #703

### DIFF
--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -2452,6 +2452,8 @@ STATIC int tpUpdateMovementStatus(TP_STRUCT * const tp, TC_STRUCT const * const 
         emcmotStatus->enables_queued = emcmotStatus->enables_new;
         emcmotStatus->requested_vel = 0;
         emcmotStatus->current_vel = 0;
+        emcmotStatus->spindleSync = 0;
+        
         emcPoseZero(&emcmotStatus->dtg);
 
         tp->motionType = 0;


### PR DESCRIPTION
Reset emcmotStatus->spindleSync on abort / empty queue
Otherwise successive spindle synched moves do not wait for index, so there
is no reset and a rapid move to catch up ensues.

Signed-off-by: andy pugh <andy@bodgesoc.org>