### PR TITLE
Improve hm2_eth logging

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -522,7 +522,7 @@ static int fetch_hwaddr(const char *board_ip, int sockfd, unsigned char buf[6]) 
     // eeprom order is backwards from arp AF_LOCAL order
     for(i=0; i<6; i++) buf[i] = response[5-i];
 
-    LL_PRINT("%s: Hardware address: %02x:%02x:%02x:%02x:%02x:%02x\n",
+    LL_PRINT("%s: INFO: Hardware address (MAC): %02x:%02x:%02x:%02x:%02x:%02x\n",
         board_ip, buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]);
 
     return 0;
@@ -594,13 +594,13 @@ static int init_board(hm2_eth_t *board, const char *board_ip) {
     board->req.arp_flags = ATF_PERM | ATF_COM;
     ret = fetch_hwaddr( board_ip, board->sockfd, (void*)&board->req.arp_ha.sa_data );
     if(ret < 0) {
-        LL_PRINT("ERROR: %s: Could not retrieve mac address\n", board_ip);
+        LL_PRINT("ERROR: Could not retrieve hardware address (MAC) of %s: %s\n", board_ip, strerror(-ret));
         return ret;
     }
 
     ret = ioctl_siocsarp(board);
     if(ret < 0) {
-        perror("ioctl SIOCSARP");
+        LL_PRINT("ERROR: ioctl SIOCSARP failed: %s\n", strerror(errno));
         board->req.arp_flags &= ~ATF_PERM;
         return -errno;
     }


### PR DESCRIPTION
 - add printing stringified 'errno' value,
 - add ERROR prefix for 'ioctl SIOCSARP' failure,
 - unify usage of hardware address and MAC.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>