### PR TITLE
Remove sincos() usage (2.8 version)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -773,6 +773,7 @@ EXTRA_CFLAGS += -msse
 EXTRA_CFLAGS += -g
 endif
 endif
+EXTRA_CFLAGS += -fno-builtin-sin -fno-builtin-cos -fno-builtin-sincos
 
 ifeq "$(USE_STUBS)" "1"
 MATHSTUB := rtapi/mathstubs.o

--- a/src/Makefile.modinc.in
+++ b/src/Makefile.modinc.in
@@ -69,6 +69,7 @@ ifeq ($(RTARCH):$(RTAI):$(filter $(RTFLAGS),-msse),x86_64:3:)
 EXTRA_CFLAGS += -msse
 endif
 endif
+EXTRA_CFLAGS += -fno-builtin-sin -fno-builtin-cos -fno-builtin-sincos
 USE_RTLIBM = @USE_RTLIBM@
 EMC2_HOME=@EMC2_HOME@
 RUN_IN_PLACE=@RUN_IN_PLACE@

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1246,25 +1246,6 @@ AH_VERBATIM([_GNU_SOURCE],
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_CHECK_FUNCS(semtimedop)
-LIBS_hold=$LIBS
-LIBS="$LIBS -lm"
-
-AC_MSG_CHECKING([for sincos function])
-sincos_ok=yes
-AC_TRY_LINK(
-    [double a, b;],
-    [sincos(1.0, &a, &b);],
-    AC_DEFINE(
-        [HAVE_SINCOS],
-        1,
-        [Define to 1 if sincos is available.]
-    ),
-    [sincos_ok=no]
-)
-AC_MSG_RESULT([$sincos_ok])
-
-AC_CHECK_FUNCS(__sincos)
-LIBS=$LIBS_hold
 
 AC_MSG_CHECKING([for optreset])
 AC_TRY_LINK(

--- a/src/libnml/posemath/_posemath.c
+++ b/src/libnml/posemath/_posemath.c
@@ -177,7 +177,7 @@ int pmAxisAngleQuatConvert(PmAxis axis, double a, PmQuaternion * const q)
     double sh;
 
     a *= 0.5;
-    sincos(a, &sh, &(q->s));
+    pm_sincos(a, &sh, &(q->s));
 
     switch (axis) {
     case PM_X:
@@ -239,7 +239,7 @@ int pmRotQuatConvert(PmRotationVector const * const r, PmQuaternion * const q)
 	return pmErrno = 0;
     }
 
-    sincos(r->s / 2.0, &sh, &(q->s));
+    pm_sincos(r->s / 2.0, &sh, &(q->s));
 
     if (q->s >= 0.0) {
 	q->x = r->x * sh;
@@ -268,7 +268,7 @@ int pmRotMatConvert(PmRotationVector const * const r, PmRotationMatrix * const m
     }
 #endif
 
-    sincos(r->s, &s, &c);
+    pm_sincos(r->s, &s, &c);
 
     /* from space book */
     m->x.x = c + pmSq(r->x) * (omc = 1 - c);	/* omc = One Minus Cos */
@@ -1087,7 +1087,7 @@ int pmQuatAxisAngleMult(PmQuaternion const * const q, PmAxis axis, double angle,
 #endif
 
     angle *= 0.5;
-    sincos(angle, &sh, &ch);
+    pm_sincos(angle, &sh, &ch);
 
     switch (axis) {
     case PM_X:

--- a/src/libnml/posemath/gomath.c
+++ b/src/libnml/posemath/gomath.c
@@ -71,8 +71,8 @@ int go_sph_cart_convert(const go_sph * s, go_cart * v)
 {
   go_real sth, cth, sph, cph;
 
-  sincos(s->theta, &sth, &cth);
-  sincos(s->phi, &sph, &cph);
+  pm_sincos(s->theta, &sth, &cth);
+  pm_sincos(s->phi, &sph, &cph);
 
   v->x = s->r * cth * sph;
   v->y = s->r * sth * sph;
@@ -85,7 +85,7 @@ int go_sph_cyl_convert(const go_sph * s, go_cyl * c)
 {
   go_real sph, cph;
 
-  sincos(s->phi, &sph, &cph);
+  pm_sincos(s->phi, &sph, &cph);
 
   c->theta = s->theta;
   c->r = s->r * sph;
@@ -138,7 +138,7 @@ int go_rvec_quat_convert(const go_rvec * r, go_quat * q)
 
   (void) go_cart_mag(&vec, &mag);
 
-  sincos(0.5 * mag, &sh, &(q->s));
+  pm_sincos(0.5 * mag, &sh, &(q->s));
 
   if (q->s >= 0) {
     q->x = uvec.x * sh;
@@ -175,7 +175,7 @@ int go_rvec_mat_convert(const go_rvec * r, go_mat * m)
 
   (void) go_cart_mag(&vec, &mag);
 
-  sincos(mag, &s, &c);
+  pm_sincos(mag, &s, &c);
   omc = 1 - c;
 
   m->x.x = c + go_sq(uvec.x) * omc;
@@ -3629,8 +3629,8 @@ int go_dh_pose_convert(const go_dh * dh, go_pose * p)
   go_real sth, cth;		/* sin, cos theta[i] */
   go_real sal, cal;		/* sin, cos alpha[i-1] */
 
-  sincos(dh->theta, &sth, &cth);
-  sincos(dh->alpha, &sal, &cal);
+  pm_sincos(dh->theta, &sth, &cth);
+  pm_sincos(dh->alpha, &sal, &cal);
 
   h.rot.x.x = cth, h.rot.y.x = -sth, h.rot.z.x = 0.0;
   h.rot.x.y = sth*cal, h.rot.y.y = cth*cal, h.rot.z.y = -sal;

--- a/src/libnml/posemath/sincos.c
+++ b/src/libnml/posemath/sincos.c
@@ -19,25 +19,11 @@
 
 #include "config.h"
 
-#if defined(__KERNEL__)
-#undef HAVE_SINCOS
-#endif
-
-#ifndef HAVE_SINCOS
-
 #include "rtapi_math.h"
 #include "sincos.h"
 
-#ifndef HAVE___SINCOS
-
-#include "posemath.h"
-
-void sincos(double x, double *sx, double *cx)
+void pm_sincos(double x, double *sx, double *cx)
 {
     *sx = sin(x);
     *cx = cos(x);
 }
-
-#endif
-
-#endif

--- a/src/libnml/posemath/sincos.h
+++ b/src/libnml/posemath/sincos.h
@@ -15,27 +15,6 @@
 #ifndef SINCOS_H
 #define SINCOS_H
 
-#include "config.h"
-/*
-  for each platform that has built-in support for the sincos function,
-  that should be discovered by ./configure
-*/
-
-/* testing for sincos now supported by ./configure */
-#ifdef HAVE___SINCOS
-#define sincos __sincos
-#endif
-
-
-/*
-  all other platforms will not have __sincos, and will
-  get the declaration for the explicit function
-*/
-
-#ifndef HAVE___SINCOS
-
-extern void sincos(double x, double *sx, double *cx);
-
-#endif
+extern void pm_sincos(double x, double *sx, double *cx);
 
 #endif /* #ifndef SINCOS_H */

--- a/src/tests/mathtest.c
+++ b/src/tests/mathtest.c
@@ -34,6 +34,7 @@
 #include <math.h>		/* sin(), cos(), isnan() etc. */
 #include <float.h>		/* DBL_MAX */
 #include <errno.h>		/* errno, EDOM */
+#include "sincos.h"
 
 /*
   math functions are:
@@ -138,7 +139,7 @@ int math_test(void)
       floor(a) + fabs(a) + ldexp(a, b);
 
   /* Test the sincos func */
-  sincos(x, &v, &u);
+  pm_sincos(x, &v, &u);
 
   return 0;
 }


### PR DESCRIPTION
If we're still merging up then #894 can be closed when this is merged.

This also adds the removal of the configure checks for sincos, like andy suggested.