### PR TITLE
Fix tests rtapi printf

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -282,6 +282,7 @@ INFILES = \
 	../share/applications/linuxcnc-latency.desktop \
 	../scripts/linuxcnc_var \
 	../scripts/halcmd_twopass \
+	../scripts/runtests \
 
 $(INFILES): %: %.in config.status
 	@./config.status --file=$@

--- a/tests/rtapi_printf.0/test.sh
+++ b/tests/rtapi_printf.0/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-g++ -DULAPI -I${HEADERS} -std=c++11 -I${HEADERS} \
+g++ -DULAPI -I${HEADERS} -std=c++0x -I${HEADERS} \
     -DSIM -rdynamic -L${LIBDIR} \
     -o test_rtapi_vsnprintf test_rtapi_vsnprintf.c
 ./test_rtapi_vsnprintf


### PR DESCRIPTION
This was broken by #888 on older architectures, since a compiler flag was included unconditionally.  Also, a problem was introduced in the build system.
