### PR TITLE
Use distinguishable error messages

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/tram.c
+++ b/src/hal/drivers/mesa-hostmot2/tram.c
@@ -165,7 +165,7 @@ int hm2_tram_read(hostmot2_t *hm2) {
 int hm2_queue_read(hostmot2_t *hm2) {
     if (!hm2->llio->send_queued_reads) return 0;
     if (!hm2->llio->send_queued_reads(hm2->llio)) {
-        HM2_ERR("error finishing read! iter=%u)\n",
+        HM2_ERR("error queuing read! iter=%u)\n",
             tram_read_iteration);
         return -EIO;
     }


### PR DESCRIPTION
Both hm2_queue_read() and hm2_finish_read() uses
the same error message:
  "error finishing read! iter=%u\n".

Use a different error message for each of the function
to easily deduce from which location the error
comes from.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>