### PR TITLE
packaging: Do not require 'six' for doc building

### DIFF
--- a/docs/src/image-wildcard
+++ b/docs/src/image-wildcard
@@ -3,27 +3,23 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import os, sys, glob
-from six.moves import map
 
-try:
-	from os.path import relpath
-except:
-	def relpath(path, start=os.path.curdir):
-	    """Return a relative version of a path"""
+def relpath(path, start):
+    """Return a relative version of a path"""
 
-	    if not path:
-	        raise ValueError("no path specified")
+    if not path:
+        raise ValueError("no path specified")
 
-	    start_list = os.path.abspath(start).split(os.path.sep)
-	    path_list = os.path.abspath(path).split(os.path.sep)
+    start_list = os.path.abspath(start).split(os.path.sep)
+    path_list = os.path.abspath(path).split(os.path.sep)
 
-	    # Work out how much of the filepath is shared by start and path.
-	    i = len(os.path.commonprefix([start_list, path_list]))
+    # Work out how much of the filepath is shared by start and path.
+    i = len(os.path.commonprefix([start_list, path_list]))
 
-	    rel_list = [os.path.pardir] * (len(start_list)-i) + path_list[i:]
-	    if not rel_list:
-	        return os.path.curdir
-	    return os.path.join(*rel_list)
+    rel_list = [os.path.pardir] * (len(start_list)-i) + path_list[i:]
+    if not rel_list:
+        return os.path.curdir
+    return os.path.join(*rel_list)
 
 if len(sys.argv) > 1:
 	image = sys.argv[1]
@@ -34,7 +30,7 @@ else:
 	docpath = '.'
 
 if len(sys.argv) > 3 and str.strip(sys.argv[3]):
-	exts = list(map(str.strip, sys.argv[3].split(',')))
+	exts = [s.strip() for s in sys.argv[3].split(',')]
 else:
 	# Standard images for web
 	exts = ['png', 'svg', 'jpg', 'jpeg']


### PR DESCRIPTION
Silent failures were occurring during the doc build because the
program `image-wildcard` could not be executed:
http://buildbot.linuxcnc.org/buildbot/builders/4042.deb-buster-rtpreempt-rpi4/builds/163/steps/shell_3/logs/stdio

    Traceback (most recent call last):
      File "../docs/src/image-wildcard", line 6, in <module>
        from six.moves import map
    ImportError: No module named six.moves

Rather than depending on six (which we _could_ do), just remove the
need for it.

While we're here, unconditionally use `relpath` just so we know
whether it works.

Testing performed: built html docs locally.  Inspected make output
and viewed axis.html; images were present.

Note:  There is no way I could find to make failures in asciidoc
`sys:` to cause asciidoc to indicate build failure back to make.
The only way to see such problems is apparently to read through
all the make output, or inspect the generated documentation files.

Note 2: This is likely to fail on buster-ish systems when imagemagic
is configured to block all reading and writing of PDF files, which was
recently done due to a known security problem in ghotscript:

    https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=964090