### PR TITLE
uspace: non-rt: Enable error-checking mode of mutexes

### DIFF
--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -493,7 +493,7 @@ static int
 get_fifo_path(char *buf, size_t bufsize) {
     const char *s = get_fifo_path();
     if(!s) return -1;
-    strncpy(buf, s, bufsize);
+    snprintf(buf, bufsize, "%s", s);
     return 0;
 }
 


### PR DESCRIPTION
It has been suggested at #912 that there may be a case where "you will simply try to unlock unlocked mutex which will generate undefined behavior".  By switching from normal to error-check, we will get an error result instead, which will promptly cause rtapi_app to abort.