### PR TITLE
Rootless preempt-rt mode (Work in Progress)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,12 @@ jobs:
         ./configure --with-realtime=uspace --disable-check-runtime-deps
         make -O -j$((1+$(nproc))) default pycheck V=1
         # Note that the package build covers html docs
-        ../scripts/rip-environment runtests -p
-    
+        sudo setcap cap_ipc_lock,cap_net_admin,cap_sys_rawio,cap_sys_nice+ep ../bin/rtapi_app
+        timeout --signal=9 3600 ../scripts/rip-environment runtests -vp || \
+          ([ -e ~/linuxcnc_debug.txt ] && (echo linuxcnc_debug.txt; cat ~/linuxcnc_debug.txt); \
+           [ -e ~/linuxcnc_print.txt ] && (echo linuxcnc_print.txt; cat ~/linuxcnc_print.txt); \
+           false)
+
   htmldocs:
     runs-on: ubuntu-16.04
     steps:

--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -368,7 +368,7 @@ static bool chain_exists() {
     return result == EXIT_SUCCESS;
 }
 
-static int iptables_state = -1;
+static int iptables_state = 0;
 static bool use_iptables() {
     if(iptables_state == -1) {
         if(!chain_exists()) {

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -397,7 +397,7 @@ static int rtapi_clock_nanosleep(clockid_t clock_id, int flags,
         const struct timespec *pnow)
 {
 #if defined(HAVE_CLOCK_NANOSLEEP)
-    return clock_nanosleep(clock_id, flags, prequest, remain);
+    return TEMP_FAILURE_RETRY(clock_nanosleep(clock_id, flags, prequest, remain));
 #else
     if(flags == 0)
         return nanosleep(prequest, remain);


### PR DESCRIPTION
Allows to run linuxcnc in `preempt-rt` mode without root _(setuid bit)_.

Benefits:
 - allows to always run using `SCHED_FIFO` policy _(on both rt and non-rt kernels)_,
 - `CI` flow can use and tests exactly the same code flow as will be used on the production,
 - `latency-test` _(on modern hardware)_ should return much more reliable results on non-rt kernel,
 - will help packaging `linuxcnc` in Fedora _(see: [setuid removal](https://fedoraproject.org/wiki/Features/RemoveSETUID))_ and maybe other distros where `setuid` binaries are not welcome.

How to run it:
- In order to run it in place, just set the following capabilities:
```
$ sudo setcap cap_ipc_lock,cap_net_admin,cap_sys_rawio,cap_sys_nice+ep  bin/rtapi_app
```
- If you're going to use parallel port, just add yourself to the appropriate group _(as you would do for accessing printer)_.


TODO list:
  - [ ] add something like `make setcap` target to set capabilities on `rtapi_app`,
  - [ ] decide how to clean up the API: like rtapi_is_realtime(),
  - [ ] add an option to not invoke `iptables` in hm2_eth.c _(it's much easier and more reliable to configure the rules using firewalld/NetworkManager e.g. on Fedora >=32 firewalld switched from iptables to [nftables backend](https://firewalld.org/2018/07/nftables-backend))_,
  - [ ] test with pci cards _(currently tested with parport and ethernet based mesa card)_,
  - [ ] very likely other things were missed - would appreciate to get a feedback.
