### PR TITLE
Change Standards-Version depending on distribution

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -745,7 +745,7 @@ linuxcnc (1:2.7.5) unstable; urgency=medium
   * build: make failure copying images an error
   * packaging: interface with udev better
 
- -- Sebastian Kuzminsky <seb@highlab.com>  Tue, 12 July 2016 21:47:18 -0600
+ -- Sebastian Kuzminsky <seb@highlab.com>  Tue, 12 Jul 2016 21:47:18 -0600
 
 linuxcnc (1:2.7.4) unstable; urgency=medium
 

--- a/debian/configure
+++ b/debian/configure
@@ -163,35 +163,32 @@ case $DISTRIB_NAME in
         EXTRA_BUILD=python-yapps
         YAPPS_RUNTIME="python-yapps"
         ;;
-Debian-9.*|Debian-10|Debian-10.*|Raspbian-9.*|Debian-testing|LinuxMint-19.*|Ubuntu-18.*)
+    Debian-9.*|Raspbian-9.*|LinuxMint-19.*|Ubuntu-18.*)
         DOC_DEPENDS="$DOC_DEPENDS, asciidoc-dblatex"
         PYTHON_GST=python-gst-1.0,gstreamer1.0-plugins-base
         ;;
-Debian-8.*|Raspbian-8.*) # Jessie
+    Debian-8.*|Raspbian-8.*) # Jessie
         ;;
-Debian-7.*|Raspbian-7) # Wheezy
+    Debian-7.*|Raspbian-7) # Wheezy
         EXTRA_BUILD=libgnomeprintui2.2-dev
         PYTHON_PACKAGING_DEPENDS=python-support
         PYTHON_PACKAGING=dh_pysupport
         TCLTK_VERSION=8.5
         ;;
-Ubuntu-18.*) # Bionic Beaver
-        PYTHON_GST=python-gst-1.0,gstreamer1.0-plugins-base
+    Ubuntu-1[456].*|LinuxMint-1[78]*) # Trusty through Xenial, LinuxMint 17 and 18
         ;;
-Ubuntu-1[456].*|LinuxMint-1[78]*) # Trusty through Xenial, LinuxMint 17 and 18
-	;;
-Ubuntu-1[12].*) # Natty Narwhal, Precise Pangolin (LTS), Quantal Quetzal
+    Ubuntu-1[12].*) # Natty Narwhal, Precise Pangolin (LTS), Quantal Quetzal
         EXTRA_BUILD=libgnomeprintui2.2-dev
         MODUTILS_DEPENDS=module-init-tools
         PYTHON_PACKAGING_DEPENDS=python-support
         PYTHON_PACKAGING=dh_pysupport
-	TCLTK_VERSION=8.5
-	;;
-*)
+        TCLTK_VERSION=8.5
+        ;;
+    *)
         echo "unknown distribution: $DISTRIB_NAME"
         echo "detected dependencies may be incomplete or wrong"
         echo "please consider fixing it and submitting a pull request"
-	;;
+        ;;
 esac
 
 TARGET_EXTRA=

--- a/debian/configure
+++ b/debian/configure
@@ -155,6 +155,7 @@ TCLTK_VERSION=8.6
 PYTHON_IMAGING="python${PYTHON_VERSION}-imaging | python-imaging | python-pil"
 PYTHON_IMAGING_TK="python${PYTHON_VERSION}-imaging-tk | python-imaging-tk | python-pil.imagetk"
 YAPPS_RUNTIME="yapps2-runtime"
+STANDARDS_VERSION="3.9.3"
 
 case $DISTRIB_NAME in
     Debian-10|Debian-10.*|Raspbian-10|Raspbian-10.*)
@@ -162,18 +163,22 @@ case $DISTRIB_NAME in
         PYTHON_GST=python-gst-1.0,gstreamer1.0-plugins-base
         EXTRA_BUILD=python-yapps
         YAPPS_RUNTIME="python-yapps"
+        STANDARDS_VERSION="4.3.0"
         ;;
     Debian-9.*|Raspbian-9.*|LinuxMint-19.*|Ubuntu-18.*)
         DOC_DEPENDS="$DOC_DEPENDS, asciidoc-dblatex"
         PYTHON_GST=python-gst-1.0,gstreamer1.0-plugins-base
+        STANDARDS_VERSION="3.9.8"
         ;;
     Debian-8.*|Raspbian-8.*) # Jessie
+        STANDARDS_VERSION="3.9.6"
         ;;
     Debian-7.*|Raspbian-7) # Wheezy
         EXTRA_BUILD=libgnomeprintui2.2-dev
         PYTHON_PACKAGING_DEPENDS=python-support
         PYTHON_PACKAGING=dh_pysupport
         TCLTK_VERSION=8.5
+        STANDARDS_VERSION="3.9.4"
         ;;
     Ubuntu-1[456].*|LinuxMint-1[78]*) # Trusty through Xenial, LinuxMint 17 and 18
         ;;
@@ -264,6 +269,7 @@ sed \
     -e "s#@TCLTK_VERSION@#$TCLTK_VERSION#g" \
     -e "s#@XENOMAI_ARCHITECTURE@#$XENOMAI_ARCHITECTURE#g" \
     -e "s|@YAPPS_RUNTIME@|$YAPPS_RUNTIME|g" \
+    -e "s#@STANDARDS_VERSION@#$STANDARDS_VERSION#g" \
     $*
 }
 

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -30,7 +30,7 @@ Build-Depends: debhelper (>= 6),
     psmisc,
     desktop-file-utils,
     yapps2,
-Standards-Version: 3.9.2
+Standards-Version: @STANDARDS_VERSION@
 Vcs-Browser: https://github.com/LinuxCNC/linuxcnc
 Vcs-Git: git://github.com/linuxcnc/linuxcnc.git
 


### PR DESCRIPTION
The change in debian/changelog is because of a warning, replicated with this command
`dpkg-parsechangelog --all | head`

I updated the default Standards-Version to 3.9.3 which is what lintian in Ubuntu Precise claims is correct, This is also the lowest version we should hit with LinuxCNC 2.8.
This site [http://wiki.linuxcnc.org/cgi-bin/wiki.pl?MinimumSoftwareVersions](http://wiki.linuxcnc.org/cgi-bin/wiki.pl?MinimumSoftwareVersions) does mention which Standards-Version the various distribution supports, though it differs from what lintian says, I have made the changes based on output from lintian.

This change is also mostly targeted the Buildbot, which is why Ubuntu 14-16 and LinuxMint 17-18 is still at default version (3.9.3). I also don't know which version they actually prefer.

I did some cleaning, removed some duplicated entries and swapped tabs witch spaces. I removed Debian-testing since Python2 is almost completely removed. We can perhaps re add it as a separate entry with a warning that it is not supported and exit the script.