### PR TITLE
Replace *get_cpuinfo_revision(char *revision)

### DIFF
--- a/src/hal/drivers/cpuinfo.c
+++ b/src/hal/drivers/cpuinfo.c
@@ -22,13 +22,12 @@ SOFTWARE.
 
 #include <stdio.h>
 #include <string.h>
-#include "cpuinfo.h"
 
 char *get_cpuinfo_revision(char *revision)
 {
    FILE *fp;
    char buffer[1024];
-   char hardware[1024];
+   char model[1024];
    int  rpi_found = 0;
 
    if ((fp = fopen("/proc/cpuinfo", "r")) == NULL)
@@ -36,14 +35,10 @@ char *get_cpuinfo_revision(char *revision)
 
    while(!feof(fp)) {
       if (fgets(buffer, sizeof(buffer) , fp)){
-      sscanf(buffer, "Hardware	: %s", hardware);
-      if (strcmp(hardware, "BCM2708") == 0)
+      sscanf(buffer, "Model           : %s", model);
+      if (strncmp(model, "Raspberry",9) == 0)
          rpi_found = 1;
-      else if (strcmp(hardware, "BCM2709") == 0)
-         rpi_found = 1;
-      else if (strcmp(hardware, "BCM2835") == 0)
-         rpi_found = 1;
-      sscanf(buffer, "Revision	: %s", revision);
+      sscanf(buffer, "Revision  : %s", revision);
       }
    }
    fclose(fp);
@@ -52,6 +47,7 @@ char *get_cpuinfo_revision(char *revision)
       revision = NULL;
    return revision;
 }
+
 
 int get_rpi_revision(void)
 {


### PR DESCRIPTION
As reported in  https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md

"As of the 4.9 kernel, all Pis report BCM2835, even those with BCM2836, BCM2837 and BCM2711 processors. You should not use this string to detect the processor. Decode the revision code using the information below, or cat /sys/firmware/devicetree/base/model"

So the get_cpuinfo_revision() function is no longer correct and above all does not work with RPi4.

Therefore, I think it is more appropriate to completely replace this function, which is now obsolete, with a simpler one that can also adapt to future models of the Raspberry.
Also it's possible to delete cpuinfo.h