### PR TITLE
hal: Remove component type magic numbers

### DIFF
--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -261,10 +261,10 @@ int hal_init(const char *name)
     /* initialize the structure */
     comp->comp_id = comp_id;
 #ifdef RTAPI
-    comp->type = 1;
+    comp->type = COMPONENT_TYPE_REALTIME;
     comp->pid = 0;
 #else /* ULAPI */
-    comp->type = 0;
+    comp->type = COMPONENT_TYPE_USER;
     comp->pid = getpid();
 #endif
     comp->ready = 0;
@@ -1768,7 +1768,7 @@ int hal_export_funct(const char *name, void (*funct) (void *, long),
 	    "HAL: ERROR: component %d not found\n", comp_id);
 	return -EINVAL;
     }
-    if (comp->type == 0) {
+    if (comp->type == COMPONENT_TYPE_USER) {
 	/* not a realtime component */
 	rtapi_mutex_give(&(hal_data->mutex));
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -3010,7 +3010,7 @@ hal_comp_t *halpr_alloc_comp_struct(void)
 	p->next_ptr = 0;
 	p->comp_id = 0;
 	p->mem_id = 0;
-	p->type = 0;
+	p->type = COMPONENT_TYPE_USER;
 	p->shmem_base = 0;
 	p->name[0] = '\0';
     }
@@ -3276,7 +3276,7 @@ static void free_comp_struct(hal_comp_t * comp)
     /* clear contents of struct */
     comp->comp_id = 0;
     comp->mem_id = 0;
-    comp->type = 0;
+    comp->type = COMPONENT_TYPE_USER;
     comp->shmem_base = 0;
     comp->name[0] = '\0';
     /* add it to free list */

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -185,6 +185,16 @@ typedef struct {
     unsigned char lock;         /* hal locking, can be one of the HAL_LOCK_* types */
 } hal_data_t;
 
+/** HAL 'component' type.
+    Assigned according to RTAPI and ULAPI definitions.
+ */
+typedef enum {
+    COMPONENT_TYPE_UNKNOWN = -1,
+    COMPONENT_TYPE_USER,
+    COMPONENT_TYPE_REALTIME,
+    COMPONENT_TYPE_OTHER
+} component_type_t;
+
 /** HAL 'component' data structure.
     This structure contains information that is unique to a HAL component.
     An instance of this structure is added to a linked list when the
@@ -194,7 +204,7 @@ typedef struct {
     rtapi_intptr_t next_ptr;		/* next component in the list */
     int comp_id;		/* component ID (RTAPI module id) */
     int mem_id;			/* RTAPI shmem ID used by this comp */
-    int type;			/* 1 if realtime, 0 if not */
+    component_type_t type;
     int ready;                  /* nonzero if ready, 0 if not */
     int pid;			/* PID of component (user components only) */
     void *shmem_base;		/* base of shmem for this component */

--- a/src/hal/utils/halcmd_completion.c
+++ b/src/hal/utils/halcmd_completion.c
@@ -343,7 +343,7 @@ static char *usrcomp_generator(const char *text, int state) {
     while(next) {
         hal_comp_t *comp = SHMPTR(next);
         next = comp->next_ptr;
-        if(comp->type) continue;
+        if(comp->type != COMPONENT_TYPE_USER) continue;
 	if(strncmp(text, comp->name, len) == 0)
             return strdup(comp->name);
     }
@@ -387,7 +387,7 @@ static char *rtcomp_generator(const char *text, int state) {
     while(next) {
         hal_comp_t *comp = SHMPTR(next);
         next = comp->next_ptr;
-        if(!comp->type) continue;
+        if(comp->type == COMPONENT_TYPE_USER) continue;
 	if ( strncmp(text, comp->name, len) == 0 )
             return strdup(comp->name);
     }

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -1316,7 +1316,7 @@ static int doUnload(char *mod_name, connectionRecType *context)
     next = hal_data->comp_list_ptr;
     while (next != 0) {
 	comp = SHMPTR(next);
-	if ( comp->type == 1 ) {
+	if ( comp->type == COMPONENT_TYPE_REALTIME ) {
 	    /* found a realtime component */
 	    if ( all || ( strcmp(mod_name, comp->name) == 0 )) {
 		/* we want to unload this component, remember its name */
@@ -1699,7 +1699,7 @@ static void getCompInfo(char *pattern, connectionRecType *context)
     while (next != 0) {
       comp = SHMPTR(next);
       if (strncmp(pattern, comp->name, len) == 0) {
-        snprintf(context->outBuf, sizeof(context->outBuf), "COMP %s %02d %s", comp->name, comp->comp_id, (comp->type ? "RT  " : "User"));
+        snprintf(context->outBuf, sizeof(context->outBuf), "COMP %s %02d %s", comp->name, comp->comp_id, (comp->type != COMPONENT_TYPE_USER) ? "RT  " : "User");
 	sockWrite(context);
 	}
       next = comp->next_ptr;
@@ -2156,7 +2156,7 @@ static void save_comps(FILE *dst)
     next = hal_data->comp_list_ptr;
     while (next != 0) {
 	comp = SHMPTR(next);
-	if ( comp->type == 1 ) {
+	if ( comp->type == COMPONENT_TYPE_REALTIME ) {
 	    /* only print realtime components */
 	    if ( comp->insmod_args == 0 ) {
 		fprintf(dst, "#loadrt %s  (not loaded by loadrt, no args saved)\n", comp->name);


### PR DESCRIPTION
Please consider these changes for inclusion in the project. 
I was browsing the code and saw these mysterious magic numbers used for the component type, so I figured it might be better to replace them with something more descriptive.

Replaced the component type magic numbers with an enumerated type.
The new types have the same values as before.
i.e.
0 == user
1 == realtime
2 == something else (not sure where this value is ever assigned)

There should be no functional change.

Please note that although I've checked that the code still builds, I'm not at all familiar with how to run/test the code to ensure it's all still OK.
