### PR TITLE
halcmd: fix "tune" command locking.

### DIFF
--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -147,6 +147,9 @@ RTAPI_BEGIN_DECLS
 #define HAL_LOCK_PARAMS   4     /* locking of parameter set commands */
 #define HAL_LOCK_RUN      8     /* locking of start/stop of HAL threads */
 
+/* locks required for the 'tune' command */
+#define HAL_LOCK_TUNE (HAL_LOCK_LOAD | HAL_LOCK_CONFIG)
+
 #define HAL_LOCK_ALL      255   /* locks every action */
 
 /***********************************************************************

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -112,18 +112,16 @@ static int match(char **patterns, char *value) {
 
 int do_lock_cmd(char *command)
 {
-    int retval=0;
+	int retval = 0;
 
-    /* if command is blank or "all", want to lock everything */
-    if ((command == NULL) || (strcmp(command, "all") == 0)) {
-	retval = hal_set_lock(HAL_LOCK_ALL);
-    } else if (strcmp(command, "none") == 0) {
-	retval = hal_set_lock(HAL_LOCK_NONE);
-    } else if (strcmp(command, "tune") == 0) {
-	retval = hal_set_lock(HAL_LOCK_LOAD & HAL_LOCK_CONFIG);
-    } else if (strcmp(command, "all") == 0) {
-	retval = hal_set_lock(HAL_LOCK_ALL);
-    }
+	/* if command is blank or "all", want to lock everything */
+	if ((command == NULL) || (strcmp(command, "all") == 0)) {
+		retval = hal_set_lock(HAL_LOCK_ALL);
+	} else if (strcmp(command, "none") == 0) {
+		retval = hal_set_lock(HAL_LOCK_NONE);
+	} else if (strcmp(command, "tune") == 0) {
+		retval = hal_set_lock(HAL_LOCK_TUNE);
+	}
 
     if (retval == 0) {
 	/* print success message */
@@ -136,16 +134,16 @@ int do_lock_cmd(char *command)
 
 int do_unlock_cmd(char *command)
 {
-    int retval=0;
+	int retval = 0;
 
-    /* if command is blank or "all", want to unlock everything */
-    if ((command == NULL) || (strcmp(command, "all") == 0)) {
-	retval = hal_set_lock(HAL_LOCK_NONE);
-    } else if (strcmp(command, "all") == 0) {
-	retval = hal_set_lock(HAL_LOCK_NONE);
-    } else if (strcmp(command, "tune") == 0) {
-	retval = hal_set_lock(HAL_LOCK_LOAD & HAL_LOCK_CONFIG);
-    }
+	/* if command is blank or "all", want to unlock everything */
+	if ((command == NULL) || (strcmp(command, "all") == 0)) {
+		retval = hal_set_lock(HAL_LOCK_NONE);
+	} else if (strcmp(command, "none") == 0) {
+		retval = hal_set_lock(HAL_LOCK_NONE);
+	} else if (strcmp(command, "tune") == 0) {
+		retval = hal_set_lock(hal_get_lock() & ~HAL_LOCK_TUNE);
+	}
 
     if (retval == 0) {
 	/* print success message */

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -622,21 +622,18 @@ static int release_HAL_mutex(void)
 
 static int doLock(char *command, connectionRecType *context)
 {
-    int retval=0;
-    const char *nakStr = "SET LOCK NAK";
+	int retval = 0;
+	const char *nakStr = "SET LOCK NAK";
 
-    /* if command is blank, want to lock everything */
-    if (*command == '\0')
-      retval = hal_set_lock(HAL_LOCK_ALL);
-    else 
-      if (strcmp(command, "none") == 0)
-        retval = hal_set_lock(HAL_LOCK_NONE);
-      else 
-        if (strcmp(command, "tune") == 0)
-          retval = hal_set_lock(HAL_LOCK_LOAD & HAL_LOCK_CONFIG);
-        else 
-	  if (strcmp(command, "all") == 0)
-            retval = hal_set_lock(HAL_LOCK_ALL);
+	/* if command is blank, want to lock everything */
+	if (*command == '\0')
+		retval = hal_set_lock(HAL_LOCK_ALL);
+	else if (strcmp(command, "none") == 0)
+		retval = hal_set_lock(HAL_LOCK_NONE);
+	else if (strcmp(command, "tune") == 0)
+		retval = hal_set_lock(HAL_LOCK_TUNE);
+	else if (strcmp(command, "all") == 0)
+		retval = hal_set_lock(HAL_LOCK_ALL);
 
     if (retval != 0) {
       snprintf(errorStr, sizeof(errorStr), "HAL:%d: Locking failed", linenumber);
@@ -650,15 +647,15 @@ static int doUnlock(char *command, connectionRecType *context)
     int retval=0;
     const char *nakStr = "SET UNLOCK NAK";
 
-    /* if command is blank, want to lock everything */
-    if (*command == '\0')
-      retval = hal_set_lock(HAL_LOCK_NONE);
-    else 
-      if (strcmp(command, "all") == 0)
-        retval = hal_set_lock(HAL_LOCK_NONE);
-      else 
-        if (strcmp(command, "tune") == 0)
-          retval = hal_set_lock(HAL_LOCK_LOAD & HAL_LOCK_CONFIG);
+	/* if command is blank, want to unlock everything */
+	if (*command == '\0')
+		retval = hal_set_lock(HAL_LOCK_NONE);
+	else if (strcmp(command, "none") == 0)
+		retval = hal_set_lock(HAL_LOCK_NONE);
+	else if (strcmp(command, "tune") == 0)
+		retval = hal_set_lock(hal_get_lock() & ~HAL_LOCK_TUNE);
+	else if (strcmp(command, "all") == 0)
+		retval = hal_set_lock(HAL_LOCK_NONE);
 
     if (retval != 0) {
       snprintf(errorStr, sizeof(errorStr), "HAL:%d: Unlocking failed", linenumber);

--- a/tests/halrun-lock/README
+++ b/tests/halrun-lock/README
@@ -1,0 +1,1 @@
+Tests that the various lock commands result in the expected locking status.

--- a/tests/halrun-lock/expected
+++ b/tests/halrun-lock/expected
@@ -1,0 +1,28 @@
+HAL locking status:
+  current lock value 0 (00)
+  HAL_LOCK_NONE - nothing is locked
+HAL locking status:
+  current lock value 255 (ff)
+  HAL_LOCK_LOAD    - loading of new components is locked
+  HAL_LOCK_CONFIG  - link and addf is locked
+  HAL_LOCK_PARAMS  - setting params is locked
+  HAL_LOCK_RUN     - running/stopping HAL is locked
+HAL locking status:
+  current lock value 0 (00)
+  HAL_LOCK_NONE - nothing is locked
+HAL locking status:
+  current lock value 3 (03)
+  HAL_LOCK_LOAD    - loading of new components is locked
+  HAL_LOCK_CONFIG  - link and addf is locked
+HAL locking status:
+  current lock value 0 (00)
+  HAL_LOCK_NONE - nothing is locked
+HAL locking status:
+  current lock value 255 (ff)
+  HAL_LOCK_LOAD    - loading of new components is locked
+  HAL_LOCK_CONFIG  - link and addf is locked
+  HAL_LOCK_PARAMS  - setting params is locked
+  HAL_LOCK_RUN     - running/stopping HAL is locked
+HAL locking status:
+  current lock value 0 (00)
+  HAL_LOCK_NONE - nothing is locked

--- a/tests/halrun-lock/halrun.hal
+++ b/tests/halrun-lock/halrun.hal
@@ -1,0 +1,14 @@
+status
+lock
+status
+unlock
+status
+lock tune
+status
+unlock tune
+status
+lock all
+status
+unlock all
+status
+

--- a/tests/halrun-lock/test.sh
+++ b/tests/halrun-lock/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+halrun -f halrun.hal | grep -i lock
+


### PR DESCRIPTION
Please consider these changes for inclusion in your project.

The "tune" command wasn't actually applying the desired locks
because it was locking a bitwise 'and' of values 1 & 2, which
gives a value of 0. This should have been a bitwise 'or' of the
values.
Also changed the associated 'unlock' functions so that the "tune"
command unlocks the same locks as it locked.
Created a new #define to represent the locks to locks for the "tune"
command to help make it clearer that that the lock and unlock
functions should alter the same locks.

Note to maintainers - I figured that the lock/unlock functions are always called in pairs for each command, so if the lock function was called for the "none" command, the unlock function would also be called for the "none" command. That is why you'll see the "none" command get a mention in the unlock functions whereas it wasn't before. If I figured wrong, sorry.

You'll also see some formatting changes in the affected code. I hope that's not a big problem.

As mentioned in my other PR, I have checked that the code compiles, but have not tested it (totally new to this code).