### PR TITLE
Fixes for issues 506, 922, 955 and some minor documentation update

### DIFF
--- a/docs/man/es/man1/thermistor.1
+++ b/docs/man/es/man1/thermistor.1
@@ -1,4 +1,4 @@
-.TH THERMISTOR "9" "2020-08-11" "LinuxCNC Documentation" "HAL Component"
+.TH THERMISTOR "1" "2020-08-11" "LinuxCNC Documentation" "HAL Component"
 .de TQ
 .br
 .ns

--- a/docs/src/common/overleaf.txt
+++ b/docs/src/common/overleaf.txt
@@ -3,7 +3,7 @@ writing, editing, or graphic preparation please contact any member
 of the writing team or join and send an email to 
 emc-users@lists.sourceforge.net.
 
-Copyright © 2000-2016 LinuxCNC.org
+Copyright © 2000-2020 LinuxCNC.org
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.1

--- a/src/hal/drivers/hal_pi_gpio.c
+++ b/src/hal/drivers/hal_pi_gpio.c
@@ -53,8 +53,8 @@ static unsigned char rev2_gpios[] = {2, 3, 4,  7,  8,  9, 10, 11, 14, 15, 17, 18
 static unsigned char rev2_pins[] = {3, 5, 7, 26, 24, 21, 19, 23, 8,  10, 11, 12, 15, 16, 18, 22, 13};
 
 // Raspberry2/3:
-static unsigned char rpi2_gpios[] = {2, 3, 4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22, 21, 23, 24, 25, 26, 27 };
-static unsigned char rpi2_pins[] =  {3, 5, 7, 29, 31, 26, 24, 21, 19, 23, 32, 33,  8, 10, 36, 11, 12, 35, 38, 15, 40, 16, 18, 22, 37, 13 };
+static unsigned char rpi2_gpios[] = {2, 3, 4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27 };
+static unsigned char rpi2_pins[] =  {3, 5, 7, 29, 31, 26, 24, 21, 19, 23, 32, 33,  8, 10, 36, 11, 12, 35, 38, 40, 15, 16, 18, 22, 37, 13 };
 
 static int npins;
 static int  mem_fd;

--- a/src/hal/user_comps/gs2_vfd.c
+++ b/src/hal/user_comps/gs2_vfd.c
@@ -529,7 +529,7 @@ int main(int argc, char **argv)
     slavedata.read_reg_start = START_REGISTER_R;
     slavedata.read_reg_count = NUM_REGISTERS_R;
     slavedata.write_reg_start = START_REGISTER_W;
-    slavedata.write_reg_count = NUM_REGISTERS_R;
+    slavedata.write_reg_count = NUM_REGISTERS_W;
 
     // process command line options
     while ((opt=getopt_long(argc, argv, option_string, long_options, NULL)) != -1) {

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -34,7 +34,6 @@ static char *license = \
     information, go to www.linuxcnc.org.\n\
 ";
 
-#include "config.h"
 #include <locale.h>
 #include <libintl.h>
 #define _(x) gettext(x)

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -1,4 +1,4 @@
-/** This file, 'halsc_disp.c', contains the portion of halscope
+/** This file, 'scope_disp.c', contains the portion of halscope
     that actually displays waveforms.
 */
 

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -1,4 +1,4 @@
-/** This file, 'halsc_horiz.c', contains the portion of halscope
+/** This file, 'scope_horiz.c', contains the portion of halscope
     that deals with horizontal stuff - sample rate, scaling,
     position and such.
 */
@@ -43,8 +43,6 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
-
-#include "config.h"
 
 #include "rtapi.h"		/* RTAPI realtime OS API */
 #include <rtapi_mutex.h>

--- a/src/hal/utils/scope_rt.c
+++ b/src/hal/utils/scope_rt.c
@@ -1,5 +1,5 @@
-/** This file, 'halscope_rt.c', is a HAL component that together with
-    'halscope.c' provides an oscilloscope to view HAL pins, signals,
+/** This file, 'scope_rt.c', is a HAL component that together with
+    'scope.c' provides an oscilloscope to view HAL pins, signals,
     and parameters
 */
 

--- a/src/hal/utils/scope_rt.h
+++ b/src/hal/utils/scope_rt.h
@@ -1,10 +1,10 @@
-#ifndef HALSC_RT_H
-#define HALSC_RT_H
-/** This file, 'halsc_rt.h', contains declarations used by
-    'halscope_rt.c' to implement the real-time portion of
+#ifndef SCOPE_RT_H
+#define SCOPE_RT_H
+/** This file, 'scope_rt.h', contains declarations used by
+    'scope_rt.c' to implement the real-time portion of
     the HAL oscilloscope.  Declarations that are common to the
-    realtime and user parts are in 'halsc_shm.h', and those used
-    only by the user part are in 'halsc_usr.h'.
+    realtime and user parts are in 'scope_shm.h', and those used
+    only by the user part are in 'scope_usr.h'.
 */
 
 /** Copyright (C) 2003 John Kasunich

--- a/src/hal/utils/scope_shm.h
+++ b/src/hal/utils/scope_shm.h
@@ -1,11 +1,11 @@
-#ifndef HALSC_SHM_H
-#define HALSC_SHM_H
-/** This file, 'halsc_shm.h', contains declarations used by both
-    'halscope.c' and 'halscope_rt.c' to implement an oscilloscope.
+#ifndef SCOPE_SHM_H
+#define SCOPE_SHM_H
+/** This file, 'scope_shm.h', contains declarations used by both
+    'scope.c' and 'scope_rt.c' to implement an oscilloscope.
     The declarations in this file are used by both the realtime
     and user space components of the scope.  Those used only in
-    realtime are in 'halsc_rt.h', and those used only in user
-    space are in 'halsc_usr.h'.
+    realtime are in 'scope_rt.h', and those used only in user
+    space are in 'scope_usr.h'.
 */
 
 /** Copyright (C) 2003 John Kasunich

--- a/src/hal/utils/scope_trig.c
+++ b/src/hal/utils/scope_trig.c
@@ -1,4 +1,4 @@
-/** This file, 'halsc_trig.c', contains the portion of halscope
+/** This file, 'scope_trig.c', contains the portion of halscope
     that deals with triggering
 */
 

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -1,10 +1,10 @@
-#ifndef HALSC_USR_H
-#define HALSC_USR_H
+#ifndef SCOPE_USR_H
+#define SCOPE_USR_H
 /** This file, 'scope_usr.h', contains declarations used by
-    'halscope.c' and other source files to implement the user
+    'scope.c' and other source files to implement the user
     space portion of the HAL oscilloscope.  Other declarations
-    used by both user and realtime code are in 'halsc_shm.h', and
-    those used only by realtime code are in 'halsc_rt.h'.
+    used by both user and realtime code are in 'scope_shm.h', and
+    those used only by realtime code are in 'scope_rt.h'.
 */
 
 /** Copyright (C) 2003 John Kasunich

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -1,4 +1,4 @@
-/** This file, 'halsc_vert.c', contains the portion of halscope
+/** This file, 'scope_vert.c', contains the portion of halscope
     that deals with vertical stuff - signal sources, scaling,
     position and such.
 */


### PR DESCRIPTION
This PR closes three issues and fixes some minor things with the documentation. #955 Is the only change I actually tested, I did that with:
```
halrun
loadrt hal_pi_gpio dir=45319 exclude=26103544
show pin
``` 
I also tested with the other bitmask, before and after the change.