### PR TITLE
stepgen: Fix user step type initialization

### DIFF
--- a/src/hal/components/stepgen.c
+++ b/src/hal/components/stepgen.c
@@ -1203,7 +1203,7 @@ static int export_stepgen(int num, stepgen_t * addr, int step_type, int pos_mode
 static int setup_user_step_type(void) {
     int used_phases = 0;
     int i = 0;
-    for(i=0; i<10 && user_step_type[i] != -1; i++) {
+    for(i=0; i < MAX_CYCLE && user_step_type[i] != -1; i++) {
         master_lut[USER_STEP_TYPE][i] = user_step_type[i];
 	used_phases |= user_step_type[i];
     }


### PR DESCRIPTION
Commit 61ebd8221e increased the max number of cycles from 10 to 16,
but didn't update an associated magic number from 10 to 16.
Changed this magic number from 10 to MAX_CYCLE so that the number of phases in a user step type is counted correctly..