### PR TITLE
changed pocket_number to mod_pocket in direction logic

### DIFF
--- a/src/hal/components/carousel.comp
+++ b/src/hal/components/carousel.comp
@@ -259,7 +259,7 @@ FUNCTION(_){
         state = 1;
         ready = 0;
     case 1: // choose direction
-        if (pocket_number < 1 || pocket_number > inst_pockets) {
+        if (mod_pocket < 1 || mod_pocket > inst_pockets) {
             state = 0;
             return;
         }


### PR DESCRIPTION
Tested and works now with a turret tool changer where tool number is grater than the effective tool positions. PR should go to 2.8 branch and master.