### PR TITLE
Add keep-integrator bit to PID

### DIFF
--- a/docs/man/man9/pid.9
+++ b/docs/man/man9/pid.9
@@ -91,6 +91,9 @@ The difference between command and feedback.
 When true, enables the PID calculations.  When false, \fBoutput\fR is zero,
 and all internal integrators, etc, are reset.
 .TP
+\fBpid.\fIN\fB.keep-integrator\fR bit in
+When true, internal integrator is not reset when \fBenable\fR is false.
+.TP
 \fBpid.\fIN\fB.index\-enable\fR bit in
 On the falling edge of \fBindex\-enable\fR, pid does not update the
 internal command derivative estimate.  On systems which use the encoder


### PR DESCRIPTION
Not sure if someone may need this but I found a case when it may be wanted to save the integrator value. My case is dual loop feedback with linear and rotary encoder, with an imperfect ballscrew. Ballscrew has an error of 0.2 mm on 750 mm of travel and when PID is disabled (machine OFF) this integrated value is lost. After disabling machine the only way to start work again is to close LinuxCNC and rehome.
![integrator_save](https://user-images.githubusercontent.com/2035089/97207973-46463580-17c3-11eb-965e-0db32d7533fe.png)
Part of .hal file responsible for this offset:
net x-enable        =>  pid.xscale.enable
net x-scale-pos-fb        =>  pid.xscale.feedback
net x-pos-cmd       =>  pid.xscale.command xscale_sum2.in0
net x-scale-output      pid.xscale.output   => xscale_sum2.in1

net x-pos-corrected xscale_sum2.out       =>  pid.x.command
Thanks to DaBit for this use case!