### PR TITLE
docs: fix source comment and doc typos in lib/python

### DIFF
--- a/lib/python/gladevcp/builtin-panels/versa-probe/versa_probe_screen.py
+++ b/lib/python/gladevcp/builtin-panels/versa-probe/versa_probe_screen.py
@@ -13,7 +13,7 @@
 # GNU General Public License for more details.
 
 import hal                  # base hal class to react to hal signals
-import os                   # needed to get the paths and directorys
+import os                   # needed to get the paths and directories
 import hal_glib             # needed to make our own hal pins
 import gtk                  # base for pygtk widgets and constants
 import gtk.glade

--- a/lib/python/gladevcp/calculatorwidget.py
+++ b/lib/python/gladevcp/calculatorwidget.py
@@ -2,7 +2,7 @@
 # GladeVcp Widget - calculator input
 # This widgets allows simple calculations.
 # The result can be returned for further use.
-# Origially to be used as numerical input on a touch screen.
+# Originally to be used as numerical input on a touch screen.
 #
 # Copyright (c) 2012 Chris Morley
 #

--- a/lib/python/gladevcp/combi_dro.py
+++ b/lib/python/gladevcp/combi_dro.py
@@ -462,8 +462,8 @@ class Combi_DRO(gtk.VBox):
             self.homed = self.status.homed[self.joint_no]
             self._set_labels()
 
-    # sets the DRO explicity to inch or mm
-    # attentions auto_units takes also effekt on that!
+    # sets the DRO explicitly to inch or mm
+    # attentions auto_units also takes effect on that!
     def set_to_inch(self, state):
         '''
         sets the DRO to show imperial units
@@ -493,7 +493,7 @@ class Combi_DRO(gtk.VBox):
     # multiplied by 2
     def set_to_diameter(self, state):
         '''
-        if True the DRO will show the diameter not the radius, specialy needed for lathes
+        if True the DRO will show the diameter not the radius, specially needed for lathes
         the DRO value will be multiplied by 2
 
         Combi_DRO.set_to_diameter(state)
@@ -503,7 +503,7 @@ class Combi_DRO(gtk.VBox):
         '''
         self.diameter = state
 
-    # this will toggle the DRO around, mainly used to mantain all DRO
+    # this will toggle the DRO around, mainly used to maintain all DRO
     # at the same state, because a click on one will only change that DRO
     # This can be used to change also the others
     def toogle_readout(self):
@@ -517,7 +517,7 @@ class Combi_DRO(gtk.VBox):
         self._set_labels()
         self.emit("clicked", self.joint_number, self._ORDER)
 
-    # You can change the automatic given axisletter using this funktion
+    # You can change the automatic given axisletter using this function
     # i.e. to use an axis as R or D insteadt of X on a lathe
     def change_axisletter(self, letter):
         '''
@@ -550,11 +550,11 @@ class Combi_DRO(gtk.VBox):
         '''
         self.axis_no = "xyzabcuvws".index(axis.lower())
 
-    # returns the order of the DRO, mainly used to mantain them consistent
+    # returns the order of the DRO, mainly used to maintain them consistent
     # the order will also be transmitted with the clicked signal
     def get_order(self):
         '''
-        returns the order of the DRO in the widget mainly used to mantain them consistent
+        returns the order of the DRO in the widget mainly used to maintain them consistent
         the order will also be transmitted with the clicked signal
 
         Combi_DRO.get_order()
@@ -563,10 +563,10 @@ class Combi_DRO(gtk.VBox):
         '''
         return self._ORDER
 
-    # sets the order of the DRO, mainly used to mantain them consistent
+    # sets the order of the DRO, mainly used to maintain them consistent
     def set_order(self, order):
         '''
-        sets the order of the DRO, mainly used to mantain them consistent
+        sets the order of the DRO, mainly used to maintain them consistent
 
         Combi_DRO.set_order(order)
 
@@ -649,7 +649,7 @@ def clicked(self, axis_number, order):
     print(self.get_position())
 #    self.set_property("joint_number", 0)
     # other_widget.set_order(order)
-    # so they may be mantained consistent
+    # so they may be maintained consistent
 
 if __name__ == "__main__":
     main()

--- a/lib/python/gladevcp/hal_mdihistory.py
+++ b/lib/python/gladevcp/hal_mdihistory.py
@@ -33,7 +33,7 @@ class EMC_MDIHistory(gtk.VBox, _EMC_ActionBase):
     '''
     EMC_MDIHistory will store each MDI command to a file on your hard drive
     and display the grabbed commands in a treeview so they can be used again
-    without typing the complete comand again
+    without typing the complete command again
     '''
 
     __gtype_name__ = 'EMC_MDIHistory'

--- a/lib/python/gladevcp/hal_sourceview.py
+++ b/lib/python/gladevcp/hal_sourceview.py
@@ -96,7 +96,7 @@ class EMC_SourceView(gtksourceview.View, _EMC_ActionBase):
             self.gstat.connect('interp_idle', lambda w: self.set_line_number(0))
 
     def set_language(self, lang, path = None):
-        # path = the search path for the langauage file
+        # path = the search path for the language file
         # if none, set to default
         # lang = the lang file to set
         if path == None:
@@ -117,8 +117,8 @@ class EMC_SourceView(gtksourceview.View, _EMC_ActionBase):
     # This load the file while not allowing undo buttons to unload the program.
     # It updates the iter because iters become invalid when anything changes.
     # We set the buffer-unmodified flag false after loading the file.
-    # Set the hilight line to the line linuxcnc is looking at.
-    # if one calls load_file without a filenname, We reload the exisiting file.
+    # Set the highlight line to the line linuxcnc is looking at.
+    # if one calls load_file without a filename, We reload the existing file.
     def load_file(self, fn=None):
         self.buf.begin_not_undoable_action()
         if fn == None:
@@ -222,7 +222,7 @@ class EMC_SourceView(gtksourceview.View, _EMC_ActionBase):
                 self.current_iter = self.end_iter.copy()
             found = gtksourceview.iter_backward_search(self.current_iter,text,CASEFLAG, None)
         if found:
-            # erase any existing hilighting tags
+            # erase any existing highlighting tags
             try:
                 self.buf.remove_tag(self.found_text_tag, self.match_start, self.match_end)
             except:

--- a/lib/python/gladevcp/iconview.py
+++ b/lib/python/gladevcp/iconview.py
@@ -57,7 +57,7 @@ class IconFileSelection(gtk.HBox):
 
 # ToDo:
 # - make the button up and down work to move faster from top to bottom
-#   unfortuantely the selection of column is not availible in pygtk before 2.22
+#   unfortunately the selection of column is not available in pygtk before 2.22
 
     __gtype_name__ = 'IconFileSelection'
     __gproperties__ = {
@@ -211,7 +211,7 @@ class IconFileSelection(gtk.HBox):
         self.iconView.connect("item-activated", self._on_item_activated)
         # will be emitted, when a icon is activated and the ENTER key has been pressed
         self.iconView.connect("activate-cursor-item", self._on_activate_cursor_item)
-        # will be emmited if the selection has changed, this happens also if the user clicks ones on an icon
+        # will be emitted if the selection has changed, this happens also if the user clicks ones on an icon
         self.iconView.connect("selection-changed",  self._on_selection_changed)
         # will be emitted, when the widget is destroyed
         self.connect("destroy", gtk.main_quit)      
@@ -227,7 +227,7 @@ class IconFileSelection(gtk.HBox):
         self._init_button_state()
         
     def _init_button_state(self):    
-        # we need this to check for differnces in the button state
+        # we need this to check for differences in the button state
         self.button_state["btn_home"] = self.btn_home.get_sensitive()
         self.button_state["btn_dir_up"] = self.btn_dir_up.get_sensitive()
         self.button_state["btn_sel_prev"] = self.btn_sel_prev.get_sensitive()
@@ -362,7 +362,7 @@ class IconFileSelection(gtk.HBox):
         self.state_changed()
         
     def state_changed(self):
-        # find the differnce
+        # find the difference
         diff = set(self.button_state.iteritems()) - set(self.old_button_state.iteritems())
         for key in self.button_state.keys():
             try:

--- a/lib/python/gladevcp/jogwheel.py
+++ b/lib/python/gladevcp/jogwheel.py
@@ -25,7 +25,7 @@ import math
 import hal
 
 # This is needed to make the hal pin, making them directly with hal, will
-# not allow to use them in glade without linuxcnc beeing started
+# not allow to use them in glade without linuxcnc being started
 from .hal_widgets import _HalJogWheelBase
 
 class JogWheel(gtk.DrawingArea, _HalJogWheelBase):
@@ -33,7 +33,7 @@ class JogWheel(gtk.DrawingArea, _HalJogWheelBase):
     The JogWheel Widget simulates a real jog wheel
 
     show counts = bool     , whether you want to display the counts in the widget or not 
-    size        = interger , the size of the widget in pixel, 
+    size        = integer , the size of the widget in pixel, 
                              allowed values are in the range from 100 to 500, 
                              default is 300
     cpr         = integer  , The counts per revolution, 
@@ -119,7 +119,7 @@ class JogWheel(gtk.DrawingArea, _HalJogWheelBase):
         self.dot_pitch_radius = self.inner_radius - self.dot_radius
 
         # create the cairo window
-        # I do not know why this workes without importing cairo
+        # I do not know why this works without importing cairo
         self.cr = widget.window.cairo_create()
 
         # the area of reactions
@@ -157,7 +157,7 @@ class JogWheel(gtk.DrawingArea, _HalJogWheelBase):
         self.cr.arc(0, 0, filldia, 0, 2*math.pi)
         self.cr.fill()
 
-        # draw a smaler circle with a finer line
+        # draw a smaller circle with a finer line
         linewith = self._size / 200
         if linewith < 1:
             linewith = 1

--- a/lib/python/gladevcp/led.py
+++ b/lib/python/gladevcp/led.py
@@ -17,7 +17,7 @@ class HAL_LED(gtk.DrawingArea, _HalSensitiveBase):
                     False, gobject.PARAM_READWRITE | gobject.PARAM_CONSTRUCT),
         'has_hal_pin' : ( gobject.TYPE_BOOLEAN, 'Create HAL pin', 'Whether to create a HAL pin',
                     True, gobject.PARAM_READWRITE | gobject.PARAM_CONSTRUCT),
-        'led_shape' : ( gobject.TYPE_INT, 'Shape', '0: round 1:oval 2:square 3:horizonal 4: vertical',
+        'led_shape' : ( gobject.TYPE_INT, 'Shape', '0: round 1:oval 2:square 3:horizontal 4: vertical',
                     0, 4, 0, gobject.PARAM_READWRITE | gobject.PARAM_CONSTRUCT),
         'led_size'  : ( gobject.TYPE_INT, 'Size', 'size of LED',
                     5, 30, 10, gobject.PARAM_READWRITE | gobject.PARAM_CONSTRUCT),
@@ -303,7 +303,7 @@ class HAL_LED(gtk.DrawingArea, _HalSensitiveBase):
         return True # keep running this event
 
     # This allows setting of the on and off colour
-    # red,green and blue are float numbers beteen 0 and 1
+    # red,green and blue are float numbers between 0 and 1
     # if color = None uses colorname. only a few names supported
     # Usage: ledname.set_color("off",[r,g,b],"colorname")
     def set_color(self, state, color):
@@ -326,7 +326,7 @@ class HAL_LED(gtk.DrawingArea, _HalSensitiveBase):
         if state == 'on' and getattr(self, 'off_color') == 'dark':
             self.set_color('off', 'dark')
 
-    # This alows setting the diameter of the LED
+    # This allows setting the diameter of the LED
     # Usage: ledname.set_dia(10)
     def set_dia(self, dia):
         self._dia = dia

--- a/lib/python/gladevcp/offsetpage_widget.py
+++ b/lib/python/gladevcp/offsetpage_widget.py
@@ -186,7 +186,7 @@ class OffsetPage(gtk.VBox):
 
         degree_tmpl = "%11.2f"
 
-        # fill each row of the liststore fron the offsets arrays
+        # fill each row of the liststore from the offsets arrays
         for row, i in enumerate([tool, g5x, rot, g92, g54, g55, g56, g57, g58, g59, g59_1, g59_2, g59_3]):
             for column in range(0, 9):
                 if row == 2:
@@ -306,7 +306,7 @@ class OffsetPage(gtk.VBox):
         self.queue_draw()
 
     # When the column is edited this does the work
-    # TODO the edited column does not end up showing the editted number even though linuxcnc
+    # TODO the edited column does not end up showing the edited number even though linuxcnc
     # registered the change
     def col_editted(self, widget, filtered_path, new_text, col):
         (store_path,) = self.modelfilter.convert_path_to_child_path(filtered_path)

--- a/lib/python/gladevcp/offsetwidget.py
+++ b/lib/python/gladevcp/offsetwidget.py
@@ -54,7 +54,7 @@ class HAL_Offset(gtk.Label):
         self.display_units_mm=0
         self.machine_units_mm=0
         self.unit_convert=[1]*9
-        # The update time: every 500 milliseonds
+        # The update time: every 500 milliseconds
         gobject.timeout_add(500, self.periodic)
 
         # check the ini file if UNITS are set to mm

--- a/lib/python/gladevcp/overridewidget.py
+++ b/lib/python/gladevcp/overridewidget.py
@@ -48,7 +48,7 @@ class Override(gtk.HScale):
         self.set_value_pos(gtk.POS_LEFT)
         #self.add_mark(100.0,gtk.POS_RIGHT,'')
         self.connect('value-changed',self.update_value)
-        # The update time: every 100 milliseonds
+        # The update time: every 100 milliseconds
         gobject.timeout_add(100, self.periodic)
 
     # we set the adjustment limits based on the INI entries

--- a/lib/python/gladevcp/persistence.py
+++ b/lib/python/gladevcp/persistence.py
@@ -237,7 +237,7 @@ class IniFile(object):
                     os.rename(self.filename,badfilename)
                     retries -= 1
                     if retries:
-                        raise UselessIniError("cant make sense of '%s', renamed to '%s'"
+                        raise UselessIniError("can not make sense of '%s', renamed to '%s'"
                                               % (self.filename, badfilename))
                     else:
                         raise Exception(error)

--- a/lib/python/gladevcp/speedcontrol.py
+++ b/lib/python/gladevcp/speedcontrol.py
@@ -25,7 +25,7 @@ from math import pi
 import hal
 
 # This is needed to make the hal pin, making them directly with hal, will
-# not allow to use them in glade without linuxcnc beeing started
+# not allow to use them in glade without linuxcnc being started
 from .hal_widgets import _HalSpeedControlBase
 
 class SpeedControl(gtk.VBox, _HalSpeedControlBase):

--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -81,7 +81,7 @@ class ToolEdit(gtk.VBox):
         # toggle button useable
         renderer = self.wTree.get_object("cell_toggle1")
         renderer.set_property('activatable', True)
-        # make colums editable
+        # make columns editable
         self.tool_cell_list = "cell_tool#","cell_pos","cell_x","cell_y","cell_z","cell_a","cell_b","cell_c","cell_u","cell_v","cell_w","cell_d", \
                 "cell_front","cell_back","cell_orient","cell_comments"
         for col,name in enumerate(self.tool_cell_list):
@@ -309,7 +309,7 @@ class ToolEdit(gtk.VBox):
                     line = line + "%s%s "%(KEYWORDS[num], locale.atof(test))
 
             print(line, file=file)
-        # Theses lines are required to make sure the OS doesn't cache the data
+        # These lines are required to make sure the OS doesn't cache the data
         # That would make linuxcnc and the widget to be out of synch leading to odd errors
         file.flush()
         os.fsync(file.fileno())
@@ -410,7 +410,7 @@ class ToolEdit(gtk.VBox):
             except:
                 pass
 
-        # depending what is editted add the right type of info integer,float or text
+        # depending what is edited add the right type of info integer,float or text
         # If it's a filtered display then we must convert the path 
     def col_editted(self, widget, path, new_text, col, filter):
         if filter == 'wear':

--- a/lib/python/gladevcp/xembed.py
+++ b/lib/python/gladevcp/xembed.py
@@ -56,8 +56,8 @@ def keyboard_forward(window, forward):
         This is kind of hack needed to properly function inside Tk windows.
         Gtk app will receive _all_ events, even not needed. So we have to forward
         back things that left over after our widgets. Connect handlers _after_
-        all others and listen for key-presss and key-release events. If key is not
-        in ignore list - forward it to window id found in evironment.
+        all others and listen for key-press and key-release events. If key is not
+        in ignore list - forward it to window id found in environment.
     """
     if not forward:
         return

--- a/lib/python/hal_glib.py
+++ b/lib/python/hal_glib.py
@@ -238,7 +238,7 @@ class _GStat(GObject.GObject):
         self.set_timer()
 
     # we put this in a function so qtvcp
-    # can overide it to fix a seg fault
+    # can override it to fix a seg fault
     def set_timer(self):
         GObject.timeout_add(100, self.update)
 
@@ -249,7 +249,7 @@ class _GStat(GObject.GObject):
         self.old['interp']= self.stat.interp_state
         # Only update file if call level is 0, which
         # means we are not executing a subroutine/remap
-        # This avoids emiting signals for bogus file names below
+        # This avoids emitting signals for bogus file names below
         if self.stat.call_level == 0:
             self.old['file']  = self.stat.file
         self.old['paused']= self.stat.paused
@@ -387,7 +387,7 @@ class _GStat(GObject.GObject):
             elif state_old == linuxcnc.STATE_ON and state_new < linuxcnc.STATE_ON:
                 self.emit('state-off')
 
-            # reset modes/interpeter on machine on
+            # reset modes/interpreter on machine on
             if state_new == linuxcnc.STATE_ON:
                 old['mode'] = 0
                 old['interp'] = 0
@@ -429,7 +429,7 @@ class _GStat(GObject.GObject):
             # still be emitted if aborting a program shortly after it ran an
             # external file subroutine, but that is fixed by not updating the
             # file name if call level != 0 in the merge() function above.
-            # do avoid that a signal is emited in that case, causing
+            # do avoid that a signal is emitted in that case, causing
             # a reload of the preview and sourceview widgets
             if self.stat.interp_state == linuxcnc.INTERP_IDLE:
                 self.emit('file-loaded', file_new)
@@ -481,7 +481,7 @@ class _GStat(GObject.GObject):
                 self._is_all_homed = False
                 self.emit('not-all-homed', unhomed_joints)
 
-        # override limts
+        # override limits
         or_limits_old = old.get('override-limits', None)
         or_limits_new = self.old['override-limits']
         or_limits_set_new = self.old['override-limits-set']
@@ -766,7 +766,7 @@ class _GStat(GObject.GObject):
             self._is_all_homed = False
             self.emit('not-all-homed', unhomed_joints)
 
-        # update external ojects
+        # update external objects
         self.emit('forced-update')
 
     # ********** Helper function ********************
@@ -805,7 +805,7 @@ class _GStat(GObject.GObject):
         relp = [x, y, z, a, b, c, u, v, w]
         return p,relp,dtg
 
-    # check for requied modes
+    # check for required modes
     # fail if mode is 0
     # fail if machine is busy
     # true if all ready in mode

--- a/lib/python/linuxcnc_util.py
+++ b/lib/python/linuxcnc_util.py
@@ -192,7 +192,7 @@ class LinuxCNC:
             if i == axis_index:
                 continue;
             if start_pos[i] != self.status.position[i]:
-                raise LinuxCNC_Exception("axis %s moved from %.3f to %.3f but shouldnt have!" % ('xyzabcuvw'[i], start_pos[i], self.status.position[i]))
+                raise LinuxCNC_Exception("axis %s moved from %.3f to %.3f but should not have!" % ('xyzabcuvw'[i], start_pos[i], self.status.position[i]))
 
 
     def wait_for_axis_to_stop_at(self, axis_letter, target, timeout=10.0, tolerance = 0.0001):
@@ -268,7 +268,7 @@ class LinuxCNC:
             the spindle.
 
             'timeout', float, the number of seconds to wait for the
-            specfied tool to show up in the spindle.
+            specified tool to show up in the spindle.
 
         This function polls the LinuxCNC Status buffer, waiting for the
         specified tool to appear in the spindle.  If the timeout expires

--- a/lib/python/pyhal.py
+++ b/lib/python/pyhal.py
@@ -157,7 +157,7 @@ class port(pin):
 
     def waitReadable(self, count):
         if self.dir != pinDir.IN:
-            raise HalException("cannot read ouput port")
+            raise HalException("cannot read output port")
 
         lib.hal_port_wait_readable(self.data_ptr, count, 0)
 

--- a/lib/python/pyngcgui.py
+++ b/lib/python/pyngcgui.py
@@ -1256,7 +1256,7 @@ class SubFile():
         self.inputlines = []
 
     def flagerror(self,e):
-        # accumulate erors from read() so entire file can be processed
+        # accumulate errors from read() so entire file can be processed
         self.errlist.append(e)
 
     def specialcomments_ngc(self,s):
@@ -1635,7 +1635,7 @@ class EntryFields():
 
     def make_entryfields(self,nparms):
         self.no_of_entries = nparms
-        # make VBoxes as required to accomodate entries
+        # make VBoxes as required to accommodate entries
         # destroy them when starting over -- this occurs
         # when a OnePg is reused for a different subfile
         try:

--- a/lib/python/pyvcp_widgets.py
+++ b/lib/python/pyvcp_widgets.py
@@ -100,7 +100,7 @@ class pyvcp_dial(Canvas):
     """
     # FIXME:
     # -jogging should be enabled only when the circle has focus
-    #   TJP nocando:   only widgets have events, not thier 'items', the circle is an item
+    #   TJP nocando:   only widgets have events, not their 'items', the circle is an item
     
     # -circle should maintain focus when mouse over dot
     #   TJP nocando:   ditto, the circle is an item, so focus & event are not aligned to it
@@ -1250,7 +1250,7 @@ class pyvcp_bar(Canvas):
         start=tmp[0]
         end=tmp[1]
         self.bar=self.create_rectangle(start,2,end,self.bh-1)
-        # default fill unless overriden
+        # default fill unless overridden
         self.itemconfig(self.bar,fill=fillcolor)
 
         # start text

--- a/lib/python/qtvcp/designer/README.txt
+++ b/lib/python/qtvcp/designer/README.txt
@@ -24,7 +24,7 @@ you must copy that proper version of libpyqt5_py2.so to the folder:
 (x86_64-linux-gnu might be called something slightly different 
 on different systems)
 
-The libpyqt5_py2.so must be the first python library to be found inthe folder.
+The libpyqt5_py2.so must be the first python library to be found in the folder.
 Some systems have the python3 library - libpyqt5.so - file in the folder.
 You must rename one of the files so it is found first.
 Renaming the python3 version to libpyqt5_py3.so should do this.

--- a/lib/python/qtvcp/lib/audio_player.py
+++ b/lib/python/qtvcp/lib/audio_player.py
@@ -54,7 +54,7 @@ try:
 except:
     ESPEAK = False
     log.warning('audio alerts - Is python-espeak installed?')
-    log.warning('Text to speach output not available. ')
+    log.warning('Text to speech output not available. ')
 
 # the player class does the work of playing the audio hints
 # http://pygstdocs.berlios.de/pygst-tutorial/introduction.html
@@ -155,7 +155,7 @@ class Player:
             #file ended, stop
             self.player.set_state(gst.STATE_NULL)
         elif t == gst.MESSAGE_ERROR:
-            #Error ocurred, print and stop
+            #Error occurred, print and stop
             self.player.set_state(gst.STATE_NULL)
             err, debug = message.parse_error()
             log.error('Audio player - Error {}'.format(err, debug))

--- a/lib/python/qtvcp/lib/gcode_utility/facing.ui
+++ b/lib/python/qtvcp/lib/gcode_utility/facing.ui
@@ -1308,7 +1308,7 @@ PROGRAM</string>
               </size>
              </property>
              <property name="toolTip">
-              <string>Create temparary macro and load in linuxcnc</string>
+              <string>Create temporary macro and load in linuxcnc</string>
              </property>
              <property name="text">
               <string>SEND AS

--- a/lib/python/qtvcp/lib/gcode_utility/hole_circle.ui
+++ b/lib/python/qtvcp/lib/gcode_utility/hole_circle.ui
@@ -1277,7 +1277,7 @@ PROGRAM</string>
               </size>
              </property>
              <property name="toolTip">
-              <string>Create temparary macro and load in linuxcnc</string>
+              <string>Create temporary macro and load in linuxcnc</string>
              </property>
              <property name="text">
               <string>SEND AS

--- a/lib/python/qtvcp/lib/mdi_text.py
+++ b/lib/python/qtvcp/lib/mdi_text.py
@@ -733,14 +733,14 @@ G59.3 = select coordinate system 9
 
 G61 = """G61 Exact Path Mode
 G61 = Exact path mode, movement exactly as
-programed. Moves will slow or stop as needed to
-reach every programed point. If two sequential
+programmed. Moves will slow or stop as needed to
+reach every programmed point. If two sequential
 moves are exactly co-linear movement will not stop
 """
 
 G61_1 = """G61.1 Exact Stop Mode
 G61.1 - Exact stop mode, movement will stop at the
-end of each programed segment.
+end of each programmed segment.
 """
 
 G64 = """G64 Path Blending

--- a/lib/python/qtvcp/lib/message.py
+++ b/lib/python/qtvcp/lib/message.py
@@ -55,7 +55,7 @@ class Message:
 
     # This is part of the user message system
     # There is status that prints to the status bar
-    # There is Okdialog that prints a dialog that the user must acknoledge
+    # There is Okdialog that prints a dialog that the user must acknowledge
     # there is yes/no dialog where the user must choose between yes or no
     # you can combine status and dialog messages so they print to the status bar 
     # and pop a dialog
@@ -118,7 +118,7 @@ class Message:
     # using clicked.connect( self.on_printmessage(pin,name,bt,t,c) ) apparently doesn't easily
     # add user data - it seems you only get the last set added
     # found this closure technique hack on the web
-    # truely weird black magic
+    # truly weird black magic
     def dummy(self,pin,name,bt,t,d,c,i):
         def calluser():
             self.on_printmessage(pin,name,bt,t,d,c,i)

--- a/lib/python/qtvcp/lib/notify.py
+++ b/lib/python/qtvcp/lib/notify.py
@@ -83,7 +83,7 @@ class Notify:
 
 
 #####################################################
-# actualy build the notices
+# actually build the notices
 #####################################################
 
     def build_error_notification(self, icon=None):

--- a/lib/python/qtvcp/lib/sys_notify.py
+++ b/lib/python/qtvcp/lib/sys_notify.py
@@ -64,7 +64,7 @@ def init(app_name):
             DBUS_IFACE.connect_to_signal('ActionInvoked', _onActionInvoked)
             DBUS_IFACE.connect_to_signal('NotificationClosed', _onNotificationClosed)
     except Exception as e:
-        LOG.warning('Descktop Notify not availale:: {}'.format(e))
+        LOG.warning('Desktop Notify not available:: {}'.format(e))
 
 def _onActionInvoked(nid, action):
     """Called when a notification action is clicked"""
@@ -134,7 +134,7 @@ class Notification(object):
             NOTIFICATIONS[self.id] = self
             return True
         except Exception as e:
-            LOG.debug('Descktop Notify: {}'.format(e))
+            LOG.debug('Desktop Notify: {}'.format(e))
 
     def close(self):
         """Ask the notification server to close the notification"""

--- a/lib/python/qtvcp/lib/toolbar_actions.py
+++ b/lib/python/qtvcp/lib/toolbar_actions.py
@@ -544,7 +544,7 @@ class ToolBarActions():
         except:
             widget.addAction(impAct)
 
-        # is this a dublicate ?
+        # is this a duplicate ?
         for i in alist:
             if i.text() == filename:
                 widget.removeAction(i)

--- a/lib/python/qtvcp/lib/writer/ext/find.py
+++ b/lib/python/qtvcp/lib/writer/ext/find.py
@@ -91,7 +91,7 @@ class Find(QtWidgets.QDialog):
 
             else:
 
-                # Make the next search start from the begining again
+                # Make the next search start from the beginning again
                 self.lastStart = 0
                 
                 self.parent.text.moveCursor(QtGui.QTextCursor.End)

--- a/lib/python/qtvcp/plugins/actionbutton_plugin.py
+++ b/lib/python/qtvcp/plugins/actionbutton_plugin.py
@@ -291,7 +291,7 @@ class ActionButtonDialog(QtWidgets.QDialog):
         layout.addWidget(self.combo)
 
         # related data selection - note the name 'self.ud' uses a number
-        # that doubles each time - binary coded. thsi is so we can specify
+        # that doubles each time - binary coded. this is so we can specify
         # multiple selectors  code 1 give ud1, code 2 gives ud2, code 3 gives
         # ud1 and ud2 etc
  
@@ -1044,7 +1044,7 @@ class ActionButtonDialog(QtWidgets.QDialog):
 
     def updateWidget(self):
         # check action-combobox last pick because it sometimes
-        # forgets whats selected. anyways...
+        # forgets what's selected. anyways...
         winProperty = self.combo.getLastPick()
         if winProperty is None:
             winProperty = 'unused'

--- a/lib/python/qtvcp/plugins/dialog_plugin.py
+++ b/lib/python/qtvcp/plugins/dialog_plugin.py
@@ -233,7 +233,7 @@ class MacroTabDialogPlugin(QPyDesignerCustomWidgetPlugin):
         return "Macro program Selection Dialog"
 
     def whatsThis(self):
-        return "Uses it to select short convience subroutines"
+        return "Uses it to select short convenience subroutines"
 
     def isContainer(self):
         return False
@@ -279,7 +279,7 @@ class OriginOffsetDialogPlugin(QPyDesignerCustomWidgetPlugin):
         return QIcon(QPixmap(ICON.get_path('originoffsetdialog')))
 
     def toolTip(self):
-        return "Orgin Offset Editting Dialog"
+        return "Origin Offset Editing Dialog"
 
     def whatsThis(self):
         return ""
@@ -328,7 +328,7 @@ class ToolOffsetDialogPlugin(QPyDesignerCustomWidgetPlugin):
         return QIcon(QPixmap(ICON.get_path('Tooloffsetdialog')))
 
     def toolTip(self):
-        return "Tool Offset Editting Dialog"
+        return "Tool Offset Editing Dialog"
 
     def whatsThis(self):
         return ""

--- a/lib/python/qtvcp/plugins/simplewidgets_plugin.py
+++ b/lib/python/qtvcp/plugins/simplewidgets_plugin.py
@@ -279,7 +279,7 @@ class GeneralHALOutputPlugin(QPyDesignerCustomWidgetPlugin):
     def toolTip(self):
         return "Generalized HAL Output Pin Widget"
     def whatsThis(self):
-        return "Used to add HAl Pins to Arbritrary widgets"
+        return "Used to add HAl Pins to Arbitrary widgets"
     def isContainer(self):
         return True
     def domXml(self):
@@ -312,7 +312,7 @@ class GeneralHALInputPlugin(QPyDesignerCustomWidgetPlugin):
     def toolTip(self):
         return "Generalized HAL Input Pin Widget"
     def whatsThis(self):
-        return "Used to add HAl Pins to Arbritrary widgets"
+        return "Used to add HAl Pins to Arbitrary widgets"
     def isContainer(self):
         return True
     def domXml(self):

--- a/lib/python/qtvcp/plugins/status_label_plugin.py
+++ b/lib/python/qtvcp/plugins/status_label_plugin.py
@@ -367,7 +367,7 @@ class StatusLabelDialog(QtWidgets.QDialog):
         layout.addWidget(self.combo)
 
         # related data selection - note the name 'self.ud' uses a number
-        # that doubles each time - binary coded. thsi is so we can specify
+        # that doubles each time - binary coded. this is so we can specify
         # multiple selectors  code 1 give ud1, code 2 gives ud2, code 3 gives
         # ud1 and ud2 etc
  

--- a/lib/python/qtvcp/plugins/toolbutton_plugin.py
+++ b/lib/python/qtvcp/plugins/toolbutton_plugin.py
@@ -30,7 +30,7 @@ class SystemToolButtonPlugin(QPyDesignerCustomWidgetPlugin):
     def icon(self):
         return QtGui.QIcon(QtGui.QPixmap(ICON.get_path('systemtoolbutton')))
     def toolTip(self):
-        return "Button for selecting a User Co-ordinate System"
+        return "Button for selecting a User Coordinate System"
     def whatsThis(self):
         return ""
     def isContainer(self):

--- a/lib/python/qtvcp/qt_action.py
+++ b/lib/python/qtvcp/qt_action.py
@@ -110,7 +110,7 @@ class _Lcnc_Action(object):
             STATUS.emit('error',linuxcnc.OPERATOR_ERROR,'Hard Limits Are Overridden!')
             self.cmd.override_limits()
         else:
-            # make it temparary
+            # make it temporary
             STATUS.emit('error',255,'Hard Limits Are Reset To Active!')
             self.cmd.override_limits()
 
@@ -247,7 +247,7 @@ class _Lcnc_Action(object):
 
     def SET_AXIS_ORIGIN(self,axis,value):
         if axis == '' or axis.upper() not in ("XYZABCUVW"):
-            log.warning("Couldn't set orgin -axis >{}< not recognized:".format(axis))
+            log.warning("Couldn't set origin -axis >{}< not recognized:".format(axis))
         m = "G10 L20 P0 %s%f"%(axis,value)
         fail, premode = self.ensure_mode(linuxcnc.MODE_MDI)
         self.cmd.mdi(m)

--- a/lib/python/qtvcp/qt_istat.py
+++ b/lib/python/qtvcp/qt_istat.py
@@ -119,7 +119,7 @@ class _IStat(object):
             log.debug('Machine is IMPERIAL based. unit Conversion constant={}'.format(self.MACHINE_UNIT_CONVERSION ))
 
         axes = self.INI.find("TRAJ", "COORDINATES")
-        if axes is not None: # i.e. LCNC is running, not just in Qt Desinger
+        if axes is not None: # i.e. LCNC is running, not just in Qt Designer
             axes = axes.replace(" ", "")
             log.debug('TRAJ COORDINATES: {}'.format(axes))
             self.AVAILABLE_AXES = []
@@ -148,7 +148,7 @@ class _IStat(object):
                 else:
                     self.GET_JOG_FROM_NAME[c] = num
 
-                # list of availble joint numbers
+                # list of available joint numbers
                 self.AVAILABLE_JOINTS.append(num)
 
                 # AXIS sanity check
@@ -171,7 +171,7 @@ class _IStat(object):
 
         # home all check
         self.HOME_ALL_FLAG = 1
-        # set Home All Flage only if ALL joints specify a HOME_SEQUENCE
+        # set Home All Flag only if ALL joints specify a HOME_SEQUENCE
         jointcount = len(self.AVAILABLE_JOINTS)
         self.JOINT_SEQUENCE_LIST = {}
         for j in range(jointcount):
@@ -193,7 +193,7 @@ class _IStat(object):
                 self.JOINT_TYPE_INT[j] = 2
             self.JOINT_SEQUENCE[j]  = int(self.INI.find(section, "HOME_SEQUENCE") or 0)
 
-        # jog syncronized sequence
+        # jog synchronized sequence
         templist = []
         for j in self.AVAILABLE_JOINTS:
             temp = []
@@ -407,7 +407,7 @@ class _IStat(object):
         c = self.MACHINE_UNIT_CONVERSION_9
         return list(map(lambda x,y: x*y, v, c))
 
-    # This finds the filter program's initilizing
+    # This finds the filter program's initializing
     # program eg python for .py from INI
     def get_filter_program(self, fname):
         ext = os.path.splitext(fname)[1]

--- a/lib/python/qtvcp/qt_makegui.py
+++ b/lib/python/qtvcp/qt_makegui.py
@@ -91,7 +91,7 @@ class _VCPWindow(QtWidgets.QMainWindow):
         self.PREFS_ = None
         self.originalCloseEvent_ = self.closeEvent
         self._halWidgetList = []
-        # make an instance with embeded variables so they
+        # make an instance with embedded variables so they
         # are available to all subclassed objects
         _HalWidgetBase(halcomp,path,self)
 

--- a/lib/python/qtvcp/qt_pstat.py
+++ b/lib/python/qtvcp/qt_pstat.py
@@ -26,7 +26,7 @@ LOG = logger.getLogger(__name__)
 
 # BASE is the absolute path to linuxcnc base
 # LIBDIR is the path to qtvcp python files
-# DATADIR is where the standarad UI files are
+# DATADIR is where the standard UI files are
 # IMAGEDIR is for icons
 class _PStat(object):
     def __init__(self):
@@ -216,7 +216,7 @@ class _PStat(object):
             return
         else:
             LOG.debug("Checking for resources.py in: yellow<{}>".format(defaultqrcpy))
-            # if there is a defult resource file or a QRC to compile it from:
+            # if there is a default resource file or a QRC to compile it from:
             if os.path.exists(defaultqrcpy) or self.QRC_IS_LOCAL is not None:
                 if os.path.exists(defaultqrcpy):
                     LOG.info("Using DEFAULT resources.py file from yellow<{}>".format(defaultqrcpy))

--- a/lib/python/qtvcp/qt_tstat.py
+++ b/lib/python/qtvcp/qt_tstat.py
@@ -330,7 +330,7 @@ class _TStat(object):
             LOG.debug("Save line: {}".format(line))
             if not skip:
                 print(line, file=file)
-        # Theses lines are required to make sure the OS doesn't cache the data
+        # These lines are required to make sure the OS doesn't cache the data
         # That would make linuxcnc and the widget to be out of synch leading to odd errors
         file.flush()
         os.fsync(file.fileno())

--- a/lib/python/qtvcp/widgets/action_button.py
+++ b/lib/python/qtvcp/widgets/action_button.py
@@ -15,7 +15,7 @@
 
 # Action buttons are used to change linuxcnc behaivor do to button pushing.
 # By making the button 'checkable' in the designer editor,
-# the buton will toggle.
+# the button will toggle.
 # In the designer editor, it is possible to select what the button will do.
 ###############################################################################
 
@@ -247,8 +247,8 @@ class ActionButton(Indicated_PushButton, _HalWidgetBase):
                 self.pressed.connect(lambda: self.jog_selected_action(-1))
                 self.released.connect(lambda: self.jog_selected_action(0))
 
-            # jog button use diferent action signals so
-            # leave early to aviod the standard 'clicked' signal
+            # jog button use different action signals so
+            # leave early to avoid the standard 'clicked' signal
             return
 
         elif True in(self.zero_axis, self.zero_g5x,self.zero_g92, self.run, self.zero_zrot,
@@ -604,7 +604,7 @@ class ActionButton(Indicated_PushButton, _HalWidgetBase):
             self.QTVCP_INSTANCE_.close()
         elif self.machine_log_dialog:
             STATUS.emit('dialog-request',{'NAME':'MACHINELOG', 'ID':'_%s_'% self.objectName()})
-        # defult error case
+        # default error case
         else:
             if state is not None:
                 self.safecheck(state)

--- a/lib/python/qtvcp/widgets/action_button_round.py
+++ b/lib/python/qtvcp/widgets/action_button_round.py
@@ -13,10 +13,10 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# This is an extention of action buttons to show a round button image.
+# This is an extension of action buttons to show a round button image.
 # Action buttons are used to control linuxcnc behaivor by pressing.
 # By making the button 'checkable' in the designer editor,
-# the buton will toggle.
+# the button will toggle.
 # In the designer editor, it is possible to select what the button will do.
 ###############################################################################
 

--- a/lib/python/qtvcp/widgets/axis_tool_button.py
+++ b/lib/python/qtvcp/widgets/axis_tool_button.py
@@ -195,7 +195,7 @@ class AxisToolButton(QToolButton, _HalWidgetBase):
                     self.hal_pin_joint.set(self.isChecked())
             else:
                 ACTION.SET_SELECTED_AXIS(self._axis)
-                # set this whithout causing a STATUS message output
+                # set this without causing a STATUS message output
                 # in case we are selecting an axis to un/home
                 STATUS.selected_joint = self._joint
                 if self._halpin_option:
@@ -205,7 +205,7 @@ class AxisToolButton(QToolButton, _HalWidgetBase):
                 ACTION.SET_SELECTED_JOINT(-1)
             else:
                 ACTION.SET_SELECTED_AXIS('None')
-                # set this whithout causing a STATUS message output
+                # set this without causing a STATUS message output
                 # in case we are selecting an axis to un/home
                 STATUS.selected_joint = -1
             if self._halpin_option:

--- a/lib/python/qtvcp/widgets/dialog_widget.py
+++ b/lib/python/qtvcp/widgets/dialog_widget.py
@@ -62,7 +62,7 @@ LOG = logger.getLogger(__name__)
     # This general function parses the geometry string and places
     # the dialog based on what it finds.
     # there are directive words allowed.
-    # If there are no letters in thw string , it will check the
+    # If there are no letters in the string, it will check the
     # preference file (if there is one) to see what the last position
     # was. If all else fails it uses it's natural Designer stated
     # geometry
@@ -106,7 +106,7 @@ class GeometryMixin(_HalWidgetBase):
                 self.setGeometry(geom)
                 return
             elif 'bottomleft' in self._geometry_string.lower():
-                # move to botton left of parent
+                # move to bottom left of parent
                 ph = self.topParent.geometry().height()
                 px = self.topParent.geometry().x()
                 py = self.topParent.geometry().y()
@@ -351,10 +351,10 @@ class ToolDialog(LcncDialog, GeometryMixin):
         self.setStandardButtons(QMessageBox.Ok)
         self.useDesktopDialog = False
 
-    # We want the tool change HAL pins the same as whats used in AXIS so it is
+    # We want the tool change HAL pins the same as what's used in AXIS so it is
     # easier for users to connect to.
     # So we need to trick the HAL component into doing this for these pins,
-    # but not anyother Qt widgets.
+    # but not any other Qt widgets.
     # So we record the original base name of the component, make our pins, then
     # switch it back
     def _hal_init(self):
@@ -374,7 +374,7 @@ class ToolDialog(LcncDialog, GeometryMixin):
         else:
             LOG.warning("""Detected hal_manualtoolchange component already loaded
    Qtvcp recommends to allow use of it's own component by not loading the original. 
-   Qtvcp Intergrated toolchange dialog will not show untill then""")
+   Qtvcp Integrated toolchange dialog will not show until then""")
         if self.PREFS_:
             self.play_sound = self.PREFS_.getpref('toolDialog_play_sound', True, bool, 'DIALOG_OPTIONS')
             self.speak = self.PREFS_.getpref('toolDialog_speak', True, bool, 'DIALOG_OPTIONS')

--- a/lib/python/qtvcp/widgets/fake_status.py
+++ b/lib/python/qtvcp/widgets/fake_status.py
@@ -17,7 +17,7 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
-# This program is used to fake the status of linuxcnc in python fot the graphics display
+# This program is used to fake the status of linuxcnc in python for the graphics display
 # in qtvcp. Now in designer it shows a fake display of an xyz machine.
 # you could probably extends this to update some attributes and fake tool movement on a demo display
 #

--- a/lib/python/qtvcp/widgets/image_switcher.py
+++ b/lib/python/qtvcp/widgets/image_switcher.py
@@ -67,7 +67,7 @@ class ImageSwitcher(QLabel, _HalWidgetBase):
             if number <0 or number > len(self._imagePath)-1:
                 LOG.debug('Path reference number out of range: {}'.format(number))
                 return
-            # resouces file images.
+            # resources file images.
             if ':/' in self._imagePath[number]:
                 path = self._imagePath[number]
                 pixmap = QPixmap(path)
@@ -79,7 +79,7 @@ class ImageSwitcher(QLabel, _HalWidgetBase):
             LOG.error('Path reference number: {}'.format(e))
             path = os.path.expanduser(self._defaultImage)
         #print 'requested:',number,self._imagePath[number]
-        # if path doesn't exisit try referencing
+        # if path doesn't exist try referencing
         # from the built in image folder
         if not os.path.exists(path):
             path = os.path.join(INFO.IMAGE_PATH, path)
@@ -178,7 +178,7 @@ class StatusImageSwitcher(ImageSwitcher):
             #print 'bool images'
             self.set_image_number(1)
         elif (len(self._imagePath)-1) == (len(INFO.AVAILABLE_JOINTS)):
-            #print 'per joint limts images', self._last_limit, group
+            #print 'per joint limits images', self._last_limit, group
             for i in range(0,len(INFO.AVAILABLE_JOINTS)):
                 if group[i] == self._last_limit[i]:
                     pass
@@ -189,7 +189,7 @@ class StatusImageSwitcher(ImageSwitcher):
                     break
         elif (len(self._imagePath)-1) == (len(INFO.AVAILABLE_JOINTS) * 2):
             pass
-            #print 'per joint and per end limts images'
+            #print 'per joint and per end limits images'
         self._last_limit = group
 
     #########################################################################

--- a/lib/python/qtvcp/widgets/jog_increments.py
+++ b/lib/python/qtvcp/widgets/jog_increments.py
@@ -39,7 +39,7 @@ class JogIncrements(QtWidgets.QComboBox, _HalWidgetBase):
         self.linear = True
         self._block_signal = False
 
-    # Default to continous jogging
+    # Default to continuous jogging
     # with a combo box display, it's assumed the showing increment
     # is valid - so we must update the rate if the units mode changes.
     def _hal_init(self):

--- a/lib/python/qtvcp/widgets/macro_widget.py
+++ b/lib/python/qtvcp/widgets/macro_widget.py
@@ -110,7 +110,7 @@ class CustomSVG(QtSvg.QSvgWidget):
 # Macro tab widget
 #
 # macro tab widget parses the subroutine path for /lathe
-# It then opens the .ngc files ther eand searches for keynames
+# It then opens the .ngc files there and searches for keynames
 # using these key names it puts together a tab widget with svg file pics
 # the svg file should be in the same folder
 ###############################################################################
@@ -176,7 +176,7 @@ class MacroTab(QtWidgets.QWidget, _HalWidgetBase):
     # first find macros
     # then build a menu page
     # then build the stack
-    # anything goes wrong display an eror page
+    # anything goes wrong display an error page
     def buildStack(self):
         macroFlag = False
         for path in INFO.SUB_PATH_LIST:
@@ -259,7 +259,7 @@ class MacroTab(QtWidgets.QWidget, _HalWidgetBase):
         vbox = QtWidgets.QVBoxLayout()
         grid = QtWidgets.QGridLayout()
         grid.setSpacing(10)
-        # we grid them in columns of (arbritrarily) 5
+        # we grid them in columns of (arbitrarily) 5
         # hopefully we don;t have too many macros...
         for i, tName in enumerate(tabNames):
             svg_name = self[tName][1][0]
@@ -459,7 +459,7 @@ class MacroTab(QtWidgets.QWidget, _HalWidgetBase):
         self.getSaveFileName()
 
     def openReturn(self, path):
-        LOG.debug("Open return filename choosen: {}".format(path))
+        LOG.debug("Open return filename chosen: {}".format(path))
         file = QtCore.QFile(path)
         file.open(QtCore.QFile.ReadOnly)
         name = str(self.stack.currentWidget().objectName())
@@ -485,7 +485,7 @@ class MacroTab(QtWidgets.QWidget, _HalWidgetBase):
     # save the current screen data to file picked by the user.
     # it's a plain text file
     def saveReturn(self, path):
-        LOG.debug("Save return filename choosen: {}".format(path))
+        LOG.debug("Save return filename chosen: {}".format(path))
         name = str(self.stack.currentWidget().objectName())
         if name == '': return
         file = QtCore.QFile(path)
@@ -505,7 +505,7 @@ class MacroTab(QtWidgets.QWidget, _HalWidgetBase):
                     file.errorString())
 
     # we do this instead of directly so the dialog version's title changes
-    # when it's overriden
+    # when it's overridden
     def setTitle(self, string):
         self.setWindowTitle(string)
 
@@ -517,7 +517,7 @@ class MacroTab(QtWidgets.QWidget, _HalWidgetBase):
         STATUS.emit('dialog-request', mess)
 
     # request the system to pop a load path picker dialog
-    # do this so the system is consistant and things like dialog
+    # do this so the system is consistent and things like dialog
     # placement are done.
     def getFileName(self):
         mess = {'NAME':self.load_dialog_code,'ID':'%s__' % self.objectName(),
@@ -528,7 +528,7 @@ class MacroTab(QtWidgets.QWidget, _HalWidgetBase):
         STATUS.emit('dialog-request', mess)
 
     # request the system to pop a save path picker dialog
-    # do this so the system is consistant and things like dialog
+    # do this so the system is consistent and things like dialog
     # placement are done.
     def getSaveFileName(self):
         mess = {'NAME':self.save_dialog_code,'ID':'%s__' % self.objectName(),

--- a/lib/python/qtvcp/widgets/nurbs_editor.py
+++ b/lib/python/qtvcp/widgets/nurbs_editor.py
@@ -215,7 +215,7 @@ class NurbsEditor(QDialog):
         print(('G5.3'), file=self.workfile)
 
         ##############################
-        # rapids to show boundry
+        # rapids to show boundary
         ##############################
         print((''), file=self.workfile)
         print(('( Show control points with rapid lines )'), file=self.workfile)

--- a/lib/python/qtvcp/widgets/origin_offsetview.py
+++ b/lib/python/qtvcp/widgets/origin_offsetview.py
@@ -246,7 +246,7 @@ class OriginOffsetView(QTableView, _HalWidgetBase):
 
         degree_tmpl = "%11.2f"
 
-        # fill each row of the liststore fron the offsets arrays
+        # fill each row of the liststore from the offsets arrays
         for row, i in enumerate([ap, rot, g92, tool, g54, g55, g56, g57, g58, g59, g59_1, g59_2, g59_3]):
             for column in range(0, 9):
                 if row == 1:

--- a/lib/python/qtvcp/widgets/overlay_widget.py
+++ b/lib/python/qtvcp/widgets/overlay_widget.py
@@ -56,8 +56,8 @@ class OverlayWidget(QWidget):
 
     # There seems to be no way to get the very top level widget
     # in QT the parent widget can be owned in another parent
-    # this addes an event filter the widget in 'top_level'
-    # so we can track what is happenning to it.
+    # this adds an event filter the widget in 'top_level'
+    # so we can track what is happening to it.
     def newParent(self):
         self.parent = self.top_level
         self.last = self.parent
@@ -136,7 +136,7 @@ class FocusOverlay(OverlayWidget, _HalWidgetBase):
 
     # This is how we plant the very top level parent into
     # our overlay widget
-    # QTVCP_INSTANCE is not accessable from Designer
+    # QTVCP_INSTANCE is not accessible from Designer
     # it should work with any main window but doesn't.
     # this worked so i stopped looking why
     # this also sets up following show or hide etc based on
@@ -286,7 +286,7 @@ class FocusOverlay(OverlayWidget, _HalWidgetBase):
         self.setLayout(vbox)
         self.setGeometry(300, 300, 300, 150)
 
-    # would need to class patch for something realy useful
+    # would need to class patch for something really useful
     def okChecked(self):
         self.hide()
     def cancelChecked(self):

--- a/lib/python/qtvcp/widgets/probe_subprog.py
+++ b/lib/python/qtvcp/widgets/probe_subprog.py
@@ -99,7 +99,7 @@ class ProbeSubprog(QObject, ProbeRoutines):
         self.cal_avg_error = False
         self.cal_x_error = False
         self.cal_y_error = False
-        # list of results to be transfered to main program
+        # list of results to be transferred to main program
         self.status_list = ['xm', 'xc', 'xp', 'ym', 'yc', 'yp', 'lx', 'ly', 'z', 'd', 'a', 'delta']
         # data structure to hold result values
         self.status_xm = 0.0
@@ -149,7 +149,7 @@ class ProbeSubprog(QObject, ProbeRoutines):
                 if not self.check_pid(self.PID):
 #                    sys.exit(0)
                     self.terminate()
-    # check for an error messsage was sent to us or
+    # check for an error message was sent to us or
     # check that the command is actually a method in our class else
     # this message isn't for us - ignore it
     def process_command(self, cmd):

--- a/lib/python/qtvcp/widgets/radio_axis_selector.py
+++ b/lib/python/qtvcp/widgets/radio_axis_selector.py
@@ -33,7 +33,7 @@ class RadioAxisSelector(QtWidgets.QRadioButton, _HalWidgetBase):
                 ACTION.SET_SELECTED_JOINT(self.joint)
             else:
                 ACTION.SET_SELECTED_AXIS(self.axis)
-                # set this whithout causing a STATUS message output
+                # set this without causing a STATUS message output
                 # in case we are selecting an axis to un/home
                 STATUS.selected_joint = self.joint
 

--- a/lib/python/qtvcp/widgets/richtext_selector.py
+++ b/lib/python/qtvcp/widgets/richtext_selector.py
@@ -266,7 +266,7 @@ class MainWindow(QMainWindow):
 
     def update_format(self):
         """
-        Update the font format toolbar/actions when a new text selection is made. This is neccessary to keep
+        Update the font format toolbar/actions when a new text selection is made. This is necessary to keep
         toolbars/etc. in sync with the current edit state.
         :return:
         """

--- a/lib/python/qtvcp/widgets/screen_options.py
+++ b/lib/python/qtvcp/widgets/screen_options.py
@@ -261,7 +261,7 @@ class ScreenOptions(QtWidgets.QWidget, _HalWidgetBase):
         if self.process_tabs:
             self.add_xembed_tabs()
 
-        # clear and add an intial machine log message
+        # clear and add an initial machine log message
         STATUS.emit('update-machine-log', '', 'DELETE')
         STATUS.emit('update-machine-log', '', 'INITIAL')
         STATUS.connect('tool-info-changed', lambda w, data: self._tool_file_info(data, TOOL.COMMENTS))
@@ -273,7 +273,7 @@ class ScreenOptions(QtWidgets.QWidget, _HalWidgetBase):
             self.init_zmq_publish()
 
     # This is called early by qt_makegui.py for access to
-    # be able to pass the preference object to ther widgets
+    # be able to pass the preference object to the widgets
     def _pref_init(self):
         if self.use_pref_file:
             # we prefer INI settings

--- a/lib/python/qtvcp/widgets/screen_options.py
+++ b/lib/python/qtvcp/widgets/screen_options.py
@@ -324,7 +324,7 @@ class ScreenOptions(QtWidgets.QWidget, _HalWidgetBase):
                 if self.desktop_notify:
                     NOTICE.update(self.notify_critical, title='Internal NML Display:', message=text)
 
-            elif kind == 255: # temparary info
+            elif kind == 255: # temporary info
                 if self.desktop_notify:
                     NOTICE.update(self.notify_normal,
                                     title='Low Priority:',

--- a/lib/python/qtvcp/widgets/simple_widgets.py
+++ b/lib/python/qtvcp/widgets/simple_widgets.py
@@ -340,7 +340,7 @@ class Indicated_PushButton(QtWidgets.QPushButton, _HalWidgetBase):
             self._flip_state(False)
 
     # arbitraray python commands are possible using 'INSTANCE' in the string
-    # gives acess to widgets and handler functions 
+    # gives access to widgets and handler functions 
     def python_command(self, state = None):
         if self._python_command:
             if state:

--- a/lib/python/qtvcp/widgets/versa_probe_subprog.py
+++ b/lib/python/qtvcp/widgets/versa_probe_subprog.py
@@ -105,7 +105,7 @@ class VersaSubprog(QObject):
                 if not self.check_pid(self.PID):
                     sys.exit(0)
 
-    # check for an error messsage was sent to us or
+    # check for an error message was sent to us or
     # check that the command is actually a method in our class else
     # this message isn't for us - ignore it
     def process_command(self, cmd):

--- a/lib/python/qtvcp/widgets/widget_baseclass.py
+++ b/lib/python/qtvcp/widgets/widget_baseclass.py
@@ -37,7 +37,7 @@ class _HalWidgetBase_(object):
         # only initialize once for all instances
         if self.__class__._instanceNum >=1:
             return
-        # embed these varibles in all instances
+        # embed these variables in all instances
         self.__class__.HAL_GCOMP_ = comp
         self.__class__.PATHS_ = path
         self.__class__.QTVCP_INSTANCE_ = window

--- a/lib/python/qtvcp/widgets/widget_switcher.py
+++ b/lib/python/qtvcp/widgets/widget_switcher.py
@@ -119,8 +119,8 @@ class WidgetSwitcher(QStackedWidget, _HalWidgetBase):
                     obj[0].setParent(obj[1])
                 obj[0].show()
 
-    # show the stacked widget as orignally layed out (hopefully)
-    # This will set the stacked widget to diplay the first page
+    # show the stacked widget as originally laid out (hopefully)
+    # This will set the stacked widget to display the first page
     # which is index 0
     def show_default(self):
         for i in self._widgetNames:

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -1099,7 +1099,7 @@ class GlCanonDraw:
 
     def show_icon(self,idx,icon):
         # only show icon once for idx for home,limit icons
-        #   accomodates hal_gremlin override format_dro()
+        #   accommodates hal_gremlin override format_dro()
         #   and prevents display for both Rad and Dia
         if icon is homeicon:
             if idx in self.show_icon_home_list: return
@@ -1316,7 +1316,7 @@ class GlCanonDraw:
                 g = re.split(" *(-?[XYZABCUVW])", self.get_geometry())
                 g = "".join(reversed(g))
 
-                for ch in g: # Apply in orignal non-reversed GEOMETRY order
+                for ch in g: # Apply in original non-reversed GEOMETRY order
                     if ch == '-':
                         sign = -1
                     elif ch == 'A':
@@ -1758,7 +1758,7 @@ class GlCanonDraw:
         glDepthFunc(GL_ALWAYS)
         diameter, frontangle, backangle, orientation = current_tool[-4:]
         w = 3/8.
-        glDisable(GL_CULL_FACE)#lathe tool needs to be visable form both sides
+        glDisable(GL_CULL_FACE)#lathe tool needs to be visible form both sides
         radius = self.to_internal_linear_unit(diameter) / 2.
         glColor3f(*self.colors['lathetool'])
         glBegin(GL_LINES)

--- a/lib/python/vismach.py
+++ b/lib/python/vismach.py
@@ -639,7 +639,7 @@ class BoxCenteredXY(Box):
         Box.__init__(self, -xw/2.0, -yw/2.0, 0, xw/2.0, yw/2.0, zw)
 
 # capture current transformation matrix
-# note that this tranforms from the current coordinate system
+# note that this transforms from the current coordinate system
 # to the viewport system, NOT to the world system
 class Capture(object):
     def __init__(self):
@@ -819,7 +819,7 @@ class O(rs274.OpenGLTk.Opengl):
         # so lets also invert the work2view matrix
         view2work = invert(self.work2view.t)
 
-        # since backplot lines only need vertexes, not orientation,
+        # since backplot lines only need vertices, not orientation,
         # and the tooltip is at the origin, getting the tool coords
         # is easy
         tx, ty, tz = self.tool2view.t[12:15]


### PR DESCRIPTION
Found via `codespell v2.0.dev`  
```
codespell -q 3  -L ans,doubleclick,halp,parms
```