### PR TITLE
Modify config file name written in external-offsets.txt (eoffsets_demo.ini -> eoffsets.ini)

### DIFF
--- a/docs/src/motion/external-offsets.txt
+++ b/docs/src/motion/external-offsets.txt
@@ -257,9 +257,9 @@ replace the 'LIB:basic_sim.tcl' item HALFILEs appropriate to the
 machine.  The provided pyvcp files (.hal and .xml) could be a
 starting point for application-specific gui interfaces.
 
-=== eoffsets_demo.ini
+=== eoffsets.ini
 
-The sim config 'sim/configs/axis/external_offsets/eoffsets_demo.ini'
+The sim config 'sim/configs/axis/external_offsets/eoffsets.ini'
 demonstrates a cartesian XYZ machine with controls to enable external
 offsets on any axis.
 

--- a/docs/src/motion/external-offsets_es.txt
+++ b/docs/src/motion/external-offsets_es.txt
@@ -256,9 +256,9 @@ reemplazar el elemento 'LIB:basic_sim.tcl' con HALFILEs apropiados para la
 máquina. Los archivos pyvcp proporcionados (.hal y .xml) podrían ser un
 punto de partida para interfaces gui específicas de la aplicación.
 
-=== eoffsets_demo.ini
+=== eoffsets.ini
 
-La configuración sim 'sim/configs/axis/external_offsets/eoffsets_demo.ini'
+La configuración sim 'sim/configs/axis/external_offsets/eoffsets.ini'
 demuestra una máquina cartesiana XYZ con controles para habilitar
 offsets externos en cualquier eje.
 


### PR DESCRIPTION
It seems that the file name `eoffsets_demo.ini` written in `external-offsets.txt` does not exist.
Maybe it's a mistaken in `eoffsets.ini` isn't it ?

![image](https://user-images.githubusercontent.com/2480694/100469234-32bb2100-3119-11eb-8442-1430fba369ee.png)
