### PR TITLE
docs: adjust hal section of toc

### DIFF
--- a/docs/src/hal/tools.txt
+++ b/docs/src/hal/tools.txt
@@ -86,7 +86,7 @@ image::images/hal-meter02.png[alt="Halmeter"]
 
 == Halshow
 
-Halshow (see separate section for complete usage description)
+Halshow (<<cha:halshow,complete usage description>>) 
 can be started from the command line to show details for selected
 components, pins, parameters, signals, functions, and threads of a running HAL.
 The WATCH tab provides a continuous display of selected pin, parameters, and

--- a/docs/src/index.tmpl
+++ b/docs/src/index.tmpl
@@ -255,13 +255,12 @@ into LinuxCNC.
 <div id="sec11">
 	<ul>
 		<li><a href="hal/intro.html">HAL Introduction</a></li>
-		<li><a href="hal/basic-hal.html">Basic HAL Tutorial</a></li>
+		<li><a href="hal/basic-hal.html">Basic HAL Reference</a></li>
 		<li><a href="hal/twopass.html">HAL Twopass</a></li>
-		<li><a href="hal/tutorial.html">Advanced HAL Tutorial</a></li>
-		<li><a href="config/core-components.html">Core HAL Components</a></li>
+		<li><a href="hal/tutorial.html">HAL Tutorial</a></li>
+		<li><a href="config/core-components.html">HAL Core Components</a></li>
 		<li><a href="hal/components.html">HAL Component List</a></li>
 		<li><a href="hal/rtcomps.html">HAL Component Descriptions</a></li>
-		<li><a href="hal/halshow.html">Halshow</a></li>
 		<li><a href="hal/hal-examples.html">HAL Examples</a></li>
 		<li><a href="hal/comp.html">HAL Component Generator</a></li>
 		<li><a href="hal/haltcl.html">HAL TCL Files</a></li>

--- a/docs/src/index_cn.tmpl
+++ b/docs/src/index_cn.tmpl
@@ -189,12 +189,11 @@ function change(el)
 	<div id="sec11" style="display:none;">
 		<UL>
 			<LI><A HREF="hal/intro.html">HAL Introduction</A>
-			<LI><A HREF="hal/basic-hal.html">Basic HAL Tutorial</A>
-			<LI><A HREF="hal/tutorial.html">Advanced HAL Tutorial</A>
-			<LI><A HREF="config/core-components.html">Core HAL Components</A>
+			<LI><A HREF="hal/basic-hal.html">Basic HAL Reference</A>
+			<LI><A HREF="hal/tutorial.html">HAL Tutorial</A>
+			<LI><A HREF="config/core-components.html">HAL Core Components</A>
 			<LI><A HREF="hal/components.html">HAL Component List</A>
 			<LI><A HREF="hal/rtcomps.html">HAL Component Descriptions</A>
-			<LI><A HREF="hal/halshow.html">Halshow</A>
 			<LI><A HREF="hal/hal-examples.html">HAL Examples</A>
 			<LI><A HREF="hal/comp.html">HAL Component Generator</A>
 			<LI><A HREF="hal/haltcl.html">HAL TCL Files</A>


### PR DESCRIPTION
Just fitted the items of the table of contents of the HAL section to the corresponding headlines and moved the separate 'Halshow' to 'HAL Tools'.