### PR TITLE
AXIS: Add an axisui.error pin

### DIFF
--- a/docs/src/gui/axis.txt
+++ b/docs/src/gui/axis.txt
@@ -1057,6 +1057,15 @@ Type  Dir    Name
 float OUT               axisui.jog.increment
 ----
 
+Axis has a Hal output pin that indicates when an error has occurred. The
+'axisui.error' pin will remain 'TRUE' until all error notifications have
+been dismissed.
+
+----
+Type  Dir    Name
+bit   OUT    axisui.error
+----
+
 Axis has Hal input pins to clear the pop up notifications for errors and
 information.
 

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -335,27 +335,29 @@ class Notification(Tkinter.Frame):
 
     def add(self, iconname, message):
         self.place(relx=1, rely=1, y=-20, anchor="se")
-        iconname = self.tk.call("load_image", "std_" + iconname)
+        iconname_image = self.tk.call("load_image", "std_" + iconname)
         close = self.tk.call("load_image", "close", "notification-close")
         if len(self.widgets) > 10:
             self.remove(self.widgets[0])
         if self.cache:
             frame, icon, text, button, discard = self.cache.pop()
-            icon.configure(image=iconname)
+            icon.configure(image=iconname_image)
             text.configure(text=message)
-            widgets = frame, icon, text, button, iconname
+            widgets = frame, icon, text, button, iconname_image
         else:
             frame = Tkinter.Frame(self)
-            icon = Tkinter.Label(frame, image=iconname)
+            icon = Tkinter.Label(frame, image=iconname_image)
             text = Tkinter.Label(frame, text=message, wraplength=300, justify="left")
             button = Tkinter.Button(frame, image=close)
-            widgets = frame, icon, text, button, iconname
+            widgets = frame, icon, text, button, iconname_image
             text.pack(side="left")
             icon.pack(side="left")
             button.pack(side="left")
         button.configure(command=lambda: self.remove(widgets))
         frame.pack(side="top", anchor="e")
         self.widgets.append(widgets)
+        if iconname == "error":
+           comp["error"] = True
 
     def remove(self, widgets):
         self.widgets.remove(widgets)
@@ -366,6 +368,18 @@ class Notification(Tkinter.Frame):
             widgets[0].destroy()
         if len(self.widgets) == 0:
             self.place_forget()
+        if self._remaining_error_count() == 0:
+            comp["error"] = False
+
+    def _remaining_error_count(self):
+        """ Returns the count of remaining error messages """
+        count = 0
+        for i, item in enumerate(self.widgets):
+            frame, icon, text, button, iname = item
+            if iname == "icon_std_error":
+                count += 1
+        return count
+
 
 def soft_limits():
     def fudge(x):
@@ -3830,6 +3844,7 @@ if hal_present == 1 :
     comp.newpin("notifications-clear-info",hal.HAL_BIT,hal.HAL_IN)
     comp.newpin("notifications-clear-error",hal.HAL_BIT,hal.HAL_IN)
     comp.newpin("resume-inhibit",hal.HAL_BIT,hal.HAL_IN)
+    comp.newpin("error", hal.HAL_BIT, hal.HAL_OUT)
 
     vars.has_ladder.set(hal.component_exists('classicladder_rt'))
 


### PR DESCRIPTION
Add an `axisui.error` pin, mirroring the behaviour of the gmoccapy error pin exactly. The pin will be set high / True upon error, and will be set low / False when all error notifications have been dismissed by the operator.

This would allow us (https://github.com/linuxcnc-probe-screen/probe-screen-ng) to remove the requirement that users install a `.axisrc` file that injects this behaviour. Here's the `.axisrc` file we currently require users to install: https://github.com/linuxcnc-probe-screen/probe-screen-ng/blob/a00dff94257a8a53c764da400bcfad415fc2b95a/.axisrc
