### PR TITLE
Mb2hal: add fnct_01, fnct_05, add bit-invert for coils, change pin names

### DIFF
--- a/docs/man/es/man1/mb2hal.1
+++ b/docs/man/es/man1/mb2hal.1
@@ -33,7 +33,10 @@
 MB2HAL is a generic userspace HAL component to communicate with one or more
 Modbus devices.
 .PP
-See the Documents for more information on mb2hal
+See 
+.UR http://linuxcnc.org/docs/html/drivers/mb2hal.html 
+.UE
+for more information.
 .SH AUTHOR
 John Thornton
 .SH LICENSE

--- a/docs/man/man1/mb2hal.1
+++ b/docs/man/man1/mb2hal.1
@@ -33,7 +33,10 @@
 MB2HAL is a generic userspace HAL component to communicate with one or more
 Modbus devices.
 .PP
-See the Documents for more information on mb2hal
+See 
+.UR http://linuxcnc.org/docs/html/drivers/mb2hal.html 
+.UE
+for more information.
 .SH AUTHOR
 John Thornton
 .SH LICENSE

--- a/docs/src/drivers/mb2hal.txt
+++ b/docs/src/drivers/mb2hal.txt
@@ -129,9 +129,12 @@ FIRST_ELEMENT=0
 NELEMENTS=16
 
 #REQUIRED: Modbus transaction function code (see www.modbus.org specifications).
+#    fnct_01_read_coils               (01 = 0x01)
 #    fnct_02_read_discrete_inputs     (02 = 0x02)
 #    fnct_03_read_holding_registers   (03 = 0x03)
 #    fnct_04_read_input_registers     (04 = 0x04)
+#    fnct_05_write_single_coil        (05 = 0x05)
+#    fnct_06_write_single_register    (06 = 0x06)
 #    fnct_15_write_multiple_coils     (15 = 0x0F)
 #    fnct_16_write_multiple_registers (16 = 0x10)
 
@@ -160,7 +163,7 @@ MB_BYTE_TIMEOUT_MS=500
 
 #OPTIONAL: Instead of giving the transaction number, use a name.
 #Example: mb2hal.00.01 could become mb2hal.plcin.01
-#The name must not exceed 32 characters.
+#The name must not exceed 28 characters.
 #NOTE: when using names be careful that you dont end up with two transactions
 #usign the same name.
 

--- a/docs/src/drivers/mb2hal.txt
+++ b/docs/src/drivers/mb2hal.txt
@@ -138,17 +138,24 @@ NELEMENTS=16
 #    fnct_15_write_multiple_coils     (15 = 0x0F)
 #    fnct_16_write_multiple_registers (16 = 0x10)
 
-#fnct_02_read_discrete_inputs: creates boolean output HAL pins.
-#fnct_03_read_holding_registers: creates a floating point output HAL pins.
-#                           also creates a u32 output HAL pins.
-#fnct_04_read_input_registers: creates a floating point output HAL pins.
-#                         also creates a u32 output HAL pins.
-#fnct_15_write_multiple_coils: creates boolean input HAL pins.
-#fnct_16_write_multiple_registers: creates a floating point input HAL pins.
+#fnct_01_read_coils and
+#fnct_02_read_discrete_inputs: creates boolean output HAL pins 'bit' and 'bit-inv'.
+#fnct_03_read_holding_registers and
+#fnct_04_read_input_registers: creates floating point output HAL pins 'float'.
+#                         also creates u32 output HAL pins 'int'.
+#fnct_05_write_single_coil:    creates a boolean input HAL pin 'bit'
+#	NELEMENTS needs to be 1 or PIN_NAMES must contain just one name
+#fnct_06_write_single_register: creates a floating point input HAL pin 'float'
+#                          also creates a u32 input HAL pin 'int'.
+#	NELEMENTS needs to be 1 or PIN_NAMES must contain just one name
+#   Both pin values are added and limited to 65535 (UINT16_MAX). Normally use one and let the other open (read as 0).
+#fnct_15_write_multiple_coils: creates boolean input HAL pins 'bit'.
+#fnct_16_write_multiple_registers: creates floating point input HAL pins 'float'.
+#                             also creates u32 input HAL pins 'int'.
+#    Both pin values are added and limited to 65535 (UINT16_MAX). Normally use one and let the other open (read as 0).
 
 #The pins are named based on component name, transaction number and order number.
-#Example: mb2hal.00.01 (transaction=00, second register=01 (00 is the first one))
-
+#Example: mb2hal.00.01.<type> (transaction=00, second register=01 (00 is the first one))
 MB_TX_CODE=fnct_03_read_holding_registers
 
 #OPTIONAL: Response timeout for this transaction. In INTEGER ms. Defaults to 500 ms.

--- a/src/hal/user_comps/mb2hal/LogBook.txt
+++ b/src/hal/user_comps/mb2hal/LogBook.txt
@@ -24,6 +24,18 @@
  * USA.
  */
 
+2020-01-08:
+    - INI: added invert bit for fnct_02_read_discrete_inputs
+    - Added:
+      . fnct_01_read_coils
+      . fnct_05_write_single_coil
+    (Hans Unzner <hansunzner@gmail.com>)
+
+2018-08-19
+  # Add fnct_06_write_single_register function as not all devices (e.g.
+    Parker AC10 VFD) support fnct_16_write_multiple_registers.
+    (Lars Bensmann <lars@almosthappy.de>)
+
 2012-11-12:
   # Arduino example added.
     - Tested with Arduino Mega 2560 R3 using Modbusino over USB at 115200 bps.

--- a/src/hal/user_comps/mb2hal/LogBook.txt
+++ b/src/hal/user_comps/mb2hal/LogBook.txt
@@ -24,9 +24,12 @@
  * USA.
  */
 
-2020-01-08:
-    - INI: added invert bit for fnct_02_read_discrete_inputs
-    - Added:
+2021-01-17:
+    - Added Pins:
+      . added bit-inv (invert bit) output for fnct_02_read_discrete_inputs and fnct_01_read_coils
+      . added int input for fnct_06_write_single_register and fnct_16_write_multiple_register, 
+        renamed float pin to sub-pin '.float'        
+    - Added function codes:
       . fnct_01_read_coils
       . fnct_05_write_single_coil
     (Hans Unzner <hansunzner@gmail.com>)

--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -186,6 +186,10 @@ void *link_loop_and_logic(void *thrd_link_num)
                 this_mb_tx->protocol_debug);
 
             switch (this_mb_tx->mb_tx_fnct) {
+
+            case mbtx_01_READ_COILS:
+                ret = fnct_01_read_coils(this_mb_tx, this_mb_link);
+                break;
             case mbtx_02_READ_DISCRETE_INPUTS:
                 ret = fnct_02_read_discrete_inputs(this_mb_tx, this_mb_link);
                 break;
@@ -194,6 +198,9 @@ void *link_loop_and_logic(void *thrd_link_num)
                 break;
             case mbtx_04_READ_INPUT_REGISTERS:
                 ret = fnct_04_read_input_registers(this_mb_tx, this_mb_link);
+                break;
+            case mbtx_05_WRITE_SINGLE_COIL:
+                ret = fnct_05_write_single_coil(this_mb_tx, this_mb_link);
                 break;
             case mbtx_06_WRITE_SINGLE_REGISTER:
                 ret = fnct_06_write_single_register(this_mb_tx, this_mb_link);
@@ -397,9 +404,11 @@ void set_init_gbl_params()
     gbl.init_dbg     = debugERR; //until readed in config file
     gbl.slowdown     = 0;        //until readed in config file
     gbl.mb_tx_fncts[mbtxERR]                         = "";
+    gbl.mb_tx_fncts[mbtx_01_READ_COILS]              = "fnct_01_read_coils";
     gbl.mb_tx_fncts[mbtx_02_READ_DISCRETE_INPUTS]    = "fnct_02_read_discrete_inputs";
     gbl.mb_tx_fncts[mbtx_03_READ_HOLDING_REGISTERS]  = "fnct_03_read_holding_registers";
     gbl.mb_tx_fncts[mbtx_04_READ_INPUT_REGISTERS]    = "fnct_04_read_input_registers";
+    gbl.mb_tx_fncts[mbtx_05_WRITE_SINGLE_COIL]       = "fnct_05_write_single_coil";
     gbl.mb_tx_fncts[mbtx_06_WRITE_SINGLE_REGISTER]   = "fnct_06_write_single_register";
     gbl.mb_tx_fncts[mbtx_15_WRITE_MULTIPLE_COILS]    = "fnct_15_write_multiple_coils";
     gbl.mb_tx_fncts[mbtx_16_WRITE_MULTIPLE_REGISTERS]= "fnct_16_write_multiple_registers";

--- a/src/hal/user_comps/mb2hal/mb2hal.h
+++ b/src/hal/user_comps/mb2hal/mb2hal.h
@@ -102,6 +102,7 @@ typedef struct {
     //hal_float_t *scale;  //not yet implemented
     //hal_float_t *offset; //not yet implemented
     hal_bit_t **bit;
+    hal_bit_t **bit_inv;
     hal_u32_t **num_errors;     //num of acummulated errors (0=last tx OK)
 } mb_tx_t;
 

--- a/src/hal/user_comps/mb2hal/mb2hal.h
+++ b/src/hal/user_comps/mb2hal/mb2hal.h
@@ -22,10 +22,11 @@
 #define MB2HAL_DEFAULT_MB_RESPONSE_TIMEOUT_MS 500
 #define MB2HAL_DEFAULT_MB_BYTE_TIMEOUT_MS     500
 #define MB2HAL_DEFAULT_TCP_PORT    502
+#define MB2HAL_MAX_FNCT01_ELEMENTS 100
 #define MB2HAL_MAX_FNCT02_ELEMENTS 100
 #define MB2HAL_MAX_FNCT03_ELEMENTS 100
 #define MB2HAL_MAX_FNCT04_ELEMENTS 100
-#define MB2HAL_MAX_FNCT05_ELEMENTS 100
+#define MB2HAL_MAX_FNCT05_ELEMENTS 1
 #define MB2HAL_MAX_FNCT06_ELEMENTS 1
 #define MB2HAL_MAX_FNCT15_ELEMENTS 100
 #define MB2HAL_MAX_FNCT16_ELEMENTS 100
@@ -41,9 +42,11 @@ typedef enum { linkRTU,
              } link_type_t;
 
 typedef enum { mbtxERR,
+               mbtx_01_READ_COILS,
                mbtx_02_READ_DISCRETE_INPUTS,
                mbtx_03_READ_HOLDING_REGISTERS,
                mbtx_04_READ_INPUT_REGISTERS,
+               mbtx_05_WRITE_SINGLE_COIL,
                mbtx_06_WRITE_SINGLE_REGISTER,
                mbtx_15_WRITE_MULTIPLE_COILS,
                mbtx_16_WRITE_MULTIPLE_REGISTERS,
@@ -179,9 +182,11 @@ retCode create_HAL_pins();
 retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx);
 
 //mb2hal_modbus.c
-retCode fnct_15_write_multiple_coils(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
+retCode fnct_01_read_coils(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
 retCode fnct_02_read_discrete_inputs(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
-retCode fnct_04_read_input_registers(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
 retCode fnct_03_read_holding_registers(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
+retCode fnct_04_read_input_registers(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
+retCode fnct_05_write_single_coil(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
 retCode fnct_06_write_single_register(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
+retCode fnct_15_write_multiple_coils(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);
 retCode fnct_16_write_multiple_registers(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link);

--- a/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
+++ b/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
@@ -95,13 +95,16 @@ NELEMENTS=16
 PIN_NAMES=cycle_start,stop,feed_hold
 
 #REQUIRED: Modbus transaction function code (see www.modbus.org specifications).
+#    fnct_01_read_coils               (01 = 0x01)
 #    fnct_02_read_discrete_inputs     (02 = 0x02)
 #    fnct_03_read_holding_registers   (03 = 0x03)
 #    fnct_04_read_input_registers     (04 = 0x04)
+#    fnct_05_write_single_coil        (05 = 0x05)
 #    fnct_06_write_single_register    (06 = 0x06)
 #    fnct_15_write_multiple_coils     (15 = 0x0F)
 #    fnct_16_write_multiple_registers (16 = 0x10)
 
+# @TODO: update description
 #fnct_02_read_discrete_inputs: creates boolean output HAL pins.
 #fnct_03_read_holding_registers: creates a floating point output HAL pins.
 #                           also creates a u32 output HAL pins.
@@ -127,7 +130,7 @@ MB_BYTE_TIMEOUT_MS=500
 
 #OPTIONAL: Instead of giving the transaction number, use a name.
 #Example: mb2hal.00.01 could become mb2hal.plcin.01
-#The name must not exceed 32 characters.
+#The name must not exceed 28 characters.
 #NOTE: when using names be careful that you dont end up with two transactions
 #usign the same name.
 HAL_TX_NAME=remoteIOcfg

--- a/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
+++ b/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
@@ -104,19 +104,24 @@ PIN_NAMES=cycle_start,stop,feed_hold
 #    fnct_15_write_multiple_coils     (15 = 0x0F)
 #    fnct_16_write_multiple_registers (16 = 0x10)
 
-# @TODO: update description
-#fnct_02_read_discrete_inputs: creates boolean output HAL pins.
-#fnct_03_read_holding_registers: creates a floating point output HAL pins.
-#                           also creates a u32 output HAL pins.
-#fnct_04_read_input_registers: creates a floating point output HAL pins.
-#                         also creates a u32 output HAL pins.
-#fnct_06_write_single_register: creates a floating point input HAL pin.
+#fnct_01_read_coils and
+#fnct_02_read_discrete_inputs: creates boolean output HAL pins 'bit' and 'bit-inv'.
+#fnct_03_read_holding_registers and
+#fnct_04_read_input_registers: creates floating point output HAL pins 'float'.
+#                         also creates u32 output HAL pins 'int'.
+#fnct_05_write_single_coil:    creates a boolean input HAL pin 'bit'
 #	NELEMENTS needs to be 1 or PIN_NAMES must contain just one name
-#fnct_15_write_multiple_coils: creates boolean input HAL pins.
-#fnct_16_write_multiple_registers: creates a floating point input HAL pins.
+#fnct_06_write_single_register: creates a floating point input HAL pin 'float'
+#                          also creates a u32 input HAL pin 'int'.
+#	NELEMENTS needs to be 1 or PIN_NAMES must contain just one name
+#   Both pin values are added and limited to 65535 (UINT16_MAX). Normally use one and let the other open (read as 0).
+#fnct_15_write_multiple_coils: creates boolean input HAL pins 'bit'.
+#fnct_16_write_multiple_registers: creates floating point input HAL pins 'float'.
+#                             also creates u32 input HAL pins 'int'.
+#    Both pin values are added and limited to 65535 (UINT16_MAX). Normally use one and let the other open (read as 0).
 
 #The pins are named based on component name, transaction number and order number.
-#Example: mb2hal.00.01 (transaction=00, second register=01 (00 is the first one))
+#Example: mb2hal.00.01.<type> (transaction=00, second register=01 (00 is the first one))
 
 MB_TX_CODE=fnct_03_read_holding_registers
 

--- a/src/hal/user_comps/mb2hal/mb2hal_hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_hal.c
@@ -163,6 +163,12 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
                     mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
                 return retERR;
             }
+            if (0 != hal_pin_s32_newf(HAL_IN, mb_tx->int_value + pin_counter, gbl.hal_mod_id,
+                                      "%s.int", hal_pin_name)) {
+                ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_s32_newf failed",
+                    mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                return retERR;
+            }
             //if (0 != hal_param_float_newf(HAL_RW, mb_tx->scale + pin_counter, gbl.hal_mod_id,
             //                              "%s.scale", hal_pin_name)) {
             //    ERR(gbl.init_dbg, "[%d] [%s] [%s]", mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
@@ -174,7 +180,7 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
             //    return retERR;
             //}
             *mb_tx->float_value[pin_counter] = 0;
-            //*mb_tx->int_value[pin_counter] = 0;
+            *mb_tx->int_value[pin_counter] = 0;
             //mb_tx->scale[pin_counter] = 1;
             //mb_tx->offset[pin_counter] = 0;
             break;

--- a/src/hal/user_comps/mb2hal/mb2hal_hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_hal.c
@@ -48,13 +48,16 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
 
     case mbtx_02_READ_DISCRETE_INPUTS:
     case mbtx_15_WRITE_MULTIPLE_COILS:
-        mb_tx->bit = hal_malloc(sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);
-        if (mb_tx->bit == NULL) {
+        mb_tx->bit     = hal_malloc(sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);
+        mb_tx->bit_inv = hal_malloc(sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);
+        
+        if (mb_tx->bit == NULL || mb_tx->bit_inv == NULL) {
             ERR(gbl.init_dbg, "[%d] [%s] NULL hal_malloc [%d] elements",
                 mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, mb_tx->mb_tx_nelem);
             return retERR;
         }
         memset(mb_tx->bit, 0, sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);
+        memset(mb_tx->bit_inv, 1, sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);    
         break;
 
     case mbtx_03_READ_HOLDING_REGISTERS:
@@ -105,12 +108,19 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
             break;
         case mbtx_02_READ_DISCRETE_INPUTS:
             if (0 != hal_pin_bit_newf(HAL_OUT, mb_tx->bit + pin_counter, gbl.hal_mod_id,
-                                      "%s", hal_pin_name)) {
+                                      "%s.bit", hal_pin_name)) {
+                ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
+                    mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                return retERR;
+            }
+            if (0 != hal_pin_bit_newf(HAL_OUT, mb_tx->bit_inv + pin_counter, gbl.hal_mod_id,
+                                      "%s.bit-inv", hal_pin_name)) {
                 ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
                     mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
                 return retERR;
             }
             *mb_tx->bit[pin_counter] = 0;
+            *mb_tx->bit_inv[pin_counter] = 1;
             break;
         case mbtx_04_READ_INPUT_REGISTERS:
         case mbtx_03_READ_HOLDING_REGISTERS:

--- a/src/hal/user_comps/mb2hal/mb2hal_hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_hal.c
@@ -46,7 +46,9 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
 
     switch (mb_tx->mb_tx_fnct) {
 
+    case mbtx_01_READ_COILS:
     case mbtx_02_READ_DISCRETE_INPUTS:
+    case mbtx_05_WRITE_SINGLE_COIL:
     case mbtx_15_WRITE_MULTIPLE_COILS:
         mb_tx->bit     = hal_malloc(sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);
         mb_tx->bit_inv = hal_malloc(sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);
@@ -97,6 +99,7 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
         DBG(gbl.init_dbg, "mb_tx_num [%d] pin_name [%s]", mb_tx->mb_tx_num, hal_pin_name);
 
         switch (mb_tx->mb_tx_fnct) {
+        case mbtx_05_WRITE_SINGLE_COIL:
         case mbtx_15_WRITE_MULTIPLE_COILS:
             if (0 != hal_pin_bit_newf(HAL_IN, mb_tx->bit + pin_counter, gbl.hal_mod_id,
                                       "%s", hal_pin_name)) {
@@ -106,6 +109,7 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
             }
             *mb_tx->bit[pin_counter] = 0;
             break;
+        case mbtx_01_READ_COILS:
         case mbtx_02_READ_DISCRETE_INPUTS:
             if (0 != hal_pin_bit_newf(HAL_OUT, mb_tx->bit + pin_counter, gbl.hal_mod_id,
                                       "%s.bit", hal_pin_name)) {
@@ -118,7 +122,7 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
                 ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
                     mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
                 return retERR;
-            }
+            }            
             *mb_tx->bit[pin_counter] = 0;
             *mb_tx->bit_inv[pin_counter] = 1;
             break;

--- a/src/hal/user_comps/mb2hal/mb2hal_hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_hal.c
@@ -102,7 +102,7 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
         case mbtx_05_WRITE_SINGLE_COIL:
         case mbtx_15_WRITE_MULTIPLE_COILS:
             if (0 != hal_pin_bit_newf(HAL_IN, mb_tx->bit + pin_counter, gbl.hal_mod_id,
-                                      "%s", hal_pin_name)) {
+                                      "%s.bit", hal_pin_name)) {
                 ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
                     mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
                 return retERR;
@@ -158,7 +158,7 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
         case mbtx_06_WRITE_SINGLE_REGISTER:
         case mbtx_16_WRITE_MULTIPLE_REGISTERS:
             if (0 != hal_pin_float_newf(HAL_IN, mb_tx->float_value + pin_counter, gbl.hal_mod_id,
-                                        "%s", hal_pin_name)) {
+                                        "%s.float", hal_pin_name)) {
                 ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_float_newf failed",
                     mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
                 return retERR;

--- a/src/hal/user_comps/mb2hal/mb2hal_modbus.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_modbus.c
@@ -31,6 +31,7 @@ retCode fnct_02_read_discrete_inputs(mb_tx_t *this_mb_tx, mb_link_t *this_mb_lin
 
     for (counter = 0; counter < this_mb_tx->mb_tx_nelem; counter++) {
         *(this_mb_tx->bit[counter]) = bits[counter];
+        *(this_mb_tx->bit_inv[counter]) = !bits[counter];
     }
 
     return retOK;


### PR DESCRIPTION
I added the function codes:
-   fnct_01_read_coils
-   fnct_05_write_single_coil

Tested with devices from SAMSON (5578 and SAM Home Gateway).

For fnct_01_read_coils I added an inverting bit an therefore added sub-pins `.bit` and `.bit-inv`. I did the same to fnct_02_read_discrete_inputs and added sub pins to the other functions like it is already implemented in e.g.  fnct_03_read_holding_registers (`.int` and `.float`).
The question is: Let it in to have a consequent structure or leave it out for compatibility?
