### PR TITLE
uspace_rtapi_app: Ensure string is NUL-terminated

### DIFF
--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -493,7 +493,7 @@ static int
 get_fifo_path(char *buf, size_t bufsize) {
     const char *s = get_fifo_path();
     if(!s) return -1;
-    strncpy(buf, s, bufsize);
+    snprintf(buf, bufsize, "%s", s);
     return 0;
 }
 


### PR DESCRIPTION
According to unix(7), the sun_path must be a null-terminated filesystem pathname.