### PR TITLE
Fix:  ImportError: 'interpreter' is not a built-in module

### DIFF
--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -306,11 +306,14 @@ PythonPlugin::PythonPlugin(struct _inittab *inittab) :
     abs_path(0),
     log_level(0)
 {
+#if PY_MAJOR_VERSION >= 3
   if (abs_path) {
     wchar_t *program = Py_DecodeLocale(abs_path, NULL);
     Py_SetProgramName(program);
   }
-
+#else
+ Py_SetProgramName((char *) abs_path);
+#endif
   if (inittab != NULL) {
     if (!Py_IsInitialized()) {
       if (PyImport_ExtendInittab(inittab) != 0) {

--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -306,23 +306,39 @@ PythonPlugin::PythonPlugin(struct _inittab *inittab) :
     abs_path(0),
     log_level(0)
 {
-#if PY_MAJOR_VERSION >=3    
-    if (abs_path){
-        wchar_t *program = Py_DecodeLocale(abs_path, NULL);
-        Py_SetProgramName(program);
-    }
-#else
-    Py_SetProgramName((char *) abs_path);
-#endif
+  if (abs_path) {
+    wchar_t *program = Py_DecodeLocale(abs_path, NULL);
+    Py_SetProgramName(program);
+  }
 
-    if ((inittab != NULL) &&
-	PyImport_ExtendInittab(inittab)) {
-	logPP(-1, "cant extend inittab");
-	status = PLUGIN_INITTAB_FAILED;
-	return;
+  if (inittab != NULL) {
+    if (!Py_IsInitialized()) {
+      if (PyImport_ExtendInittab(inittab) != 0) {
+        logPP(-1, "cannot extend inittab");
+        status = PLUGIN_INITTAB_FAILED;
+        return;
+      }
+    } else {
+      PyObject *sys_modules = PyImport_GetModuleDict(); // borrowed
+
+      for (int i = 0; inittab[i].name != NULL; i++) {
+        struct _inittab tab = inittab[i];
+        PyObject *module = tab.initfunc();
+        if (module == NULL) {
+          logPP(-1, "failed to initialize built-in module '%s'", tab.name);
+          status = PLUGIN_INITTAB_FAILED;
+          return;
+        }
+
+        PyImport_AddModule(tab.name); // borrowed
+        PyDict_SetItemString(sys_modules, tab.name, module);
+        Py_DECREF(module);
+      }
     }
-    Py_Initialize();
-    initialize();
+  }
+  Py_UnbufferedStdioFlag = 1;
+  Py_Initialize();
+  initialize();
 }
 
 

--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -339,7 +339,9 @@ PythonPlugin::PythonPlugin(struct _inittab *inittab) :
       }
     }
   }
+#if PY_MAJOR_VERSION >= 3
   Py_UnbufferedStdioFlag = 1;
+#endif
   Py_Initialize();
   initialize();
 }

--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -342,7 +342,6 @@ PythonPlugin::PythonPlugin(struct _inittab *inittab) :
     Py_SetProgramName((char *) abs_path);
     if ((inittab != NULL) && PyImport_ExtendInittab(inittab)) {
 	    logPP(-1, "cant extend inittab");
-	    Py_DECREF(module);
 	    status = PLUGIN_INITTAB_FAILED;
 	    return;
     }

--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -311,36 +311,41 @@ PythonPlugin::PythonPlugin(struct _inittab *inittab) :
     wchar_t *program = Py_DecodeLocale(abs_path, NULL);
     Py_SetProgramName(program);
   }
-#else
- Py_SetProgramName((char *) abs_path);
-#endif
-  if (inittab != NULL) {
-    if (!Py_IsInitialized()) {
-      if (PyImport_ExtendInittab(inittab) != 0) {
-        logPP(-1, "cannot extend inittab");
-        status = PLUGIN_INITTAB_FAILED;
-        return;
-      }
-    } else {
-      PyObject *sys_modules = PyImport_GetModuleDict(); // borrowed
-
-      for (int i = 0; inittab[i].name != NULL; i++) {
-        struct _inittab tab = inittab[i];
-        PyObject *module = tab.initfunc();
-        if (module == NULL) {
-          logPP(-1, "failed to initialize built-in module '%s'", tab.name);
+    if (inittab != NULL) {
+      if (!Py_IsInitialized()) {
+        if (PyImport_ExtendInittab(inittab) != 0) {
+          logPP(-1, "cannot extend inittab");
           status = PLUGIN_INITTAB_FAILED;
           return;
         }
-
-        PyImport_AddModule(tab.name); // borrowed
-        PyDict_SetItemString(sys_modules, tab.name, module);
-        Py_DECREF(module);
       }
-    }
+      else {
+        PyObject *sys_modules = PyImport_GetModuleDict(); // borrowed
+
+        for (int i = 0; inittab[i].name != NULL; i++) {
+          struct _inittab tab = inittab[i];
+          PyObject *module = tab.initfunc();
+          if (module == NULL) {
+            logPP(-1, "failed to initialize built-in module '%s'", tab.name);
+            status = PLUGIN_INITTAB_FAILED;
+            return;
+          }
+
+          PyImport_AddModule(tab.name); // borrowed
+          PyDict_SetItemString(sys_modules, tab.name, module);
+          Py_DECREF(module);
+        }
+      }
   }
-#if PY_MAJOR_VERSION >= 3
   Py_UnbufferedStdioFlag = 1;
+#else
+    Py_SetProgramName((char *) abs_path);
+    if ((inittab != NULL) && PyImport_ExtendInittab(inittab)) {
+	    logPP(-1, "cant extend inittab");
+	    Py_DECREF(module);
+	    status = PLUGIN_INITTAB_FAILED;
+	    return;
+    }
 #endif
   Py_Initialize();
   initialize();

--- a/src/emc/rs274ngc/interpmodule.cc
+++ b/src/emc/rs274ngc/interpmodule.cc
@@ -783,7 +783,6 @@ static inline void set_current_tool(Interp &interp, int value)  {
 
 BOOST_PYTHON_MODULE(interpreter) {
     using namespace boost::python;
-    using namespace boost;
 
     scope().attr("__doc__") =
         "Interpreter introspection\n"
@@ -837,7 +836,7 @@ BOOST_PYTHON_MODULE(interpreter) {
     export_ParamClass();
     export_Internals();
     export_Block();
-    class_<InterpreterException>InterpreterExceptionClass("InterpreterException",							bp::init<std::string, int, std::string>());
+    bp::class_<InterpreterException>InterpreterExceptionClass("InterpreterException",	bp::init<std::string, int, std::string>());
     InterpreterExceptionClass
 	.add_property("error_message", &InterpreterException::get_error_message)
 	.add_property("line_number", &InterpreterException::get_line_number)
@@ -849,7 +848,7 @@ BOOST_PYTHON_MODULE(interpreter) {
     bp::register_exception_translator<InterpreterException>
 	(&translateInterpreterException);
 
-    class_< Interp, noncopyable >("Interp",no_init) 
+    bp::class_< Interp, boost::noncopyable >("Interp",bp::no_init)
 
 	.def("find_tool_pocket", &wrap_find_tool_pocket)
 	.def("load_tool_table", &Interp::load_tool_table)

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -140,7 +140,6 @@ Interp::Interp()
 
 // KLUDGE just to get unit tests to stop complaining about python modules we won't use anyway
 #ifndef UNIT_TEST
-#if PY_MAJOR_VERSION < 3
   try {
     // this import will register the C++->Python converter for Interp
     bp::object interp_module = bp::import("interpreter");
@@ -171,7 +170,6 @@ Interp::Interp()
     PyErr_Clear();
     Error("PYTHON: exception during 'this' export:\n%s\n",exception_msg.c_str());
   }
-#endif
 #endif
 }
 

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -140,20 +140,21 @@ Interp::Interp()
 
 // KLUDGE just to get unit tests to stop complaining about python modules we won't use anyway
 #ifndef UNIT_TEST
+#if PY_MAJOR_VERSION < 3
   try {
     // this import will register the C++->Python converter for Interp
     bp::object interp_module = bp::import("interpreter");
-	
+
     // use a boost::cref to avoid per-call instantiation of the
     // Interp Python wrapper (used for the 'self' parameter in handlers)
     // since interp.init() may be called repeatedly this would create a new
     // wrapper instance on every init(), abandoning the old one and all user attributes
     // tacked onto it, so make sure this is done exactly once
-    _setup.pythis = new boost::python::object(boost::cref(*this));
-	
+    _setup.pythis = new bp::object(boost::cref(*this));
+
     // alias to 'interpreter.this' for the sake of ';py, .... ' comments
     // besides 'this', eventually use proper instance names to handle
-	// several instances 
+	// several instances
     bp::scope(interp_module).attr("this") =  *_setup.pythis;
 
     // make "this" visible without importing interpreter explicitly
@@ -170,6 +171,7 @@ Interp::Interp()
     PyErr_Clear();
     Error("PYTHON: exception during 'this' export:\n%s\n",exception_msg.c_str());
   }
+#endif
 #endif
 }
 

--- a/src/emc/task/taskmodule.cc
+++ b/src/emc/task/taskmodule.cc
@@ -248,7 +248,6 @@ static const char *ini_filename() { return emc_inifile; }
 
 BOOST_PYTHON_MODULE(emctask) {
     using namespace boost::python;
-    using namespace boost;
 
     scope().attr("__doc__") =
         "Task introspection\n"
@@ -321,7 +320,7 @@ BOOST_PYTHON_MODULE(emctask) {
             .BOOST_PYENUM_VAL(EMC_ABORT_USER)
             ;
 
-    class_<TaskWrap, shared_ptr<TaskWrap>, noncopyable >("Task")
+    class_<TaskWrap, boost::shared_ptr<TaskWrap>, boost::noncopyable >("Task")
 
 	.def_readonly("use_iocontrol", &Task::use_iocontrol)
 	.def_readonly("random_toolchanger", &Task::random_toolchanger)
@@ -330,7 +329,7 @@ BOOST_PYTHON_MODULE(emctask) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    class_ <EMC_TRAJ_STAT, noncopyable>("EMC_TRAJ_STAT",no_init)
+    class_ <EMC_TRAJ_STAT, boost::noncopyable>("EMC_TRAJ_STAT",no_init)
 	.def_readwrite("linearUnits", &EMC_TRAJ_STAT::linearUnits )
 	.def_readwrite("angularUnits", &EMC_TRAJ_STAT::angularUnits )
 	.def_readwrite("cycleTime", &EMC_TRAJ_STAT::cycleTime )
@@ -365,7 +364,7 @@ BOOST_PYTHON_MODULE(emctask) {
 	.def_readwrite("feed_hold_enabled", &EMC_TRAJ_STAT::feed_hold_enabled )
 	;
 #pragma GCC diagnostic pop
-    class_ <EMC_JOINT_STAT, noncopyable>("EMC_JOINT_STAT",no_init)
+    class_ <EMC_JOINT_STAT, boost::noncopyable>("EMC_JOINT_STAT",no_init)
 	.def_readwrite("units", &EMC_JOINT_STAT::units)
 	.def_readwrite("backlash", &EMC_JOINT_STAT::backlash)
 	.def_readwrite("minPositionLimit", &EMC_JOINT_STAT::minPositionLimit)
@@ -389,7 +388,7 @@ BOOST_PYTHON_MODULE(emctask) {
 	.def_readwrite("overrideLimits",  &EMC_JOINT_STAT::overrideLimits)
 	;
 
-    class_ <EMC_SPINDLE_STAT, noncopyable>("EMC_SPINDLE_STAT",no_init)
+    class_ <EMC_SPINDLE_STAT, boost::noncopyable>("EMC_SPINDLE_STAT",no_init)
 	.def_readwrite("speed", &EMC_SPINDLE_STAT::speed )
 	.def_readwrite("direction", &EMC_SPINDLE_STAT::direction )
 	.def_readwrite("brake", &EMC_SPINDLE_STAT::brake )
@@ -401,17 +400,17 @@ BOOST_PYTHON_MODULE(emctask) {
 	.def_readwrite("spindle_orient_fault", &EMC_SPINDLE_STAT::orient_fault )
 	;
 
-    class_ <EMC_COOLANT_STAT , noncopyable>("EMC_COOLANT_STAT ",no_init)
+    class_ <EMC_COOLANT_STAT , boost::noncopyable>("EMC_COOLANT_STAT ",no_init)
 	.def_readwrite("mist", &EMC_COOLANT_STAT::mist )
 	.def_readwrite("flood", &EMC_COOLANT_STAT::flood )
 	;
 
-    class_ <EMC_LUBE_STAT, noncopyable>("EMC_LUBE_STAT",no_init)
+    class_ <EMC_LUBE_STAT, boost::noncopyable>("EMC_LUBE_STAT",no_init)
 	.def_readwrite("on", &EMC_LUBE_STAT::on )
 	.def_readwrite("level", &EMC_LUBE_STAT::level )
 	;
 
-    class_ <EMC_MOTION_STAT, noncopyable>("EMC_MOTION_STAT",no_init)
+    class_ <EMC_MOTION_STAT, boost::noncopyable>("EMC_MOTION_STAT",no_init)
 	.def_readwrite("traj", &EMC_MOTION_STAT::traj)
 	.add_property( "axis",
 		       bp::make_function( axis_w(&axis_wrapper),
@@ -434,7 +433,7 @@ BOOST_PYTHON_MODULE(emctask) {
 	;
 
 
-    class_ <EMC_TASK_STAT, noncopyable>("EMC_TASK_STAT",no_init)
+    class_ <EMC_TASK_STAT, boost::noncopyable>("EMC_TASK_STAT",no_init)
 	.def_readwrite("mode",  &EMC_TASK_STAT::mode)
 	.def_readwrite("state",  &EMC_TASK_STAT::state)
 	.def_readwrite("execState",  &EMC_TASK_STAT::execState)
@@ -470,7 +469,7 @@ BOOST_PYTHON_MODULE(emctask) {
 	.def_readwrite("delayLeft", &EMC_TASK_STAT::delayLeft)
 	;
 
-    class_ <EMC_TOOL_STAT, noncopyable>("EMC_TOOL_STAT",no_init)
+    class_ <EMC_TOOL_STAT, boost::noncopyable>("EMC_TOOL_STAT",no_init)
 	.def_readwrite("pocketPrepped", &EMC_TOOL_STAT::pocketPrepped )
 	.def_readwrite("toolInSpindle", &EMC_TOOL_STAT::toolInSpindle )
 	.add_property( "toolTable",
@@ -478,11 +477,11 @@ BOOST_PYTHON_MODULE(emctask) {
 					  bp::with_custodian_and_ward_postcall< 0, 1 >()))
 	;
 
-    class_ <EMC_AUX_STAT, noncopyable>("EMC_AUX_STAT",no_init)
+    class_ <EMC_AUX_STAT, boost::noncopyable>("EMC_AUX_STAT",no_init)
 	.def_readwrite("estop", &EMC_AUX_STAT::estop)
 	;
 
-    class_ <EMC_IO_STAT, noncopyable>("EMC_IO_STAT",no_init)
+    class_ <EMC_IO_STAT, boost::noncopyable>("EMC_IO_STAT",no_init)
 	.def_readwrite("cycleTime", &EMC_IO_STAT::cycleTime )
 	.def_readwrite("debug", &EMC_IO_STAT::debug )
 	.def_readwrite("reason", &EMC_IO_STAT::reason )
@@ -495,7 +494,7 @@ BOOST_PYTHON_MODULE(emctask) {
 	;
 
 
-    class_ <EMC_STAT, emcstatus_ptr, noncopyable>("EMC_STAT",no_init)
+    class_ <EMC_STAT, emcstatus_ptr, boost::noncopyable>("EMC_STAT",no_init)
 	.def_readwrite("task", &EMC_STAT::task)
 	.def_readwrite("motion", &EMC_STAT::motion)
 	.def_readwrite("io", &EMC_STAT::io)


### PR DESCRIPTION
Fix works in python3 for removing  ImportError: 'interpreter' is not a built-in module error. Thanks to Jlama for the code