### PR TITLE
Fix limit check on variables with double accuracy

### DIFF
--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -205,13 +205,13 @@ static int check_axis_constraint(double target, int id, char *move_type,
          && (fabs(axes[axis_no].min_pos_limit) < eps)
          && (fabs(axes[axis_no].max_pos_limit) < eps) ) { return 1;}
 
-    if(target < nl) {
+    if(target < nl && fabs(nl-target)>0.000000000001) {
         in_range = 0;
         reportError(_("%s move on line %d would exceed %c's %s limit"),
                     move_type, id, axis_name, _("negative"));
     }
 
-    if(target > pl) {
+    if(target > pl && fabs(pl-target)>0.000000000001) {
         in_range = 0;
         reportError(_("%s move on line %d would exceed %c's %s limit"),
                     move_type, id, axis_name, _("positive"));


### PR DESCRIPTION
This fixes a bug which avoided to be able to drive to the Z limit after a tool change via G-Code in Axis.

I created an issue:
https://github.com/LinuxCNC/linuxcnc/issues/1046