### PR TITLE
xhc-whb04b-6 add is-homed hal pin

### DIFF
--- a/docs/src/man/man1/xhc-whb04b-6.1.txt
+++ b/docs/src/man/man1/xhc-whb04b-6.1.txt
@@ -464,6 +464,10 @@ net pdnt.mode.is-mdi                      halui.mode.is-mdi                     
 net pdnt.mode.is-joint                    halui.mode.is-joint                   whb.halui.mode.is-joint
 net pdnt.mode.is-teleop                   halui.mode.is-teleop                  whb.halui.mode.is-teleop
 
+# "is-homed" axis signal for allowing pendant when machine is not homed
+net pdnt.axis.X.is-homed                  halui.joint.0.is-homed                whb.halui.joint.x.is-homed
+net pdnt.axis.Y.is-homed                  halui.joint.1.is-homed                whb.halui.joint.y.is-homed
+net pdnt.axis.Z.is-homed                  halui.joint.2.is-homed                whb.halui.joint.z.is-homed
 
 # "selected axis" signals
 net pdnt.axis.X.select                    whb.halui.axis.x.select               halui.axis.x.select

--- a/src/hal/user_comps/xhc-whb04b-6/example-configuration.md
+++ b/src/hal/user_comps/xhc-whb04b-6/example-configuration.md
@@ -66,6 +66,10 @@ net pdnt.mode.is-mdi                      halui.mode.is-mdi                     
 net pdnt.mode.is-joint                    halui.mode.is-joint                   whb.halui.mode.is-joint
 net pdnt.mode.is-teleop                   halui.mode.is-teleop                  whb.halui.mode.is-teleop
 
+# "is-homed" axis signal for allowing pendant when machine is not homed
+net pdnt.axis.X.is-homed                  halui.joint.0.is-homed                whb.halui.joint.x.is-homed
+net pdnt.axis.Y.is-homed                  halui.joint.1.is-homed                whb.halui.joint.y.is-homed
+net pdnt.axis.Z.is-homed                  halui.joint.2.is-homed                whb.halui.joint.z.is-homed
 
 # "selected axis" signals
 net pdnt.axis.X.select                    whb.halui.axis.x.select               halui.axis.x.select

--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -118,6 +118,13 @@ Hal::~Hal()
     freeSimulatedPin((void**)(&memory->in.isModeMdi));
     freeSimulatedPin((void**)(&memory->in.isModeTeleop));
 
+    freeSimulatedPin((void**)(&memory->in.JointXisHomed));
+    freeSimulatedPin((void**)(&memory->in.JointYisHomed));
+    freeSimulatedPin((void**)(&memory->in.JointZisHomed));
+    freeSimulatedPin((void**)(&memory->in.JointAisHomed));
+    freeSimulatedPin((void**)(&memory->in.JointBisHomed));
+    freeSimulatedPin((void**)(&memory->in.JointCisHomed));
+
     freeSimulatedPin((void**)(&memory->in.isMachineOn));
 
     constexpr size_t pinsCount = sizeof(memory->out.button_pin) / sizeof(hal_bit_t * );
@@ -543,6 +550,16 @@ void Hal::init(const MetaButtonCodes* metaButtons, const KeyCodes& keyCodes)
     newHalBit(HAL_IN, &(memory->in.isModeManual), mHalCompId, "%s.halui.mode.is-manual", mComponentPrefix);
     newHalBit(HAL_IN, &(memory->in.isModeMdi), mHalCompId, "%s.halui.mode.is-mdi", mComponentPrefix);
     newHalBit(HAL_IN, &(memory->in.isModeTeleop), mHalCompId, "%s.halui.mode.is-teleop", mComponentPrefix);
+
+
+    newHalBit(HAL_IN, &(memory->in.JointXisHomed), mHalCompId, "%s.halui.joint.x.is-homed", mComponentPrefix);
+    newHalBit(HAL_IN, &(memory->in.JointYisHomed), mHalCompId, "%s.halui.joint.y.is-homed", mComponentPrefix);
+    newHalBit(HAL_IN, &(memory->in.JointZisHomed), mHalCompId, "%s.halui.joint.z.is-homed", mComponentPrefix);
+    newHalBit(HAL_IN, &(memory->in.JointAisHomed), mHalCompId, "%s.halui.joint.a.is-homed", mComponentPrefix);
+    newHalBit(HAL_IN, &(memory->in.JointBisHomed), mHalCompId, "%s.halui.joint.b.is-homed", mComponentPrefix);
+    newHalBit(HAL_IN, &(memory->in.JointCisHomed), mHalCompId, "%s.halui.joint.c.is-homed", mComponentPrefix);
+
+
     newHalBit(HAL_OUT, &(memory->out.doModeAuto), mHalCompId, "%s.halui.mode.auto", mComponentPrefix);
     newHalBit(HAL_OUT, &(memory->out.doModeJoint), mHalCompId, "%s.halui.mode.joint", mComponentPrefix);
     newHalBit(HAL_OUT, &(memory->out.doModeManual), mHalCompId, "%s.halui.mode.manual", mComponentPrefix);
@@ -986,7 +1003,7 @@ void Hal::toggleSpindleDirection(bool enabled)
             }
             else
             {
-                *memory->out.spindleDoRunReverse = true;               
+                *memory->out.spindleDoRunReverse = true;
                 *memory->out.spindleDoIncrease = true;
             }
         }
@@ -1020,7 +1037,7 @@ void Hal::toggleSpindleOnOff(bool enabled)
             {
                 *memory->out.spindleDoRunReverse = true;
                 *memory->out.spindleDoIncrease = true;
-                
+
             }
             *memory->out.spindleStart = true;
         }
@@ -1297,8 +1314,16 @@ void Hal::setPin(bool enabled, const char* pinName)
 // ----------------------------------------------------------------------
 void Hal::setJogCounts(const HandWheelCounters& counters)
 {
-        requestManualMode(true);
-        requestTeleopMode(true);
+    // If axis is not homed we need to ask Teleop mode but we need to bypass that if machine is homed
+    // https://forum.linuxcnc.org/49-basic-configuration/40581-how-to-configure-a-xhc-whb04b-pendant
+    if      (*memory->out.axisXSelect && false == *memory->in.JointXisHomed) {requestTeleopMode(true);}
+    else if (*memory->out.axisYSelect && false == *memory->in.JointYisHomed) {requestTeleopMode(true);}
+    else if (*memory->out.axisZSelect && false == *memory->in.JointZisHomed) {requestTeleopMode(true);}
+    else if (*memory->out.axisASelect && false == *memory->in.JointAisHomed) {requestTeleopMode(true);}
+    else if (*memory->out.axisBSelect && false == *memory->in.JointBisHomed) {requestTeleopMode(true);}
+    else if (*memory->out.axisCSelect && false == *memory->in.JointCisHomed) {requestTeleopMode(true);}
+    {requestManualMode(true);}
+
     *memory->out.axisXJogCounts = counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_X);
     *memory->out.axisYJogCounts = counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_Y);
     *memory->out.axisZJogCounts = counters.counts(HandWheelCounters::CounterNameToIndex::AXIS_Z);

--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -1036,24 +1036,25 @@ void Hal::toggleSpindleOnOff(bool enabled)
             {
                 *memory->out.spindleDoRunForward = true;
                 *memory->out.spindleDoIncrease = true;
+                *memory->out.spindleStart = true;
             }
             else
             {
                 *memory->out.spindleDoRunReverse = true;
                 *memory->out.spindleDoIncrease = true;
-
+                *memory->out.spindleStart = true;
+                
             }
-            *memory->out.spindleStart = true;
         }
     }
     else
     {
         // on button released
-        *memory->out.spindleStart        = false;
         *memory->out.spindleStop         = false;
         *memory->out.spindleDoRunForward = false;
         *memory->out.spindleDoRunReverse = false;
         *memory->out.spindleDoIncrease   = false;
+        *memory->out.spindleStart        = false;
     }
     setPin(enabled, KeyCodes::Buttons.spindle_on_off.text);
 }

--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -118,6 +118,8 @@ Hal::~Hal()
     freeSimulatedPin((void**)(&memory->in.isModeMdi));
     freeSimulatedPin((void**)(&memory->in.isModeTeleop));
 
+    // If axis is not homed we need to ask Teleop mode but we need to bypass that if machine is homed
+    // https://forum.linuxcnc.org/49-basic-configuration/40581-how-to-configure-a-xhc-whb04b-pendant
     freeSimulatedPin((void**)(&memory->in.JointXisHomed));
     freeSimulatedPin((void**)(&memory->in.JointYisHomed));
     freeSimulatedPin((void**)(&memory->in.JointZisHomed));
@@ -552,6 +554,8 @@ void Hal::init(const MetaButtonCodes* metaButtons, const KeyCodes& keyCodes)
     newHalBit(HAL_IN, &(memory->in.isModeTeleop), mHalCompId, "%s.halui.mode.is-teleop", mComponentPrefix);
 
 
+    // If axis is not homed we need to ask Teleop mode but we need to bypass that if machine is homed
+    // https://forum.linuxcnc.org/49-basic-configuration/40581-how-to-configure-a-xhc-whb04b-pendant
     newHalBit(HAL_IN, &(memory->in.JointXisHomed), mHalCompId, "%s.halui.joint.x.is-homed", mComponentPrefix);
     newHalBit(HAL_IN, &(memory->in.JointYisHomed), mHalCompId, "%s.halui.joint.y.is-homed", mComponentPrefix);
     newHalBit(HAL_IN, &(memory->in.JointZisHomed), mHalCompId, "%s.halui.joint.z.is-homed", mComponentPrefix);

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -158,6 +158,19 @@ public:
         //! to be connected to \ref halui.mode.is-teleop
         hal_bit_t* isModeTeleop{nullptr};
 
+
+        // If axis is not homed we need to ask Teleop mode but we need to bypass that if machine is homed
+        // https://forum.linuxcnc.org/49-basic-configuration/40581-how-to-configure-a-xhc-whb04b-pendant
+        hal_bit_t* JointXisHomed{nullptr};
+        hal_bit_t* JointYisHomed{nullptr};
+        hal_bit_t* JointZisHomed{nullptr};
+        hal_bit_t* JointAisHomed{nullptr};
+        hal_bit_t* JointBisHomed{nullptr};
+        hal_bit_t* JointCisHomed{nullptr};
+
+
+
+
         //! to be connected to \ref halui.machine.is-on
         hal_bit_t* isMachineOn{nullptr};
 


### PR DESCRIPTION
Hi

after some user report some problem with teleop mode i have investigate more and add some hal pin "joint._.is-homed" for allowing pendant working with unhomed machine and prevent some lag when machine is homed.

https://forum.linuxcnc.org/49-basic-configuration/40581-how-to-configure-a-xhc-whb04b-pendant?start=0#195293