### PR TITLE
Mb2hal: added debuglevel 'DBGMAX'

### DIFF
--- a/docs/src/drivers/mb2hal.txt
+++ b/docs/src/drivers/mb2hal.txt
@@ -37,6 +37,7 @@ Consider using Mb2hal if:
 # 1 = error messages (default).
 # 2 = OK confirmation messages.
 # 3 = debugging messages.
+# 4 = maximum debugging messages (only in transactions).
 
 INIT_DEBUG=3
 

--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -149,7 +149,7 @@ void *link_loop_and_logic(void *thrd_link_num)
             this_mb_tx_num = tx_counter;
             this_mb_tx = &gbl.mb_tx[this_mb_tx_num];
 
-            DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] going to TEST availability",
+            DBGMAX(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] going to TEST availability",
                 this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_link_num, modbus_get_socket(this_mb_link->modbus));
 
             //corresponding link and time (update_rate)
@@ -159,13 +159,13 @@ void *link_loop_and_logic(void *thrd_link_num)
                 return NULL;
             }
             if (ret_available == 0) {
-                DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] NOT available",
+                DBGMAX(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] NOT available",
                     this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_link_num, modbus_get_socket(this_mb_link->modbus));
                 usleep(1000);
                 continue;
             }
 
-            DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] going to TEST connection",
+            DBGMAX(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] going to TEST connection",
                 this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_link_num, modbus_get_socket(this_mb_link->modbus));
 
             //first time connection or reconnection, run time parameters setting
@@ -175,13 +175,13 @@ void *link_loop_and_logic(void *thrd_link_num)
                 return NULL;
             }
             if (ret_connected == 0) {
-                DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] NOT connected",
+                DBGMAX(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] NOT connected",
                     this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_link_num, modbus_get_socket(this_mb_link->modbus));
                 usleep(1000);
                 continue;
             }
 
-            DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] lk_dbg[%d] going to EXECUTE transaction",
+            DBGMAX(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] lk_dbg[%d] going to EXECUTE transaction",
                 this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_link_num, modbus_get_socket(this_mb_link->modbus),
                 this_mb_tx->protocol_debug);
 
@@ -351,11 +351,11 @@ retCode get_tx_connection(const int this_mb_tx_num, int *ret_connected)
                 this_mb_tx_num, this_mb_tx->mb_link_num, ret, modbus_get_socket(this_mb_link->modbus));
             return retOK; //not connected
         }
-        DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] new connection -> fd[%d]",
+        DBGMAX(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] new connection -> fd[%d]",
             this_mb_tx_num, this_mb_tx->mb_link_num, modbus_get_socket(this_mb_link->modbus));
     }
     else {
-        DBG(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] already connected to fd[%d]",
+        DBGMAX(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] already connected to fd[%d]",
             this_mb_tx_num, this_mb_tx->mb_link_num, modbus_get_socket(this_mb_link->modbus));
     }
 

--- a/src/hal/user_comps/mb2hal/mb2hal.h
+++ b/src/hal/user_comps/mb2hal/mb2hal.h
@@ -60,6 +60,7 @@ typedef enum { retOK, retOKwithWarning, retERR
 #define ERR(debug, fmt, args...) if(debug >= debugERR) {fprintf(stderr, "%s %s ERR: "fmt"\n", gbl.hal_mod_name, fnct_name, ## args);}
 #define OK(debug, fmt, args...) if(debug >= debugOK) {fprintf(stdout, "%s %s OK: "fmt"\n", gbl.hal_mod_name, fnct_name, ## args);}
 #define DBG(debug, fmt, args...) if(debug >= debugDEBUG) {fprintf(stdout, "%s %s DEBUG: "fmt"\n", gbl.hal_mod_name, fnct_name, ## args);}
+#define DBGMAX(debug, fmt, args...) if(debug >= debugMAX) {fprintf(stdout, "%s %s DEBUGMAX: "fmt"\n", gbl.hal_mod_name, fnct_name, ## args);}
 
 //Modbus transaction structure (mb_tx_t)
 //Store each transaction defined in INI config file

--- a/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
+++ b/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
@@ -13,6 +13,7 @@
 # 1 = error messages (default).
 # 2 = OK confirmation messages.
 # 3 = debugging messages.
+# 4 = maximum debugging messages (only in transactions).
 INIT_DEBUG=3
 
 #OPTIONAL: HAL module (component) name. Defaults to "mb2hal".


### PR DESCRIPTION
Setting DEBUG=3 on transactions produces a lot of useless debug information what makes it impossible to read the data bytes. That is now displayed when setting DEBUG=4.