### PR TITLE
typo's and compiler warnings

### DIFF
--- a/docs/man/man1/gladevcp_demo.1
+++ b/docs/man/man1/gladevcp_demo.1
@@ -23,8 +23,8 @@
 .\"
 .\"
 .TH GLADEVCP_DEMO "1"  "2020-08-26" "LinuxCNC Documentation" "The Enhanced Machine Controller"
-.SH NAME \- used by sample configs to deonstrate Glade Virtual
-gladevcp_demo
+.SH NAME
+gladevcp \- used by sample configs to deonstrate Glade Virtual_demo
 .SH SYNOPSIS
 .B gladevcp_demo
 Control Panels
@@ -34,7 +34,7 @@ Control Panels
 
 
 .SH "SEE ALSO"
-\fBhttp://linuxcnc.org/docs/html/gui/gladevcp.html\fR
+\fBhttps://linuxcnc.org/docs/html/gui/gladevcp.html\fR
 \fBLinuxCNC(1)\fR
 
 Much more information about LinuxCNC and HAL is available in the LinuxCNC
@@ -43,7 +43,7 @@ and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
 .SH HISTORY
 
 .SH BUGS
-None known at this time. 
+None known at this time.
 .PP
 .SH AUTHOR
 This man page written by andypugh, as part of the LinuxCNC project.

--- a/docs/man/man1/hy_vfd.1
+++ b/docs/man/man1/hy_vfd.1
@@ -194,7 +194,7 @@ number of poles in the motor.  If specified, this value is sent to the
 VFD's register PD143.  If not specified, the value is read from PD143
 and reported on the corresponding HAL pin.
 .B
-.IP \-x,\ \-\-register PDnnn=mmm <n>
+.IP \-x,\ \-\-register\ PDnnn=mmm\ <n>
 Set a specific register to a new value. Can be used to set up to 10
 registers. Parameters will "stick" (but only after hy_vfd.enable has
 been set true) so to set more than ten parameters it is possible to

--- a/docs/man/man1/linuxcncrsh.1
+++ b/docs/man/man1/linuxcncrsh.1
@@ -111,7 +111,7 @@ insensitive. The exceptions are passwords, file paths and text strings.
 .P
 Requests to linuxcncrsh are terminated with line endings, any combination of
 one or more '\\r' and '\\n' characters.  Replies from linuxcncrsh are terminated
-with the sequence \'\\r\\n\'.
+with the sequence '\\r\\n'.
 .P
 The supported commands are as follows:
 .P

--- a/docs/man/man1/rs274.1
+++ b/docs/man/man1/rs274.1
@@ -30,7 +30,7 @@ rs274 \- standalone G-code interpreter
           [-b] [-s] [-g] [input file [output file]]
 
 .SH DESCRIPTION
-\fBrs274\fR Standalone G-code intepreter interface
+\fBrs274\fR Standalone G-code interpreter interface
 
 Usage: rs274 [-p interp.so] [-t tool.tbl] [-v var-file.var] [-n 0|1|2]
           [-b] [-s] [-g] [input file [output file]]

--- a/docs/man/man9/hostmot2.9
+++ b/docs/man/man9/hostmot2.9
@@ -1408,7 +1408,7 @@ X and Y acceleration commands in units of fullscale_position/second^2
 
 .TP 
 (float in) posx_scale, posy_scale
-This sets the full scale range of the postion command and feedback
+This sets the full scale range of the position command and feedback
 default is +- 1.0
 
 .TP 
@@ -1436,7 +1436,7 @@ When true, these enable the 18 bit data mode for the respective channel
 
 .TP 
 (bit out) posx-overflow, posy-overflow
-When true, these indicate an attempted postion move beyond the full scale value
+When true, these indicate an attempted position move beyond the full scale value
 
 .TP 
 (bit out) velx-overflow, vely-overflow

--- a/docs/man/man9/rosekins.9
+++ b/docs/man/man9/rosekins.9
@@ -41,7 +41,7 @@ continuously as the spindle is rotated.  Hal pins are provided for
 the principal value and a count of the number of revolutions.
 
 The transverse motion is exactly perpendicular to the spindle.  In a
-traditional rose engine, the transverse motion is created by \'rocking\'
+traditional rose engine, the transverse motion is created by 'rocking'
 the headstock about a pivot.  A typical pivot length combined with the
 limited amount of X travel in a real machine make the perpendicular
 approximation a reasonable model.

--- a/src/hal/drivers/cpuinfo.c
+++ b/src/hal/drivers/cpuinfo.c
@@ -5,7 +5,7 @@ Revised by Ernesto Lo Valvo  (ernesto.lovalvo@unipa.it) (12/01/2021)
  Added new version of Raspberry Pi4 and Raspberry Pi 400
  Revised for version 3B (15/01/2021)
  https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
- 
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to
@@ -30,84 +30,76 @@ SOFTWARE.
 
 char *get_cpuinfo_revision(char *revision)
 {
-   FILE *fp;
-   char buffer[1024];
-   char model[1024];
-   int  rpi_found = 0;
-   int t;
+    FILE *fp;
+    char buffer[1024];
 
+    if ((fp = fopen("/sys/firmware/devicetree/base/model", "r")) == NULL)
+        return 0;
 
-  if ((fp = fopen("/sys/firmware/devicetree/base/model", "r")) == NULL)
-      return 0;
+    fgets(buffer, sizeof(buffer) , fp);
 
-      fgets(buffer, sizeof(buffer) , fp);  
-      
-   /*   sscanf(buffer, "Raspberry %s", model);
-      printf(" MOD =  RASPBERRY %s \n", model);  */
-      
-      if (strncmp(buffer, "Raspberry",9) == 0)
-         rpi_found = 1;
-      fclose(fp);
-      
-   if (!rpi_found) return  NULL;
-   
-   if ((fp = fopen("/proc/cpuinfo", "r")) == NULL)
-      return 0;
+    if (strncmp(buffer, "Raspberry",9) != 0)
+        return NULL;
+    fclose(fp);
 
-   while(!feof(fp)) {
-      if (fgets(buffer, sizeof(buffer) , fp)){
-      sscanf(buffer, "Revision  : %s", revision);
-      }
-   }
-   fclose(fp);
+    if ((fp = fopen("/proc/cpuinfo", "r")) == NULL)
+        return 0;
 
-   return revision;
+    while(!feof(fp)) {
+        if (fgets(buffer, sizeof(buffer) , fp)){
+            sscanf(buffer, "Revision  : %s", revision);
+        }
+    }
+    fclose(fp);
+
+    return revision;
 }
 
 
 int get_rpi_revision(void)
 {
-   char revision[1024] = {'\0'};
+    char revision[1024] = {'\0'};
 
-   if (get_cpuinfo_revision(revision) == NULL)
-      return -1;
+    if (get_cpuinfo_revision(revision) == NULL)
+        return -1;
 
-   if ((strcmp(revision, "0002") == 0) ||
-       (strcmp(revision, "1000002") == 0 ) ||
-       (strcmp(revision, "0003") == 0) ||
-       (strcmp(revision, "1000003") == 0 ))
-      return 1;
-   else if ((strcmp(revision, "0004") == 0) ||
-            (strcmp(revision, "1000004") == 0 ) ||
-            (strcmp(revision, "0005") == 0) ||
-            (strcmp(revision, "1000005") == 0 ) ||
-            (strcmp(revision, "0006") == 0) ||
-            (strcmp(revision, "1000006") == 0 ))
-      return 2;
-   else if ((strcmp(revision, "a01040") == 0) ||   /* Raspberry Pi 2B */
-            (strcmp(revision, "a01041") == 0) ||
-	    (strcmp(revision, "a02042") == 0) ||
-            (strcmp(revision, "a21041") == 0) ||
-            (strcmp(revision, "a22042") == 0))
-      return 3;
-   else if ((strcmp(revision, "a02082") == 0) ||   /* Raspberry Pi 3B */
-            (strcmp(revision, "a22082") == 0) ||
-            (strcmp(revision, "a32082") == 0) ||
-	    (strcmp(revision, "a52082") == 0) ||
-	    (strcmp(revision, "a22083") == 0) ||									   
-            (strcmp(revision, "a020d3") == 0))     /* Raspberry Pi 3B+ */
-      return 4;
-   else if ((strcmp(revision, "a03111") == 0) ||   /* Raspberry Pi 4B */
-            (strcmp(revision, "b03111") == 0) ||
-            (strcmp(revision, "b03112") == 0) ||
-	    (strcmp(revision, "b03114") == 0) ||
-            (strcmp(revision, "c03111") == 0) ||
-            (strcmp(revision, "c03112") == 0) ||
-	    (strcmp(revision, "c03114") == 0) ||
-            (strcmp(revision, "d03114") == 0)) 
-      return 5;
-   else if  (strcmp(revision, "c03130") == 0)      /* Raspberry Pi 400 */
-      return 6;
-   else // assume rev 7
-      return 7;
+    if ((strcmp(revision, "0002") == 0) ||
+        (strcmp(revision, "1000002") == 0 ) ||
+        (strcmp(revision, "0003") == 0) ||
+        (strcmp(revision, "1000003") == 0 ))
+        return 1;
+    else if ((strcmp(revision, "0004") == 0) ||
+             (strcmp(revision, "1000004") == 0 ) ||
+             (strcmp(revision, "0005") == 0) ||
+             (strcmp(revision, "1000005") == 0 ) ||
+             (strcmp(revision, "0006") == 0) ||
+             (strcmp(revision, "1000006") == 0 ))
+        return 2;
+    else if ((strcmp(revision, "a01040") == 0) ||   /* Raspberry Pi 2B */
+             (strcmp(revision, "a01041") == 0) ||
+             (strcmp(revision, "a02042") == 0) ||
+             (strcmp(revision, "a21041") == 0) ||
+             (strcmp(revision, "a22042") == 0))
+        return 3;
+    else if ((strcmp(revision, "a02082") == 0) ||   /* Raspberry Pi 3B */
+             (strcmp(revision, "a22082") == 0) ||
+             (strcmp(revision, "a32082") == 0) ||
+             (strcmp(revision, "a52082") == 0) ||
+             (strcmp(revision, "a22083") == 0) ||
+             (strcmp(revision, "a020d3") == 0))     /* Raspberry Pi 3B+ */
+        return 4;
+    else if ((strcmp(revision, "a03111") == 0) ||   /* Raspberry Pi 4B */
+             (strcmp(revision, "b03111") == 0) ||
+             (strcmp(revision, "b03112") == 0) ||
+             (strcmp(revision, "b03114") == 0) ||
+             (strcmp(revision, "c03111") == 0) ||
+             (strcmp(revision, "c03112") == 0) ||
+             (strcmp(revision, "c03114") == 0) ||
+             (strcmp(revision, "d03114") == 0))
+        return 5;
+    else if  (strcmp(revision, "c03130") == 0)      /* Raspberry Pi 400 */
+        return 6;
+    else                                            /* assume rev 7 */
+        return 7;
 }
+

--- a/src/hal/user_comps/huanyang-vfd/hy_vfd.c
+++ b/src/hal/user_comps/huanyang-vfd/hy_vfd.c
@@ -530,7 +530,7 @@ int read_setup(hycomm_param_t *hc_param, hycomm_data_t *hc_data, haldata_t *hald
 	    if ((retval = hy_comm(hc_param, hc_data)) != 0)
 		goto failed;
 	    if (hc_param->debug)
-		printf ("Register %i succesfully set to %i\n",
+		printf ("Register %i successfully set to %i\n",
 		hc_param->extra_reg[i], hc_param->extra_val[i]);
 	}
 


### PR DESCRIPTION
Most of this pr is typos, but the important changes in commit 9387380 might be difficult to see since I change the indentation. It's line 41 and 42 which has some actual code change, though the end result should be the same.

The compiler warnings can be seen in the logs from the buildbot, I'm copying them in here for convenience.
```
hal/drivers/cpuinfo.c:40:3: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
hal/drivers/cpuinfo.c:37:8: warning: unused variable ‘t’ [-Wunused-variable]
hal/drivers/cpuinfo.c:35:9: warning: unused variable ‘model’ [-Wunused-variable]
```