### PR TITLE
WJ200_vfd: Modified parity argument validation

### DIFF
--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -199,10 +199,10 @@ void userinit(int argc, char **argv)
 			case 1:
 				parity = toupper(optarg[0]);
 
-				if(parity != 'Y' && parity != 'N')
+				if(parity != 'E' && parity != 'O' && parity != 'N')
 				{
 					fprintf(stderr, 
-						"Invalid argument: parity must be 'y' or 'n'. Given '%s'\n", 
+						"Invalid argument: parity must be 'e', 'o' or 'n'. Given '%s'\n", 
 						optarg);
 					exit(1);
 				}


### PR DESCRIPTION
Changed argument for parity to be in line with libmodbus
expected values (o for odd, e for even, n for no parity)