### PR TITLE
Addresses bug #368, stop on probe

### DIFF
--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -624,11 +624,10 @@ static void process_probe_inputs(void)
         int i;
         int aborted = 0;
 
-        if(!GET_MOTION_INPOS_FLAG() && tpQueueDepth(&emcmotDebug->coord_tp) &&
-           tpGetExecId(&emcmotDebug->coord_tp) <= 0) {
-            // running an MDI command
+        if(!GET_MOTION_INPOS_FLAG() && tpQueueDepth(&emcmotDebug->coord_tp)) {
+            // running an command
             tpAbort(&emcmotDebug->coord_tp);
-            reportError(_("Probe tripped during non-probe MDI command."));
+            reportError(_("Probe tripped during non-probe move."));
 	    SET_MOTION_ERROR_FLAG(1);
         }
 


### PR DESCRIPTION
Fixed stop on probe behavior.  In the original code the call to tpGetExecId would not return a 0 after a ngc program was run or an o word was executed from MDI.  This led to the probe input being ignored during commanded moves, a dangerous situation.  After removing the check on tpGetExecId, motion will stop when the probe contact is triggered during o word functions as well as ngc programs.

Has been compiled and tested in simulation.
