### PR TITLE
updated po readme

### DIFF
--- a/src/po/README
+++ b/src/po/README
@@ -5,7 +5,7 @@ Make a copy of the pot file renaming it to reflect the language it is
 being translated in to. For example, for a German translation of linuxcnc.pot,
 your working file would be de.po - If the file does not exist within
 the source repository, then create one from the linuxcnc.pot template:
-    cp linuxcnc.pot de.pot
+    cp linuxcnc.pot de.po
 
 To update a language's .po file from its .pot file, use the "msgmerge" command.
 Because doing this needlessly creates lots of uneeded revisions of the
@@ -19,13 +19,15 @@ If you are working by hand, you can also update just a single pofile:
 
 When you are done, "git commit" the new .po file.  If you have push access,
 "git push".  Otherwise, format your changes as a patch with "git format-patch"
-and send it to the emc-developers mailing list.
+and send it to the emc-developers mailing list or create a Pull Request on GitHub.
 
 
 Graphical tools for editing .po files
 =====================================
-On Dapper there seem to be two graphical front-ends for editing .po files:
-gtranslator (a part of the Gnome desktop) and kbabel (part of KDE).
+On Dapper there seem to be three graphical front-ends for editing .po files:
+- gtranslator (a part of the Gnome desktop),
+- lokalize (former kbabel as part of KDE) and
+- poedit
 
 
 Required versions of xgettext and msgmerge


### PR DESCRIPTION
- Updated the file list as kbabel is now lokalize

>Otherwise, format your changes as a patch with "git format-patch"
and send it to the emc-developers mailing list

Is that still a possible procedure? Otherwise it should be removed.

And I wonder why the linuxcnc.pot is on the gitignore. I thought that is the catalogue that holds all translations that are needed and should be updated if new strings are added to the GUIs.