### PR TITLE
Gmoccapy stop button / fix in translation

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -7112,7 +7112,7 @@ F12 or $ key does the same</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Close moccapy / leave the program</property>
+                    <property name="tooltip_text" translatable="yes">Close gmoccapy / leave the program</property>
                     <property name="image">img_close</property>
                     <signal name="clicked" handler="on_btn_exit_clicked" swapped="no"/>
                   </object>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -171,6 +171,7 @@
     <signal name="motion-mode-changed" handler="on_hal_status_motion_mode_changed" swapped="no"/>
     <signal name="metric-mode-changed" handler="on_hal_status_metric_mode_changed" swapped="no"/>
     <signal name="interp-run" handler="on_hal_status_interp_run" swapped="no"/>
+    <signal name="program-pause-changed" handler="on_hal_status_pause_changed" swapped="no"/>    
   </object>
   <object class="EMC_ToggleAction_Pause" id="hal_tgl_pause"/>
   <object class="GtkImage" id="img_auto">

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -2451,6 +2451,7 @@ class gmoccapy(object):
             self.macro_dic["keyboard"].set_sensitive(False)
 
         self.widgets.btn_run.set_sensitive(True)
+        self.widgets.btn_stop.set_sensitive(False)
 
         if self.tool_change:
             self.command.mode(linuxcnc.MODE_MANUAL)
@@ -2474,6 +2475,7 @@ class gmoccapy(object):
 
         self._sensitize_widgets(widgetlist, False)
         self.widgets.btn_run.set_sensitive(False)
+        self.widgets.btn_stop.set_sensitive(True)
 
         self._change_kbd_image("stop")
         self.macro_dic["keyboard"].set_sensitive(True)
@@ -4766,7 +4768,7 @@ class gmoccapy(object):
     # this can not be done with the status widget,
     # because it will not emit a RESUME signal
     def on_tbtn_pause_toggled(self, widget, data=None):
-        widgetlist = ["rbt_forward", "rbt_reverse", "rbt_stop"]
+        widgetlist = ["rbt_forward", "rbt_reverse", "rbt_stop", "ntb_jog"]
         self._sensitize_widgets(widgetlist, widget.get_active())
 
     def on_btn_stop_clicked(self, widget, data=None):

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -4767,9 +4767,19 @@ class gmoccapy(object):
 
     # this can not be done with the status widget,
     # because it will not emit a RESUME signal
-    def on_tbtn_pause_toggled(self, widget, data=None):
-        widgetlist = ["rbt_forward", "rbt_reverse", "rbt_stop", "ntb_jog"]
-        self._sensitize_widgets(widgetlist, widget.get_active())
+    def on_hal_status_pause_changed(self, emc_stat, is_paused):
+        if is_paused:
+            self.widgets.ntb_jog.set_sensitive(True)
+            self.widgets.rbt_forward.set_sensitive(True)
+            self.widgets.rbt_reverse.set_sensitive(True)
+            self.widgets.rbt_stop.set_sensitive(True)
+            self.widgets.tbtn_pause.set_active(True)
+        else:
+            self.widgets.ntb_jog.set_sensitive(False)
+            self.widgets.rbt_forward.set_sensitive(False)
+            self.widgets.rbt_reverse.set_sensitive(False)
+            self.widgets.rbt_stop.set_sensitive(False)
+            self.widgets.tbtn_pause.set_active(False)
 
     def on_btn_stop_clicked(self, widget, data=None):
         self.command.abort()

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -2497,14 +2497,14 @@ msgid "motion stopped by enable input"
 msgstr "Bewegung durch Enable-Eingabe angehalten."
 
 #: src/emc/motion/control.c:734
-#, fuzzy, c-format
+#, c-format
 msgid "spindle %d amplifier fault"
-msgstr "Verstärkerfehler an Achse/Gelenk %d"
+msgstr "Verstärkerfehler an Spindel %d"
 
 #: src/emc/motion/control.c:757
 #, c-format
 msgid "joint %d on limit switch error"
-msgstr "Fehler: Achse/Gelenk %d am Endschalter"
+msgstr "Achse/Gelenk %d am Endschalter"
 
 #: src/emc/motion/control.c:769
 #, c-format
@@ -19858,7 +19858,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -19760,7 +19760,7 @@ msgid "make the preview as large as possible"
 msgstr "haga que la vista previa sea lo más grande posible"
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr "Cerrar moccapy / salir del programa"
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -18861,7 +18861,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -19997,7 +19997,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/gmoccapy/de.po
+++ b/src/po/gmoccapy/de.po
@@ -375,8 +375,7 @@ msgstr "FEHLER : Externer Not Aus ist aktiv, konnte den Status nicht wechseln!"
 
 #: gmoccapy.py:2325
 msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-"FEHLER : Konnte die Maschine nicht einschalten, ist ein Endschalter aktiv?"
+msgstr "FEHLER : Konnte die Maschine nicht einschalten, ist ein Endschalter aktiv?"
 
 #: gmoccapy.py:2405
 msgid "No file loaded"
@@ -1587,7 +1586,7 @@ msgid "make the preview as large as possible"
 msgstr "Zeige die Vorschau so groß wie möglich"
 
 #: gmoccapy.glade.h:198
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr "Beende gmoccapy / verlasse das Programm"
 
 #: gmoccapy.glade.h:199

--- a/src/po/gmoccapy/es.po
+++ b/src/po/gmoccapy/es.po
@@ -1580,7 +1580,7 @@ msgid "make the preview as large as possible"
 msgstr "Hacer la vista previa lo mas grande posible "
 
 #: gmoccapy.glade.h:198
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr "Cerrar moccapy / salir del  programa"
 
 #: gmoccapy.glade.h:199

--- a/src/po/gmoccapy/fr.po
+++ b/src/po/gmoccapy/fr.po
@@ -1578,7 +1578,7 @@ msgid "make the preview as large as possible"
 msgstr "rendre le parcours le plus grand possible"
 
 #: gmoccapy.glade.h:198
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr "Fermer gmoccapy / l quitter le programme"
 
 #: gmoccapy.glade.h:199

--- a/src/po/gmoccapy/hu.po
+++ b/src/po/gmoccapy/hu.po
@@ -1585,7 +1585,7 @@ msgid "make the preview as large as possible"
 msgstr "Nézet maximális kinagyítása"
 
 #: gmoccapy.glade.h:198
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr "Kilépés a programból"
 
 #: gmoccapy.glade.h:199

--- a/src/po/gmoccapy/pl.po
+++ b/src/po/gmoccapy/pl.po
@@ -1562,7 +1562,7 @@ msgid "make the preview as large as possible"
 msgstr "Wielkość podglądu"
 
 #: gmoccapy.glade.h:198
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr "Wyjście z programu"
 
 #: gmoccapy.glade.h:199

--- a/src/po/gmoccapy/sr.po
+++ b/src/po/gmoccapy/sr.po
@@ -1578,7 +1578,7 @@ msgid "make the preview as large as possible"
 msgstr "povećaj prikaz po celom ekranu"
 
 #: gmoccapy.glade.h:198
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr "zatvori i napusti program"
 
 #: gmoccapy.glade.h:199

--- a/src/po/gmoccapy/zh_CN.po
+++ b/src/po/gmoccapy/zh_CN.po
@@ -1534,7 +1534,7 @@ msgid "make the preview as large as possible"
 msgstr "缩放预览窗口"
 
 #: gmoccapy.glade.h:198
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr "关闭moccapy /离开程序"
 
 #: gmoccapy.glade.h:199

--- a/src/po/hu.po
+++ b/src/po/hu.po
@@ -19407,7 +19407,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -19829,7 +19829,7 @@ msgid "make the preview as large as possible"
 msgstr "rende la preview più larga possibile"
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr "Chiude moccapy / lascia il programma"
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -19320,7 +19320,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -19597,7 +19597,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -19773,7 +19773,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/ro.po
+++ b/src/po/ro.po
@@ -19981,7 +19981,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -19772,7 +19772,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/sk.po
+++ b/src/po/sk.po
@@ -19533,7 +19533,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/sr.po
+++ b/src/po/sr.po
@@ -19770,7 +19770,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -19410,7 +19410,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -19468,7 +19468,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/zh_HK.po
+++ b/src/po/zh_HK.po
@@ -19398,7 +19398,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -19404,7 +19404,7 @@ msgid "make the preview as large as possible"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close moccapy / leave the program"
+msgid "Close gmoccapy / leave the program"
 msgstr ""
 
 #: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208


### PR DESCRIPTION
-  disable stop button in gmoccapy when idle/stopped
- enable scrolling in gcode when paused
-  fix some translations, see https://github.com/LinuxCNC/linuxcnc/issues/1111