### PR TITLE
stepconf: prevent limit swich errors when all home switches selected

### DIFF
--- a/src/emc/usr_intf/stepconf/build_HAL.py
+++ b/src/emc/usr_intf/stepconf/build_HAL.py
@@ -266,7 +266,7 @@ class HAL:
             print("net all-limit-home => lut5.0.in-4", file=file)
             print("net all-limit <= lut5.0.out", file=file)
             for j in self.d.axislist:
-                print("net homing-{0} <= joint.{1}.homing => lut5.0.in-{1}".format(j.upper(), self.d.axislist.index(j)), file=file)
+                print("net {0}homing <= joint.{1}.homing => lut5.0.in-{1}".format(j, self.d.axislist.index(j)), file=file)
 
         # connect the joints
         for j in self.d.axislist:
@@ -542,6 +542,15 @@ class HAL:
                 print("net {:21}sim-hardware.{}bothsw-homesw-out".format("fake-both-home-" + j, j.upper()), file=f1)
                 print("net {:21}sim-hardware.{}maxsw-homesw-out".format("fake-max-home-" + j, j.upper()), file=f1)
                 print("net {:21}sim-hardware.{}minsw-homesw-out".format("fake-min-home-" + j, j.upper()), file=f1)
+
+#        if self.d.sim_hardware:
+            print(file=f1)
+            for j in self.d.axislist:
+                if SIG.ALL_LIMIT_HOME in inputs:
+                    print("net {}homing => sim-hardware.{}homing".format(j, j.upper()), file=f1)
+                else:
+                    print("net {}homing  joint.{}.homing => sim-hardware.{}homing".format(j, self.d.axislist.index(j), j.upper()), file=f1)
+
             f1.close()
         else:
             if os.path.exists(custom):

--- a/src/hal/components/sim_axis_hardware.comp
+++ b/src/hal/components/sim_axis_hardware.comp
@@ -70,7 +70,16 @@ pin in float Ahomesw_hyst =.02;
 pin in float Uhomesw_hyst =.02;
 pin in float Vhomesw_hyst =.02;
 
-pin out bit Xhomesw_out" Home switch for the X axis";
+pin in bit Xhoming "True is homing in progress";
+pin in bit X2homing;
+pin in bit Yhoming;
+pin in bit Y2homing;
+pin in bit Zhoming;
+pin in bit Ahoming;
+pin in bit Uhoming;
+pin in bit Vhoming;
+
+pin out bit Xhomesw_out "Home switch for the X axis";
 pin out bit X2homesw_out;
 pin out bit Yhomesw_out;
 pin out bit Y2homesw_out;
@@ -147,7 +156,6 @@ pin out bit Vmaxsw_homesw_out;
 pin out bit Vminsw_homesw_out;
 pin out bit Vbothsw_homesw_out;
 
-
 pin in float limit_offset =.01 "how much the limit switches are offset from inputed position. added to max, subracted from min";
 
 function update fp;
@@ -188,41 +196,43 @@ Zhomesw_out = comp(Zhomesw_pos,Zcurrent_pos,Zhomesw_hyst);
 Ahomesw_out = comp(Ahomesw_pos,Acurrent_pos,Ahomesw_hyst);
 Uhomesw_out = comp(Uhomesw_pos,Ucurrent_pos,Uhomesw_hyst);
 Vhomesw_out = comp(Vhomesw_pos,Vcurrent_pos,Vhomesw_hyst);
-homesw_all = Xhomesw_out || X2homesw_out || Yhomesw_out || Y2homesw_out
- || Zhomesw_out || Ahomesw_out || Uhomesw_out || Vhomesw_out;
+int homing = Xhoming || X2homing || Yhoming || Y2homing ||
+             Zhoming || Ahoming || Uhoming || Vhoming;
+homesw_all = (Xhomesw_out || X2homesw_out || Yhomesw_out || Y2homesw_out ||
+             Zhomesw_out || Ahomesw_out || Uhomesw_out || Vhomesw_out) && homing;
 
 /* set limit switches */
 Xmaxsw_out = wcomp(Xcurrent_pos,Xmaxsw_upper,Xmaxsw_lower+limit_offset);
 Xminsw_out = wcomp(Xcurrent_pos,Xminsw_upper-limit_offset,Xminsw_lower);
-Xbothsw_out = Xmaxsw_out || Xminsw_out;
+Xbothsw_out = (Xmaxsw_out || Xminsw_out) && !homing;
 
 X2maxsw_out = wcomp(X2current_pos,X2maxsw_upper,X2maxsw_lower+limit_offset);
 X2minsw_out = wcomp(X2current_pos,X2minsw_upper-limit_offset,X2minsw_lower);
-X2bothsw_out = X2maxsw_out || X2minsw_out;
+X2bothsw_out = (X2maxsw_out || X2minsw_out) && !homing;
 
 Ymaxsw_out = wcomp(Ycurrent_pos,Ymaxsw_upper,Ymaxsw_lower+limit_offset);
 Yminsw_out = wcomp(Ycurrent_pos,Yminsw_upper-limit_offset,Yminsw_lower);
-Ybothsw_out = Ymaxsw_out || Yminsw_out;
+Ybothsw_out = (Ymaxsw_out || Yminsw_out) && !homing;
 
 Y2maxsw_out = wcomp(Y2current_pos,Y2maxsw_upper,Y2maxsw_lower+limit_offset);
 Y2minsw_out = wcomp(Y2current_pos,Y2minsw_upper-limit_offset,Y2minsw_lower);
-Y2bothsw_out = Y2maxsw_out || Y2minsw_out;
+Y2bothsw_out = (Y2maxsw_out || Y2minsw_out) && !homing;
 
 Zmaxsw_out = wcomp(Zcurrent_pos,Zmaxsw_upper,Zmaxsw_lower+limit_offset);
 Zminsw_out = wcomp(Zcurrent_pos,Zminsw_upper-limit_offset,Zminsw_lower);
-Zbothsw_out = Zmaxsw_out || Zminsw_out;
+Zbothsw_out = (Zmaxsw_out || Zminsw_out) && !homing;
 
 Amaxsw_out = wcomp(Acurrent_pos,Amaxsw_upper,Amaxsw_lower+limit_offset);
 Aminsw_out = wcomp(Acurrent_pos,Aminsw_upper-limit_offset,Aminsw_lower);
-Abothsw_out = Amaxsw_out || Aminsw_out;
+Abothsw_out = (Amaxsw_out || Aminsw_out) && !homing;
 
 Umaxsw_out = wcomp(Ucurrent_pos,Umaxsw_upper,Umaxsw_lower+limit_offset);
 Uminsw_out = wcomp(Ucurrent_pos,Uminsw_upper-limit_offset,Uminsw_lower);
-Ubothsw_out = Umaxsw_out || Uminsw_out;
+Ubothsw_out = (Umaxsw_out || Uminsw_out) && !homing;
 
 Vmaxsw_out = wcomp(Vcurrent_pos,Vmaxsw_upper,Vmaxsw_lower+limit_offset);
 Vminsw_out = wcomp(Vcurrent_pos,Vminsw_upper-limit_offset,Vminsw_lower);
-Vbothsw_out = Vmaxsw_out || Vminsw_out;
+Vbothsw_out = (Vmaxsw_out || Vminsw_out) && !homing;
 
 limitsw_all = (Xbothsw_out || X2bothsw_out || Ybothsw_out || Y2bothsw_out
  || Zbothsw_out || Abothsw_out || Ubothsw_out || Vbothsw_out);


### PR DESCRIPTION
Prevent false limit switch errors when "All home" or "All limits + homes" as a parport input.

> If I set home position to 0 and table travel to 0 to 8 (say for y axis) for a simulation, linuxcnc starts with the limit switches tripped.
> Which shouldn't be as the switch is at -.01
> I think this is related to hysteresis of the simulated limit switch.

I did see this but if I set the home switch position 0.02 or greater outside the table travel then it seems OK.