### PR TITLE
docs: reworked iocontrol/io/iov2 man pages part 2

### DIFF
--- a/docs/man/man1/io.1
+++ b/docs/man/man1/io.1
@@ -6,18 +6,19 @@
 ..
 
 .SH NAME
-iocontrol \- accepts NML I/O commands, interacts with HAL in userspace
+iocontrol \- interacts with HAL or G-code in userspace
 
 .SH SYNOPSIS
 
-\fBloadusr io [\-ini \fIinifile\fB]
-
 .B [EMCIO]
 .br
-.B EMCIO = iov2
+.B EMCIO = io
 
 .SH DESCRIPTION
-These pins are created by the userspace IO controller, usually found in $LINUXCNC_HOME/bin/io
+
+I/O control handles I/O tasks like coolant, toolchange, e-stop and lube. The signals are turned on and off in userspace with G-code or in the case of e-stop in hal. 
+
+The following pins are created by the userspace IO controller, usually found in $LINUXCNC_HOME/bin/io
 .P
 The signals are turned on and off in userspace - if you have strict timing requirements or simply need more i/o, consider using the realtime synchronized i/o provided by \fBmotion\fR(9) instead.
 .P
@@ -119,3 +120,14 @@ successful tool change (M6).
 \fBmotion\fR(9)
 
 \}
+.SH REPORTING BUGS
+Report bugs at 
+.UR https://github.com/LinuxCNC/linuxcnc/issues
+.UE
+.SH AUTHOR
+Derived from a work by Fred Proctor & Will Shackleford.
+.SH COPYRIGHT
+Copyright \(co 2004 the LinuxCNC project.
+.br
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/docs/man/man1/iocontrol.1
+++ b/docs/man/man1/iocontrol.1
@@ -1,8 +1,7 @@
 .TH IOCONTROL "1" "2021-04" "LinuxCNC Documentation" "HAL Component" 
 
 .SH NAME
-iocontrol \- accepts NML I/O commands, interacts with HAL in userspace
- 
+iocontrol \- interacts with HAL or G-code in userspace 
 
 .SH SYNOPSIS
 
@@ -17,13 +16,15 @@ or
 
 .SH DESCRIPTION
 
-
-
-\fBiov2\fR is an alternative (extended) interface to \fBio\fR. 
-It creates additional pins and does some things differently. 
+I/O control handles I/O tasks like coolant, toolchange, e-stop and lube. The signals are turned on and off in userspace with G-code or in the case of e-stop in hal. 
+.br
+I/O Control V2 (iov2) adds more toolchager support for communication with the toolchanger.
 
 Whether \fBio\fR or \fBiov2\fR is used can be chosen in the [EMCIO] section of the INI file.
 
+See also 
+.UR http://linuxcnc.org/docs/html/config/iov2.html
+.UE
 .SH SEE ALSO
 
 .ie '\*[.T]'html' \{\

--- a/docs/man/man1/iov2.1
+++ b/docs/man/man1/iov2.1
@@ -24,7 +24,7 @@
 .\"
 .TH "IOCONTROL - IOV2" "1"  "2021-04" "LinuxCNC Documentation" "The Enhanced Machine Controller"
 .SH NAME
-iov2 \- an alternative to iocontrol
+iov2 \- interacts with HAL or G-code in userspace
 .SH SYNOPSIS
 
 .B [EMCIO]
@@ -32,14 +32,79 @@ iov2 \- an alternative to iocontrol
 .B EMCIO = iov2
 
 .SH DESCRIPTION
-\fBiov2\fR is an alternative (extended) interface to \fBio\fR. 
-It creates additional pins and does some things differently. 
+
+I/O control handles I/O tasks like coolant, toolchange, e-stop and lube. The signals are turned on and off in userspace with G-code or in the case of e-stop in hal. 
 .br
+I/O Control V2 (iov2) adds more toolchager support for communication with the toolchanger.
+
 Whether \fBio\fR or \fBiov2\fR is used can be chosen in the [EMCIO] section of the INI file.
 
+.SH Pins
+.SS Basic pins
 
-.B These pins are created additionally to \fIio\fB:\fR
-.HTML <br>
+.TP
+\fBiocontrol.0.coolant\-flood
+(Bit, Out) TRUE when flood coolant is requested
+
+
+.TP
+\fBiocontrol.0.coolant\-mist 
+(Bit, Out) TRUE when mist coolant is requested
+
+.TP
+\fBiocontrol.0.emc\-enable\-in 
+(Bit, In) Should be driven FALSE when an external estop condition exists.
+
+.TP
+\fBiocontrol.0.lube 
+(Bit, Out) TRUE when lube is requested.  This pin gets driven True when
+the controller comes out of E-stop, and when the "Lube On" command gets
+sent to the controller.  It gets driven False when the controller goes
+into E-stop, and when the "Lube Off" command gets sent to the controller.
+
+.TP
+\fBiocontrol.0.lube_level 
+(Bit, In) Should be driven FALSE when lubrication tank is empty.
+
+.TP
+\fBiocontrol.0.tool\-change 
+(Bit, Out) TRUE when a tool change is requested
+
+.TP
+\fBiocontrol.0.tool\-changed 
+(Bit, In) Should be driven TRUE when a tool change is completed.
+
+.TP
+\fBiocontrol.0.tool\-number
+(s32, Out) Current tool number
+
+.TP
+\fBiocontrol.0.tool\-prep\-number 
+(s32, Out) The number of the next tool, from the RS274NGC T-word
+
+.TP
+\fBiocontrol.0.tool\-prep\-pocket
+(s32, Out) This is the pocket number (location in the tool storage
+mechanism) of the tool requested by the most recent T-word.
+
+.TP
+\fBiocontrol.0.tool\-prepare 
+(Bit, Out) TRUE when a T\fIn\fR tool prepare is requested
+
+.TP
+\fBiocontrol.0.tool\-prepared 
+(Bit, In) Should be driven TRUE when a tool prepare is completed.
+
+.TP
+\fBiocontrol.0.user\-enable\-out 
+(Bit, Out) FALSE when an internal estop condition exists
+
+.TP
+\fBiocontrol.0.user\-request\-enable 
+(Bit, Out) TRUE when the user has requested that estop be cleared
+
+
+.SS Additional IO v2 pins
 .TP
 \fBiocontrol.0.emc\-abort
 (BIT,OUT) Signals emc\-originated abort to toolchanger.
@@ -74,7 +139,8 @@ Whether \fBio\fR or \fBiov2\fR is used can be chosen in the [EMCIO] section of t
 \fBiocontrol.0.state
 (S32,OUT) Debugging pin reflecting internal state
 
-.TP 0
+.HTML <br>
+.PP
 See 
 .UR http://wiki.linuxcnc.org/cgi-bin/wiki.pl?ToolchangerProtocolProposal 
 .UE
@@ -106,12 +172,16 @@ for additional information.
 
 
 .PP
-.SH AUTHOR
-Written by andypugh, as part of the LinuxCNC project. Updated by Hans Unzner.
 .SH REPORTING BUGS
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at 
+.UR https://github.com/LinuxCNC/linuxcnc/issues
+.UE
+.SH AUTHOR
+Derived from a work by Fred Proctor & Will Shackleford.
+.br
+Rework & adding v2 protocol support by Michael Haberler.
 .SH COPYRIGHT
-Copyright \(co 2020 andypugh.
+Copyright \(co 2011 Michael Haberler.
 .br
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


### PR DESCRIPTION
Due to a little missunderstanding here the changes of https://github.com/LinuxCNC/linuxcnc/pull/1127 until there is a decision if both io and iov2 are still maintained or if one is dropped.

Closes https://github.com/LinuxCNC/linuxcnc/issues/1108