### PR TITLE
docs: fixed merge errors

### DIFF
--- a/docs/man/man1/io.1
+++ b/docs/man/man1/io.1
@@ -6,11 +6,9 @@
 ..
 
 .SH NAME
-iocontrol \- accepts NML I/O commands, interacts with HAL in userspace
+iocontrol \- interacts with HAL or G-code in userspace
 
 .SH SYNOPSIS
-
-\fBloadusr io [\-ini \fIinifile\fB]
 
 .B [EMCIO]
 .br
@@ -18,9 +16,9 @@ iocontrol \- accepts NML I/O commands, interacts with HAL in userspace
 
 .SH DESCRIPTION
 
-iocontrol handles I/O tasks like coolant, toolchange, e-stop and lube. The
-signals are turned on and off with G code or in the case of e-stop
-in hal.
+I/O control handles I/O tasks like coolant, toolchange, e-stop and lube. The signals are turned on and off in userspace with G-code or in the case of e-stop in hal. 
+
+The following pins are created by the userspace IO controller, usually found in $LINUXCNC_HOME/bin/io
 .P
 iocontrol is a userspace process - if you have strict timing requirements
 or simply need more i/o, consider using the realtime synchronized i/o
@@ -91,11 +89,9 @@ mechanism) of the tool requested by the most recent T-word.
 \fBiocontrol.0.user\-request\-enable 
 (Bit, Out) TRUE when the user has requested that estop be cleared
 
-.SH PARAMETERS
-
 .TP
 \fBiocontrol.0.tool\-prep\-index
-(s32, RO) IO's internal array index of the prepped tool requested
+(s32, Out) IO's internal array index of the prepped tool requested
 by the most recent T-word.  0 if no tool is prepped.  On Random
 toolchanger machines this is the tool's pocket number (ie, the same as the
 tool\-prep\-pocket pin), on Non-random toolchanger machines this is
@@ -125,3 +121,14 @@ successful tool change (M6).
 \fBmotion\fR(9)
 
 \}
+.SH REPORTING BUGS
+Report bugs at 
+.UR https://github.com/LinuxCNC/linuxcnc/issues
+.UE
+.SH AUTHOR
+Derived from a work by Fred Proctor & Will Shackleford.
+.SH COPYRIGHT
+Copyright \(co 2004 the LinuxCNC project.
+.br
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/docs/man/man1/iocontrol.1
+++ b/docs/man/man1/iocontrol.1
@@ -1,8 +1,7 @@
 .TH IOCONTROL "1" "2021-04" "LinuxCNC Documentation" "HAL Component" 
 
 .SH NAME
-iocontrol \- accepts NML I/O commands, interacts with HAL in userspace
- 
+iocontrol \- interacts with HAL or G-code in userspace 
 
 .SH SYNOPSIS
 
@@ -17,21 +16,16 @@ or
 
 .SH DESCRIPTION
 
-iocontrol handles I/O tasks like coolant, toolchange, e-stop and lube. The
-signals are turned on and off with G code or in the case of e-stop
-in hal.
-.P
-iocontrol is a userspace process - if you have strict timing
-requirements or simply need more i/o, consider using the realtime
-synchronized i/o provided by \fBmotion\fR(9) instead.
-.P
-The inifile is searched for in the directory from which halcmd was run, unless an absolute path is specified.
+I/O control handles I/O tasks like coolant, toolchange, e-stop and lube. The signals are turned on and off in userspace with G-code or in the case of e-stop in hal. 
+.br
+I/O Control V2 (iov2) adds more toolchager support for communication with the toolchanger.
 
-.SH PINS
+Whether \fBio\fR or \fBiov2\fR is used can be chosen in the [EMCIO] section of the INI file.
 
-These pins are created by the userspace IO controller, usually found in $LINUXCNC_HOME/bin/io and loaded by ini file setting: [EMCIO]EMCIO=io.
-.P
-See the individual manpages for io and iov2 for pin descriptions.
+See also 
+.UR http://linuxcnc.org/docs/html/config/iov2.html
+.UE
+.SH SEE ALSO
 
 .ie '\*[.T]'html' \{\
 

--- a/docs/man/man1/iov2.1
+++ b/docs/man/man1/iov2.1
@@ -24,7 +24,7 @@
 .\"
 .TH "IOCONTROL - IOV2" "1"  "2021-04" "LinuxCNC Documentation" "The Enhanced Machine Controller"
 .SH NAME
-iov2 \- an alternative to iocontrol
+iov2 \- interacts with HAL or G-code in userspace
 .SH SYNOPSIS
 
 .B [EMCIO]
@@ -33,23 +33,78 @@ iov2 \- an alternative to iocontrol
 
 .SH DESCRIPTION
 
-iocontrol handles I/O tasks like coolant, toolchange, e-stop and lube. The
-signals are turned on and off with G code or in the case of e-stop
-in hal.
-.P
-iocontrol is a userspace process - if you have strict timing
-requirements or simply need more i/o, consider using the realtime
-synchronized i/o provided by \fBmotion\fR(9) instead.
-.P
-\fBiov2\fR is an alternative (extended) interface to \fBio\fR. 
-It creates additional pins to handle toolchange fault states and has better
-handling of certain race conditions.
+I/O control handles I/O tasks like coolant, toolchange, e-stop and lube. The signals are turned on and off in userspace with G-code or in the case of e-stop in hal. 
 .br
+I/O Control V2 (iov2) adds more toolchager support for communication with the toolchanger.
+
 Whether \fBio\fR or \fBiov2\fR is used can be chosen in the [EMCIO] section of the INI file.
 
-.SH PINS
+.SH Pins
+.SS Basic pins
 
-.HTML <br>
+.TP
+\fBiocontrol.0.coolant\-flood
+(Bit, Out) TRUE when flood coolant is requested
+
+
+.TP
+\fBiocontrol.0.coolant\-mist 
+(Bit, Out) TRUE when mist coolant is requested
+
+.TP
+\fBiocontrol.0.emc\-enable\-in 
+(Bit, In) Should be driven FALSE when an external estop condition exists.
+
+.TP
+\fBiocontrol.0.lube 
+(Bit, Out) TRUE when lube is requested.  This pin gets driven True when
+the controller comes out of E-stop, and when the "Lube On" command gets
+sent to the controller.  It gets driven False when the controller goes
+into E-stop, and when the "Lube Off" command gets sent to the controller.
+
+.TP
+\fBiocontrol.0.lube_level 
+(Bit, In) Should be driven FALSE when lubrication tank is empty.
+
+.TP
+\fBiocontrol.0.tool\-change 
+(Bit, Out) TRUE when a tool change is requested
+
+.TP
+\fBiocontrol.0.tool\-changed 
+(Bit, In) Should be driven TRUE when a tool change is completed.
+
+.TP
+\fBiocontrol.0.tool\-number
+(s32, Out) Current tool number
+
+.TP
+\fBiocontrol.0.tool\-prep\-number 
+(s32, Out) The number of the next tool, from the RS274NGC T-word
+
+.TP
+\fBiocontrol.0.tool\-prep\-pocket
+(s32, Out) This is the pocket number (location in the tool storage
+mechanism) of the tool requested by the most recent T-word.
+
+.TP
+\fBiocontrol.0.tool\-prepare 
+(Bit, Out) TRUE when a T\fIn\fR tool prepare is requested
+
+.TP
+\fBiocontrol.0.tool\-prepared 
+(Bit, In) Should be driven TRUE when a tool prepare is completed.
+
+.TP
+\fBiocontrol.0.user\-enable\-out 
+(Bit, Out) FALSE when an internal estop condition exists
+
+.TP
+\fBiocontrol.0.user\-request\-enable 
+(Bit, Out) TRUE when the user has requested that estop be cleared
+
+
+.SS Additional IO v2 pins
 .TP
 \fBiocontrol.0.coolant\-flood
 (Bit, Out) TRUE when flood coolant is requested
@@ -130,7 +185,8 @@ mechanism) of the tool requested by the most recent T-word.
 \fBiocontrol.0.state
 (S32,OUT) Debugging pin reflecting internal state
 
-.TP 0
+.HTML <br>
+.PP
 See 
 .UR http://wiki.linuxcnc.org/cgi-bin/wiki.pl?ToolchangerProtocolProposal 
 .UE
@@ -162,12 +218,16 @@ for additional information.
 
 
 .PP
-.SH AUTHOR
-Written by andypugh, as part of the LinuxCNC project. Updated by Hans Unzner.
 .SH REPORTING BUGS
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at 
+.UR https://github.com/LinuxCNC/linuxcnc/issues
+.UE
+.SH AUTHOR
+Derived from a work by Fred Proctor & Will Shackleford.
+.br
+Rework & adding v2 protocol support by Michael Haberler.
 .SH COPYRIGHT
-Copyright \(co 2021 The LinuxCNC Project
+Copyright \(co 2011 Michael Haberler.
 .br
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


### PR DESCRIPTION
- Fixes errors through merge 1c11906e2b3b946dee582866bb180b0392c9e22c
- "Fixes" pin `iocontrol.0.tool-prep-index` that was changed in 2dbb2f640fb87e7fe40c6d83cee381f8643233be