### PR TITLE
uspace: hal: Show involuntary context switches as hal pin

### DIFF
--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -301,13 +301,13 @@ typedef struct {
     int task_id;		/* ID of the task that runs this thread */
     hal_s32_t* runtime;	/* (pin) duration of last run, in CPU cycles */
     hal_s32_t maxtime;	/* (param) duration of longest run, in CPU cycles */
-#ifndef __KERNEL__
-    hal_s32_t *involuntary;	/* (param) total of involuntary context switches (uspace only) */
-    hal_bit_t involuntary_increased;	/* on last call, involuntary increased */
-#endif
     hal_list_t funct_list;	/* list of functions to run */
     char name[HAL_NAME_LEN + 1];	/* thread name */
     int comp_id;
+    // These two only are used in uspace, but so that the structure has
+    // consistent layout the fields are enabled unconditionally.
+    hal_s32_t *involuntary;	/* (param) total of involuntary context switches (uspace only) */
+    hal_bit_t involuntary_increased;	/* on last call, involuntary increased */
 } hal_thread_t;
 
 /* IMPORTANT:  If any of the structures in this file are changed, the

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -301,6 +301,10 @@ typedef struct {
     int task_id;		/* ID of the task that runs this thread */
     hal_s32_t* runtime;	/* (pin) duration of last run, in CPU cycles */
     hal_s32_t maxtime;	/* (param) duration of longest run, in CPU cycles */
+#ifndef __KERNEL__
+    hal_s32_t *involuntary;	/* (param) total of involuntary context switches (uspace only) */
+    hal_bit_t involuntary_increased;	/* on last call, involuntary increased */
+#endif
     hal_list_t funct_list;	/* list of functions to run */
     char name[HAL_NAME_LEN + 1];	/* thread name */
     int comp_id;


### PR DESCRIPTION
Linux accounts the number of "involuntary context switches", occasions where it interrupted a thread in the middle of CPU-bound work.  In a properly functioning RT system, this number would always be 0.  So, it can be used to diagnose whether involuntary context switches are a cause of poor RT performance.

This may not be a great idea to do unconditionally, since it adds an additional syscall to each thread period (at the end).

The same value can be seen in /proc/<TID>/status as nonvoluntary_ctxt_switches, so it's also possible to check it manually.

Typical (running in non-realtime mode)
```
halcmd: show pin thread1.involuntary
Component Pins:
Owner   Type  Dir         Value  Name
     5  s32   OUT             2  thread1.involuntary
```