### PR TITLE
rs274: Temporarily force the LC_NUMERIC setting to C as needed

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -1271,6 +1271,7 @@ int Interp::convert_axis_offsets(int g_code,     //!< g_code being executed (mus
 
 int Interp::convert_param_comment(char *comment, char *expanded, int len)
 {
+    FORCE_LC_NUMERIC_C;
     int i;
     char param[LINELEN+1];
     int paramNumber;
@@ -2737,6 +2738,7 @@ int Interp::gen_settings(
     double *float_current, double *float_saved,  // S, F, other
     std::string &cmd)                            // command buffer
 {
+    FORCE_LC_NUMERIC_C;
     int i, val;
     int g64_changed = 0;
     char buf[LINELEN];
@@ -2864,6 +2866,7 @@ int Interp::gen_settings(
  */
 int Interp::gen_m_codes(int *current, int *saved, std::string &cmd)
 {
+    FORCE_LC_NUMERIC_C;
     int i,val;
     char buf[LINELEN];
     for (i = 0; i < ACTIVE_M_CODES; i++) {

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -13,6 +13,7 @@
 #ifndef INTERP_INTERNAL_HH
 #define INTERP_INTERNAL_HH
 
+#include <locale.h>
 #include <algorithm>
 #include "config.h"
 #include <limits.h>
@@ -990,5 +991,14 @@ macros totally crash-proof. If the function call stack is deeper than
        CHP(call); \
      }
 
+;
 
+struct scoped_locale {
+    scoped_locale(int category_, const char *locale_) : category(category_), oldlocale(setlocale(category, NULL)) { setlocale(category, locale_); }
+    ~scoped_locale() { setlocale(category, oldlocale); }
+    int category;
+    const char *oldlocale;
+};
+
+#define FORCE_LC_NUMERIC_C scoped_locale force_lc_numeric_c(LC_NUMERIC, "C")
 #endif // INTERP_INTERNAL_HH

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -1821,6 +1821,7 @@ has its value set to zero.
 */
 int Interp::restore_parameters(const char *filename)   //!< name of parameter file to read  
 {
+  FORCE_LC_NUMERIC_C;
   FILE *infile;
   char line[256];
   int variable;
@@ -1914,6 +1915,7 @@ complain, but does write it in the output file.
 int Interp::save_parameters(const char *filename,      //!< name of file to write
                              const double parameters[]) //!< parameters to save   
 {
+  FORCE_LC_NUMERIC_C;
   FILE *infile;
   FILE *outfile;
   char line[PATH_MAX];


### PR DESCRIPTION
Code in the gcode interpreter assumes that number parsing/formatting
is done according to the C locale, as gcode part programs always use
"." as the decimal separator.

However, some of the user interfaces set the LC_NUMERIC to the user's
locale and then call into the interpreter to prepare previews of the
part program.

The last time I addressed this, it was by changing one routine to work via
an ostringstream, which is not affected by locales by default.
This time I took a different approach, which is to temporarily force the
LC_NUMERIC to C at entry to certain functions, and to restore it on exit.

If UIs or other embedders of the interpreter also use threads, they
must use `uselocale` to switch from program-wide to per-thread locale
settings, or the behavior of their program becomes undefined.

This hopefully fixes multiple bugs in affected locales, and closes #1158.
However, I did not actually set up a testing environment that would allow
me to check it.  Additionally, saving & restoring parameters will now
take place in the C locale.