### PR TITLE
Alkabal patch add an axisui.abort pin

### DIFF
--- a/docs/src/gui/axis.txt
+++ b/docs/src/gui/axis.txt
@@ -1057,6 +1057,14 @@ Type  Dir    Name
 float OUT               axisui.jog.increment
 ----
 
+Axis has a Hal output pin that indicates when an abort has occurred. The
+'axisui.abort' pin will be 'TRUE' and come back to 'FALSE' after 0.3ms.
+
+----
+Type  Dir    Name
+bit   OUT    axisui.abort
+----
+
 Axis has a Hal output pin that indicates when an error has occurred. The
 'axisui.error' pin will remain 'TRUE' until all error notifications have
 been dismissed.

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -2346,8 +2346,11 @@ class TclCommands(nf.TclCommands):
     def task_stop(*event):
         if s.task_mode == linuxcnc.MODE_AUTO and vars.running_line.get() != 0:
             o.set_highlight_line(vars.running_line.get())
+        comp["abort"] = True
         c.abort()
         c.wait_complete()
+        time.sleep(0.3)
+        comp["abort"] = False
 
     def mdi_up_cmd(*args):
         if args and args[0].char: return   # e.g., for KP_Up with numlock on
@@ -3845,6 +3848,7 @@ if hal_present == 1 :
     comp.newpin("notifications-clear-error",hal.HAL_BIT,hal.HAL_IN)
     comp.newpin("resume-inhibit",hal.HAL_BIT,hal.HAL_IN)
     comp.newpin("error", hal.HAL_BIT, hal.HAL_OUT)
+    comp.newpin("abort", hal.HAL_BIT, hal.HAL_OUT)
 
     vars.has_ladder.set(hal.component_exists('classicladder_rt'))
 


### PR DESCRIPTION
Add an axisui.abort pin. The pin will be set high / True after user kill operation from Axis GUI.

This pin is reverted to low / False after 0.3ms

This help to inform user component program if action is killed from GUI for prevent bad things.

If the time.sleep(0.3) is the not the good way i apologize i haven't found other working method.