### PR TITLE
Increasing Hal Size as we Maxed out pin count.

### DIFF
--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -291,7 +291,7 @@ typedef struct {
     int funct_ptr;		/* pointer to function */
 } hal_funct_entry_t;
 
-#define HAL_STACKSIZE 16384	/* realtime task stacksize */
+#define HAL_STACKSIZE 65536	/* realtime task stacksize */
 
 typedef struct {
     rtapi_intptr_t next_ptr;		/* next thread in linked list */
@@ -329,8 +329,8 @@ typedef struct {
 */
 
 #define HAL_KEY   0x48414C32	/* key used to open HAL shared memory */
-#define HAL_VER   0x00000010	/* version code */
-#define HAL_SIZE  (256*4096)
+#define HAL_VER   0x00000011	/* version code */
+#define HAL_SIZE  (1024*4096)
 #define HAL_PSEUDO_COMP_PREFIX "__" /* prefix to identify a pseudo component */
 
 /* These pointers are set by hal_init() to point to the shmem block


### PR DESCRIPTION
On this ever increasing complexity of a build, Hal in formed us we were out of memory. 
```bash
HAL: ERROR: Insufficient memory for signal 'j2-master-ctrl8'
``` 
We increased this on our current repo. The Hal File that caused this has 330 nets, in addition to the built in Hal pins. As computers increase in memory size I see no reason to not use the available memory. 

Future thought if I had more time would be to be able to give a compile flag to change the size at compile time.

Note: Tested for about 2 days and it no issues yet.