### PR TITLE
Python3 doesn't really have 'int's anymore

### DIFF
--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -90,10 +90,12 @@ bool from_python(PyObject *o, double *d) {
 bool from_python(PyObject *o, uint32_t *u) {
     PyObject *tmp = 0;
     long long l;
+#if !IS_PY3
     if(PyInt_Check(o)) {
         l = PyInt_AsLong(o);
         goto got_value;
     }
+#endif
 
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
     if(!tmp) goto fail;
@@ -101,7 +103,9 @@ bool from_python(PyObject *o, uint32_t *u) {
     l = PyLong_AsLongLong(tmp);
     if(PyErr_Occurred()) goto fail;
 
+#if !IS_PY3
 got_value:
+#endif
     if(l < 0 || l != (uint32_t)l) {
         PyErr_Format(PyExc_OverflowError, "Value %lld out of range", l);
         goto fail;
@@ -118,10 +122,12 @@ fail:
 bool from_python(PyObject *o, int32_t *i) {
     PyObject *tmp = 0;
     long long l;
+#if !IS_PY3
     if(PyInt_Check(o)) {
         l = PyInt_AsLong(o);
         goto got_value;
     }
+#endif
 
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
     if(!tmp) goto fail;
@@ -129,7 +135,9 @@ bool from_python(PyObject *o, int32_t *i) {
     l = PyLong_AsLongLong(tmp);
     if(PyErr_Occurred()) goto fail;
 
+#if !IS_PY3
 got_value:
+#endif
     if(l != (int32_t)l) {
         PyErr_Format(PyExc_OverflowError, "Value %lld out of range", l);
         goto fail;


### PR DESCRIPTION
We were seeing problems like this on 32-bit systems with python3:
```diff
--- /data/home/buildslave/emc2-buildbot/buster-rtpreempt-rpi4/rip-buster-rtpreempt-rpi4/build/tests/halmodule.0/expected	2021-05-31 15:54:51.441684157 -0600
+++ /data/home/buildslave/emc2-buildbot/buster-rtpreempt-rpi4/rip-buster-rtpreempt-rpi4/build/tests/halmodule.0/result	2021-06-03 10:03:22.171214440 -0600
@@ -8,7 +8,7 @@
 set s -2147483648 ok
 set u 0 ok
 set u 1 ok
-set u 4294967295 ok
+set u 4294967295 fail
 set f 0 ok
 set f 0.0 ok
 set f 0 ok
@@ -19,8 +19,8 @@
 set f 1.0 ok
 set f 1 ok
 set f 89884656743115795386465259539451236680898848947115328636715040578866337902750481566354238661203768010560056939935696678829394884407208311246423715319737062188883946712432742638151109800623047059726541476042502884419075341171231440736956555270413618581675255342293149119973622969239858152417678164812112068608 ok
-set s 2147483648 fail
-set s -2147483649 fail
+set s 2147483648 -1
+set s -2147483649 -1
 set u -1 fail
 set u 4294967296 fail
 set f 179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137216 fail
```

python3 doesn't distinguish between ints and longs in its C API, and the py3c code we have as a compatibility layer apparently doesn't behave quite like python2's C API.

If we simply bypass the "int" code under python3, it appears to resolve the problem.  So that it's compatible back to py2 systems I put in a #if section.  The IS_PY3 identifier is provided by py3c.