### PR TITLE
Fix compilation with '-Werror=format-security'

### DIFF
--- a/src/emc/tooldata/tooldata_db.cc
+++ b/src/emc/tooldata/tooldata_db.cc
@@ -244,7 +244,7 @@ int tooldata_db_init(char progname[],int random_toolchanger)
     child_argv[0] = progname;
     child_argv[1] = (char*)DB_VERSION;
     child_argv[2] = 0;
-    snprintf(db_childname,sizeof(db_childname),progname);
+    snprintf(db_childname,sizeof(db_childname),"%s",progname);
     is_random_toolchanger = random_toolchanger;
 
     if (access(progname,X_OK)) {


### PR DESCRIPTION
Compiling with '-Werror=format-security' runs into:

```
emc/tooldata/tooldata_db.cc: In function 'int tooldata_db_init(char*, int)':
emc/tooldata/tooldata_db.cc:247:13: error: format not a string literal and no format arguments [-Werror=format-security]
  247 |     snprintf(db_childname,sizeof(db_childname),progname);
      |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes that issue.
Here a short FAQ on why compiling with '-Werror=format-security' is a good idea: https://fedoraproject.org/wiki/Format-Security-FAQ