### PR TITLE
Display SI standard units in halscope

### DIFF
--- a/src/hal/utils/scope_files.c
+++ b/src/hal/utils/scope_files.c
@@ -276,7 +276,7 @@ void write_log_file (char *filename)
 	log->order=INTERLACED;
 
     /* write data */
-    fprintf(fp, "Sampling period is %i nSec \n", sample_period_ns );
+    fprintf(fp, "Sampling period is %i ns \n", sample_period_ns );
 
 	/* point to the first sample in the display buffer */
 	start = ctrl_usr->disp_buf ;

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -168,10 +168,10 @@ static void init_horiz_window(void)
     /* third column - scale display */
     horiz->scale_label = gtk_label_new_in_box("----", hbox, FALSE, FALSE, 5);
     gtk_label_size_to_fit(GTK_LABEL(horiz->scale_label),
-	"99.9 mSec\nper div");
+	"99.9 ms\nper div");
     /* fourth column - record length and sample rate button */
     horiz->record_button =
-	gtk_button_new_with_label(_("----- Samples\nat ---- KHz"));
+	gtk_button_new_with_label(_("----- Samples\nat ---- kHz"));
     horiz->record_label = gtk_bin_get_child(GTK_BIN(horiz->record_button));
     gtk_label_size_to_fit(GTK_LABEL(horiz->record_label),
 	"99999 Samples\nat 99.9 MHz");
@@ -976,7 +976,7 @@ static void calc_horiz_scaling(void)
     horiz->sample_period = horiz->sample_period_ns / 1000000000.0;
     total_rec_time = ctrl_shm->rec_len * horiz->sample_period;
     if (total_rec_time < 0.000010) {
-	/* out of range, set to 1uS per div */
+	/* out of range, set to 1 us per div */
 	horiz->disp_scale = 0.000001;
 	return;
     }
@@ -1155,18 +1155,18 @@ static void format_time_value(char *buf, int buflen, double timeval)
 
     /* convert to nanoseconds */
     timeval *= 1000000000.0;
-    units = _("nSec");
+    units = _("ns");
     if (timeval >= 1000.0) {
 	timeval /= 1000.0;
-	units = _("uSec");
+	units = _("us");
     }
     if (timeval >= 1000.0) {
 	timeval /= 1000.0;
-	units = _("mSec");
+	units = _("ms");
     }
     if (timeval >= 1000.0) {
 	timeval /= 1000.0;
-	units = _("Sec");
+	units = _("s");
     }
     decimals = 2;
     if (timeval >= 10.0) {
@@ -1186,11 +1186,11 @@ static void format_freq_value(char *buf, int buflen, double freqval)
     units = _("Hz");
     if (freqval >= 1000.0) {
 	freqval /= 1000.0;
-	units = _("KHz");
+	units = _("kHz");
     }
     if (freqval >= 1000.0) {
 	freqval /= 1000.0;
-	units = _("Mhz");
+	units = _("MHz");
     }
     decimals = 2;
     if (freqval >= 10.0) {

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -976,7 +976,7 @@ static void calc_horiz_scaling(void)
     horiz->sample_period = horiz->sample_period_ns / 1000000000.0;
     total_rec_time = ctrl_shm->rec_len * horiz->sample_period;
     if (total_rec_time < 0.000010) {
-	/* out of range, set to 1 us per div */
+	/* out of range, set to 1 µs per div */
 	horiz->disp_scale = 0.000001;
 	return;
     }
@@ -1158,7 +1158,7 @@ static void format_time_value(char *buf, int buflen, double timeval)
     units = _("ns");
     if (timeval >= 1000.0) {
 	timeval /= 1000.0;
-	units = _("us");
+	units = _("µs");
     }
     if (timeval >= 1000.0) {
 	timeval /= 1000.0;

--- a/src/po/Submakefile
+++ b/src/po/Submakefile
@@ -65,7 +65,7 @@ TOOLI18NSRCS := \
 
 po/linuxcnc.pot:
 	$(ECHO) Localizing linuxcnc.pot
-	$(Q)(cd ..; $(XGETTEXT) -k_ -o src/$@ `$(PYTHON) src/po/fixpaths.py -j src $^`)
+	$(Q)(cd ..; $(XGETTEXT) --from-code=UTF-8 -k_ -o src/$@ `$(PYTHON) src/po/fixpaths.py -j src $^`)
 	$(Q)touch $@
 TARGETS += po/linuxcnc.pot
 

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2020-02-09 13:45+0200\n"
 "Last-Translator: Benjamin Weis <benjamin.weis@gmx.com>\n"
 "Language-Team: German Translation Team <emc-developers@lists.sourceforge>\n"
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 0.5\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
@@ -22,70 +22,70 @@ msgstr ""
 "%s kann nicht ausgeführt werden, solange der Notaus  aktiv ist und die "
 "Maschine nicht eingeschaltet ist"
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "%s kann im manuellen Modus nicht ausgeführt werden"
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr ""
 "%s kann im automatischen Modus nicht ausgeführt werden, wenn der Interpreter "
 "stillsteht"
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr ""
 "%s kann im automatischen Modus nicht ausgeführt werden, wenn der Interpreter "
 "liest"
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 "%s kann im automatischen Modus nicht ausgeführt werden, wenn der Interpreter "
 "Pause macht"
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 "%s kann im automatischen Modus nicht ausgeführt werden, wenn der Interpreter "
 "wartet"
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "%s kann im MDI-Modus nicht ausgeführt werden"
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 "Modus kann nicht gewechselt werden, solange er auf AUTO ist und der "
 "Interpreter stillsteht"
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 #, fuzzy
 msgid "failed to close file"
 msgstr "Datei kann nicht geöffnet werden"
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "%s kann nicht geöffnet werden"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr "MDI-Befehl kann ohne vorherige Refernzfahrt nicht ausgeführt werden"
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "MDI-Befehl kann nur im MDI-Modus ausgeführt werden"
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr "Programm kann ohne vorherige Referenzfahrt nicht ausgeführt werden"
 
@@ -211,259 +211,261 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 #, fuzzy
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr ""
 "Ein Kreisbogen mit einer Vorschubgeschwindigkeit von 0 ist nicht möglich"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 #, fuzzy
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr "G53 kann nicht mit aktiver Werkzeugbahnkorrektur verwendet werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 #, fuzzy
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
-msgstr "kann nicht zustellen ohne Spindelgeschwindigkeit im Vorschub pro Umdrehung Modus"
+msgstr ""
+"kann nicht zustellen ohne Spindelgeschwindigkeit im Vorschub pro Umdrehung "
+"Modus"
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, fuzzy, c-format
 msgid "%c word missing in absolute center arc"
 msgstr ""
 "Angabe eines F-Wörters zum Fahren eines Kreisbogens im zeitreziproken "
 "Vorschub-Modus fehlt"
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr "Modus kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 "Koordinatensystem kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt "
 "werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr "G%S.1 ohne D-Wort"
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr "D-Wort bei G%d muss eine Ganzzahl sein"
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 #, fuzzy
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 #, fuzzy
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr "Kein gültiges P-Wort mit M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 #, fuzzy
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr "Kein gültiges P-Wort mit M63"
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 #, fuzzy
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr "Kein gültiges P-Wort mit M64"
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr "Kein gültiges P-Wort mit M65"
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 #, fuzzy
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 #, fuzzy
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 #, fuzzy
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 #, fuzzy
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
@@ -472,7 +474,7 @@ msgstr ""
 "Spindel ($) Nummer ausserhalb des Limits in M3 Befehl\n"
 "num_spindles =%i. $=%d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
@@ -481,7 +483,7 @@ msgstr ""
 "Spindel ($) Nummer ausserhalb des Limits in M4 Befehl\n"
 "num_spindles =%i. $=%d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
@@ -490,85 +492,84 @@ msgstr ""
 "Spindel ($) Nummer ausserhalb des Limits in M5 Befehl\n"
 "num_spindles =%i. $=%d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
-msgstr ""
-"Spindel ($) Nummer ausserhalb des Limits in M19 Befehl"
+msgstr "Spindel ($) Nummer ausserhalb des Limits in M19 Befehl"
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr "Q Befehl mit M19 benötigt einen Wrt > 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 #, fuzzy
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 #, fuzzy
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr "Unbekannte Spindle Nummer ($) in M51 Befehl"
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 #, fuzzy
 msgid "Cannot probe with feed per rev mode"
 msgstr "Abtast-Fahrt mit einer Verfahrgeschwindigkeit von 0 nicht möglich"
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 #, fuzzy
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 #, fuzzy
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 "Befehle G43.1, G41 R, und G42 R dürfen keine X-, Y-, Z-, A-, B-, C-. oder J-"
 "Wörter enthalten"
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 #, fuzzy
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
@@ -576,95 +577,98 @@ msgstr ""
 "Koordinatensystem kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt "
 "werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr "Ungültige Spindel Nummer in G33 Bewegung"
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr "Spindel nicht eingeschaltet in M33 Befehl"
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr "Ungültige Spindel Nummer in G33.1 Bewegung"
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr "Spindel nicht eingeschaltet in M33.1 Befehl"
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr "Ungültige D Nummer in G76 Zyklus"
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, fuzzy, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "Gewählte Spindel (%i) ohne Bewegung in G76"
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 #, fuzzy
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
-msgstr "G76 Zyklus kann nicht bei aktiver Werkzeugradiuskorrektur verwendet werden"
+msgstr ""
+"G76 Zyklus kann nicht bei aktiver Werkzeugradiuskorrektur verwendet werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr "Bei G76 Befehl darf I nicht Null sein"
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr "Bei G76 Befehl muss J größer Null sein"
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr "Bei G76 Befehl mus sK größer J sein"
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr "Der Werkzeugeinlaufpfad ist nicht größer wie der Werkzeugradius"
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr "Null Grad Innenecke ist bei Werkzeugradienkorrektur unzulässig"
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
-msgstr "Bogen zu linearer Bewegung bildet eine Ecke die der Fräser nicht ohne Kollision erreichen kann"
+msgstr ""
+"Bogen zu linearer Bewegung bildet eine Ecke die der Fräser nicht ohne "
+"Kollision erreichen kann"
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 #, fuzzy
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 #, fuzzy
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -785,31 +789,31 @@ msgstr "Unbekannte Spindel ($) im Spindel Vorschub Befehl"
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr "Unbekannte Spindel ($) im Spindel Geschwindigkeits Befehl"
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 #, fuzzy
 msgid "Cannot use polar coordinates with G53"
 msgstr "Rotations-Achse kann nicht mit G76 bewegt werden"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr "Angefordertes Werkzeug %d nicht in der Werkzeugtabelle gefunden"
@@ -932,102 +936,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, fuzzy, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "Nicht in der Definition der Unterfunktion"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, c-format
 msgid "cant open ini file '%s'"
 msgstr "INI-Datei »%s« kann nicht geöffnet werden"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "Warteschlange ist nach Werkzeugwechsel nicht leer"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, fuzzy, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "Datei kann nicht geöffnet werden"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 #, fuzzy
 msgid "Parameter file name is missing"
 msgstr "Parameterdatei ist »%s«"
@@ -1483,7 +1487,8 @@ msgid "Negative spindle speed used"
 msgstr "Geschwindigkeit der Werkzeug-Spindel kleiner Null"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "Negative Werkzeugnummer verwendet"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1875,24 +1880,23 @@ msgstr "R ist kleiner als U während Arbeitszyklus in VW-Ebene"
 msgid "R less than V in cycle in UW plane"
 msgstr "R ist kleiner als V während Arbeitszyklus in UW-Ebene"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "FEHLER: »%s« ist kein gültiger Typ\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "FEHLER: Kein Pin-, Signal- oder Parameter-Name\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr "FEHLER: Kein Pin-, Signal- oder Parameter-Name mit -s\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "HAL-Meter"
 
@@ -1904,27 +1908,27 @@ msgstr "_Auswahl ändern"
 msgid "E_xit"
 msgstr "_Beenden"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "Element zum Anzeigen auswählen"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr " _Pins "
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr " _Signale "
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr " Para_meter "
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr "_Schließen"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
@@ -1932,67 +1936,89 @@ msgstr ""
 "Aufruf:\n"
 "  halscope [-h] [-i Eingabedatei] [-o Ausgabedatei] [Anzahl der Samples]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "Konfigurationsdatei öffnen:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Abbrechen"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "Öffnen..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Konfigurationsdatei öffnen:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "Speichern"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "K_onfiguration laden..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "Konfiguration _speichern..."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "_Datendatei öffnen..."
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "D_atendatei speichern..."
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "_Beenden"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "Über Halscope"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "_Datei"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "HAL-Oszilloskop"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "Ausgewähler Kanal"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "Modus"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "Trigger"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "Vertikal"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -2000,39 +2026,40 @@ msgstr "Vertikal"
 msgid "Stop"
 msgstr "Stopp"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "Normal"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "Single"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "Roll"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "Zoom"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr " Pos "
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "----- Samples\n"
 "bei ---- kHz"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "Echtzeicht-Komponente nicht geladen"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 #, fuzzy
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
@@ -2058,11 +2085,39 @@ msgstr ""
 "oder\n"
 "wählen Sie »Beenden« um HALSCOPE zu beenden"
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "Beenden"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "Echtzeitfunktion nicht gelinkt"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -2084,11 +2139,11 @@ msgstr ""
 "oder\n"
 "klicken Sie 'Quit' um HALSCOPE zu verlassen."
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "Abtastrate auswählen"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 #, fuzzy
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
@@ -2100,95 +2155,71 @@ msgstr ""
 "oder\n"
 "wählen Sie »Beenden« um HALSCOPE zu beenden\n"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr "Thread:"
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr "Abtastperiode:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr "Abtastrate:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr "Thread"
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "Periode"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "Vervielfacher:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 #, fuzzy
 msgid "Record Length"
 msgstr "Länge der Aufzeichnung"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d Samples (1 Kanal)"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d Samples (2 Kanäle)"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d Samples (4 Kanäle)"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d Samples (8 Kanäle)"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d Samples (16 Kanäle)"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "Beenden"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr "Echtzeit-Thread ist nicht gestarted"
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2213,15 +2244,15 @@ msgstr ""
 "oder\n"
 "klicken Sie 'Quit', um HALSCOPE zu verlassen."
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr "Wählen Sie eine Log-Datei zum Speichern:"
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr "Nicht genügend Kanäle"
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
@@ -2232,7 +2263,7 @@ msgstr ""
 "sind. Wählen Sie einen kürzeren Wert,\n"
 "um mehr Kanäle zu unterstützen."
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, fuzzy, c-format
 msgid ""
 "%s\n"
@@ -2241,7 +2272,7 @@ msgstr ""
 "%s\n"
 "pro Teilstrich"
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
@@ -2250,27 +2281,35 @@ msgstr ""
 "%s Samples\n"
 "bei %s"
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
-msgstr "ns"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
-msgstr "µs"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
-msgstr "ms"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
-msgstr "s"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2284,17 +2323,17 @@ msgstr "s"
 #: src/emc/usr_intf/pncconf/mesa1.glade:460
 #: src/emc/usr_intf/pncconf/mesa1.glade:473
 msgid "Hz"
-msgstr "Hz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
-msgstr "kHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
-msgstr "MHz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
+msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
@@ -2303,24 +2342,25 @@ msgstr ""
 "Offset\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "Gain"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr "Pos"
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr "Skala"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
@@ -2329,15 +2369,11 @@ msgstr ""
 "Offset\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr "Kan. aus"
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "Offset setzen"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
@@ -2346,35 +2382,19 @@ msgstr ""
 "Vertikaler Offset\n"
 "für Kanal %d"
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "Offset setzen"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr "AC-Kopplung"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr "Zu viele Kanäle"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2387,21 +2407,7 @@ msgstr ""
 "oder die Datensatzlänge verkleinern,\n"
 "um mehr Kanäle zu ermöglichen."
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr "Kanal-Quelle auswählen"
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
@@ -2410,29 +2416,33 @@ msgstr ""
 "Einen Pin, ein Signal oder einen Parameter\n"
 "als Quelle für den Kanal %d wählen."
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "Kanal-Quelle auswählen"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "Pins"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "Signale"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "Parameter"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr "Fallende"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr "Steigende"
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
@@ -2440,7 +2450,7 @@ msgstr ""
 "Quelle:\n"
 "Keine"
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
@@ -2449,111 +2459,112 @@ msgstr ""
 "Quelle:\n"
 "Kanal %2d"
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "Auto"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr "Erzwingen"
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr "Schwelle"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr "Trigger-Quelle"
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr "Einen Kanal als Trigger-Quelle wählen."
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "Trigger-Quelle"
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr "Kanal"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr "Quelle"
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr "G38.4: Bewegung ohne Kontaktöffnung beendet."
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr "G38.4: Bewegung ohne Kontaktschließung beendet."
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+#, fuzzy
+msgid "Probe tripped during non-probe move."
 msgstr "Tastspitze bei inaktivem MDI-Befehl ausgelöst."
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr "Tastspitze bei Referenzfahrt ausgelöst."
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr "Tastspitze bei Motorfahrt (joint) ausgelöst."
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr "Tastspitze bei Koordinatenbewegung ausgelöst."
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr "Bewegung durch Enable-Eingabe angehalten."
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr "Verstärkerfehler an Spindel %d"
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "Achsen- oder Gelenkfehler %d am Endschalter"
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "Verstärkerfehler an Achse/Gelenk %d"
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "Motor %d Positionssfehler"
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr "Negatives Softlimit bei (%.5f) Motor %d überschritten\n"
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, fuzzy, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr "Positiver Softanschlag bei Achse/Gelenk %d überschritten"
@@ -2625,188 +2636,189 @@ msgstr ""
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr "Keine Handsteuerung während der Referenzfahrt."
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr "Keine Handsteuerung während der Referenzfahrt."
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr "Keine Linearbewegung jenseits der Grenzen"
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, fuzzy, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr "Keine Linearbewegung jenseits der Grenzen"
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr "Keine Kreisbewegung jenseits der Grenzen"
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, fuzzy, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr "Keine Kreisbewegung jenseits der Grenzen"
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr "MOTION: bereits begonnen, STEP nicht möglich"
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr "Bewegung nicht möglich, Enable-Eingang ist falsch"
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr "Referenzfahrt nur im Gelenk-Modus möglich"
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr "Referenzfahrt bereits begonnen"
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr ""
 "Kann nur im Gelenk-Modus oder abgeschaltet aus der Referenzpos. gefahren "
 "werden"
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr ""
 "Achse/Gelenk %d: Während Referenzfahrt kann nicht aus der Referenzpos. "
 "gefahren werden"
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr ""
 "Achse/Gelenk %d: Während der Bewegung kann nicht aus der Referenzpos. "
 "gefahren werden"
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, fuzzy, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr ""
 "Achse/Gelenk %d: Ungültige(s) Achse/Gelenk kann nicht aus der Referenzpos. "
 "gefahren werden (max. %d)"
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr ""
 "Inaktive(s) Achse/Gelenk %d kann nicht aus der Referenzpos. gefahren werden"
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr ""
 "Achse/Gelenk %d: Ungültige(s) Achse/Gelenk kann nicht aus der Referenzpos. "
 "gefahren werden (max. %d)"
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr "Kann Tastspitze nicht außerhalb der Grenzen bewegen"
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr "Tastspitze schon abgehoben bei Start durch G38.4 oder G38.5"
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr "Tastspitze schon ausgelöst bei Start durch G38.4 oder G38.5"
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr "Keine weitere Bewegung der Tastspitze möglich"
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr "Muß aktiviert werden, im Koordinatenmodus für Gewindebohren"
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr "Kein Gewindebohren außerhalb der Grenzen"
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, fuzzy, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr "Kein Gewindebohren außerhalb der Grenzen"
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr "Versuch eine nicht existierende Spindel einzuschalten"
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr "Versuch eine nicht existierende Spindel auszuschalten"
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr "Versuch eine nicht existierende Spindel zu orrientieren"
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr "Versuche Geschwindigkeit einer nicht existierenden Spindel zu erhöhen"
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
-msgstr "Versuche Geschwindigkeit einer nicht existierenden Spindel zu verringern"
+msgstr ""
+"Versuche Geschwindigkeit einer nicht existierenden Spindel zu verringern"
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr "Versuch Bremse einer nicht existierenden Spindel zu schalten"
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr "Versuch Bremse einer nicht existierenden Spindel zu lösen"
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr "Achse/Gelenk %d: zu viele Kompensationseingaben"
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr "Achse/Gelenk %d: Kompensationswerte müssen ansteigen"
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr "Unerkannter Befehl %d"
@@ -2895,26 +2907,26 @@ msgstr "MOTION: hal_exit() fehlgeschlagen, Rückgabewert %d\n"
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr "MOTION: emcmot_hal_data malloc fehlgeschlagen\n"
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr "MOTION: Spindel %d Pinexport fehlgeschlagen"
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr "MOTION: Achse/Gelenk %d Pin/Parameterexport fehlgeschlagen\n"
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr "MOTION: export_joint_home_pins fehlgeschlagen\n"
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr "MOTION: Achse/Gelenk %d Pin/Parameterexport fehlgeschlagen\n"
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr "MOTION: Achse %c Pin/Parameterexport fehlgeschlagen\n"
@@ -3088,7 +3100,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr "Ok"
 
@@ -3178,19 +3190,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "Ja"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr "Nein"
 
@@ -3244,7 +3256,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "Speichern"
 
@@ -3263,7 +3275,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "Editor"
 
@@ -3278,7 +3290,6 @@ msgid "Config"
 msgstr "HAL konfigurieren"
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 msgid "Preview"
 msgstr "Vorschau"
 
@@ -3717,7 +3728,7 @@ msgid "Edit mode..."
 msgstr "Bearbeiten..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "Löschen"
 
@@ -3726,7 +3737,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "Dazuzählen"
 
@@ -3737,6 +3748,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "Ändern"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Abbrechen"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3926,7 +3955,7 @@ msgid "Parameter"
 msgstr "Parameter"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -4116,7 +4145,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "Haupt"
 
@@ -4202,11 +4230,13 @@ msgid "Delete section"
 msgstr "Relative Position"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 #, fuzzy
 msgid "Move Down"
 msgstr "Abwärts"
@@ -4730,6 +4760,7 @@ msgid "Exit"
 msgstr "Beenden"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -4773,7 +4804,6 @@ msgid "Renumber File..."
 msgstr "Zeilennummerierung aktualisieren..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -5054,15 +5084,15 @@ msgstr "Ansicht"
 msgid "Test HAL command :"
 msgstr "HAL-Befehl ausprobieren:"
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr "Eine Beobachtungsliste laden"
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr "Aktuelle Beobachtungsliste speichern"
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr ""
 "Die Befehle können hier ausprobiert werden, werden aber NICHT gespeichert."
@@ -5194,11 +5224,11 @@ msgstr "RICHTUNG"
 msgid "SIZE :"
 msgstr "GRÖSSE :"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr "LinuxCNC-Fehler"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 #, fuzzy
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
@@ -5207,12 +5237,12 @@ msgstr ""
 "EMC2 wurde mit einem Fehler beendet. Falls Sie den Fehler melden wollen, "
 "fügen Sie bitte Ihrer Mitteilung die unten stehenden Informationen bei."
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 #, fuzzy
 msgid "Create Report File"
 msgstr "Erstellen oder Bearbeiten"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "Schließen"
 
@@ -5291,7 +5321,7 @@ msgstr "Werkzeugoffset"
 msgid "Tool:"
 msgstr "Werkzeug:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Alle Dateien"
@@ -5358,18 +5388,18 @@ msgstr "Maßeinheit"
 msgid "auto"
 msgstr "Auto"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "Zoll"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5528,7 +5558,7 @@ msgstr "Achse/Gelenk"
 msgid "world"
 msgstr "Global"
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "Home"
 
@@ -5609,16 +5639,15 @@ msgstr "Überprüfen"
 msgid "Optional Stop"
 msgstr "Wahlweiser Halt"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "Schrift auswählen"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "Schriftart"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "Größe"
 
@@ -5727,7 +5756,7 @@ msgid "Coordinate System Control Window"
 msgstr "Koordinatensystem Kontroll-Fenster"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "Achse "
 
@@ -6284,9 +6313,9 @@ msgstr "entfernen"
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
@@ -6306,8 +6335,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr "Warnung"
 
@@ -6380,148 +6409,148 @@ msgstr "INI-Datei"
 msgid "not found"
 msgstr "nicht gefunden"
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr "Problem mit"
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr "Kein Eintrag für"
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr "Text"
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr "keine"
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr "Standard"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr "Modus"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr "normal"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr "Schriftname"
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr "Unicode"
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr "Drehung erlauben"
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 msgid "no such file"
 msgstr "keine solche Datei"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr "Datei ist nicht lesbar"
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 #, fuzzy
 msgid "not readable"
 msgstr "Datei ist nicht lesbar"
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 #, fuzzy
 msgid "LinuxCNC"
 msgstr "TKLinuxCNC"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "LinuxCNC-Fehler"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7193,34 +7222,34 @@ msgstr ""
 msgid "Open a Menu"
 msgstr "Eine neue Unterdatei öffnen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Unbekanntes Werkzeug %d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Kein Werkzeug"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Werkzeug %(tool)d, Werkzeugverschiebung %(zo)g, Durchmesser %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "Werkzeug %(tool)d, Zo %(zo)g, Xo %(xo)g, Durchmesser %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "Arbeite..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "Konvertierung fehlgeschlagen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
@@ -7229,12 +7258,12 @@ msgstr ""
 "Der Konverter %(program)r hat den Vorgang mit Status %(code)d beendet. "
 "Folgende Fehlermeldungen sind vorhanden:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "G-Code Fehler in %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7243,130 +7272,128 @@ msgstr ""
 "Nahe Zeile %(seq)d in %(f)s:\n"
 "%(error_str)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "Durchgehend"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr "T   Werkzeugtabelle"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "in"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr " Radius"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr " Durchmesser"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr "°"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "Koordinatensystem:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr "Werkstück"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "Name:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "Größe:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "Werkzeugreichenfolge:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "Eilgang-Weg:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "Vorschub-Weg:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "Gesamter Weg:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "Laufzeit:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "X-Bereich:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Y-Bereich:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Z-Bereich:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "A-Bereich:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "B-Bereich:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "C-Bereich:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "Programm überschreitet den unteren Grenzwert der Achse %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "Programm überschreitet den oberen Grenzwert der Achse %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "Programm überschreitet die Maschinengrenzwerte"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Trotzdem ausführen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "Keine Datei geladen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "Erstellt von »%«"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
@@ -7375,44 +7402,44 @@ msgstr ""
 "%(size)s Byte\n"
 "%(lines)s Zeilen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr "%.1f Minuten"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr "%d s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%(a)f bis %(b)f = %(diff)f %(units)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "G-Code Eigenschaften"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "Alle einlesbaren Dateien"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "NC Dateien"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 #, fuzzy
 msgid "File not Writable:"
 msgstr "Datei ist nicht lesbar"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7423,60 +7450,60 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Custom Grid"
 msgstr "Benutzerdefiniert"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, fuzzy, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr "Referenzfahrt nur im Gelenk-Modus möglich"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 #, fuzzy
 msgid "Touch Off (system)"
 msgstr "Antasten"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "%s-Koordinate relativ zu %%s:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, fuzzy, python-format
 msgid "Tool %s TouchOff"
 msgstr "Antasten"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "Fehler beim Speichern der Datei"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7485,7 +7512,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7494,7 +7521,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7503,91 +7530,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "Achse/Gelenk:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "Referenzfahrt"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, fuzzy, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "Referenzfahrt mit allen Achsen [Strg-Pos1]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "Referenzfahrt"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "Referenzfahrt aufheben bei allen Achsen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "Achse/Gelenk:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "_Referenzpunkt:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, fuzzy, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "Referenzfahrt aufheben bei _%s-Achse"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "Ab hier ausführen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "Fehler in »~/.axisrc«"
 
@@ -7904,11 +7931,13 @@ msgid "_Properties..."
 msgstr "_Eigenschaften..."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "_Werkzeugtabelle bearbeiten..."
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+#, fuzzy
+msgid "Reload tool _data"
 msgstr "We_rkzeugtabelle neu laden"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8239,11 +8268,11 @@ msgstr "Zeilen beginnend mit '/' überspringen [Alt-M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "Wahlweiser Halt ein/aus [Alt-M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "Vergrößern"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "Verkleinern"
 
@@ -8422,9 +8451,10 @@ msgstr "Spindelübersteuerung:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr "%"
 
@@ -8479,7 +8509,7 @@ msgid "Position:"
 msgstr "Position:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr "Maschine"
 
@@ -8585,22 +8615,21 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Erlaubt über die Endschalter zu verfahren [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 #, fuzzy
 msgid "Follow System Theme"
 msgstr "Systemthema folgen\n"
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "Spindel rechts"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "Spindel links"
@@ -8948,6 +8977,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8957,43 +8988,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr "0"
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr "3"
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr "2"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr "1"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr "6"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr "5"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr "4"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr "9"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr "7"
 
@@ -9050,7 +9126,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr "<b>Spindel</b>"
 
@@ -9218,7 +9293,6 @@ msgstr ""
 "3"
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr "Status"
 
@@ -9280,8 +9354,8 @@ msgstr "<b>Anzeigeoptionen</b>"
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr "Zoll"
@@ -9418,10 +9492,10 @@ msgid "Stepconf"
 msgstr "Schritt"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9442,13 +9516,13 @@ msgid "Parallel Port 1"
 msgstr "Konfiguration der Druckerschnittstelle"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 #, fuzzy
 msgid "Parallel Port 2"
 msgstr "Konfiguration der Druckerschnittstelle"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "GUI-Optionen"
@@ -9458,235 +9532,285 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Null-X-Taste"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Achse "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Achse "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Achse "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Achse "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Achse "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Achse "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "Spindle"
 msgstr "Spindel"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr "Gecko 201"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr "Gecko 202"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr "Gecko 203v"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr "Gecko 210"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr "Gecko 212"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr "Gecko 320"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr "Gecko 540"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr "L297"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr "PMDX-150"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr "Sherline"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr "Xylotex 8S-3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr "Parker-Compumotor oem750"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr "JVL-SMD41 oder 42"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr "Hobbycnc Pro Chopper"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr "Keling 4030"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr "X Schritt"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr "X Richtung"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr "Y-Schritt"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr "Y Richtung"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr "Z-Schritt"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr "Z Richtung"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr "A Schritt"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr "A Richtung"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "X Schritt"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "X Richtung"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "X Schritt"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "X Richtung"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "Spindel StepGen"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "X Richtung"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "Spindel StepGen"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Y Richtung"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr "Spindel ein"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr "Spindel PWM"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr "Spindelbremse"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr "Kühlnebel"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr "Kühlmittel"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr "NOTAUS Ausgang"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr "Endstufe aktivieren"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr "Ladungspumpe"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr "Digitaler Ausgang 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr "Digitaler Ausgang 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr "Digitaler Ausgang 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr "Digitaler Ausgang 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9697,257 +9821,352 @@ msgstr "Digitaler Ausgang 1"
 msgid "Unused"
 msgstr "Unbenutzt"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr "NOTAUS Eingang"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr "Sensor"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Index"
 msgstr "Spindel Index"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr "Spindelencoder Kanal A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr "Spindelencoder Kanal B"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr "Referenzschalter X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr "Referenzschalter Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr "Referenzschalter Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr "Referenzschalter A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "Referenzschalter X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "Referenzschalter X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Referenzschalter X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Referenzschalter Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr "Min. End. + Ref. Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem X"
+msgstr "Min. End. + Ref. X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem Y"
+msgstr "Min. End. + Ref. Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr "Min. End. + Ref. Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr "Min. End. + Ref. A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home U"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home V"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr "Max. End. + Ref. Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem X"
+msgstr "Max. End. + Ref. X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem Y"
+msgstr "Max. End. + Ref. Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr "Max. End. + Ref. Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr "Max. End. + Ref. A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home U"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home V"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr "Beide End. + Ref. Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr "Beide End. + Ref. Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr "Beide End. + Ref. A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home U"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home V"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Beide End. + Ref. X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Beide End. + Ref. Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr "Endschalter Mimimum Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem X"
+msgstr "Endschalter Mimimum X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem Y"
+msgstr "Endschalter Mimimum Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr "Endschalter Mimimum Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr "Endschalter Mimimum A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit U"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit V"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr "Endschalter Maximum Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem X"
+msgstr "Endschalter Maximum X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem Y"
+msgstr "Endschalter Maximum Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr "Endschalter Maximum Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr "Endschalter Maximum Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit U"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit V"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr "Beide Endschalter Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr "Beide Endschalter Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr "Beide Endschalter A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit U"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit V"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Beide Endschalter X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Beide Endschalter Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr "Alle Endschalter"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr "Alle Referenzschalter"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits + homes"
 msgstr "Alle Endschalter"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr "Digitaler Eingang 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr "Digitaler Eingang 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr "Digitaler Eingang 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr "Digitaler Eingang 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "Abwärts"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Spindel vorwärts"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -9957,9 +10176,9 @@ msgstr ""
 "Eine bestehende »Custom.clp«-Datei wird in custom_backup.clp« umbenannt.\n"
 "Eine bestehende »custom_backup.clp«-Dateien geht somit verloren."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9973,8 +10192,8 @@ msgstr ""
 "\n"
 "Sind Sie sicher?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
@@ -9982,7 +10201,7 @@ msgstr ""
 "Für dieses Programm muss ein Notaus-Eingang auf der Seite zur Konfiguration "
 "der parallelen Schnitstelle festgelegt wein."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
@@ -9993,26 +10212,26 @@ msgstr ""
 "Eine bestehende »Custom.clp«-Datei wird in custom_backup.clp« umbenannt.\n"
 "Eine bestehende »custom_backup.clp«-Dateien geht somit verloren."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr "Maschinenkonfiguration beenden und Änderungen verwerfen?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -10023,17 +10242,17 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr ""
 "Die Datei %r wurde geändert, seitdem sie von stepconf geschrieben wurde"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
@@ -10041,30 +10260,30 @@ msgstr ""
 "Beim Speichern dieser Konfigurationsdatei werden Konfigurationsänderungen, "
 "die außerhalb von stepconf vorgenommen wurden, verworfen."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr "Fortsetzen? "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr "jJ"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr "%s starten"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr ""
 "Verknüpfung zum starten von EMC mit einer festgelegten Konfiguration, "
 "erstellt von Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -10072,34 +10291,34 @@ msgid ""
 "{}"
 msgstr "LinuxCNC-Konfigurationswähler"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr "Benutzerdefiniert"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr "Test %s-Achse"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr "Grad / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr "Grad / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr "Grad"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -10114,8 +10333,8 @@ msgstr "Grad"
 msgid "mm / s"
 msgstr "mm / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -10130,13 +10349,13 @@ msgstr "mm / s"
 msgid "mm / s²"
 msgstr "mm / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr "in / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr "in / s²"
 
@@ -10145,19 +10364,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "LinuxCNC »stepconf«-Konfigurationsdateien"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr "Bestehende Konfiguration bearbeiten"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr "Grad / Umdrehung"
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr "Schritte / Grad"
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10169,7 +10388,7 @@ msgstr "Schritte / Grad"
 msgid "mm / rev"
 msgstr "mm / Umdrehung"
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10180,28 +10399,28 @@ msgstr "mm / Umdrehung"
 msgid "Steps / mm"
 msgstr "Schritte / mm"
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr "Umdrehungen / in"
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr "Schritte / in"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, fuzzy, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr "# Erstellt von stepconf am %s"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10209,104 +10428,111 @@ msgstr "# Änderungen an dieser Datei werden beim nächsten"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 #, fuzzy
 msgid "# overwritten when you run stepconf again"
 msgstr "# wird überschrieben, wenn Sie stepconf erneut ausführen"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr "# HalUI-MDI-Befehle hier einfügen (max. 64)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr "Benutzerdefiniertes PyVCP-Panel hier einbinden.\n"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, fuzzy, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 "# Benutzerdefinierte HAL-Anweisungen können nachfolgend angegeben werden"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 #, fuzzy
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 "# Diese Datei wird nicht überschrieben, wenn Sie stepconf erneut ausführen"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
 msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+#, fuzzy
+msgid "# Include your custom HAL commands here"
+msgstr ""
+"# Benutzerdefinierte HAL-Anweisungen können nachfolgend angegeben werden"
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
 #, fuzzy
@@ -10377,11 +10603,16 @@ msgstr "LinuxCNC Maschinenkonfiguration"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr "Beschriftung"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "Zurück"
 
@@ -10431,17 +10662,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
 msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
-msgstr "ns"
 
 #: src/emc/usr_intf/stepconf/base.glade:209
 msgid "Step _Time:"
@@ -10809,55 +11029,152 @@ msgstr "Spindelübersteuerung:"
 msgid "Scale %"
 msgstr "Skala %"
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr "Achse"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+#, fuzzy
+msgid "Gmoccapy"
+msgstr "gmoccapy Grundeinstellungen"
+
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
-msgstr "Benutze Gmoccapy Benutzeroberfläche"
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Werkzeugoffset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Werkzeugoffset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Notaus gesetzt"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+#, fuzzy
+msgid "4:3"
+msgstr "47:"
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Taste"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "Modus"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 #, fuzzy
 msgid "_Onscreen prompt for manual tool change"
 msgstr "_Bildschirmmitteilung bei Werkzeugwechsel"
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-#, fuzzy
-msgid "Include Halui user interface component"
-msgstr "HalUI-Benutzerschnittstelle einbinden"
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr "Benutzerdefiniertes PyVCP-Panel einbinden"
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr "Leeres Programm"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 msgid "Spindle speed display  "
 msgstr "Spindeldrehzahl-Anzeige  "
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr "Bestehendes benutzerdefiniertes Programm"
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr "Verbindungen zum HAL zulassen"
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10869,75 +11186,75 @@ msgstr ""
 "Panel\n"
 "_anzeigen"
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 #, fuzzy
 msgid "Set pyVCP options"
 msgstr "Geometrieoptionen"
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 #, fuzzy
 msgid "Include _Classicladder PLC"
 msgstr "SPS (Classicladder) einbinden"
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr "Digitale Eingänge:"
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 #, fuzzy
 msgid "Number of digital  out pins:"
 msgstr "Digitale Ausgänge:"
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 #, fuzzy
 msgid " Number of analog (s32) in pins:"
 msgstr "Analoge Eingänge (s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 #, fuzzy
 msgid " Number of analog (s32) out pins:"
 msgstr "Analoge Ausgänge (s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 #, fuzzy
 msgid " Number of analog (float) in pins:"
 msgstr "Analoge Eingänge (float):"
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 #, fuzzy
 msgid " Number of analog (float) out pins:"
 msgstr "Analoge Ausgänge (float):"
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr "Anzahl der externen Pins einrichten"
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr "Modbus-Master-Unterstützung einbinden"
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr "Leeres Programm"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr "Notaus-Programm"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr "Serielles Modbus-Programm"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 #, fuzzy
 msgid ""
@@ -10945,10 +11262,15 @@ msgid ""
 "program"
 msgstr "SPS-Programm bearbeiten"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "Beispieloptionen"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+#, fuzzy
+msgid "Include Halui user interface component"
+msgstr "HalUI-Benutzerschnittstelle einbinden"
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10966,16 +11288,170 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+#, fuzzy
+msgid "NUM"
+msgstr "NML"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+#, fuzzy
+msgid "10"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+#, fuzzy
+msgid "11"
+msgstr "11:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+#, fuzzy
+msgid "12"
+msgstr "123"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+#, fuzzy
+msgid "13"
+msgstr "13:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+#, fuzzy
+msgid "14"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+#, fuzzy
+msgid "15"
+msgstr "15:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+#, fuzzy
+msgid "16"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+#, fuzzy
+msgid "17"
+msgstr "17:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+#, fuzzy
+msgid "18"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+#, fuzzy
+msgid "19"
+msgstr "19:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+#, fuzzy
+msgid "20"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+#, fuzzy
+msgid "IDX"
+msgstr "PID"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+#, fuzzy
+msgid "32"
+msgstr "3"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+#, fuzzy
+msgid "64"
+msgstr "6"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+#, fuzzy
+msgid "128"
+msgstr "123"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "Modus"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10985,10 +11461,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr ""
@@ -11019,15 +11495,6 @@ msgstr "_:"
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
 msgstr "_bis"
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
-msgstr "s"
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
 #: src/emc/usr_intf/stepconf/axisy.glade:402
@@ -11245,39 +11712,39 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 #, fuzzy
 msgid "Specific Help page is unavailable\n"
 msgstr "Hilfeseite ist nicht verfügbar\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr "Hilfeseiten"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11285,22 +11752,22 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "LinuxCNC »PNCconf«-Konfigurationsdateien"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11310,33 +11777,33 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 #, fuzzy
 msgid "Discovery is  unavailable\n"
 msgstr "Gerätenamen sind nicht verfügbar\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr "USB-Gerät-Seite ist nicht verfügbar\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr "Pin-Namen sind nicht verfügbar\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr "Gerätenamen sind nicht verfügbar\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 #, fuzzy
 msgid ""
 "OK to replace existing glade panel ?\n"
@@ -11349,7 +11816,7 @@ msgstr ""
 "Eine bestehende »Custom.clp«-Datei wird in custom_backup.clp« umbenannt.\n"
 "Eine bestehende »custom_backup.clp«-Dateien geht somit verloren."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
@@ -11360,169 +11827,169 @@ msgstr ""
 "Eine bestehende »Custom.clp«-Datei wird in custom_backup.clp« umbenannt.\n"
 "Eine bestehende »custom_backup.clp«-Dateien geht somit verloren."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr "Unbenutzter Kanal"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr "Spindelsteigung"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr "Spindelsteigung TPI"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr "("
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr " / min"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr " / sec²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 msgid " / Step"
 msgstr " / Schritt"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 msgid "Steps / "
 msgstr "Schritte / "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "Zeit zwischen zwei _Schritten:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Konfiguration der Spindel"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11540,59 +12007,62 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr "PCI-Suchseite ist nicht verfügbar\n"
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr " / min"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr "mm / min"
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 #, fuzzy
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 "Für dieses Programm muss ein Notaus-Eingang auf der Seite zur Konfiguration "
 "der parallelen Schnitstelle festgelegt wein."
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 #, fuzzy
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 "Für dieses Programm muss ein Notaus-Eingang auf der Seite zur Konfiguration "
 "der parallelen Schnitstelle festgelegt wein."
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 #, fuzzy
 msgid ""
 "OK to replace existing custom ladder program?\n"
@@ -11606,8 +12076,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr "# Erstellt von PNCconf am %s"
@@ -11624,172 +12094,177 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr "# wird überschrieben, wenn Sie PNCconf erneut ausführen"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 #, fuzzy
 msgid "# The commands in this file are run after the GUI loads"
 msgstr "# Die Befehle in dieser Datei werden nach dem Laden der GUI ausgeführt"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 #, fuzzy
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 "# Diese Datei wird nicht überschrieben, wenn Sie PNCconf erneut ausführen"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
+#: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
 msgid "Generated by PNCconf at %s"
 msgstr "Generiert von PNCconf am %s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
 msgid "configures LinuxCNC as:\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
 msgid "type CNC\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
 msgid "will be used as the frontend display"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
 msgid " connector"
 msgstr " Verbinder"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
 msgid "invrt"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
 #, python-format
 msgid "%(name)s Parport"
 msgstr "%(name)s Parallelport"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
 msgid "-> inverted"
 msgstr "-> invertiert"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1059
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
 #, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11805,1623 +12280,1678 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 msgid "External Controls"
 msgstr "Externe Steuerungen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 #, fuzzy
 msgid "Parallel Port"
 msgstr "Konfiguration der Druckerschnittstelle"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 #, fuzzy
 msgid "X Motor"
 msgstr "Motor invertieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "X Axis"
 msgstr "X-Achse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 #, fuzzy
 msgid "Y Motor"
 msgstr "Motor invertieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Y Axis"
 msgstr "Y-Achse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 #, fuzzy
 msgid "Z Motor"
 msgstr "Motor invertieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Z Axis"
 msgstr "Achse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 #, fuzzy
 msgid "A Motor"
 msgstr "Motor invertieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "A Axis"
 msgstr "A-Achse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Spindel aus"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr "Nicht benutzt"
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr "8i20 Servoantrieb"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Dir"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Input"
 msgstr "GPIO-Eingang"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Output"
 msgstr "GPIO-Ausgang"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO O Drain"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:113
+#: src/emc/usr_intf/pncconf/private_data.py:117
 #, fuzzy
 msgid "SSR Output"
 msgstr "Ausgabe"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 0"
 msgstr "Unbenutzt"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 1"
 msgstr "Unbenutzt"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "muxed Enc I"
 msgstr "Unbenutzt"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc M"
 msgstr "Unbenutzt"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step Gen-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-P"
 msgstr "Unbenutzter PWM-Generator"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-D"
 msgstr "Unbenutzter PWM-Generator"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-E"
 msgstr "Unbenutzter PWM-Generator"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 #, fuzzy
 msgid "UDM-Down"
 msgstr "Abwärts"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "Analoge Steuerung"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "X Home"
 msgstr "Pos1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Y Home"
 msgstr "Pos1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Z Home"
 msgstr "Pos1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "A Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "All Home"
 msgstr "Alle Referenzschalter"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "Pos1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "Pos1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "Pos1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "A2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 #, fuzzy
 msgid "X Minimum Limit + Home"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 #, fuzzy
 msgid "Y Minimum Limit + Home"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 #, fuzzy
 msgid "Z Minimum Limit + Home"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 #, fuzzy
 msgid "A Minimum Limit + Home"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 #, fuzzy
 msgid "X Maximum Limit + Home"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 #, fuzzy
 msgid "Y Maximum Limit + Home"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 #, fuzzy
 msgid "Z Maximum Limit + Home"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 #, fuzzy
 msgid "A Maximum Limit + Home"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 #, fuzzy
 msgid "X Both Limit + Home"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 #, fuzzy
 msgid "Y Both Limit + Home"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 #, fuzzy
 msgid "Z Both Limit + Home"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Alle Endschalter"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 #, fuzzy
 msgid "X2 Minimum Limit + Home"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Y2 Minimum Limit + Home"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Z2 Minimum Limit + Home"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "A2 Minimum Limit + Home"
 msgstr "Min. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "X2 Maximum Limit + Home"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Y2 Maximum Limit + Home"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Z2 Maximum Limit + Home"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "A2 Maximum Limit + Home"
 msgstr "Max. End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "X2 Both Limit + Home"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Y2 Both Limit + Home"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Z2 Both Limit + Home"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 #, fuzzy
 msgid "A2 Both Limit + Home"
 msgstr "Beide End. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr "Aktive(s) Achse/Gelenk A verfahren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr "Aktive(s) Achse/Gelenk B verfahren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr "Aktive(s) Achse/Gelenk C verfahren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr "Aktive(s) Achse/Gelenk D verfahren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "Vorschubübersteuerung Inkr. A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "Vorschubübersteuerung Inkr. B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "Vorschubübersteuerung Inkr. C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "Vorschubübersteuerung Inkr. D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Spindle Override incr A"
 msgstr "Spindelübersteuerung Inkr. A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr B"
 msgstr "Spindelübersteuerung Inkr. B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr C"
 msgstr "Spindelübersteuerung Inkr. C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr D"
 msgstr "Spindelübersteuerung Inkr. D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "Vorschubübersteuerung"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "Spindelübersteuerung:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "Vorschubübersteuerung:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CW"
 msgstr "Manuelle Spindel rechts"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CCW"
 msgstr "Manuelle Spindel links"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle Stop"
 msgstr "Manuelle Spindel stopp"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Spindle Up-To-Speed"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "Alles markieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr "Zyklus-Start"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr "Abbrechen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "ein Leerzeichen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 #, fuzzy
 msgid "Jog X +"
 msgstr "X +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 #, fuzzy
 msgid "Jog X -"
 msgstr "X -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected +"
 msgstr "Aktive Achse verfahren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected -"
 msgstr "Aktive Achse verfahren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "X Minimum Limit"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "Y Minimum Limit"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "Z Minimum Limit"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "A Minimum Limit"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "X Maximum Limit"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "Y Maximum Limit"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "Z Maximum Limit"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "A Maximum Limit"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "X Both Limit"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "Y Both Limit"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "Z Both Limit"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 #, fuzzy
 msgid "All Limits"
 msgstr "Alle Endschalter"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "X2 Minimum Limit"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Y2 Minimum Limit"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Z2 Minimum Limit"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "A2 Minimum Limit"
 msgstr "Endschalter Mimimum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "X2 Maximum Limit"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Y2 Maximum Limit"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Z2 Maximum Limit"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "A2 Maximum Limit"
 msgstr "Endschalter Maximum X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "X2 Both Limit"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Y2 Both Limit"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Z2 Both Limit"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "A2 Both Limit"
 msgstr "Beide Endschalter X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "X-Achse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "Referenzfahrt"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Arc OK"
+msgstr "Bogen rechts"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Ohmic Probe"
+msgstr "Sensor"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Float Switch"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr "Unbenutzter Eingang"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Limits"
 msgstr "Alle Endschalter"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr "Digital"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr "Achsenauswahl"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "Grenzwerte aufheben"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "Operation"
 msgstr "Vorgang"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "External Control"
 msgstr "Externe Steuerung"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "Achse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr "Benutzerdefinierte Signale"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "X Axis PWM"
 msgstr "X-Achse PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "Y Axis PWM"
 msgstr "Y-Achse PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "Z Axis PWM"
 msgstr "Z-Achse PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "A Axis PWM"
 msgstr "A-Achse PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Unused PWM Gen"
 msgstr "Unbenutzter PWM-Generator"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Axis PWM"
 msgstr "X-Achse PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 msgid "X Axis StepGen"
 msgstr "X-Achse StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Y Axis StepGen"
 msgstr "Y-Achse StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 #, fuzzy
 msgid "Z Axis StepGen"
 msgstr "Z-Achse StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 msgid "A Axis StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "X2 Tandem StepGen"
 msgstr "Spindel StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "Y2 Tandem StepGen"
 msgstr "Spindel StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 #, fuzzy
 msgid "Z2 Tandem StepGen"
 msgstr "Spindel StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 #, fuzzy
 msgid "Unused StepGen"
 msgstr "Unbenutzter StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr "Achse"
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Charge Pump StepGen"
 msgstr "Ladungspumpe"
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Spindle StepGen"
 msgstr "Spindel StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "Bild invertieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "Bild invertieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "Bild invertieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "Bild invertieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr "X-Handrad"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr "Y-Handrad"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr "Z-Handrad"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr "A-Handrad"
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr "Multi-Handrad"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Feed Override"
 msgstr "Vorschubübersteuerung"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "spindle Override"
 msgstr "Spindelübersteuerung"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "Vorschubübersteuerung:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Spindle Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Bild invertieren"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 #, fuzzy
 msgid "Unused Unused"
 msgstr "Unbenutzt"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Spindelbremse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "Machine Is Enabled"
 msgstr "Maschine ist eingeschaltet"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "X Amplifier Enable"
 msgstr "Endstufe aktivieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Y Amplifier Enable"
 msgstr "Endstufe aktivieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Z Amplifier Enable"
 msgstr "Endstufe aktivieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "A Amplifier Enable"
 msgstr "Endstufe aktivieren"
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Aktivieren"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Maschine an"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "Antasten"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr "Unbenutzter Ausgang"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Coolant"
 msgstr "Kühlflüssigkeit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr "Strg"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr "Unbenutzter analoger Ausgang"
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Spindle Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr "Unbenutzter TPPWM-Generator"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr "7i64 E/A-Karte"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr "7i69 E/A-Karte"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr "7i70 E/A-Karte"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr "7i71 E/A-Karte"
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 #, fuzzy
 msgid "7i76 Mode 2 I/O Card"
 msgstr "7i64 E/A-Karte"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 #, fuzzy
 msgid "7i77 Mode 0 I/O Card"
 msgstr "7i70 E/A-Karte"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 #, fuzzy
 msgid "7i77 Mode 3 I/O Card"
 msgstr "7i70 E/A-Karte"
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 #, fuzzy
 msgid "7i84 Mode 1 I/O Card"
 msgstr "7i71 E/A-Karte"
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 #, fuzzy
 msgid "7i84 Mode 3 I/O Card"
 msgstr "7i64 E/A-Karte"
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Unused Analog In"
 msgstr "Unbenutzter analoger Ausgang"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 #, fuzzy
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr "Unbenutzter analoger Ausgang"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 #, fuzzy
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr "Unbenutzter analoger Ausgang"
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13436,17 +13966,17 @@ msgstr ""
 "Bereits bestehende Dateien »custompanel_backup.xml« and »custom_postgui.hal« "
 "werden überschrieben."
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 #, fuzzy
 msgid "Quit PNCconf and discard changes?"
 msgstr "PNCconfig beenden und Änderungen verwerfen?"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 #, fuzzy
 msgid "Do you want to quit?"
 msgstr "Folgende Optionen stehen zur Verfügung:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13461,80 +13991,89 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr "Grad"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr "Grad / Minute"
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr "Grad / Sekunde²"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr "Umdrehungen"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr "UPM"
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr "Umdrehungen / Sekunde²"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr "mm / Minute"
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr "mm / Sekunde²"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr "Zoll / Minute"
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr "Zoll / Sekunde²"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr "Achse %s einstellen"
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13547,7 +14086,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "meine_LinuxCNC-Maschine"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13557,12 +14096,12 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr "Die Datei %r wurde geändert, seitdem sie von PNCconf geschrieben wurde"
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
@@ -13570,7 +14109,7 @@ msgstr ""
 "Beim Speichern dieser Konfigurationsdatei werden Konfigurationsänderungen, "
 "die außerhalb von PNCconf vorgenommen wurden, verworfen."
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
@@ -15262,9 +15801,9 @@ msgid "Z"
 msgstr "Z"
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15421,6 +15960,13 @@ msgstr ""
 #, fuzzy
 msgid "Mux options"
 msgstr "Achssteuerung"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "s"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15612,180 +16158,198 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr "<b>Standardeinstellungen und Optionen</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 #, fuzzy
 msgid "<b>GUI Screen list</b>"
 msgstr "<b>GUI-Frontend-Liste</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr "Max. Spindelübersteuerung "
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr "Min. Spindelübersteuerung"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr "Max. Vorschubübersteuerung"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr "xyzabc"
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 #, fuzzy
 msgid "Display Geometry"
 msgstr "Achsengeometrie"
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr "<b>Allgemeine GUI-Standardeinstellungen</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr "Standard-Lineargeschwindigkeit "
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr "Min. Lineargeschwindigkeit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr "Max. Lineargeschwindigkeit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr "Standard-Drehgeschwindigkeit "
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr "gedit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr "Min. Drehgeschwindigkeit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr "Inkremente "
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr "5 mm 1 mm .5 mm .1 mm .05 mm .01 mm .005 mm"
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr "Max. Drehgeschwindigkeit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr "Grad / min"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr "Größe"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr "Position"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr "X"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr "W"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr "H"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 #, fuzzy
 msgid "AXIS Defaults"
 msgstr "AXIS-Standardwerte"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr "GTK-Thema"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 msgid "Relative Textcolor"
 msgstr "Relative Textfarbe"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr "DTG-Textfarbe"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr "Fehler-Textfarbe"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 #, fuzzy
 msgid "Touchy Defaults"
 msgstr "Standardwerte verwenden"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr "strtae gmoccapy maximiert"
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr "gmoccapy Grundeinstellungen"
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "SPS-Optionen"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15876,143 +16440,157 @@ msgstr "Gladevcp-Details"
 msgid "Include custom GladeVCP GUI panel"
 msgstr "Benutzerdefiniertes PyVCP-Panel einbinden"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Unicode"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
+msgid "Use Encoder Index For Home:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
+#, fuzzy
+msgid "Home Final Velocity:"
+msgstr "Gesch_windigkeit Referenzfahrt:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
+#, fuzzy
+msgid "Home Latch Direction:"
+msgstr "Ric_htung beim Übernehmen des Referenzpunkt:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
+#, fuzzy
+msgid "Home Search Direction:"
+msgstr "Ric_htung beim Übernehmen des Referenzpunkt:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
+#, fuzzy
+msgid "Home latch Velocity:"
+msgstr "Gesch_windigkeit Referenzfahrt:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Kompensationsdatei verwenden:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
+msgid "Use Backlash Compensation:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
+msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
+#, fuzzy
+msgid "Home Search Velocity:"
+msgstr "Gesch_windigkeit Referenzfahrt:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
+msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
+#, fuzzy
+msgid "Home Search Sequence:"
+msgstr "Gesch_windigkeit Referenzfahrt:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
 #, fuzzy
 msgid "Type 1"
 msgstr ""
 "Typ 1\n"
 "Typ 2"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
 #, fuzzy
 msgid "Type 2"
 msgstr ""
 "Typ 1\n"
 "Typ 2"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
 msgid "Towards Negative Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
 msgid "Towards Positive Limit"
 msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
-msgid "Use Encoder Index For Home:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
-#, fuzzy
-msgid "Home Final Velocity:"
-msgstr "Gesch_windigkeit Referenzfahrt:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
-#, fuzzy
-msgid "Home Latch Direction:"
-msgstr "Ric_htung beim Übernehmen des Referenzpunkt:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
-#, fuzzy
-msgid "Home Search Direction:"
-msgstr "Ric_htung beim Übernehmen des Referenzpunkt:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
-#, fuzzy
-msgid "Home latch Velocity:"
-msgstr "Gesch_windigkeit Referenzfahrt:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr "Dateiname:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr "Kompensationsdatei verwenden:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
-msgid "Use Backlash Compensation:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
-msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
-#, fuzzy
-msgid "Home Search Velocity:"
-msgstr "Gesch_windigkeit Referenzfahrt:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
-msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
-#, fuzzy
-msgid "Home Search Sequence:"
-msgstr "Gesch_windigkeit Referenzfahrt:"
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -16968,11 +17546,6 @@ msgstr ""
 msgid "24"
 msgstr "2"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-#, fuzzy
-msgid "17"
-msgstr "17:"
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 #, fuzzy
 msgid "Number of connectors:"
@@ -17062,11 +17635,6 @@ msgstr "Mikroschritt-Multiplikationsfaktor:"
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr "Motorschritte pro Umdrehung:"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-#, fuzzy
-msgid "10"
-msgstr "0"
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17539,7 +18107,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr "INFO"
 
@@ -17706,31 +18273,23 @@ msgid "Manual Toolchange"
 msgstr "AXIS Manueller Werkzeugwechsel"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr "Anwender Nachricht"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 msgid "Restart Entry"
 msgstr "Eingabe Neustart"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr "Aufwärts"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr "Eingabe"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr "Abwärts"
 
@@ -17811,33 +18370,33 @@ msgstr "Aufruf"
 msgid "%d RPM"
 msgstr "Max. UPM"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, fuzzy, python-format
 msgid "%4.2f mm/min"
 msgstr "mm/min "
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, fuzzy, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr "                    "
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17960,7 +18519,6 @@ msgid "<b>Status</b>"
 msgstr " <b>a)</b>"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
@@ -17969,7 +18527,6 @@ msgstr ""
 "Text"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 msgid ""
 "Replace\n"
 "  Text:"
@@ -17978,7 +18535,6 @@ msgstr ""
 "  mit:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 msgid ""
 "Replace\n"
 "   All"
@@ -17987,7 +18543,6 @@ msgstr ""
 "ersetzen"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -18005,7 +18560,6 @@ msgid "Main Level"
 msgstr "Schwelle"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr "Thema:"
 
@@ -18020,12 +18574,10 @@ msgid "DTG Text Color"
 msgstr "DTG-Textfarbe"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr "Warnung Töne"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr "Gefahren Töne"
 
@@ -18034,7 +18586,6 @@ msgid "Grid Size"
 msgstr "Raster Größe"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 msgid "Starting RPM"
 msgstr "Anfangsdrehzahl"
 
@@ -18116,7 +18667,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 msgid "Calibration"
 msgstr "Kalibrierung"
 
@@ -18395,12 +18945,10 @@ msgid ""
 msgstr "Suchpfad"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "Rückgängig"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "Wiederherstellen"
 
@@ -18425,6 +18973,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18490,1684 +19040,826 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr "**** GMOCCAPY INI Eintrag **** \n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-msgid "user mode selected"
-msgstr "Anwender Modus gewählt"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr "Logo Eintrag = {0} gefunden "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr "**** GMOCCAPY Fehler in INI Eintrag **** \n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr "Logodatei eintrag gefunden, konnte aber nicht in eine Pfad gewandelt werden\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr "Der Dateipfad darf keine Leerzeichen enthalten"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr "Drücken um alle Achsen zu referenzieren"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr "Drücken um vorherige Refernzbutton zu zeigen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr "Drücken um zu referenzieren {0} {1}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "Unbekanntes G-Wort"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-#, fuzzy
-msgid "this is not a usual config\n"
-msgstr "Achse reagiert nicht"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-#, fuzzy
-msgid "mm/min"
-msgstr "mm/min "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-#, fuzzy
-msgid "inch/min"
-msgstr "Zoll / min"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "Gelenk-Modus"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "Noch keine Parameter"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-#, fuzzy
-msgid "conversion error"
-msgstr "Unbekannter Fehler"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-#, fuzzy
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr ""
-"%s kann im automatischen Modus nicht ausgeführt werden, wenn der Interpreter "
-"stillsteht"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-#, fuzzy
-msgid "No tool description available"
-msgstr "Es ist keine Beschreibung verfügbar."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-#, fuzzy
-msgid "Classicladder real-time component not detected"
-msgstr "Echtzeicht-Komponente nicht geladen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-#, fuzzy
-msgid "Enter value for diameter"
-msgstr ""
-"Angabe eines nicht-ganzzahligen Wertes, obwohl eine Ganzzahl erwartet wurde"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-#, fuzzy
-msgid "Set diameter to:"
-msgstr " Durchmesser"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-#, fuzzy
-msgid "Enter value for radius"
-msgstr ""
-"Angabe eines nicht-ganzzahligen Wertes, obwohl eine Ganzzahl erwartet wurde"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr " Radius"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, fuzzy, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr ""
-"Angabe eines nicht-ganzzahligen Wertes, obwohl eine Ganzzahl erwartet wurde"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, fuzzy, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "Achsenwert festlegen:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "AXIS Manueller Werkzeugwechsel"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-#, fuzzy
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "Element zum Anzeigen auswählen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "World-Modus"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-#, fuzzy
-msgid "no button here"
-msgstr "Aktive Achse verfahren"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "Programmdatei"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "Werkzeugpfad löschen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "Perspektivische Ansicht"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "Offset-Wert "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "Werkzeuge"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "Achsenauswahl"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-#, fuzzy
-msgid "jog joints"
-msgstr "Achse/Gelenk"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "Grenzw. aufheben"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "<b>Referenzfahrt</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Werkzeug-Info"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-#, fuzzy
-msgid "Diameter"
-msgstr "Durchmesser:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "Offsets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "Offsets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "<b>Konfiguration</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Aktive Codes:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Aktive Codes:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "<b>Leistung</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "<b>Kühlflüssigkeit</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "<b>Spindel</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "Eilgangübersteuerung:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Vorschubübersteuerung von 0% bis 100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "<b>Externe Vorschubübersteuerung</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-#, fuzzy
-msgid ""
-"Search\n"
-" back"
-msgstr "Suchpfad"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-#, fuzzy
-msgid ""
-"Search\n"
-"  fwd"
-msgstr "Suchpfad"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr "Ersetzen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-#, fuzzy
-msgid "X Pos."
-msgstr " Pos "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-#, fuzzy
-msgid "Y Pos."
-msgstr " Pos "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "<b>Maschinen-Grundlagen</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "_Offsets anzeigen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "<b>Leistung</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Vorschau"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "_Offsets anzeigen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "Relative Textfarbe"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-#, fuzzy
-msgid "Absolute Color"
-msgstr "Absolut"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-#, fuzzy
-msgid "DTG Color"
-msgstr "DTG-Textfarbe"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "Referenzfahrt"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "Referenzfahrt aufheben bei allen Achsen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-#, fuzzy
-msgid "Digits"
-msgstr "Digital"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr " <b>a)</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-#, fuzzy
-msgid "Grid size"
-msgstr "Größe"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "Anzeigen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "_Offsets anzeigen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-#, fuzzy
-msgid "Show DTG"
-msgstr "Anzeigen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "<b>Bewegungsdaten</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<b>Seite</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "in der aktuellen Unterdatei"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "Schrittgeschwindigkeit auswählen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "Element zum Anzeigen auswählen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-#, fuzzy
-msgid "<b>Themes and sound</b>"
-msgstr "<b>Standardeinstellungen und Optionen</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "Spindelübersteuerung"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "Geschwi_ndigkeit anzeigen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "Vorschubübersteuerung:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Spindelübersteuerung"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "<b>Schrittmotor-Skala</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-msgid "Use unlock code"
-msgstr ""
-
-# Anmerkung:FJ: Hmmmm ....
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-#, fuzzy
-msgid "Do not use unlock code"
-msgstr "Das Koordinaten-Wort C kann hier nicht verwendet werden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "<b>Werkzeugeinstellung</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Spindelbremse an"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Spindelbremse"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "<b>Frontend</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-#, fuzzy
-msgid "Probe Height"
-msgstr "Sensor"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-#, fuzzy
-msgid "Z Pos."
-msgstr " Pos "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-#, fuzzy
-msgid "Max. Probe"
-msgstr "Sensor"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "<b>Programmoptionen</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-#, fuzzy
-msgid "Search Vel."
-msgstr "Suchpfad"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-#, fuzzy
-msgid "Probe Vel."
-msgstr "Sensor"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-#, fuzzy
-msgid "<b>Probe velocitys</b>"
-msgstr "<b>GUI-Frontend-Liste</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "<b>Kühlflüssigkeit</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "Werkzeugtabelle neu laden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Werkzeugtabelle neu laden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "Ab gewählter _Zeile ausführen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "<b>Referenzfahrt</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "Erweiterte Optionen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Maschine an"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "Serielles Modbus-Programm"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "Status anzeigen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "World-Modus"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr "gmoccapy beenden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Programm neu laden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Programm neu laden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Programmausführung oder Laden der"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Programmausführung oder Laden der"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Programmausführung oder Laden der"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr "SPS-Programm bearbeiten"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-#, fuzzy
-msgid "delete MDI"
-msgstr "Löschen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-#, fuzzy
-msgid "delete MDI history"
-msgstr "MDI-Verlauf leeren"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-#, fuzzy
-msgid "Open classicladder"
-msgstr "SPS (Classicladder) einbinden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "HAL-Scope"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-#, fuzzy
-msgid "launch hal scope"
-msgstr "%s starten"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "_Kalibrierung"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-#, fuzzy
-msgid "delete selected tool or tools"
-msgstr "Angegebene Werkzeug-Nummer zu groß"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "We_rkzeugtabelle neu laden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "_Neu laden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "We_rkzeugtabelle neu laden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "Angegebene Werkzeug-Nummer zu groß"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-#, fuzzy
-msgid "touch off the tool and set the value to the tool table"
-msgstr "Angefordertes Werkzeug %d nicht in der Werkzeugtabelle gefunden"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
+#: lib/python/gladevcp/iconview.py:120
 #, fuzzy
-msgid "Move to parrent directory"
+msgid "Move to parent directory"
 msgstr "Aktuelles Verzeichnis"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "Element zum Anzeigen auswählen"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Element zum Anzeigen auswählen"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "Geladene Datei:"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
 #, fuzzy
-msgid "home joints"
-msgstr "Achse/Gelenk"
+msgid "Toolfile does not exist"
+msgstr "Werkzeugdatei ist »%s«"
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "We_rkzeugtabelle neu laden"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+#, fuzzy
+msgid "Tool file was modified since it was last read"
+msgstr ""
+"Die Datei %r wurde geändert, seitdem sie von stepconf geschrieben wurde"
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+#, fuzzy
+msgid "radiobutton"
+msgstr "Taste"
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Taste"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+msgid "button"
+msgstr "Taste"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "Taste"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Werkzeug:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Schwarz"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "XY-Drehung:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+#, fuzzy
+msgid "G92"
+msgstr "_G92"
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+#, fuzzy
+msgid "G59.1"
+msgstr "P7  G59._1"
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+#, fuzzy
+msgid "G59.2"
+msgstr "P8  G59._2"
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+#, fuzzy
+msgid "G59.3"
+msgstr "P9  G59._3"
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Werkzeugoffset:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Offset-Wert "
+
+#: lib/python/gladevcp/offsetpage.glade:442
+#, fuzzy
+msgid ""
+"Zero\n"
+"G92"
+msgstr "G59.2 auf Null setzen"
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "Horizontal"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "_Auswahl ändern"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Werkzeug:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+#, fuzzy
+msgid "Diameter"
+msgstr "Durchmesser:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "vorne"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "Vorgang"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "Bemerkung"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "_Neu laden"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "Achsoffset"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "Durchmesser:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "Arbeitsoffset:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Werkzeug:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Werkzeug:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Werkzeugoffset"
+
+#~ msgid "Use Gmoccapy Screen"
+#~ msgstr "Benutze Gmoccapy Benutzeroberfläche"
+
+#~ msgid "filename:"
+#~ msgstr "Dateiname:"
+
+#~ msgid "**** GMOCCAPY INI Entry **** \n"
+#~ msgstr "**** GMOCCAPY INI Eintrag **** \n"
+
+#~ msgid "user mode selected"
+#~ msgstr "Anwender Modus gewählt"
+
+#~ msgid "logo entry found = {0}"
+#~ msgstr "Logo Eintrag = {0} gefunden "
+
+#~ msgid "**** GMOCCAPY INI Entry Error **** \n"
+#~ msgstr "**** GMOCCAPY Fehler in INI Eintrag **** \n"
+
+#~ msgid "Logofile entry found, but could not be converted to path.\n"
+#~ msgstr ""
+#~ "Logodatei eintrag gefunden, konnte aber nicht in eine Pfad gewandelt "
+#~ "werden\n"
+
+#~ msgid "The file path should not contain any spaces"
+#~ msgstr "Der Dateipfad darf keine Leerzeichen enthalten"
+
+#~ msgid "Press to home all {0}"
+#~ msgstr "Drücken um alle Achsen zu referenzieren"
+
+#~ msgid "Press to display previous homing button"
+#~ msgstr "Drücken um vorherige Refernzbutton zu zeigen"
+
+#~ msgid "Press to home {0} {1}"
+#~ msgstr "Drücken um zu referenzieren {0} {1}"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "Unbekanntes G-Wort"
+
+#, fuzzy
+#~ msgid "this is not a usual config\n"
+#~ msgstr "Achse reagiert nicht"
+
+#, fuzzy
+#~ msgid "mm/min"
+#~ msgstr "mm/min "
+
+#, fuzzy
+#~ msgid "inch/min"
+#~ msgstr "Zoll / min"
+
+#, fuzzy
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "Gelenk-Modus"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "Noch keine Parameter"
+
+#, fuzzy
+#~ msgid "conversion error"
+#~ msgstr "Unbekannter Fehler"
+
+#, fuzzy
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr ""
+#~ "%s kann im automatischen Modus nicht ausgeführt werden, wenn der "
+#~ "Interpreter stillsteht"
+
+#, fuzzy
+#~ msgid "No tool description available"
+#~ msgstr "Es ist keine Beschreibung verfügbar."
+
+#, fuzzy
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "Echtzeicht-Komponente nicht geladen"
+
+#, fuzzy
+#~ msgid "Enter value for diameter"
+#~ msgstr ""
+#~ "Angabe eines nicht-ganzzahligen Wertes, obwohl eine Ganzzahl erwartet "
+#~ "wurde"
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr " Durchmesser"
+
+#, fuzzy
+#~ msgid "Enter value for radius"
+#~ msgstr ""
+#~ "Angabe eines nicht-ganzzahligen Wertes, obwohl eine Ganzzahl erwartet "
+#~ "wurde"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr " Radius"
+
+#, fuzzy
+#~ msgid "Enter value for axis {0}"
+#~ msgstr ""
+#~ "Angabe eines nicht-ganzzahligen Wertes, obwohl eine Ganzzahl erwartet "
+#~ "wurde"
+
+#, fuzzy
+#~ msgid "Set axis {0} to:"
+#~ msgstr "Achsenwert festlegen:"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "AXIS Manueller Werkzeugwechsel"
+
+#, fuzzy
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr ""
+#~ "Ebene kann nicht bei aktiver Werkzeugradiuskorrektur gewechselt werden"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "Element zum Anzeigen auswählen"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "World-Modus"
+
+#, fuzzy
+#~ msgid "no button here"
+#~ msgstr "Aktive Achse verfahren"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "Programmdatei"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "Werkzeugpfad löschen"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "Perspektivische Ansicht"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Werkzeuge"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "Achsenauswahl"
+
+#, fuzzy
+#~ msgid "jog joints"
+#~ msgstr "Achse/Gelenk"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "Grenzw. aufheben"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "<b>Referenzfahrt</b>"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Werkzeug-Info"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "Offsets"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "Offsets"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "<b>Konfiguration</b>"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Aktive Codes:"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Aktive Codes:"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "<b>Leistung</b>"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "<b>Kühlflüssigkeit</b>"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "<b>Spindel</b>"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "Eilgangübersteuerung:"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Vorschubübersteuerung von 0% bis 100%"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "<b>Externe Vorschubübersteuerung</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "Search\n"
+#~ " back"
+#~ msgstr "Suchpfad"
+
+#, fuzzy
+#~ msgid ""
+#~ "Search\n"
+#~ "  fwd"
+#~ msgstr "Suchpfad"
+
+#~ msgid "Replace"
+#~ msgstr "Ersetzen"
+
+#, fuzzy
+#~ msgid "X Pos."
+#~ msgstr " Pos "
+
+#, fuzzy
+#~ msgid "Y Pos."
+#~ msgstr " Pos "
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "<b>Maschinen-Grundlagen</b>"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "_Offsets anzeigen"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "<b>Leistung</b>"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Vorschau"
+
+#, fuzzy
+#~ msgid "show offsets"
+#~ msgstr "_Offsets anzeigen"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Relative Textfarbe"
+
+#, fuzzy
+#~ msgid "Absolute Color"
+#~ msgstr "Absolut"
+
+#, fuzzy
+#~ msgid "DTG Color"
+#~ msgstr "DTG-Textfarbe"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "Referenzfahrt"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "Referenzfahrt aufheben bei allen Achsen"
+
+#, fuzzy
+#~ msgid "Digits"
+#~ msgstr "Digital"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr " <b>a)</b>"
+
+#, fuzzy
+#~ msgid "Grid size"
+#~ msgstr "Größe"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "Anzeigen"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "_Offsets anzeigen"
+
+#, fuzzy
+#~ msgid "Show DTG"
+#~ msgstr "Anzeigen"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "<b>Bewegungsdaten</b>"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Seite</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "in der aktuellen Unterdatei"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "Schrittgeschwindigkeit auswählen"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "Element zum Anzeigen auswählen"
+
+#, fuzzy
+#~ msgid "<b>Themes and sound</b>"
+#~ msgstr "<b>Standardeinstellungen und Optionen</b>"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Spindelübersteuerung"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "Geschwi_ndigkeit anzeigen"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Vorschubübersteuerung:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Spindelübersteuerung"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "<b>Schrittmotor-Skala</b>"
+
+# Anmerkung:FJ: Hmmmm ....
+#, fuzzy
+#~ msgid "Do not use unlock code"
+#~ msgstr "Das Koordinaten-Wort C kann hier nicht verwendet werden"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "<b>Werkzeugeinstellung</b>"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Spindelbremse an"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Spindelbremse"
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "<b>Frontend</b>"
+
+#, fuzzy
+#~ msgid "Probe Height"
+#~ msgstr "Sensor"
+
+#, fuzzy
+#~ msgid "Z Pos."
+#~ msgstr " Pos "
+
+#, fuzzy
+#~ msgid "Max. Probe"
+#~ msgstr "Sensor"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "<b>Programmoptionen</b>"
+
+#, fuzzy
+#~ msgid "Search Vel."
+#~ msgstr "Suchpfad"
+
+#, fuzzy
+#~ msgid "Probe Vel."
+#~ msgstr "Sensor"
+
+#, fuzzy
+#~ msgid "<b>Probe velocitys</b>"
+#~ msgstr "<b>GUI-Frontend-Liste</b>"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "<b>Kühlflüssigkeit</b>"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Werkzeugtabelle neu laden"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Werkzeugtabelle neu laden"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "Ab gewählter _Zeile ausführen"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "<b>Referenzfahrt</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "Erweiterte Optionen"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Maschine an"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "Serielles Modbus-Programm"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "Status anzeigen"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "World-Modus"
+
+#~ msgid "Close gmoccapy / leave the program"
+#~ msgstr "gmoccapy beenden"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Programm neu laden"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Programm neu laden"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Programmausführung oder Laden der"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Programmausführung oder Laden der"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Programmausführung oder Laden der"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr "SPS-Programm bearbeiten"
+
+#, fuzzy
+#~ msgid "delete MDI"
+#~ msgstr "Löschen"
+
+#, fuzzy
+#~ msgid "delete MDI history"
+#~ msgstr "MDI-Verlauf leeren"
+
+#, fuzzy
+#~ msgid "Open classicladder"
+#~ msgstr "SPS (Classicladder) einbinden"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "HAL-Scope"
+
+#, fuzzy
+#~ msgid "launch hal scope"
+#~ msgstr "%s starten"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "_Kalibrierung"
+
+#, fuzzy
+#~ msgid "delete selected tool or tools"
+#~ msgstr "Angegebene Werkzeug-Nummer zu groß"
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "We_rkzeugtabelle neu laden"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "Angegebene Werkzeug-Nummer zu groß"
+
+#, fuzzy
+#~ msgid "touch off the tool and set the value to the tool table"
+#~ msgstr "Angefordertes Werkzeug %d nicht in der Werkzeugtabelle gefunden"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "Geladene Datei:"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "Achse/Gelenk"
 
 #, fuzzy
 #~ msgid "Substituting"
@@ -20321,9 +20013,6 @@ msgstr "Achse/Gelenk"
 #~ msgid "Tool File"
 #~ msgstr "Werkzeugdatei"
 
-#~ msgid "Tool file is %s"
-#~ msgstr "Werkzeugdatei ist »%s«"
-
 #~ msgid "Active G Codes"
 #~ msgstr "Aktive G-Codes"
 
@@ -20336,9 +20025,6 @@ msgstr "Achse/Gelenk"
 
 #~ msgid "CONTINUE"
 #~ msgstr "FORTSETZEN"
-
-#~ msgid "Tool #:"
-#~ msgstr "Werkzeug:"
 
 #~ msgid "Length :"
 #~ msgstr "Länge:"
@@ -20506,9 +20192,6 @@ msgstr "Achse/Gelenk"
 #~ msgid "Zero All G59.1"
 #~ msgstr "G59.1 auf Null setzen"
 
-#~ msgid "Zero All G59.2"
-#~ msgstr "G59.2 auf Null setzen"
-
 #~ msgid "Zero All G59.3"
 #~ msgstr "G59.3 auf Null setzen"
 
@@ -20611,9 +20294,6 @@ msgstr "Achse/Gelenk"
 
 #~ msgid "Show Setup"
 #~ msgstr "Einrichtung anzeigen"
-
-#~ msgid "Axis Offset"
-#~ msgstr "Achsoffset"
 
 #~ msgid "Home All Axes"
 #~ msgstr "Referenzfahrt mit allen Achsen"
@@ -20973,9 +20653,6 @@ msgstr "Achse/Gelenk"
 #~ msgid "Step generator"
 #~ msgstr "Schrittgenerator"
 
-#~ msgid "button"
-#~ msgstr "Taste"
-
 #~ msgid "Minimum Software Limit on axis %d exceeded."
 #~ msgstr "Unteres Software-Limit der Achse %d ist erreicht."
 
@@ -21216,9 +20893,6 @@ msgstr "Achse/Gelenk"
 #~ msgid "Pyvcp Example Options"
 #~ msgstr "Pyvcp-Beispieloptionen"
 
-#~ msgid "PLC Options"
-#~ msgstr "SPS-Optionen"
-
 #~ msgid ""
 #~ "All the necessary information has now been gathered.  Click \"Apply\" to "
 #~ "write your configuration files to disk.\n"
@@ -21373,9 +21047,6 @@ msgstr "Achse/Gelenk"
 
 #~ msgid "x 4 ="
 #~ msgstr "x 4 ="
-
-#~ msgid "123"
-#~ msgstr "123"
 
 #~ msgid "PWM generator"
 #~ msgstr "PWM-Generator"

--- a/src/po/es.po
+++ b/src/po/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-15 09:02+0200\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2020-07-15 05:10+0100\n"
 "Last-Translator: J.M. Garcia <jmgardeto@gmail.com>\n"
 "Language: es_ES\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 2.0\n"
 
-#: src/emc/task/emctaskmain.cc:867
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
@@ -25,61 +25,61 @@ msgstr ""
 "el comando (%s) no se puede ejecutar hasta que la máquina salga de Estop y "
 "esté encendida"
 
-#: src/emc/task/emctaskmain.cc:997
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "no se puede hacer (%s:%d) en modo manual"
 
-#: src/emc/task/emctaskmain.cc:1104
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr "no se puede hacer (%s) en modo auto con el intérprete inactivo"
 
-#: src/emc/task/emctaskmain.cc:1173
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr "no se puede hacer (%s) en modo auto con la lectura del intérprete"
 
-#: src/emc/task/emctaskmain.cc:1260
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr "no se puede hacer (%s) en modo auto con el intérprete en pausa"
 
-#: src/emc/task/emctaskmain.cc:1331
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr "no se puede hacer (%s) en modo auto con el intérprete en espera"
 
-#: src/emc/task/emctaskmain.cc:1458
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "no se puede hacer (%s:%d) en modo MDI"
 
-#: src/emc/task/emctaskmain.cc:2120
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 "No se puede cambiar el modo mientras el modo es AUTO y el intérprete no está "
 "inactivo"
 
-#: src/emc/task/emctaskmain.cc:2173
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr "no se pudo cerrar el archivo"
 
-#: src/emc/task/emctaskmain.cc:2187 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "no se puede abrir %s"
 
-#: src/emc/task/emctaskmain.cc:2199
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr "No se puede emitir el comando MDI sin homed"
 
-#: src/emc/task/emctaskmain.cc:2204
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "Debe estar en modo MDI para emitir un comando MDI"
 
-#: src/emc/task/emctaskmain.cc:2286
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr "Falta homing. No se puede ejecutar el programa"
 
@@ -129,38 +129,40 @@ msgstr "Valor P fuera de rango con G10 L%d"
 msgid "Between G5.2 and G5.3 codes, only additional G5.2 codes are allowed."
 msgstr "Entre códigos G5.2 y G5.3 solo se permiten códigos G5.2 adicionales."
 
-#: src/emc/rs274ngc/interp_check.cc:258
-msgid "D word with no G41, G41.1, G42, G42.1, or G96 to use it"
+#: src/emc/rs274ngc/interp_check.cc:260
+#, fuzzy
+msgid ""
+"D word with no G41, G41.1, G42, G42.1, G71, G71.1, G71.2 or G96 to use it"
 msgstr "Palabra D sin G41, G41.1, G42, G42.1 o G96"
 
-#: src/emc/rs274ngc/interp_check.cc:267
+#: src/emc/rs274ngc/interp_check.cc:269
 msgid ""
 "$ (spindle selection) word with no G41, G41.1, G42, G42.1, G76 G95 or G96 to "
 "use it"
 msgstr ""
 " palabra $ (spindle selection) sin G41, G41.1, G42, G42.1, G76 G95 o G96"
 
-#: src/emc/rs274ngc/interp_check.cc:274
+#: src/emc/rs274ngc/interp_check.cc:277
 msgid "E word with no G76, M3, M4, M5, M19, M51, M66, M67 or M68 to use it"
 msgstr "Palabra E sin G76, M3, M4, M5, M19, M51, M66, M67 o M68 "
 
-#: src/emc/rs274ngc/interp_check.cc:279
+#: src/emc/rs274ngc/interp_check.cc:282
 msgid "H word with no G43 or G76 to use it"
 msgstr "Palabra H sin G43 o G76"
 
-#: src/emc/rs274ngc/interp_check.cc:285
+#: src/emc/rs274ngc/interp_check.cc:290
 msgid "I word with no G2, G3, G5, G5.1, G10, G33.1, G76, or G87 to use it"
 msgstr "Palabra I sin G2, G3, G5, G5.1, G10, G33.1, G76 o G87"
 
-#: src/emc/rs274ngc/interp_check.cc:291
+#: src/emc/rs274ngc/interp_check.cc:296
 msgid "J word with no G2, G3, G5, G5.1, G10, G76 or G87 to use it"
 msgstr "Palabra J sin G2, G3, G5, G5.1, G10, G76 o G87"
 
-#: src/emc/rs274ngc/interp_check.cc:297
+#: src/emc/rs274ngc/interp_check.cc:302
 msgid "K word with no G2, G3, G33, G33.1, G76, or G87 to use it"
 msgstr "Palabra K sin G2, G3, G33, G33.1, G76 o G87"
 
-#: src/emc/rs274ngc/interp_check.cc:309
+#: src/emc/rs274ngc/interp_check.cc:314
 msgid ""
 "L word with no G10, cutter compensation, canned cycle, digital/analog input, "
 "M98 or NURBS code"
@@ -168,7 +170,7 @@ msgstr ""
 "Palabra L sin G10, compensación de cortador, ciclo fijo, entrada digital/"
 "analógica,M98 o NURBS"
 
-#: src/emc/rs274ngc/interp_check.cc:324
+#: src/emc/rs274ngc/interp_check.cc:330
 msgid ""
 "P word with no G2 G3 G4 G10 G64 G5 G5.2 G76 G82 G86 G88 G89 or M50 M51 M52 "
 "M53 M62 M63 M64 M65 M66 M98 or user M code to use it"
@@ -176,19 +178,19 @@ msgstr ""
 "Palabra P sin G2 G3 G4 G10 G64 G5 G5.2 G76 G82 G86 G88 G89 o M50 M51 M52M53 "
 "M62 M63 M64 M65 M66 M98 o código M de usuario"
 
-#: src/emc/rs274ngc/interp_check.cc:330
+#: src/emc/rs274ngc/interp_check.cc:336
 msgid "P value not an integer with M19 G2 or G3"
 msgstr "El valor P no es un entero con M19 G2 o G3"
 
-#: src/emc/rs274ngc/interp_check.cc:332
+#: src/emc/rs274ngc/interp_check.cc:338
 msgid "P value must be 0,1,or 2 with M19"
 msgstr "El valor P debe ser 0, 1 o 2 con M19"
 
-#: src/emc/rs274ngc/interp_check.cc:334
+#: src/emc/rs274ngc/interp_check.cc:340
 msgid "P value should be 1 or greater with G2 or G3"
 msgstr "El valor P debe ser 1 o mayor con G2 o G3"
 
-#: src/emc/rs274ngc/interp_check.cc:342
+#: src/emc/rs274ngc/interp_check.cc:351
 msgid ""
 "Q word with no G5, G10, G64, G73, G76, G83, M19, M66, M67, M68 or user M "
 "code that uses it"
@@ -196,31 +198,31 @@ msgstr ""
 "Palabra Q sin G5, G10, G64, G73, G76, G83, M19, M66, M67, M68 o código M de "
 "usuario"
 
-#: src/emc/rs274ngc/interp_check.cc:353
+#: src/emc/rs274ngc/interp_check.cc:364
 msgid "R value must be within 0..360 with M19"
 msgstr "El valor R debe estar dentro de 0..360 con M19"
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr "Debe especificar las coordenadas X e Y para los puntos de control"
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr "Puede especificar P sin X e Y solo para el primer punto de control"
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr "Debe especificar un peso positivo P para cada punto de control"
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr "No se puede hacer NURBS con velocidad de avance 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr "No se puede usar G5.3 sin G5.2 previo"
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
@@ -228,31 +230,31 @@ msgid ""
 msgstr ""
 "Debe especificar un número de puntos de control al menos igual al orden L =%d"
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr "No se puede convertir spline con compensación de radio de corte"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr "Las Splines deben estar en el plano XY"
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr "Las Splines pueden no tener movimiento en Z, A, B o C"
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr "Debe especificar tanto I como J con G5.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr "Debe especificar ambos, I y  J, o ninguno"
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr "Debe especificar P y Q con G5"
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
@@ -260,49 +262,49 @@ msgstr ""
 "El movimiento después de salir del modo de compensación del cortador debe "
 "ser recto, noun arco"
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr "No se puede hacer un arco en los planos G17.1, G18.1 o G19.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4478
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 "No se puede alimentar con velocidad de husillo cero en modo avancepor "
 "revolución"
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr "Falta la palabra %c en arco central absoluto"
 
-#: src/emc/rs274ngc/interp_convert.cc:668
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 "El radio del arco de entrada de compensación del cortador no es mayor que el "
 "radio de la herramienta"
 
-#: src/emc/rs274ngc/interp_convert.cc:887
-#: src/emc/rs274ngc/interp_convert.cc:897 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 "La herramienta no puede alcanzar el movimiento del arco en la esquina "
 "cóncava sin socavar"
 
-#: src/emc/rs274ngc/interp_convert.cc:923
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 "El movimiento de arco a arco no es válido porque los arcos tienen el mismo "
 "centro"
 
-#: src/emc/rs274ngc/interp_convert.cc:926
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
@@ -310,55 +312,60 @@ msgstr ""
 "El movimiento de arco a arco hace una esquina que la herramienta compensada "
 "no puedehacer sin socavar"
 
-#: src/emc/rs274ngc/interp_convert.cc:1058
-#: src/emc/rs274ngc/interp_convert.cc:1062
 #: src/emc/rs274ngc/interp_convert.cc:1066
-#: src/emc/rs274ngc/interp_convert.cc:3897
-#: src/emc/rs274ngc/interp_convert.cc:3900
-#: src/emc/rs274ngc/interp_convert.cc:3903 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr "Posición absoluta inválida %5.2f para eje giratorio %c"
 
-#: src/emc/rs274ngc/interp_convert.cc:1568
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 "No se puede cambiar el modo de control con la compensación del radio de "
 "corte ON"
 
-#: src/emc/rs274ngc/interp_convert.cc:1681
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 "No se pueden cambiar los sistemas de coordenadas con la compensación del "
 "radio de corte ON"
 
-#: src/emc/rs274ngc/interp_convert.cc:1926
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr "G%d.1 sin palabra D"
 
-#: src/emc/rs274ngc/interp_convert.cc:1929
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr "G%d.1 con palabra L, pero el plano no es G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:1940
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr "G%d requiere que la palabra D sea un número entero"
 
-#: src/emc/rs274ngc/interp_convert.cc:1947
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr "G%d con herramienta de torno, pero el plano no es G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:2346
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 "No se puede establecer el punto de referencia con compensación de cortador "
 "activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:2866
+#: src/emc/rs274ngc/interp_convert.cc:2945
+#, fuzzy, c-format
+msgid "gen_restore G20/G21 failed: '%s'"
+msgstr "M7x: ha fallado restore_settings G20 / G21: '%s'"
+
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
@@ -366,103 +373,108 @@ msgstr ""
 "ERROR: no se puede restaurar desde un nivel de llamada inferior (%d) a uno "
 "superior (%d)"
 
-#: src/emc/rs274ngc/interp_convert.cc:2867
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr "ERROR: ¿restaurar desde el nivel %d !?"
 
-#: src/emc/rs274ngc/interp_convert.cc:2868
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr "ERROR: ¿restaurar al nivel %d !?"
 
-#: src/emc/rs274ngc/interp_convert.cc:2887
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr "M7x: ha fallado restore_settings G20 / G21: '%s'"
 
-#: src/emc/rs274ngc/interp_convert.cc:2905
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr "M7x: no se pudo ejecutar restore_settings: '%s':%s"
 
-#: src/emc/rs274ngc/interp_convert.cc:2974
+#: src/emc/rs274ngc/interp_convert.cc:3110
+#, c-format
+msgid "Failed to restore interp state on abort '%s': %s"
+msgstr ""
+
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 "No se puede dar salida de movimiento con la compensación del radio de corte "
 "activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:2975
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr "No hay palabra P válida con M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:2979
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 "No se puede dar salida digital de movimiento con la compensación del radio "
 "de corte activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:2980
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr "No hay una palabra P válida con M63"
 
-#: src/emc/rs274ngc/interp_convert.cc:2984
-#: src/emc/rs274ngc/interp_convert.cc:2989
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 "No se puede configurar la salida digital auxiliar con la compensación del "
 "radio de corte activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:2985
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr "No hay una palabra P válida con M64"
 
-#: src/emc/rs274ngc/interp_convert.cc:2990
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr "No hay una palabra P válida con M65"
 
-#: src/emc/rs274ngc/interp_convert.cc:3020
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr "Palabra P inválida con M66"
 
-#: src/emc/rs274ngc/interp_convert.cc:3035
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 "No se puede esperar a entrada digital con compensación de radio de corte "
 "activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:3047
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 "No se puede esperar a entrada analógica con compensación de radio de corte "
 "activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:3062
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 "No se puede dar salida analógica de movimiento con la compensación de radio "
 "de corte activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:3063
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr "Índex analógico inválido con M67"
 
-#: src/emc/rs274ngc/interp_convert.cc:3069
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 "No se puede dar salida analógica auxiliar con compensación de radio de corte "
 "activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:3070
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr "Índex analógico no válido con M68"
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 "Se necesita Q no negativa para especificar número de herramienta con M61"
 
-#: src/emc/rs274ngc/interp_convert.cc:3145
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
@@ -471,7 +483,7 @@ msgstr ""
 "Número de husillo ($) fuera de rango en comando M3\n"
 "nº husillos =%i. $=%d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3162
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
@@ -480,7 +492,7 @@ msgstr ""
 "Número de husillo ($) fuera de rango en el comando M4\n"
 "nº husillos =%i. $ =%d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3179
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
@@ -489,163 +501,164 @@ msgstr ""
 "Número de husillo ($) fuera de rango en el comando M5\n"
 "nº husillos =%i. $ =%d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3198
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr "Número de husillo ($) fuera de rango en el comando M19"
 
-#: src/emc/rs274ngc/interp_convert.cc:3205
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr "La palabra Q con M19 requiere un valor > 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 "No se puede restaurar el contexto desde un marco de pila inválido - falta "
 "M70 / M73?"
 
-#: src/emc/rs274ngc/interp_convert.cc:3275
-#: src/emc/rs274ngc/interp_convert.cc:3296
-#: src/emc/rs274ngc/interp_convert.cc:3316
-#: src/emc/rs274ngc/interp_convert.cc:3338
-#: src/emc/rs274ngc/interp_convert.cc:3352
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 "No se pueden habilitar ajustes con la compensación del radio de corte activo"
 
-#: src/emc/rs274ngc/interp_convert.cc:3284
-#: src/emc/rs274ngc/interp_convert.cc:3301
-#: src/emc/rs274ngc/interp_convert.cc:3325
-#: src/emc/rs274ngc/interp_convert.cc:3343
-#: src/emc/rs274ngc/interp_convert.cc:3357
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 "No se pueden desactivar ajustes con la compensación de radio de corte activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:3311
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr "Número de husillo ($) no válido en el comando M51"
 
-#: src/emc/rs274ngc/interp_convert.cc:3463
-#: src/emc/rs274ngc/interp_convert.cc:3464
-#: src/emc/rs274ngc/interp_convert.cc:3465
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr "El eje indexado %c solo se puede mover con G0"
 
-#: src/emc/rs274ngc/interp_convert.cc:3472
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3476
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr "El eje indexado %c solo se puede mover solitario"
 
-#: src/emc/rs274ngc/interp_convert.cc:3573
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr "No se puede sondear con modo de alimentación por revolucion"
 
-#: src/emc/rs274ngc/interp_convert.cc:3621
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 "No se puede cambiar el modo de retracción con la compensación del radio de "
 "corte activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:3655
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr "G10 L1 sin offsets no tiene efecto"
 
-#: src/emc/rs274ngc/interp_convert.cc:3761
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr "El número Q en G10 no es un entero"
 
-#: src/emc/rs274ngc/interp_convert.cc:3762
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr "Orientación inválida de herramienta inválida"
 
-#: src/emc/rs274ngc/interp_convert.cc:3885
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr "No se permiten palabras I o J con G10 L2"
 
-#: src/emc/rs274ngc/interp_convert.cc:3906
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 "No se puede cambiar el sistema de coordenadas activo con la compensación de "
 "radio de corte activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:3914
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr "R no permitido en G10 L20"
 
-#: src/emc/rs274ngc/interp_convert.cc:4258
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr "Error: Alcanzado convert_stop() desde M99 como retorno de subprograma"
 
-#: src/emc/rs274ngc/interp_convert.cc:4535
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr "Número de husillo ($) no válido en G33"
 
-#: src/emc/rs274ngc/interp_convert.cc:4540
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr "El husillo no gira en G33"
 
-#: src/emc/rs274ngc/interp_convert.cc:4550
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr "Número de husillo inválido ($) en G33.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:4555
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr "El husillo no gira en G33.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:4570
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr "Número D inválido en ciclo G76"
 
-#: src/emc/rs274ngc/interp_convert.cc:4575
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "El husillo elegido (%i) no gira en G76"
 
-#: src/emc/rs274ngc/interp_convert.cc:4613
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr "ERROR: Un eje incorrectamente movido junto con un indexador"
 
-#: src/emc/rs274ngc/interp_convert.cc:4626
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr "ERROR: intentando indexar un eje incorrecto"
 
-#: src/emc/rs274ngc/interp_convert.cc:4718
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 "No se puede usar el ciclo de roscado G76 con la compensación del radio de "
 "corte activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:4721
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr "En G76, I no debe ser 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4723
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr "En G76, J debe ser mayor que 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4725
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr "En G76, K debe ser mayor que J"
 
-#: src/emc/rs274ngc/interp_convert.cc:4868
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
-"La longitud del movimiento de entrada de compensación del cortador no es mayor\n"
+"La longitud del movimiento de entrada de compensación del cortador no es "
+"mayor\n"
 "que el radio de la herramienta"
 
-#: src/emc/rs274ngc/interp_convert.cc:5087
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 "La esquina interior de cero grados no es válida para compensación del "
 "cortador"
 
-#: src/emc/rs274ngc/interp_convert.cc:5125
-#: src/emc/rs274ngc/interp_convert.cc:5133
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
@@ -653,20 +666,25 @@ msgstr ""
 "El movimiento arco a recto hace una esquina en la que la herramienta "
 "compensada no puede caber sin socavar"
 
-#: src/emc/rs274ngc/interp_convert.cc:5217
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 "No se pueden cambiar las herramientas con la compensación del radio de corte "
 "activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:5341
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 "No se puede cambiar el offset de herramienta con compensación de radio de "
 "corte activa"
 
-#: src/emc/rs274ngc/interp_convert.cc:5383
-msgid "G43.2: H-word missing"
+#: src/emc/rs274ngc/interp_convert.cc:5621
+msgid "G43.2: Can not have both H and axis words"
+msgstr ""
+
+#: src/emc/rs274ngc/interp_convert.cc:5624
+#, fuzzy
+msgid "G43.2: No axes specified and H word missing"
 msgstr "G43.2: Falta la palabra H"
 
 #: src/emc/rs274ngc/interp_queue.cc:605
@@ -733,42 +751,42 @@ msgstr "No se puede usar avance de tiempo inverso con ciclos fijos"
 msgid "Cannot use canned cycles with cutter compensation on"
 msgstr "No se pueden usar ciclos fijos con compensación de cortador activa"
 
-#: src/emc/rs274ngc/interp_cycles.cc:914
+#: src/emc/rs274ngc/interp_cycles.cc:922
 msgid "G17 canned cycle is not possible on a machine without Z axis"
 msgstr "El ciclo fijo G17 no es posible en una máquina sin eje Z"
 
-#: src/emc/rs274ngc/interp_cycles.cc:1012
-#: src/emc/rs274ngc/interp_cycles.cc:1200
-#: src/emc/rs274ngc/interp_cycles.cc:1433
-#: src/emc/rs274ngc/interp_cycles.cc:1617
-#: src/emc/rs274ngc/interp_cycles.cc:2041
-#: src/emc/rs274ngc/interp_cycles.cc:2060
-#: src/emc/rs274ngc/interp_cycles.cc:2077
-#: src/emc/rs274ngc/interp_cycles.cc:2101
+#: src/emc/rs274ngc/interp_cycles.cc:1021
+#: src/emc/rs274ngc/interp_cycles.cc:1212
+#: src/emc/rs274ngc/interp_cycles.cc:1449
+#: src/emc/rs274ngc/interp_cycles.cc:1637
+#: src/emc/rs274ngc/interp_cycles.cc:2069
+#: src/emc/rs274ngc/interp_cycles.cc:2088
+#: src/emc/rs274ngc/interp_cycles.cc:2105
+#: src/emc/rs274ngc/interp_cycles.cc:2129
 msgid "Invalid spindle ($) number in G74/G84 cycle"
 msgstr "Número de husillo ($) no válido en el ciclo G74/G84"
 
-#: src/emc/rs274ngc/interp_cycles.cc:1120
+#: src/emc/rs274ngc/interp_cycles.cc:1131
 msgid "G17.1 canned cycle is not possible on a machine without W axis"
 msgstr "El ciclo fijo G17.1 no es posible en una máquina sin eje W"
 
-#: src/emc/rs274ngc/interp_cycles.cc:1353
+#: src/emc/rs274ngc/interp_cycles.cc:1368
 msgid "G19 canned cycle is not possible on a machine without X axis"
 msgstr "El ciclo fijo G19 no es posible en una máquina sin eje X"
 
-#: src/emc/rs274ngc/interp_cycles.cc:1537
+#: src/emc/rs274ngc/interp_cycles.cc:1556
 msgid "G19.1 canned cycle is not possible on a machine without U axis"
 msgstr "El ciclo fijo G19.1 no es posible en una máquina sin eje U"
 
-#: src/emc/rs274ngc/interp_cycles.cc:1778
+#: src/emc/rs274ngc/interp_cycles.cc:1801
 msgid "G18 canned cycle is not possible on a machine without Y axis"
 msgstr "El ciclo fijo G18 no es posible en una máquina sin eje Y"
 
-#: src/emc/rs274ngc/interp_cycles.cc:1858
+#: src/emc/rs274ngc/interp_cycles.cc:1882
 msgid "Invalid E-number in G74/G84 cycle"
 msgstr "Número E inválido en el ciclo G74/G84"
 
-#: src/emc/rs274ngc/interp_cycles.cc:1961
+#: src/emc/rs274ngc/interp_cycles.cc:1988
 msgid "G18.1 canned cycle is not possible on a machine without V axis"
 msgstr "El ciclo fijo G18.1 no es posible en una máquina sin eje V"
 
@@ -784,34 +802,34 @@ msgstr "Número de husillo ($) no válido en el comando Alimentación de Husillo
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr "Número de husillo no válido ($) en el comando de velocidad del husillo"
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "No se pueden usar coordenadas polares con G53"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr "No se pueden especificar palabras X o Y con coordenadas polares"
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr "Debe especificar el ángulo en coordenadas polares si está en el origen"
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 "El movimiento incremental con coordenadas polares es indeterminado cuando "
 "está en el origen"
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 "El movimiento G91 con coordenadas polares es indeterminado cuando está en el "
 "origen"
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -836,8 +854,8 @@ msgid "Cannot specify both polar coordinate and Y word"
 msgstr "No se puede especificar coordenada polar y palabra Y"
 
 #: src/emc/rs274ngc/interp_internal.cc:183
-#: src/emc/rs274ngc/interp_internal.cc:197
-#: src/emc/rs274ngc/interp_internal.cc:212
+#: src/emc/rs274ngc/interp_internal.cc:200
+#: src/emc/rs274ngc/interp_internal.cc:216
 msgid "Polar coordinates can only be used for motion"
 msgstr "Las coordenadas polares solo pueden usarse para movimiento"
 
@@ -932,108 +950,108 @@ msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 "Archivo:%s línea:%d redefiniendo sub: o|%s| ya definido en el archivo:%s"
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "%d: no está en una definición de subrutina: '%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr "%d: etiqueta O-word duplicada: '%s' - definida en la línea %d"
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr "%d: etiqueta O-word duplicada - ya definida en la línea %d: '%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr "%d: etiqueta O-word indefinida: '%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 "%d: no coincide con la etiqueta 'if': '%s' (se encontró '%s' en la línea %d)"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 "%d: sin etiqueta coincidente: '%s' (encontrado '%s' en la línea %d): '%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 "%d: no coincide con la etiqueta while/do: '%s' (se encontró '%s' en la línea "
 "%d)"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr "%d: sin etiqueta coincidente: '%s' (se encontró '%s' en la línea %d)"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "Parámetro con nombre #<%s> no definido"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, c-format
 msgid "cant open ini file '%s'"
 msgstr "no se puede abrir el archivo ini '%s'"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr ""
 "El parámetro ini nombrado #<%s> no se encuentra en el archivo '%s': error=0x"
 "%x"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:243
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr "fetch_hal_param: hal_init(%s): %d"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr "fetch_hal_param: hal_ready(): %d"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:422
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr "Error interno: no se pudo asignar #<%s>"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:430
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr "No se puede asignar al parámetro de solo lectura #<%s>"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:749
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr "ERROR: lookup_named_param(%s): índice no manejado= %fn"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "La cola no está vacía después del cambio de herramienta"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "No se puede abrir el archivo de parámetros: '%s'"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2407
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 msgid "Parameter file name is missing"
 msgstr "Falta el nombre del archivo de parámetros"
 
@@ -1452,7 +1470,8 @@ msgid "Negative spindle speed used"
 msgstr "Velocidad de husillo negativa"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "ID de herramienta negativa"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1839,17 +1858,17 @@ msgstr "R menor que U en ciclo en plano VW"
 msgid "R less than V in cycle in UW plane"
 msgstr "R menor que V en ciclo en plano UW"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "ERROR: '%s' no es un tipo de sonda válido\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "ERROR: sin pin/señal/nombre de parámetro\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
@@ -1857,8 +1876,7 @@ msgstr ""
 "ERROR: la opción -s requiere un tipo de sonda y un pin/señal/nombre de "
 "parámetro\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "Hal Meter"
 
@@ -1870,133 +1888,156 @@ msgstr "_Seleccionar"
 msgid "E_xit"
 msgstr "Salir"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "Seleccionar elemento a sondear"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr "_Pines"
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr "_Señales"
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr "Pará_metros"
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr "_Cerrar"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 msgstr "Uso:halscope [-h] [-i archivo-in] [-o archivo-out] [num_muestras]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "Abrir archivo de configuración:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Cancelar"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "Abrir"
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Abrir archivo de configuración:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "Guardar"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "Abrir configuración..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "_Salvar configuración..."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "Abrir archivo de datos..."
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "S_alvar archivo de datos..."
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "Salir (_Q)"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "_Acerca de Halscope"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "Archivos (_F)"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "Ayuda"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "Osciloscopio HAL"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "Canal Seleccionado"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "Modo de Ejecución"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "Disparador"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "Vertical"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
-#: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4455
-#: src/emc/usr_intf/gscreen/gscreen.py:4456
+#: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
+#: src/emc/usr_intf/gscreen/gscreen.py:4459
 #: src/emc/usr_intf/gscreen/gscreen.glade:2649
 msgid "Stop"
 msgstr "Detener"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "Normal"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "Unico"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "Roll"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "Zoom"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr "Pos"
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "----- Muestras\n"
-"a ---- KHz"
+"a ---- kHz"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "Componente en tiempo real no cargado"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -2021,11 +2062,39 @@ msgstr ""
 "o\n"
 "Haga clic en 'Salir' para salir de HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "Aceptar"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "Salir"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "Función en tiempo real no vinculada"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -2046,11 +2115,11 @@ msgstr ""
 "o \n"
 "Haga clic en 'Salir' para salir de HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "Seleccionar frecuencia de muestreo"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
@@ -2060,94 +2129,70 @@ msgstr ""
 "o\n"
 "Haga clic en 'Salir' para salir de HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "Aceptar"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr "Hilo:"
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr "Período de muestreo:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr "Frecuencia de muestreo:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr "Hilo"
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "Periodo"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "Multiplicador:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr "Longitud de registro"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d muestras (1 canal)"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d muestras (2 canales)"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d muestras (4 canales)"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d muestras (8 canales)"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d muestras (16 canales)"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1139
-#: src/emc/usr_intf/axis/scripts/axis.py:1240
-#: src/emc/usr_intf/axis/scripts/axis.py:1605
-#: src/emc/usr_intf/axis/scripts/axis.py:2907
-#: src/emc/usr_intf/axis/scripts/axis.py:4120
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:723
-#: lib/python/propertywindow.py:34 share/axis/tcl/axis.tcl:1600
-#: share/axis/tcl/axis.tcl:1637
-msgid "OK"
-msgstr "Aceptar"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-msgid "Quit"
-msgstr "Salir"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr "Hilo(s) en tiempo real no ejecutándose"
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2170,15 +2215,15 @@ msgstr ""
 "o\n"
 "Haga clic en 'Salir' para salir de HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr "Seleccione el archivo de registro donde escribir:"
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr "No hay suficientes canales"
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
@@ -2188,7 +2233,7 @@ msgstr ""
 "que están habilitados actualmente. Elija una longitud\n"
 "de grabación más corta que admita más canales\"."
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
@@ -2197,7 +2242,7 @@ msgstr ""
 "%s\n"
 "por div"
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
@@ -2206,27 +2251,35 @@ msgstr ""
 "%s muestras\n"
 "a %s"
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
-msgstr "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
-msgstr "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
-msgstr "mSeg"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
-msgstr "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2240,17 +2293,17 @@ msgstr "Sec"
 #: src/emc/usr_intf/pncconf/mesa1.glade:460
 #: src/emc/usr_intf/pncconf/mesa1.glade:473
 msgid "Hz"
-msgstr "Hz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
-msgstr "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
-msgstr "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
+msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
@@ -2259,24 +2312,25 @@ msgstr ""
 "Offset\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "Ganancia"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr "Pos"
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr "Escala"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 msgid ""
 "Offset\n"
 "----"
@@ -2284,15 +2338,11 @@ msgstr ""
 "Offset\n"
 "----"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr "Chan Off"
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "Establecer Offset"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
@@ -2301,35 +2351,19 @@ msgstr ""
 "Establecer el offset vertical\n"
 "para el canal %d."
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "Establecer Offset"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr "AC Coupled"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1550
-#: src/emc/usr_intf/axis/scripts/axis.py:1606
-#: src/emc/usr_intf/axis/scripts/axis.py:1834
-#: src/emc/usr_intf/axis/scripts/axis.py:2248
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:725
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:548
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr "Demasiados canales"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2341,21 +2375,7 @@ msgstr ""
 "Apague uno o más canales o acorte\n"
 "la longitud de grabación para permitir más canales"
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr "siguiente búsqueda: %d\n"
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr "buscar: %d (rotativo=%d)\n"
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr "Seleccionar fuente de canal"
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
@@ -2364,29 +2384,33 @@ msgstr ""
 "Seleccione un pin, señal o parámetro\n"
 "como la fuente del canal %d."
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "Seleccionar fuente de canal"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "Pines"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "Señales"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "Parámetros"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr "Descendente"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr "Ascendente"
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
@@ -2394,7 +2418,7 @@ msgstr ""
 "Fuente\n"
 "Ninguna"
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
@@ -2403,114 +2427,115 @@ msgstr ""
 "Fuente\n"
 "Canal %2d"
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "Auto"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr "Forzar"
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr "Nivel"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr "Fuente de disparo"
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr "Seleccione un canal para usar como disparo."
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "Fuente de disparo"
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr "Canal"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr "Fuente"
 
-#: src/emc/motion/control.c:490
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr "error %d durante orientación en progreso"
 
-#: src/emc/motion/control.c:649
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr "Movimiento G38.4 terminado sin romper el contacto."
 
-#: src/emc/motion/control.c:652
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr "Movimiento G38.2 terminado sin hacer contacto."
 
-#: src/emc/motion/control.c:666
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+#, fuzzy
+msgid "Probe tripped during non-probe move."
 msgstr "La sonda se disparó durante comando no-sonda MDI."
 
-#: src/emc/motion/control.c:704
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr "La sonda se disparó durante el movimiento homing."
 
-#: src/emc/motion/control.c:708
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr "La sonda se disparó durante un jog articular."
 
-#: src/emc/motion/control.c:711
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr "La sonda se disparó durante un jog coordinado\"."
 
-#: src/emc/motion/control.c:727
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr "movimiento detenido por entrada habilitada"
 
-#: src/emc/motion/control.c:734
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr "fallo del amplificador del husillo %d"
 
-#: src/emc/motion/control.c:757
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "error articulacion %d en el interruptor de límite"
 
-#: src/emc/motion/control.c:769
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "fallo del amplificador de articulacion %d"
 
-#: src/emc/motion/control.c:778
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "error de seguimiento en articulacion %d"
 
-#: src/emc/motion/control.c:1369 src/emc/motion/control.c:1455
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 "kinematicsInverse proporcionó una ubicación de articulación no finita en la "
 "articulación %d"
 
-#: src/emc/motion/control.c:1386 src/emc/motion/control.c:1474
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr "error cinemática inversa"
 
-#: src/emc/motion/control.c:1551
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr "Límite soft NEGATIVO excedido (%.5f) en la articulacion %d\n"
 
-#: src/emc/motion/control.c:1554 src/emc/motion/control.c:1563
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr "La articulación debe ser unhomed, jog entre límites y rehomed"
 
-#: src/emc/motion/control.c:1556 src/emc/motion/control.c:1565
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 "Sugerencia: cambie al modo articulacion para jog despues del límite soft"
 
-#: src/emc/motion/control.c:1560
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr "Límite soft POSITIVO excedido (%.5f) en la articulacion %d\n"
@@ -2540,57 +2565,57 @@ msgstr "No jog de articulación %d más allá del límite soft máximo."
 msgid "Can't jog joint %d further past min soft limit."
 msgstr "No jog de articulación %d más allá del límite soft min."
 
-#: src/emc/motion/command.c:208 src/emc/motion/command.c:214
+#: src/emc/motion/command.c:210 src/emc/motion/command.c:216
 #, c-format
 msgid "%s move on line %d would exceed %c's %s limit"
 msgstr "el movimiento %s en la línea %d excedería el límite %s %c"
 
-#: src/emc/motion/command.c:209
+#: src/emc/motion/command.c:211
 msgid "negative"
 msgstr "negativo"
 
-#: src/emc/motion/command.c:215
+#: src/emc/motion/command.c:217
 msgid "positive"
 msgstr "positivo"
 
-#: src/emc/motion/command.c:260
+#: src/emc/motion/command.c:263
 #, c-format
 msgid "%s move on line %d fails kinematicsInverse"
 msgstr "el movimiento %s en la línea %d falla en cinemática Inversa"
 
-#: src/emc/motion/command.c:275
+#: src/emc/motion/command.c:278
 #, c-format
 msgid "%s move on line %d gave non-finite joint location on joint %d"
 msgstr ""
 "El movimiento %s en la línea %d proporcionó una ubicación no finita en la "
 "articulacion %d"
 
-#: src/emc/motion/command.c:282
+#: src/emc/motion/command.c:285
 #, c-format
 msgid "%s move on line %d would exceed joint %d's positive limit"
 msgstr ""
 "el movimiento %s en la línea %d excedería el límite positivo de la "
 "articulacion %d"
 
-#: src/emc/motion/command.c:288
+#: src/emc/motion/command.c:291
 #, c-format
 msgid "%s move on line %d would exceed joint %d's negative limit"
 msgstr ""
 "el movimiento %s en la línea %d excedería el límite negativo de articulacion "
 "%d's"
 
-#: src/emc/motion/command.c:628
+#: src/emc/motion/command.c:627
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 "todas las articulaciones deben estar con home antes de entrar en modo "
 "coordinado"
 
-#: src/emc/motion/command.c:813 src/emc/motion/command.c:909
-#: src/emc/motion/command.c:1011
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr "No se puede mover la articulación cuando no está habilitada."
 
-#: src/emc/motion/command.c:818 src/emc/motion/command.c:1016
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr "No se pueden mover las articulaciones mientras hacen homing."
 
@@ -2598,29 +2623,29 @@ msgstr "No se pueden mover las articulaciones mientras hacen homing."
 msgid "Can't jog any joint while homing."
 msgstr "No se puede mover ninguna articulación mientras se hace homing."
 
-#: src/emc/motion/command.c:1098
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr "necesita estar habilitado en modo coord para movimiento lineal"
 
-#: src/emc/motion/command.c:1103
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr "parámetros inválidos en comando lineal"
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr "no se puede hacer movimiento lineal con límites excedidos"
 
-#: src/emc/motion/command.c:1133
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 "no se puede agregar movimiento lineal en la línea %d, código de error %d"
 
-#: src/emc/motion/command.c:1160
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr "necesita estar habilitado, en modo coord para movimiento circular"
 
-#: src/emc/motion/command.c:1170
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr "no se puede hacer movimiento circular con límites excedidos"
 
@@ -2652,212 +2677,257 @@ msgstr "Homing negado por motion.homing-inhibit joint=%d\n"
 msgid "homing sequence already in progress"
 msgstr "secuencia homing en progreso"
 
-#: src/emc/motion/command.c:1522
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr "debe estar en modo articulacion o deshabilitado para unhome"
 
-#: src/emc/motion/command.c:1534 src/emc/motion/command.c:1557
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr "No se puede hacer unhome mientras se hace homing, articulación %d"
 
-#: src/emc/motion/command.c:1538 src/emc/motion/command.c:1561
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr "No se puede hacer unhome mientras se mueve, articulacion %d"
 
-#: src/emc/motion/command.c:1566
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
+#, fuzzy, c-format
+msgid "Cannot unhome extrajoint <%d> with motion enabled"
+msgstr "No se puede mover la articulación cuando no está habilitada."
+
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr "No se puede hacer unhome en articulacion inactiva %d"
 
-#: src/emc/motion/command.c:1570
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr "No se puede hacer unhome en articulacion inválida %d (max %d)"
 
-#: src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr "necesita estar habilitado, en modo coord para mover la sonda"
 
-#: src/emc/motion/command.c:1598
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr "no se puede mover la sonda con los límites excedidos"
 
-#: src/emc/motion/command.c:1612
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr "La sonda ya está libre al iniciar el movimiento G38.4 o G38.5"
 
-#: src/emc/motion/command.c:1614
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr "La sonda ya está disparada al iniciar el movimiento G38.2 o G38.3"
 
-#: src/emc/motion/command.c:1626
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr "no se puede agregar movimiento de sonda"
 
-#: src/emc/motion/command.c:1648
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 "necesita estar habilitado, en modo coord para el movimiento de roscado rígido"
 
-#: src/emc/motion/command.c:1658
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 "no se puede hacer un movimiento de roscado rígido con límites excedidos"
 
-#: src/emc/motion/command.c:1670
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 "no se puede agregar un movimiento de roscado rígido en la línea %d, código "
 "de error %d"
 
-#: src/emc/motion/command.c:1712
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr "Intento de iniciar un husillo inexistente"
 
-#: src/emc/motion/command.c:1760
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr "Intento de detener el husillo inexistente <%d>"
 
-#: src/emc/motion/command.c:1790
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr "Intento de orientar el husillo inexistente <%d>"
 
-#: src/emc/motion/command.c:1836
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr "Intento de aumentar revs. en husillo inexistente <%d>"
 
-#: src/emc/motion/command.c:1859
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr "Intento de disminuir revs. en husillo inexistente <%d>"
 
-#: src/emc/motion/command.c:1874
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr "Intento de activar el freno de husillo inexistente <%d>"
 
-#: src/emc/motion/command.c:1896
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr "Intento de liberar el freno de husillo inexistente <%d>"
 
-#: src/emc/motion/command.c:1918
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr "articulacion %d: demasiadas entradas de compensación"
 
-#: src/emc/motion/command.c:1924
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr "articulacion %d: los valores de compensación deben aumentar"
 
-#: src/emc/motion/command.c:2002
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr "comando no reconocido %d"
 
-#: src/emc/motion/motion.c:154
+#: src/emc/motion/motion.c:162
 msgid "all joints must be homed before going into teleop mode"
 msgstr "todas las articulaciones deben estar en homed antes del modo teleop"
 
-#: src/emc/motion/motion.c:210
+#: src/emc/motion/motion.c:218
 msgid "MOTION: hal_init() failed\n"
 msgstr "MOTION: hal_init() falló\n"
 
-#: src/emc/motion/motion.c:215
+#: src/emc/motion/motion.c:223
 #, c-format
 msgid "MOTION: num_joints is %d, must be between 1 and %d\n"
 msgstr "MOTION: num_joints es %d, debe estar entre 1 y %d\n"
 
-#: src/emc/motion/motion.c:222
+#: src/emc/motion/motion.c:230
+#, fuzzy, c-format
+msgid ""
+"\n"
+"MOTION: num_extrajoints is %d, must be between 0 and %d\n"
+"\n"
+msgstr "MOTION: num_joints es %d, debe estar entre 1 y %d\n"
+
+#: src/emc/motion/motion.c:235
+msgid ""
+"\n"
+"MOTION: nonzero num_extrajoints requires KINEMATICS_BOTH\n"
+"\n"
+msgstr ""
+
+#: src/emc/motion/motion.c:240
+#, c-format
+msgid ""
+"\n"
+"MOTION: kinematicjoints=%2d\n"
+"            extrajoints=%2d\n"
+"           Total joints=%2d\n"
+"\n"
+msgstr ""
+
+#: src/emc/motion/motion.c:247
 #, c-format
 msgid "MOTION: num_spindles is %d, must be between 0 and %d\n"
 msgstr "MOTION: nº husillos es %d, debe estar entre 0 y %d\n"
 
-#: src/emc/motion/motion.c:230
+#: src/emc/motion/motion.c:255
 #, c-format
 msgid "MOTION: num_dio is %d, must be between 1 and %d\n"
 msgstr "MOTION: num_dio es %d, debe estar entre 1 y %d\n"
 
-#: src/emc/motion/motion.c:237
+#: src/emc/motion/motion.c:262
 #, c-format
 msgid "MOTION: num_aio is %d, must be between 1 and %d\n"
 msgstr "MOTION: num_aio es %d, debe estar entre 1 y %d\n"
 
-#: src/emc/motion/motion.c:245
+#: src/emc/motion/motion.c:270
 msgid "MOTION: init_hal_io() failed\n"
 msgstr "MOTION: init_hal_io() falló\n"
 
-#: src/emc/motion/motion.c:253
+#: src/emc/motion/motion.c:278
 msgid "MOTION: init_comm_buffers() failed\n"
 msgstr "MOTION: init_comm_buffers() falló\n"
 
-#: src/emc/motion/motion.c:261
+#: src/emc/motion/motion.c:286
 msgid "MOTION: init_threads() failed\n"
 msgstr "MOTION: init_threads() falló\n"
 
-#: src/emc/motion/motion.c:286
+#: src/emc/motion/motion.c:311
 #, c-format
 msgid "MOTION: hal_stop_threads() failed, returned %d\n"
 msgstr "MOTION: hal_stop_threads() falló, devolvió %d\n"
 
-#: src/emc/motion/motion.c:292
+#: src/emc/motion/motion.c:317
 #, c-format
 msgid "MOTION: rtapi_shmem_delete() failed, returned %d\n"
 msgstr "MOTION: rtapi_shmem_delete() falló, devolvió %d\n"
 
-#: src/emc/motion/motion.c:298
+#: src/emc/motion/motion.c:323
 #, c-format
 msgid "MOTION: hal_exit() failed, returned %d\n"
 msgstr "MOTION: hal_exit() falló, devolvió %d\n"
 
-#: src/emc/motion/motion.c:321
+#: src/emc/motion/motion.c:347
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr "MOTION: falló malloc emcmot_hal_data\n"
 
-#: src/emc/motion/motion.c:450
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr "MOTION: error en la exportación del pin husillo %d"
 
-#: src/emc/motion/motion.c:462
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr "MOTION: falló la exportación pin/param articulacion %d\n"
 
-#: src/emc/motion/motion.c:503
+#: src/emc/motion/motion.c:505
+#, fuzzy
+msgid "MOTION: export_joint_home_pins failed\n"
+msgstr "MOTION: init_hal_io() falló\n"
+
+#: src/emc/motion/motion.c:513
+#, fuzzy, c-format
+msgid "MOTION: ejoint %d pin/param export failed\n"
+msgstr "MOTION: falló la exportación pin/param articulacion %d\n"
+
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr "MOTION: falló la exportación pin/param del eje %c\n"
 
-#: src/emc/motion/homing.c:93
+#: src/emc/motion/homing.c:163
 #, c-format
 msgid "hit limit in home state %d"
 msgstr "alcanzado límite en estado home %d"
 
-#: src/emc/motion/homing.c:103
+#: src/emc/motion/homing.c:173
 #, c-format
 msgid "end of move in home state %d"
 msgstr "fin del movimiento en estado home %d"
 
-#: src/emc/motion/homing.c:300
+#: src/emc/motion/homing.c:231
+#, fuzzy
+msgid "HOMING: all_joints_home_data_t malloc failed\n"
+msgstr "MOTION: falló malloc emcmot_hal_data\n"
+
+#: src/emc/motion/homing.c:565
 #, c-format
 msgid "unknown state '%d' during homing sequence"
 msgstr "estado desconocido '%d' durante la secuencia homing"
 
-#: src/emc/motion/homing.c:362
+#: src/emc/motion/homing.c:628
 #, c-format
 msgid "Cannot home while shared home switch is closed j=%d"
 msgstr ""
 "No se puede hacer home mientras el interruptor compartido está cerrado a=%d"
 
-#: src/emc/motion/homing.c:422
+#: src/emc/motion/homing.c:688
 msgid ""
 "invalid homing config: non-zero LATCH_VEL needs either SEARCH_VEL or "
 "USE_INDEX"
@@ -2865,35 +2935,35 @@ msgstr ""
 "configuración homing no válida: LATCH_VEL distinto de cero necesita "
 "SEARCH_VEL o USE_INDEX"
 
-#: src/emc/motion/homing.c:431
+#: src/emc/motion/homing.c:697
 msgid "invalid homing config: non-zero SEARCH_VEL needs LATCH_VEL"
 msgstr ""
 "configuración homing inválida: SEARCH_VEL distinto de cero necesita LATCH_VEL"
 
-#: src/emc/motion/homing.c:579
+#: src/emc/motion/homing.c:845
 #, c-format
 msgid "Home switch inactive before start of backoff move j=%d"
 msgstr ""
 "Interruptor home inactivo antes del inicio del movimiento de retroceso a=%d"
 
-#: src/emc/motion/homing.c:628
+#: src/emc/motion/homing.c:894
 #, c-format
 msgid "Home switch active before start of latch move j=%d"
 msgstr "Interruptor home activo antes del inicio del movimiento de latch a=%d"
 
-#: src/emc/motion/homing.c:685
+#: src/emc/motion/homing.c:951
 #, c-format
 msgid "Home switch inactive before start of latch move j=%d"
 msgstr ""
 "Interruptor de inicio inactivo antes del inicio del movimiento de retención "
 "j=%d"
 
-#: src/emc/motion/homing.c:924
+#: src/emc/motion/homing.c:1202
 #, c-format
 msgid "hit limit in home state j=%d"
 msgstr "alcanzado límite en  estado home a=%d"
 
-#: src/emc/motion/homing.c:981
+#: src/emc/motion/homing.c:1259
 #, c-format
 msgid "unknown state '%d' during homing j=%d"
 msgstr "estado desconocido '%d' durante homing a=%d"
@@ -2951,7 +3021,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:337 tcl/tklinuxcnc.tcl:1547
 #: src/emc/usr_intf/stepconf/main_page.glade:292
-#: src/emc/usr_intf/pncconf/dialogs.glade:3683
+#: src/emc/usr_intf/pncconf/dialogs.glade:3739
 #: src/emc/usr_intf/gscreen/gscreen.glade:2660
 msgid "Run"
 msgstr "Ejecutar"
@@ -3013,7 +3083,7 @@ msgstr "Error al cargar el archivo del proyecto..."
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1549
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr "Aceptar"
 
@@ -3105,21 +3175,21 @@ msgid "Okay"
 msgstr "Bien"
 
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
-#: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:153
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:568
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "Sí"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
-#: src/emc/usr_intf/axis/scripts/axis.py:153
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/axis/scripts/axis.py:163
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr "No"
 
@@ -3173,7 +3243,7 @@ msgstr "Cargar"
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2247
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "Guardar"
 
@@ -3191,7 +3261,7 @@ msgstr "Vars"
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "Editor"
 
@@ -3204,8 +3274,7 @@ msgstr "Símbolos"
 msgid "Config"
 msgstr "Config"
 
-#: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1333
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
+#: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
 msgid "Preview"
 msgstr "Vista previa"
 
@@ -3537,7 +3606,7 @@ msgstr "Base"
 
 #: src/hal/classicladder/edit.c:164 src/hal/classicladder/edit.c:173
 #: src/hal/classicladder/edit.c:181 src/hal/classicladder/edit.c:190
-#: src/emc/usr_intf/stepconf/pport1.glade:953
+#: src/emc/usr_intf/stepconf/pport1.glade:1303
 msgid "Preset"
 msgstr "Preset"
 
@@ -3637,7 +3706,7 @@ msgid "Edit mode..."
 msgstr "Modo Edición..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -3646,7 +3715,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr "¿Realmente quieres eliminar el escalon actual?"
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "Agregar"
 
@@ -3657,6 +3726,24 @@ msgstr "Insertar"
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "Modificar"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Cancelar"
 
 #: src/hal/classicladder/edit_sequential.c:68
 msgid "Step Nbr"
@@ -3846,7 +3933,7 @@ msgid "Parameter"
 msgstr "Parámetro"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr "Aplicar"
 
@@ -3871,8 +3958,8 @@ msgid "None -Internal Error Status"
 msgstr "Ninguno - Estado de error interno"
 
 #: src/hal/classicladder/emc_mods.c:128
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:616
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:629
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:625
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:638
 #: src/emc/usr_intf/touchy/emc_interface.py:442
 #: src/emc/usr_intf/pncconf/base.glade:508
 msgid "None"
@@ -4035,7 +4122,6 @@ msgstr "Escalera"
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "Principal"
 
@@ -4113,11 +4199,13 @@ msgid "Delete section"
 msgstr "Eliminar sección"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr "Subir"
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Down"
 msgstr "Mover hacia abajo"
 
@@ -4311,8 +4399,8 @@ msgstr "Serie"
 
 #: src/hal/classicladder/socket_modbus_master.c:124
 #: src/emc/usr_intf/pncconf/dialogs.glade:36
-#: src/emc/usr_intf/pncconf/dialogs.glade:278
 #: src/emc/usr_intf/pncconf/dialogs.glade:304
+#: src/emc/usr_intf/pncconf/dialogs.glade:330
 msgid "Ethernet"
 msgstr "Ethernet"
 
@@ -4632,7 +4720,7 @@ msgstr "NML"
 msgid "Motion time"
 msgstr "Tiempo de movimiento"
 
-#: tcl/bin/emcdebug.tcl:193 src/emc/usr_intf/axis/scripts/debuglevel.py:42
+#: tcl/bin/emcdebug.tcl:193 src/emc/usr_intf/axis/scripts/debuglevel.py:48
 msgid "Interpreter"
 msgstr "Intérprete"
 
@@ -4662,6 +4750,7 @@ msgid "Exit"
 msgstr "Salir"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "Editar"
 
@@ -4704,7 +4793,6 @@ msgid "Renumber File..."
 msgstr "Renumerar archivo..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "Configuraciones"
 
@@ -4993,15 +5081,15 @@ msgstr "Vista de árbol"
 msgid "Test HAL command :"
 msgstr "Probar comando HAL:"
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr "Cargar una lista de vigilancia"
 
-#: tcl/bin/halshow.tcl:535
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr "Guardar lista de vigilancia actual"
 
-#: tcl/bin/halshow.tcl:559
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "Los comandos pueden probarse aquí pero NO se guardarán"
 
@@ -5132,11 +5220,11 @@ msgstr "DIRECCIÓN"
 msgid "SIZE :"
 msgstr "TAMAÑO:"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr "Errores de LinuxCNC"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
@@ -5144,11 +5232,11 @@ msgstr ""
 "LinuxCNC finalizó con un error. Al informar sobre problemas, cree un archivo "
 "de informe e incluya su mensaje."
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 msgid "Create Report File"
 msgstr "Crear archivo de informe"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "Cerrar"
 
@@ -5227,8 +5315,8 @@ msgstr "Establecer offset de herramienta"
 msgid "Tool:"
 msgstr "Herramienta:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2168
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:759
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Todos los archivos"
 
@@ -5286,7 +5374,7 @@ msgstr "Depurar..."
 msgid "Font..."
 msgstr "Fuente..."
 
-#: tcl/tklinuxcnc.tcl:783 src/emc/usr_intf/axis/scripts/image-to-gcode.py:670
+#: tcl/tklinuxcnc.tcl:783 src/emc/usr_intf/axis/scripts/image-to-gcode.py:679
 msgid "Units"
 msgstr "Unidades"
 
@@ -5294,18 +5382,18 @@ msgstr "Unidades"
 msgid "auto"
 msgstr "auto"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:511
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "pulgadas"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1705
-#: src/emc/usr_intf/axis/scripts/axis.py:1985
-#: src/emc/usr_intf/axis/scripts/axis.py:2556
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1404
-#: src/emc/usr_intf/stepconf/pages.py:785
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:506
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5317,7 +5405,7 @@ msgstr "pulgadas"
 #: src/emc/usr_intf/pncconf/z_motor.glade:1660
 #: src/emc/usr_intf/pncconf/a_motor.glade:1591
 #: src/emc/usr_intf/pncconf/a_motor.glade:1660
-#: src/emc/usr_intf/pncconf/dialogs.glade:3521
+#: src/emc/usr_intf/pncconf/dialogs.glade:3577
 msgid "mm"
 msgstr "mm"
 
@@ -5462,7 +5550,7 @@ msgstr "articulación"
 msgid "world"
 msgstr "universal"
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "home"
 
@@ -5502,7 +5590,7 @@ msgstr "Velocidad de jog lineal"
 msgid "Angular Jog Speed (deg)/min:"
 msgstr "Velocidad angular de jog (grados)/min:"
 
-#: tcl/tklinuxcnc.tcl:1465 share/axis/tcl/axis.tcl:1511
+#: tcl/tklinuxcnc.tcl:1465 share/axis/tcl/axis.tcl:1491
 msgid "Feed Override:"
 msgstr "Ajustar Avance:"
 
@@ -5522,7 +5610,7 @@ msgstr "Programa:"
 msgid "  -  Status: "
 msgstr "  - Estado: "
 
-#: tcl/tklinuxcnc.tcl:1548 src/emc/usr_intf/pncconf/dialogs.glade:3601
+#: tcl/tklinuxcnc.tcl:1548 src/emc/usr_intf/pncconf/dialogs.glade:3657
 #: src/emc/usr_intf/gscreen/gscreen.glade:2673
 msgid "Pause"
 msgstr "Pausa"
@@ -5543,16 +5631,15 @@ msgstr "Verificar"
 msgid "Optional Stop"
 msgstr "Parada opcional"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "Establecer fuente"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "Fuente"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "Tamaño"
 
@@ -5564,11 +5651,11 @@ msgstr "Estilo"
 msgid "MANUAL"
 msgstr "MANUAL"
 
-#: tcl/tklinuxcnc.tcl:2086 share/axis/tcl/axis.tcl:1788
+#: tcl/tklinuxcnc.tcl:2086 share/axis/tcl/axis.tcl:1771
 msgid "ESTOP"
 msgstr "ESTOP"
 
-#: tcl/tklinuxcnc.tcl:2088 tcl/ngcgui.tcl:2991 share/axis/tcl/axis.tcl:1790
+#: tcl/tklinuxcnc.tcl:2088 tcl/ngcgui.tcl:2991 share/axis/tcl/axis.tcl:1773
 msgid "ON"
 msgstr "ON"
 
@@ -5661,7 +5748,7 @@ msgid "Coordinate System Control Window"
 msgstr "Ventana de control del sistema de coordenadas"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3567
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "Eje"
 
@@ -6079,7 +6166,7 @@ msgstr "Debería actualizar linuxcnc >= linuxcnc2.5"
 msgid "pre2.4_send_file_to_axis:error"
 msgstr "pre2.4_send_file_to_axis:error"
 
-#: tcl/ngcgui.tcl:2990 share/axis/tcl/axis.tcl:1789
+#: tcl/ngcgui.tcl:2990 share/axis/tcl/axis.tcl:1772
 msgid "OFF"
 msgstr "APAGADO"
 
@@ -6215,9 +6302,9 @@ msgstr "eliminar"
 msgid "move"
 msgstr "mover"
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3846
-#: src/emc/usr_intf/pncconf/pncconf.py:3952
-#: src/emc/usr_intf/pncconf/pncconf.py:4112
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr "Personalizado"
 
@@ -6237,8 +6324,8 @@ msgstr "Se encontraron múltiples coincidencias para"
 msgid "using path"
 msgstr "usando la ruta"
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2617
-#: src/emc/usr_intf/axis/scripts/axis.py:2644
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr "Advertencia"
 
@@ -6312,119 +6399,119 @@ msgstr "archivo ini"
 msgid "not found"
 msgstr "no encontrado"
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr "encontró truetype-tracer v4 -OK"
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr "Se requiere truetype-tracer v4"
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr "Nota: se requiere truetype-tracer v4"
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr "ngcgui_app.tcl debe cargarse antes"
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr "Crear un archivo de subrutina desde truetype-tracer (V4 requerido)"
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr "problema con"
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr "No hay entrada para"
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr "versión incorrecta de truetype-tracer"
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr "no escribible, usando"
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr "y configurando expandsub"
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr "Texto"
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr "Escala de línea"
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr "ninguno"
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr "Subdiv"
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr "predeterminado"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr "Modo"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr "normal"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr "fecha"
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr "nombre de fuente"
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr "Interruptores"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr "Unicode"
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr "Permitir rotación"
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr "Crear subfile compatible con ngcgui y una nueva pestaña"
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr "Texto nulo"
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr "Usando la fuente predeterminada truetype-tracer"
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 msgid "no such file"
 msgstr "no existe tal archivo"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr "archivo no legible"
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr "Creando una nueva pestaña"
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
@@ -6432,35 +6519,27 @@ msgstr ""
 "requiere comando inifindall\n"
 "de axis.py (LinuxCNC 2.5) o"
 
-#: tcl/ngcgui_app.tcl:55
-msgid "Substituting"
-msgstr "Sustituir"
-
-#: tcl/ngcgui_app.tcl:55
-msgid "for"
-msgstr "para"
-
-#: tcl/ngcgui_app.tcl:59
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr "no legible"
 
-#: tcl/ngcgui_app.tcl:65 tcl/ngcgui_app.tcl:68
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr "Inesperado: múltiples inicios para ngcgui"
 
-#: tcl/ngcgui_app.tcl:66
+#: tcl/ngcgui_app.tcl:50
 msgid "LinuxCNC"
 msgstr "LinuxCNC"
 
-#: tcl/ngcgui_app.tcl:67
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr "para linuxCNC 2.5.xxx, No incluya tkapp.py en el archivo ini"
 
-#: tcl/ngcgui_app.tcl:86
+#: tcl/ngcgui_app.tcl:70
 msgid "LinuxCNC version"
 msgstr "Versión de LinuxCNC"
 
-#: tcl/ngcgui_app.tcl:87
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr "para LinuxCNC 2.5.xxx, No incluya tkapp.py en el archivo ini"
 
@@ -6758,401 +6837,401 @@ msgstr "Los nombres de columna permitidos son: %s"
 msgid "Missing filename"
 msgstr "Falta el nombre de archivo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:152
+#: src/emc/usr_intf/axis/scripts/axis.py:162
 msgid "Do you really want to close LinuxCNC?"
 msgstr "¿Realmente quiere cerrar LinuxCNC?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:153
+#: src/emc/usr_intf/axis/scripts/axis.py:163
 msgid "Confirm Close"
 msgstr "Confirmar Cierre"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:177
+#: src/emc/usr_intf/axis/scripts/axis.py:187
 msgid "Emergency stop"
 msgstr "Parada de Emergencia"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:178
+#: src/emc/usr_intf/axis/scripts/axis.py:188
 msgid "Turn machine on"
 msgstr "Máquina ON / OFF"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:180
+#: src/emc/usr_intf/axis/scripts/axis.py:190
 msgid "Activate first axis"
 msgstr "Activar primer eje"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:181
+#: src/emc/usr_intf/axis/scripts/axis.py:191
 msgid "Activate second axis"
 msgstr "Activar segundo eje"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:182
+#: src/emc/usr_intf/axis/scripts/axis.py:192
 msgid "Activate third axis"
 msgstr "Activar tercer eje"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:183
+#: src/emc/usr_intf/axis/scripts/axis.py:193
 msgid "Activate fourth axis"
 msgstr "Activar cuarto eje"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:184
+#: src/emc/usr_intf/axis/scripts/axis.py:194
 msgid "Activate first through ninth joint"
 msgstr "Activar de primera a novena articulación"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:185
+#: src/emc/usr_intf/axis/scripts/axis.py:195
 msgid "if joints radiobuttons visible"
 msgstr "si botones radio de articulaciones son visibles"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:186
+#: src/emc/usr_intf/axis/scripts/axis.py:196
 msgid "Set Feed Override from 0% to 100%"
 msgstr "Establecer ajuste de avance de 0% a 100%"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:187
+#: src/emc/usr_intf/axis/scripts/axis.py:197
 msgid "if axes radiobuttons visible"
 msgstr "si los botones de radio de los ejes son visibles"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:188
+#: src/emc/usr_intf/axis/scripts/axis.py:198
 msgid ", and ."
 msgstr ", y . "
 
-#: src/emc/usr_intf/axis/scripts/axis.py:188
+#: src/emc/usr_intf/axis/scripts/axis.py:198
 msgid "Select jog speed"
 msgstr "Seleccionar velocidad de jog"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:189
+#: src/emc/usr_intf/axis/scripts/axis.py:199
 msgid "< and >"
 msgstr "< y >"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:189
+#: src/emc/usr_intf/axis/scripts/axis.py:199
 msgid "Select angular jog speed"
 msgstr "Seleccionar velocidad de jog angular"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:190
+#: src/emc/usr_intf/axis/scripts/axis.py:200
 msgid "I, Shift-I"
 msgstr "I, Shift-I"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:190 share/axis/tcl/axis.tcl:2281
+#: src/emc/usr_intf/axis/scripts/axis.py:200 share/axis/tcl/axis.tcl:2269
 msgid "Select jog increment"
 msgstr "Seleccionar incremento de jog"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:191
+#: src/emc/usr_intf/axis/scripts/axis.py:201
 msgid "Continuous jog"
 msgstr "Jog continuo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:192
+#: src/emc/usr_intf/axis/scripts/axis.py:202
 msgid "Home"
 msgstr "Inicio"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:192
+#: src/emc/usr_intf/axis/scripts/axis.py:202
 msgid "Send active joint home"
 msgstr "Hacer home en articulación activa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:193
+#: src/emc/usr_intf/axis/scripts/axis.py:203
 msgid "Ctrl-Home"
 msgstr "Ctrl-Inicio"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:193
+#: src/emc/usr_intf/axis/scripts/axis.py:203
 msgid "Home all joints"
 msgstr "Home de todas las articulaciones"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:194
+#: src/emc/usr_intf/axis/scripts/axis.py:204
 msgid "Shift-Home"
 msgstr "Shift-Inicio"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:194
+#: src/emc/usr_intf/axis/scripts/axis.py:204
 msgid "Zero G54 offset for active axis"
 msgstr "Offset cero G54 para eje activo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:195
+#: src/emc/usr_intf/axis/scripts/axis.py:205
 msgid "End"
 msgstr "Fin"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:195
+#: src/emc/usr_intf/axis/scripts/axis.py:205
 msgid "Set G54 offset for active axis"
 msgstr "Establecer el offset G54 para el eje activo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:196
+#: src/emc/usr_intf/axis/scripts/axis.py:206
 msgid "Ctrl-End"
 msgstr "Ctrl-Fin"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:196
+#: src/emc/usr_intf/axis/scripts/axis.py:206
 msgid "Set tool offset for loaded tool"
 msgstr "Establecer offset de herramienta para herramienta cargada"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:197
+#: src/emc/usr_intf/axis/scripts/axis.py:207
 msgid "Jog active axis or joint"
 msgstr "Jog eje o articulación activo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:198
+#: src/emc/usr_intf/axis/scripts/axis.py:208
 msgid "Select Max velocity"
 msgstr "Seleccionar velocidad máxima"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:201
+#: src/emc/usr_intf/axis/scripts/axis.py:211
 msgid "Left, Right"
 msgstr "Izquierda, Derecha"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:201
+#: src/emc/usr_intf/axis/scripts/axis.py:211
 msgid "Jog first axis or joint"
 msgstr "Jog del primer eje o articulación"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:202
+#: src/emc/usr_intf/axis/scripts/axis.py:212
 msgid "Up, Down"
 msgstr "Arriba, Abajo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:202
+#: src/emc/usr_intf/axis/scripts/axis.py:212
 msgid "Jog second axis or joint"
 msgstr "Jog del segundo eje o articulación"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:203
+#: src/emc/usr_intf/axis/scripts/axis.py:213
 msgid "Pg Up, Pg Dn"
 msgstr "Re Pag, Av Pag"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:203
+#: src/emc/usr_intf/axis/scripts/axis.py:213
 msgid "Jog third axis or joint"
 msgstr "Jog del tercer eje o articulación"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:204
+#: src/emc/usr_intf/axis/scripts/axis.py:214
 msgid "Shift+above jogs"
 msgstr "Mayús + anteriores jog"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:204
+#: src/emc/usr_intf/axis/scripts/axis.py:214
 msgid "Jog at traverse speed"
 msgstr "Jog a velocidad traverse"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:205
+#: src/emc/usr_intf/axis/scripts/axis.py:215
 msgid "Jog fourth axis or joint"
 msgstr "Jog del cuarto eje o articulación"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:208
+#: src/emc/usr_intf/axis/scripts/axis.py:218
 msgid "Toggle between Drag and Rotate mode"
 msgstr "Conmutar Modos Arrastrar / Rotar"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:209
+#: src/emc/usr_intf/axis/scripts/axis.py:219
 msgid "Left Button"
 msgstr "Botón izquierdo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:209
+#: src/emc/usr_intf/axis/scripts/axis.py:219
 msgid "Pan, rotate or select line"
 msgstr "Desplazar, rotar o seleccionar línea"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:210
+#: src/emc/usr_intf/axis/scripts/axis.py:220
 msgid "Shift+Left Button"
 msgstr "Mayús + botón izquierdo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:210
+#: src/emc/usr_intf/axis/scripts/axis.py:220
 msgid "Rotate or pan"
 msgstr "Girar o desplazar"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:211
+#: src/emc/usr_intf/axis/scripts/axis.py:221
 msgid "Right Button"
 msgstr "Botón derecho"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:211
-#: src/emc/usr_intf/axis/scripts/axis.py:213
-#: src/emc/usr_intf/axis/scripts/axis.py:214
+#: src/emc/usr_intf/axis/scripts/axis.py:221
+#: src/emc/usr_intf/axis/scripts/axis.py:223
+#: src/emc/usr_intf/axis/scripts/axis.py:224
 msgid "Zoom view"
 msgstr "Vista de zoom"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:212
+#: src/emc/usr_intf/axis/scripts/axis.py:222
 msgid "Wheel Button"
 msgstr "Botón de rueda"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:212
+#: src/emc/usr_intf/axis/scripts/axis.py:222
 msgid "Rotate view"
 msgstr "Girar vista"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:213
+#: src/emc/usr_intf/axis/scripts/axis.py:223
 msgid "Rotate Wheel"
 msgstr "Girar rueda"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:214
+#: src/emc/usr_intf/axis/scripts/axis.py:224
 msgid "Control+Left Button"
 msgstr "Control + Botón izquierdo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:217
+#: src/emc/usr_intf/axis/scripts/axis.py:227
 msgid "Manual control"
 msgstr "Control manual"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:218
+#: src/emc/usr_intf/axis/scripts/axis.py:228
 msgid "Code entry (MDI)"
 msgstr "Entrada de código (MDI)"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:219
+#: src/emc/usr_intf/axis/scripts/axis.py:229
 msgid "Control-M"
 msgstr "Control-M"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:219
+#: src/emc/usr_intf/axis/scripts/axis.py:229
 msgid "Clear MDI history"
 msgstr "Borrar historial MDI"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:220
+#: src/emc/usr_intf/axis/scripts/axis.py:230
 msgid "Control-H"
 msgstr "Control-H"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:220
+#: src/emc/usr_intf/axis/scripts/axis.py:230
 msgid "Copy selected MDI history elements"
 msgstr "Copiar elementos seleccionados del historial MDI"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:221
+#: src/emc/usr_intf/axis/scripts/axis.py:231
 msgid "to clipboard"
 msgstr "al portapapeles"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:222
+#: src/emc/usr_intf/axis/scripts/axis.py:232
 msgid "Control-Shift-H"
 msgstr "Control-Shift-H"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:222
+#: src/emc/usr_intf/axis/scripts/axis.py:232
 msgid "Paste clipboard to MDI history"
 msgstr "Pegar portapapeles al historial MDI"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:223 share/axis/tcl/axis.tcl:950
+#: src/emc/usr_intf/axis/scripts/axis.py:233 share/axis/tcl/axis.tcl:950
 #: src/emc/usr_intf/touchy/touchy.glade:508
 msgid "Override Limits"
 msgstr "Ajustar Límites"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:225
+#: src/emc/usr_intf/axis/scripts/axis.py:235
 msgid "Open program"
 msgstr "Abrir programa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:226
+#: src/emc/usr_intf/axis/scripts/axis.py:236
 msgid "Control-R"
 msgstr "Control-R"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:226
+#: src/emc/usr_intf/axis/scripts/axis.py:236
 msgid "Reload program"
 msgstr "Recargar Programa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:227
+#: src/emc/usr_intf/axis/scripts/axis.py:237
 msgid "Control-S"
 msgstr "Control-S"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:227
+#: src/emc/usr_intf/axis/scripts/axis.py:237
 msgid "Save g-code as"
 msgstr "Guardar código g como"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:228
+#: src/emc/usr_intf/axis/scripts/axis.py:238
 msgid "Run program"
 msgstr "Ejecutar programa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:229
+#: src/emc/usr_intf/axis/scripts/axis.py:239
 msgid "Step program"
 msgstr "Programa a pasos"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:230
+#: src/emc/usr_intf/axis/scripts/axis.py:240
 msgid "Pause program"
 msgstr "Pausar programa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:231
+#: src/emc/usr_intf/axis/scripts/axis.py:241
 msgid "Resume program"
 msgstr "Reanudar programa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:232
+#: src/emc/usr_intf/axis/scripts/axis.py:242
 msgid "Stop running program, or"
 msgstr "Dejar de ejecutar el programa o"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:233
+#: src/emc/usr_intf/axis/scripts/axis.py:243
 msgid "stop loading program preview"
 msgstr "detener carga de vista previa del programa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:235
+#: src/emc/usr_intf/axis/scripts/axis.py:245
 msgid "Toggle mist"
 msgstr "Conmutar niebla"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:236
+#: src/emc/usr_intf/axis/scripts/axis.py:246
 msgid "Toggle flood"
 msgstr "Conmutar inundación"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:237
+#: src/emc/usr_intf/axis/scripts/axis.py:247
 msgid "Spindle brake off"
 msgstr "Freno de husillo OFF"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:238
+#: src/emc/usr_intf/axis/scripts/axis.py:248
 msgid "Shift-B"
 msgstr "Shift-B"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:238
+#: src/emc/usr_intf/axis/scripts/axis.py:248
 msgid "Spindle brake on"
 msgstr "Freno de husillo ON"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:239
+#: src/emc/usr_intf/axis/scripts/axis.py:249
 msgid "Turn spindle clockwise"
 msgstr "Girar husillo en sentido horario"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:240
+#: src/emc/usr_intf/axis/scripts/axis.py:250
 msgid "Turn spindle counterclockwise"
 msgstr "Girar husillo en sentido antihorario"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:241
+#: src/emc/usr_intf/axis/scripts/axis.py:251
 msgid "Turn spindle more slowly"
 msgstr "Relentizar giro del husillo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:242
+#: src/emc/usr_intf/axis/scripts/axis.py:252
 msgid "Turn spindle more quickly"
 msgstr "Aumentar giro del husillo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:243
+#: src/emc/usr_intf/axis/scripts/axis.py:253
 msgid "Control-K"
 msgstr "Control-K"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:243
+#: src/emc/usr_intf/axis/scripts/axis.py:253
 msgid "Clear live plot"
 msgstr "Borrar plot en vivo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:244
+#: src/emc/usr_intf/axis/scripts/axis.py:254
 msgid "Cycle among preset views"
 msgstr "Ciclo entre vistas preestablecidas"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:245
+#: src/emc/usr_intf/axis/scripts/axis.py:255
 msgid "Cycle among preview, DRO, and user tabs"
 msgstr "Ciclo entre vista previa, DRO y pestañas de usuario"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:246
+#: src/emc/usr_intf/axis/scripts/axis.py:256
 msgid "toggle Actual/Commanded"
 msgstr "Conmutar Actual/Ordenada"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:247
+#: src/emc/usr_intf/axis/scripts/axis.py:257
 msgid "toggle Relative/Machine"
 msgstr "Conmutar Relativa/Máquina"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:248
+#: src/emc/usr_intf/axis/scripts/axis.py:258
 msgid "Ctrl-Space"
 msgstr "Ctrl-Espacio"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:248
+#: src/emc/usr_intf/axis/scripts/axis.py:258
 msgid "Clear notifications"
 msgstr "Borrar notificaciones"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:249
+#: src/emc/usr_intf/axis/scripts/axis.py:259
 msgid "Alt-F, M, V"
 msgstr "Alt-F, M, V"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:249
+#: src/emc/usr_intf/axis/scripts/axis.py:259
 msgid "Open a Menu"
 msgstr "Abrir un menú"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:891
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Herramienta %d desconocida"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:893 share/axis/tcl/axis.tcl:1889
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Sin herramienta"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:895
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Herramienta %(tool)d, offset %(zo)g, diámetro %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:897
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "Herramienta %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1072
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "Filtrando..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1135
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "Error de filtro"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1136
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
@@ -7161,12 +7240,12 @@ msgstr ""
 "El programa %(program)r salió con el código %(code)d. Cualquier mensaje de "
 "error producido se muestran a continuación:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1238
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "Error de código G en %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1239
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7175,130 +7254,128 @@ msgstr ""
 "Cerca de la línea %(seq)d de %(f)s:\n"
 "%(error_str)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1433
-#: src/emc/usr_intf/axis/scripts/axis.py:3189 share/axis/tcl/axis.tcl:922
-#: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2068
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
+#: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
 msgid "Continuous"
 msgstr "Continuo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1696
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr "Tabla de herramientas T"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1706
-#: src/emc/usr_intf/axis/scripts/axis.py:1989
-#: src/emc/usr_intf/axis/scripts/axis.py:2557
-#: src/emc/usr_intf/stepconf/stepconf.py:1418
-#: src/emc/usr_intf/stepconf/pages.py:791
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "in"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1709
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr " radio"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr " diámetro"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1712
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr "°"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1722
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "Sistema de coordenadas:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1740
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr "plantilla"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1741
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr "pieza de trabajo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1762
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "Nombre:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1762
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "Tamaño:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1763
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "Orden de herramienta:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1763
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "Distancia rápidos:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1764
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "Distancia avance:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1764
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "Distancia total:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1765
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "Tiempo de ejecución:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1765
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "Límites X:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1766
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Límites Y:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1766
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Límites Z:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1767
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "Límites A:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1767
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "Límites B:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1768
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "Límites C:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1823
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "El programa excede el mínimo de la máquina en el eje %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1826
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "El programa excede el máximo de la máquina en el eje %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1831
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "El programa excede los límites de la máquina"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1834
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Ejecutar de todos modos"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1967
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "No hay archivos cargados"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1975
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "generado a partir de %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1981
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
@@ -7307,43 +7384,43 @@ msgstr ""
 "%(size)s bytes\n"
 "%(lines)s líneas de gcode"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2007
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr "%.1f minutos"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2009
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr "%d segundos"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2017
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%(a)f a %(b)f = %(diff)f %(units)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2018
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "Propiedades del código G"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2166
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "Todos los archivos de mecanizado"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2167
-#: src/emc/usr_intf/axis/scripts/axis.py:2894
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "Archivos rs274ngc"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2183
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr "el eje no puede aceptar el comando remoto mientras se ejecuta"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2238
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 msgid "File not Writable:"
 msgstr "Archivo no escribible:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2239
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7357,29 +7434,29 @@ msgstr ""
 "o\n"
 "Guárdelo en su propio directorioluego abra ese archivo guardado y grabable"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2246
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr "Editar-solo lectura"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2558
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Custom Grid"
 msgstr "Cuadrícula personalizada"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2558
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr "Ingrese el tamaño de la cuadrícula"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2617
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr "las articulaciones ya tienen home, ¿estás seguro que quiere rehoming?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2632
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr ""
 "home_joint <%s> Usar el modo articulacion para el recorrido de referencia"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2635
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
@@ -7388,37 +7465,32 @@ msgstr ""
 "\n"
 "Referencia de eje individual no permitida para letra duplicada: <%s>"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2644
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 "Esta articulación ya está alojada, ¿estás seguro de que quieres volver a "
 "casa?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2654
-#, python-format
-msgid "unhome_joint <%s> Use joint mode for unhoming"
-msgstr "unhome_joint <%s> Usar el modo articulacion para desconectar"
-
-#: src/emc/usr_intf/axis/scripts/axis.py:2696
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 msgid "Touch Off (system)"
 msgstr "Touch Off (sistema)"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2697
-#: src/emc/usr_intf/axis/scripts/axis.py:2738
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "Ingrese la coordenada %s relativa a %%s:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2737
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, python-format
 msgid "Tool %s TouchOff"
 msgstr "Herramienta %s TouchOff"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2906
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "Error al guardar el archivo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3357
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7431,7 +7503,7 @@ msgstr ""
 "%s\n"
 "Consulte los documentos de 'Configuración INI'\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3370
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7444,7 +7516,7 @@ msgstr ""
 "%s\n"
 "Consulte los documentos de 'Configuración INI'\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3383
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7453,48 +7525,48 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3484
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr "Ejes"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3486
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 msgid "Joints"
 msgstr "Articulaciones"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3488
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "Home Todos"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3490
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "Home todos los %s [Ctrl-Inicio]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3493
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, python-format
 msgid "Home All %s"
 msgstr "Home todos los %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3495
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, python-format
 msgid "Unhome All %s"
 msgstr "Unhome todos los %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3536
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 "Advertencia: la cinemática directa debe manejar letras de coordenadas "
 "duplicadas:%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3539
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr "Nota: el número de [TRAJ]COORDINATES=%(t)s excede [KINS]JOINTS=%(l)d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3571
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
@@ -7503,76 +7575,76 @@ msgstr ""
 "\n"
 "No diezLa referencia de eje individual no se admite actualmente para"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3572
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr "KINEMATICS_IDENTITY con letra de eje duplicada <%s>\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3584
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 msgid "Joint"
 msgstr "articulacion"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 msgid "Home Joint"
 msgstr "Inicio articulacion"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3594
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr "Home %(name)s _%(id)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3596
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "Unhome %(name)s _%(id)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3790
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "Ejecutar desde aquí"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3848
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr "alternar la visibilidad del panel PYVCP"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3850 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr "Mostrar pyVCP pan_el"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4119
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "Error en ~ / .axisrc"
 
-#: src/emc/usr_intf/axis/scripts/linuxcnctop.py:126
+#: src/emc/usr_intf/axis/scripts/linuxcnctop.py:133
 msgid "LinuxCNC Status"
 msgstr "Estado de LinuxCNC"
 
-#: src/emc/usr_intf/axis/scripts/linuxcnctop.py:142
+#: src/emc/usr_intf/axis/scripts/linuxcnctop.py:149
 msgid "Copy All"
 msgstr "Copiar todo"
 
-#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:37
+#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:41
 #, python-format
 msgid "Insert tool %d and click continue when ready"
 msgstr "Inserte la herramienta %d y haga clic en continuar cuando esté listo"
 
-#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:39
+#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:43
 msgid "Remove the tool and click continue when ready"
 msgstr "Retire la herramienta y haga clic en continuar cuando esté listo"
 
-#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:45
+#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:49
 #: src/emc/usr_intf/touchy/mdi.py:49 src/emc/usr_intf/gscreen/mdi.py:49
 msgid "Tool change"
 msgstr "Cambio de herramienta"
 
-#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:45
+#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:49
 msgid "Continue"
 msgstr "Continuar"
 
-#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:64
+#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:73
 msgid "AXIS Manual Toolchanger"
 msgstr "Cambiador de herramientas manual de AXIS"
 
-#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:68
+#: src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py:77
 msgid ""
 "This window is part of the AXIS manual toolchanger.  It is safe to close or "
 "iconify this window, or it will close automatically after a few seconds."
@@ -7581,16 +7653,16 @@ msgstr ""
 "seguro cerrar o iconificar esta ventana, o se cerrará automáticamente "
 "después de unos segundos."
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:512
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:521
 #, python-format
 msgid "%s: Image to gcode"
 msgstr "%s: imagen a gcode"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:513
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:522
 msgid "Image to gcode"
 msgstr "Imagen para gcode"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:523
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:532
 #, python-format
 msgid ""
 "Image size: %(w)d x %(h)d pixels\n"
@@ -7601,207 +7673,212 @@ msgstr ""
 "Valor mínimo de píxel: %(min)d\n"
 "Valor máximo de píxel: %(max)d"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:613
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:622
 msgid "G20 (in)"
 msgstr "G20 (en)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:613
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:622
 msgid "G21 (mm)"
 msgstr "G21 (mm)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:616
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:625
 msgid "White"
 msgstr "Blanco"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:616
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:625
 msgid "Black"
 msgstr "negro"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:622
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:631
 msgid "Rows"
 msgstr "Filas"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:622
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:631
 msgid "Columns"
 msgstr "Columnas"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:622
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:631
 msgid "Rows then Columns"
 msgstr "Filas y luego columnas"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:622
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:631
 msgid "Columns then Rows"
 msgstr "Columnas luego filas"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:623
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:632
 msgid "Positive"
 msgstr "Positivo"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:623
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:632
 msgid "Negative"
 msgstr "Negativo"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:623
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:632
 msgid "Alternating"
 msgstr "Alternando"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:623
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:632
 msgid "Up Milling"
 msgstr "Fresado arriba"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:623
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:632
 msgid "Down Milling"
 msgstr "Fresado descendente"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:628
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:637
 msgid "Ball End"
 msgstr "Ball End"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:628
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:637
 msgid "Flat End"
 msgstr "extremo plano"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:628
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:637
 msgid "30 Degree"
 msgstr "30 grados"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:628
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:637
 msgid "45 Degree"
 msgstr "45 grados"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:628
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:637
 msgid "60 Degree"
 msgstr "60 grados"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:629
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:638
 msgid "Secondary"
 msgstr "Secundario"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:629
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:638
 msgid "Full"
 msgstr "Completo"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:659
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:668
 msgid "Invert Image"
 msgstr "Invertir imagen"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:660
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:669
 msgid "Normalize Image"
 msgstr "Normalizar imagen"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:661
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:670
 msgid "Extend Image Border"
 msgstr "Extender borde de imagen"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:662
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:671
 msgid "Pixel Size (Units)"
 msgstr "Tamaño de píxel (unidades)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:663
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:672
 msgid "Depth (units)"
 msgstr "Profundidad (unidades)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:664
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:673
 msgid "Tolerance (units)"
 msgstr "Tolerancia (unidades)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:665
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:674
 msgid "Stepover (pixels)"
 msgstr "Stepover (píxeles)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:666
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:675
 msgid "Tool Diameter (units)"
 msgstr "Diámetro de herramienta (unidades)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:667
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:676
 msgid "Tool Type"
 msgstr "Tipo de herramienta"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:668
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:677
 msgid "Feed Rate (units per minute)"
 msgstr "Velocidad de avance (unidades por minuto)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:669
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:678
 msgid "Plunge Feed Rate (units per minute)"
 msgstr "Velocidad de avance de inmersión (unidades por minuto)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:671
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:680
 msgid "Safety Height (units)"
 msgstr "Altura de seguridad (unidades)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:672
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:681
 msgid "Scan Pattern"
 msgstr "Patrón de escaneo"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:673
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:682
 msgid "Scan Direction"
 msgstr "Dirección de escaneo"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:674
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:683
 msgid "Lace Bounding"
 msgstr "Encaje de encaje"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:675
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:684
 msgid "Contact Angle (degrees)"
 msgstr "Ángulo de contacto (grados)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:676
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:685
 msgid "Spindle Speed (RPM)"
 msgstr "Velocidad del husillo (RPM)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:677
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:686
 msgid "Roughing offset (units, 0=no roughing)"
 msgstr "offset de desbaste (unidades, 0 = sin desbaste)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:678
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:687
 msgid "Roughing depth per pass (units)"
 msgstr "Profundidad de desbaste por pasada (unidades)"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:745
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:754
 msgid "image-to-gcode: User pressed cancel"
 msgstr "image-to-gcode: el usuario presionó cancelar"
 
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:758
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:773
 msgid "Depth images"
 msgstr "Imágenes de profundidad"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:22
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:28
 msgid "LinuxCNC Debug Level"
 msgstr "Nivel de depuración LinuxCNC"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:23
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:29
 msgid "debuglevel"
 msgstr "debuglevel"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:36
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:42
 msgid "Configuration *"
 msgstr "Configuración *"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:37
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:43
 msgid "Version Numbers *"
 msgstr "Números de versión *"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:38
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:44
 msgid "NML *"
 msgstr "NML *"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:39
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:45
 msgid "RCS *"
 msgstr "RCS *"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:40
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:46
 msgid "Task Issue"
 msgstr "Problema con Task"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:41
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:47
 msgid "Motion Time"
 msgstr "Tiempo de movimiento"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:43
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:49
 msgid "Interpreter List"
 msgstr "Lista de intérpretes"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:47
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:50
+#, fuzzy
+msgid "State Tags"
+msgstr "Estado"
+
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:54
 #, python-format
 msgid ""
 "Inifile setting for this debug level:\n"
@@ -7809,7 +7886,7 @@ msgid ""
 msgstr ""
 "Configuración de archivo para este nivel de depuración:[EMC]DEBUG=0x%08x"
 
-#: src/emc/usr_intf/axis/scripts/debuglevel.py:81
+#: src/emc/usr_intf/axis/scripts/debuglevel.py:88
 msgid "  * This option can only be enabled in the inifile"
 msgstr "* Esta opción solo se puede habilitar en el archivo"
 
@@ -7846,11 +7923,13 @@ msgid "_Properties..."
 msgstr "_Propiedades..."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "Editar _tabla herramientas..."
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+#, fuzzy
+msgid "Reload tool _data"
 msgstr "Recargar ta_bla de herramientas"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8177,11 +8256,11 @@ msgstr "Conmutar salto de lineas con '/' [Alt-M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "Alternar pausa opcional [Alt-M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "Acercar"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "Alejar"
 
@@ -8225,8 +8304,8 @@ msgstr "Control manual [F3]"
 msgid "MDI [F5]"
 msgstr "MDI [F5]"
 
-#: share/axis/tcl/axis.tcl:835 share/axis/tcl/axis.tcl:1940
-#: share/axis/tcl/axis.tcl:2127
+#: share/axis/tcl/axis.tcl:835 share/axis/tcl/axis.tcl:1923
+#: share/axis/tcl/axis.tcl:2110
 msgid "Axis:"
 msgstr "Ejes:"
 
@@ -8249,14 +8328,14 @@ msgstr "Husillo:"
 #: share/axis/tcl/axis.tcl:1068 src/emc/usr_intf/touchy/touchy.glade:946
 #: src/emc/usr_intf/stepconf/main_page.glade:29
 #: src/emc/usr_intf/pncconf/main_page.glade:41
-#: src/emc/usr_intf/pncconf/dialogs.glade:3236
+#: src/emc/usr_intf/pncconf/dialogs.glade:3292
 #: src/emc/usr_intf/gscreen/gscreen.glade:4111
 msgid "-"
 msgstr "-"
 
 #: share/axis/tcl/axis.tcl:1082 src/emc/usr_intf/stepconf/main_page.glade:26
 #: src/emc/usr_intf/pncconf/main_page.glade:38
-#: src/emc/usr_intf/pncconf/dialogs.glade:3233
+#: src/emc/usr_intf/pncconf/dialogs.glade:3289
 #: src/emc/usr_intf/gscreen/gscreen.glade:4100
 msgid "+"
 msgstr "+"
@@ -8289,28 +8368,28 @@ msgstr "Entrada de Comandos MDI:"
 msgid "Go"
 msgstr "Ir"
 
-#: share/axis/tcl/axis.tcl:1254
-msgid "Active G-Codes:"
-msgstr "Códigos G activos:"
-
-#: share/axis/tcl/axis.tcl:1334
+#: share/axis/tcl/axis.tcl:1302
 msgid "DRO"
 msgstr "DRO"
 
-#: share/axis/tcl/axis.tcl:1417 share/axis/tcl/axis.tcl:1430
+#: share/axis/tcl/axis.tcl:1385
+msgid "Active G-Codes:"
+msgstr "Códigos G activos:"
+
+#: share/axis/tcl/axis.tcl:1397 share/axis/tcl/axis.tcl:1410
 msgid "Jog Speed:"
 msgstr "Velocidad Jog:"
 
-#: share/axis/tcl/axis.tcl:1442
+#: share/axis/tcl/axis.tcl:1422
 msgid "Max Velocity:"
 msgstr "Velocidad máxima:"
 
-#: share/axis/tcl/axis.tcl:1471
+#: share/axis/tcl/axis.tcl:1451
 msgid "Spindle Override:"
 msgstr "Ajustar Husillo:"
 
-#: share/axis/tcl/axis.tcl:1473 share/axis/tcl/axis.tcl:1513
-#: share/axis/tcl/axis.tcl:1551 src/emc/usr_intf/pncconf/external.glade:2715
+#: share/axis/tcl/axis.tcl:1453 share/axis/tcl/axis.tcl:1493
+#: share/axis/tcl/axis.tcl:1531 src/emc/usr_intf/pncconf/external.glade:2715
 #: src/emc/usr_intf/pncconf/external.glade:2727
 #: src/emc/usr_intf/pncconf/external.glade:2856
 #: src/emc/usr_intf/pncconf/external.glade:2870
@@ -8358,17 +8437,18 @@ msgstr "Ajustar Husillo:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr "%"
 
-#: share/axis/tcl/axis.tcl:1549
+#: share/axis/tcl/axis.tcl:1529
 msgid "Rapid Override:"
 msgstr "Ajustar Rápidos:"
 
-#: share/axis/tcl/axis.tcl:1591
+#: share/axis/tcl/axis.tcl:1571
 msgid ""
 "LinuxCNC/AXIS version $version\n"
 "\n"
@@ -8386,144 +8466,148 @@ msgstr ""
 "condicionescondiciones. Vea el archivo COPYING, incluido con LinuxCNC.\n"
 "Visite el sitio web LinuxCNC:"
 
-#: share/axis/tcl/axis.tcl:1619
+#: share/axis/tcl/axis.tcl:1599
 msgid "About AXIS"
 msgstr "Acerca de AXIS"
 
-#: share/axis/tcl/axis.tcl:1648
+#: share/axis/tcl/axis.tcl:1628
 msgid "AXIS Quick Reference"
 msgstr "Referencia rápida de AXIS"
 
-#: share/axis/tcl/axis.tcl:1773
+#: share/axis/tcl/axis.tcl:1756
 msgid "AXIS $::version on $::machine"
 msgstr "AXIS $::version en $::machine"
 
-#: share/axis/tcl/axis.tcl:1775
+#: share/axis/tcl/axis.tcl:1758
 msgid "(no file)"
 msgstr "(sin archivo)"
 
-#: share/axis/tcl/axis.tcl:1850 share/axis/tcl/axis.tcl:1855
+#: share/axis/tcl/axis.tcl:1833 share/axis/tcl/axis.tcl:1838
 msgid "Position:"
 msgstr "Posición:"
 
-#: share/axis/tcl/axis.tcl:1852 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4560
+#: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr "Máquina"
 
-#: share/axis/tcl/axis.tcl:1852 src/emc/usr_intf/touchy/touchy.glade:155
+#: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/touchy/touchy.glade:155
 #: src/emc/usr_intf/pncconf/screen.glade:92
 msgid "Relative"
 msgstr "Relativa"
 
-#: share/axis/tcl/axis.tcl:1853 src/emc/usr_intf/touchy/touchy.glade:3329
+#: share/axis/tcl/axis.tcl:1836 src/emc/usr_intf/touchy/touchy.glade:3329
 #: src/emc/usr_intf/pncconf/screen.glade:78
 msgid "Actual"
 msgstr "Actual"
 
-#: share/axis/tcl/axis.tcl:1853 src/emc/usr_intf/touchy/touchy.glade:3318
+#: share/axis/tcl/axis.tcl:1836 src/emc/usr_intf/touchy/touchy.glade:3318
 #: src/emc/usr_intf/pncconf/screen.glade:75
 msgid "Commanded"
 msgstr "Ordenada"
 
-#: share/axis/tcl/axis.tcl:1927 share/axis/tcl/axis.tcl:2127
+#: share/axis/tcl/axis.tcl:1910 share/axis/tcl/axis.tcl:2110
 msgid "Joint:"
 msgstr "articulacion:"
 
-#: share/axis/tcl/axis.tcl:2262
+#: share/axis/tcl/axis.tcl:2230
+#, fuzzy
+msgid "_Clear Recents List"
+msgstr "Borrar entradas"
+
+#: share/axis/tcl/axis.tcl:2250
 msgid "Turn spindle counterclockwise [F10]"
 msgstr "Gire el husillo en sentido antihorario [F10]"
 
-#: share/axis/tcl/axis.tcl:2263
+#: share/axis/tcl/axis.tcl:2251
 msgid "Turn spindle clockwise [F9]"
 msgstr "Gire el husillo en sentido horario [F9]"
 
-#: share/axis/tcl/axis.tcl:2264
+#: share/axis/tcl/axis.tcl:2252
 msgid "Stop spindle [F9/F10]"
 msgstr "Detener husillo [F9 / F10]"
 
-#: share/axis/tcl/axis.tcl:2265
+#: share/axis/tcl/axis.tcl:2253
 msgid "Turn spindle Faster [F12]"
 msgstr "Girar el husillo más rápido [F12]"
 
-#: share/axis/tcl/axis.tcl:2266
+#: share/axis/tcl/axis.tcl:2254
 msgid "Turn spindle Slower [F11]"
 msgstr "Girar el husillo más lento [F11]"
 
-#: share/axis/tcl/axis.tcl:2267
+#: share/axis/tcl/axis.tcl:2255
 msgid "Turn spindle brake on [Shift-B] or off [B]"
 msgstr "Activar el freno del husillo [Shift-B] o desactivar [B]"
 
-#: share/axis/tcl/axis.tcl:2268
+#: share/axis/tcl/axis.tcl:2256
 msgid "Turn flood on or off [F8]"
 msgstr "Activa o desactiva la inundación [F8]"
 
-#: share/axis/tcl/axis.tcl:2269
+#: share/axis/tcl/axis.tcl:2257
 msgid "Turn mist on or off [F7]"
 msgstr "Activa o desactiva la niebla [F7]"
 
-#: share/axis/tcl/axis.tcl:2270
+#: share/axis/tcl/axis.tcl:2258
 msgid "Send active axis home [Home]"
 msgstr "Enviar eje activo a casa [Inicio]"
 
-#: share/axis/tcl/axis.tcl:2271
+#: share/axis/tcl/axis.tcl:2259
 msgid "Set G54 offset for active axis [End]"
 msgstr "Establecer el offset G54 para el eje activo [Fin]"
 
-#: share/axis/tcl/axis.tcl:2272
+#: share/axis/tcl/axis.tcl:2260
 msgid "Set tool offset for loaded tool [Control-End]"
 msgstr ""
 "Establecer el offset de la herramienta para la herramienta cargada [Control-"
 "Fin]"
 
-#: share/axis/tcl/axis.tcl:2273
+#: share/axis/tcl/axis.tcl:2261
 msgid "Activate axis [X]"
 msgstr "Activar eje [X]"
 
-#: share/axis/tcl/axis.tcl:2274
+#: share/axis/tcl/axis.tcl:2262
 msgid "Activate axis [Y]"
 msgstr "Activar eje [Y]"
 
-#: share/axis/tcl/axis.tcl:2275
+#: share/axis/tcl/axis.tcl:2263
 msgid "Activate axis [Z]"
 msgstr "Activar eje [Z]"
 
-#: share/axis/tcl/axis.tcl:2276
+#: share/axis/tcl/axis.tcl:2264
 msgid "Activate axis [A]"
 msgstr "Activar eje [A]"
 
-#: share/axis/tcl/axis.tcl:2277
+#: share/axis/tcl/axis.tcl:2265
 msgid "Activate axis [4]"
 msgstr "Activar eje [4]"
 
-#: share/axis/tcl/axis.tcl:2278
+#: share/axis/tcl/axis.tcl:2266
 msgid "Activate axis [5]"
 msgstr "Activar eje [5]"
 
-#: share/axis/tcl/axis.tcl:2279 share/axis/tcl/axis.tcl:2280
+#: share/axis/tcl/axis.tcl:2267 share/axis/tcl/axis.tcl:2268
 msgid "Jog selected axis"
 msgstr "Ejecutar eje seleccionado"
 
-#: share/axis/tcl/axis.tcl:2282
+#: share/axis/tcl/axis.tcl:2270
 msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Permitir temporalmente correr fuera de los límites de la máquina [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1673
-#: src/emc/usr_intf/pncconf/pncconf.py:1676
-#: src/emc/usr_intf/gscreen/gscreen.py:1321
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
+#: src/emc/usr_intf/gscreen/gscreen.py:1324
 msgid "Follow System Theme"
 msgstr "Seguir el tema del sistema"
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:209
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "Husillo CW"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:209
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "Husillo CCW"
@@ -8809,12 +8893,12 @@ msgid "Estop"
 msgstr "Estop"
 
 #: src/emc/usr_intf/touchy/touchy.glade:475
-#: src/emc/usr_intf/gscreen/gscreen.py:2546
+#: src/emc/usr_intf/gscreen/gscreen.py:2548
 msgid "Machine On"
 msgstr "Máquina On"
 
 #: src/emc/usr_intf/touchy/touchy.glade:490
-#: src/emc/usr_intf/gscreen/gscreen.py:2551
+#: src/emc/usr_intf/gscreen/gscreen.py:2553
 msgid "Machine Off"
 msgstr "Máquina Off"
 
@@ -8863,52 +8947,99 @@ msgid "."
 msgstr "."
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
-#: src/emc/usr_intf/pncconf/dialogs.glade:2830
-#: src/emc/usr_intf/pncconf/dialogs.glade:3981
-#: src/emc/usr_intf/pncconf/dialogs.glade:3994
-#: src/emc/usr_intf/pncconf/dialogs.glade:4007
-#: src/emc/usr_intf/pncconf/dialogs.glade:4020
-#: src/emc/usr_intf/pncconf/dialogs.glade:4033
-#: src/emc/usr_intf/pncconf/dialogs.glade:4046
-#: src/emc/usr_intf/pncconf/dialogs.glade:4201
-#: src/emc/usr_intf/pncconf/dialogs.glade:4214
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
+#: src/emc/usr_intf/pncconf/dialogs.glade:2856
+#: src/emc/usr_intf/pncconf/dialogs.glade:4037
+#: src/emc/usr_intf/pncconf/dialogs.glade:4050
+#: src/emc/usr_intf/pncconf/dialogs.glade:4063
+#: src/emc/usr_intf/pncconf/dialogs.glade:4076
+#: src/emc/usr_intf/pncconf/dialogs.glade:4089
+#: src/emc/usr_intf/pncconf/dialogs.glade:4102
+#: src/emc/usr_intf/pncconf/dialogs.glade:4257
+#: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr "0"
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr "3"
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr "2"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr "1"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr "6"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
-#: src/emc/usr_intf/pncconf/dialogs.glade:1432
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr "5"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr "4"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr "9"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr "8"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr "7"
 
@@ -8963,7 +9094,6 @@ msgid "label26"
 msgstr "label26"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr "<b> Husillo </b>"
 
@@ -9011,7 +9141,7 @@ msgstr "Distancia:"
 
 #: src/emc/usr_intf/touchy/touchy.glade:2526
 #: src/emc/usr_intf/stepconf/main_page.glade:324
-#: src/emc/usr_intf/pncconf/dialogs.glade:3706
+#: src/emc/usr_intf/pncconf/dialogs.glade:3762
 msgid "Velocity:"
 msgstr "Velocidad:"
 
@@ -9127,13 +9257,12 @@ msgid ""
 "<b>1</b>\n"
 "2\n"
 "3"
-msgstr  ""
+msgstr ""
 "<b>1</b>\n"
 "2\n"
 "3"
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr "Estado"
 
@@ -9192,8 +9321,8 @@ msgstr "<b> Opciones de visualización </b>"
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
-#: src/emc/usr_intf/gscreen/gscreen.py:4620
-#: src/emc/usr_intf/gscreen/gscreen.py:4621
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
+#: src/emc/usr_intf/gscreen/gscreen.py:4624
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr "Pulgadas"
@@ -9313,275 +9442,326 @@ msgstr "  W  "
 msgid "<b>Handwheel</b>"
 msgstr "<b>Volante</b>"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:68
+#: src/emc/usr_intf/stepconf/stepconf.py:78
 msgid ""
 "Stepconf encountered an error.  The following information may be useful in "
 "troubleshooting:\n"
 "\n"
 msgstr ""
-"Stepconf encontró un error. La siguiente información puede ser útil "
-"para solución de problemas:\n"
+"Stepconf encontró un error. La siguiente información puede ser útil para "
+"solución de problemas:\n"
 "\n"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:139
+#: src/emc/usr_intf/stepconf/stepconf.py:153
 msgid "Stepconf"
 msgstr "Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:139
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:153
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:989
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
-#: src/emc/usr_intf/gscreen/gscreen.py:4453
-#: src/emc/usr_intf/gscreen/gscreen.py:4454
+#: src/emc/usr_intf/gscreen/gscreen.py:4456
+#: src/emc/usr_intf/gscreen/gscreen.py:4457
 #: src/emc/usr_intf/gscreen/gscreen.glade:4087
 msgid "Start"
 msgstr "Inicio"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:140
+#: src/emc/usr_intf/stepconf/stepconf.py:154
 #: src/emc/usr_intf/pncconf/private_data.py:40
 msgid "Base Information"
 msgstr "Información básica"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:141
+#: src/emc/usr_intf/stepconf/stepconf.py:155
 msgid "Parallel Port 1"
 msgstr "Puerto paralelo 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:141
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/stepconf/stepconf.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:48
 msgid "Parallel Port 2"
 msgstr "Puerto paralelo 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:142
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/stepconf/stepconf.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:59
 msgid "Options"
 msgstr "Opciones"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:142
+#: src/emc/usr_intf/stepconf/stepconf.py:156
 msgid "HALUI"
 msgstr "HALUI"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:143
-msgid "Axis X"
-msgstr "Eje X"
-
-#: src/emc/usr_intf/stepconf/stepconf.py:144
-msgid "Axis Y"
-msgstr "Eje Y"
-
-#: src/emc/usr_intf/stepconf/stepconf.py:144
-msgid "Axis Z"
-msgstr "Eje Z"
-
-#: src/emc/usr_intf/stepconf/stepconf.py:145
-msgid "Axis U"
-msgstr "Eje U"
-
-#: src/emc/usr_intf/stepconf/stepconf.py:145
-msgid "Axis V"
-msgstr "Eje V"
-
-#: src/emc/usr_intf/stepconf/stepconf.py:146
-msgid "Axis A"
-msgstr "Eje A"
-
-#: src/emc/usr_intf/stepconf/stepconf.py:147
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
-msgid "Spindle"
-msgstr "Husillo"
-
-#: src/emc/usr_intf/stepconf/stepconf.py:147
-#: src/emc/usr_intf/pncconf/private_data.py:59
-msgid "Almost Done"
-msgstr "Casi hecho"
-
-#: src/emc/usr_intf/stepconf/stepconf.py:151
-#: src/emc/usr_intf/pncconf/private_data.py:950
-msgid "Gecko 201"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:152
-#: src/emc/usr_intf/pncconf/private_data.py:951
-msgid "Gecko 202"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/pncconf/private_data.py:952
-msgid "Gecko 203v"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:154
-#: src/emc/usr_intf/pncconf/private_data.py:953
-msgid "Gecko 210"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:954
-msgid "Gecko 212"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:955
-msgid "Gecko 320"
-msgstr ""
-
 #: src/emc/usr_intf/stepconf/stepconf.py:157
-#: src/emc/usr_intf/pncconf/private_data.py:956
-msgid "Gecko 540"
-msgstr ""
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Botón Zero X"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:158
-#: src/emc/usr_intf/pncconf/private_data.py:957
-msgid "L297"
+msgid "QtPlasmaC THCAD"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:159
-#: src/emc/usr_intf/pncconf/private_data.py:958
+msgid "Axis X"
+msgstr "Eje X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:160
+msgid "Axis Y"
+msgstr "Eje Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:160
+msgid "Axis Z"
+msgstr "Eje Z"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:161
+msgid "Axis U"
+msgstr "Eje U"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:161
+msgid "Axis V"
+msgstr "Eje V"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:162
+msgid "Axis A"
+msgstr "Eje A"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
+msgid "Spindle"
+msgstr "Husillo"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
+msgid "Almost Done"
+msgstr "Casi hecho"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
+msgid "Gecko 201"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
+msgid "Gecko 202"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
+msgid "Gecko 203v"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
+msgid "Gecko 210"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
+msgid "Gecko 212"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
+msgid "Gecko 320"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
+msgid "Gecko 540"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
+msgid "L297"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
-#: src/emc/usr_intf/stepconf/pport1.glade:32
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:176
+#: src/emc/usr_intf/stepconf/pport1.glade:43
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:162
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:163
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:164
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:206
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr "Paso X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:206
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr "Dirección X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:206
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr "Paso Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:206
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr "Dirección Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:207
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr "Paso Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:207
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr "Dirección Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:207
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr "Paso A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:207
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr "Dirección A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:208
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "U Step"
 msgstr "Paso U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:208
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "U Direction"
 msgstr "Dirección U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:208
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "V Step"
 msgstr "Paso V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:208
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "V Direction"
 msgstr "Dirección V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:209
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "X2 Tandem StepGen"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "Dirección X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "X2 Tandem StepGen"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Dirección Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr "Husillo ON"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:209
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr "Husillo PWM"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:209
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr "Freno de husillo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:210
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr "Refrigerante Niebla"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:210
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr "Refrigerante Inundación"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:210
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr "E-STOP"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:210
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr "Amplificador habilitado"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:211
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr "Bomba de carga"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:212
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr "Salida digital 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:212
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr "Salida digital 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:212
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr "Salida digital 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:212
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr "Salida digital 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:213
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+#, fuzzy
+msgid "Plasma Ohmic Enable"
+msgstr "Habilitar POT"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9592,240 +9772,336 @@ msgstr "Salida digital 3"
 msgid "Unused"
 msgstr "Sin usar"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:215
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr "E-STOP"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:215
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr "Sonda"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:216
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr "Índice de husillo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:216
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr "Husillo Fase A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:216
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr "Husillo Fase B"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:217
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr "Home X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:217
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr "Home Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:217
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr "Home Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:217
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr "Home A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:217
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home U"
 msgstr "Home U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:217
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home V"
 msgstr "Home V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:218
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Home X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Home Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr "Límite mínimo + Home X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:218
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr "Límite mínimo + Home Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:219
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem X"
+msgstr "Límite mínimo + Home X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem Y"
+msgstr "Límite mínimo + Home Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr "Límite mínimo + Home Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:219
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr "Límite mínimo + Home A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr "Límite mínimo + Home U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr "Límite mínimo + Home V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr "Límite máximo + Home X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr "Límite máximo + Home Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem X"
+msgstr "Límite máximo + Home X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem Y"
+msgstr "Límite máximo + Home Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr "Límite máximo + Home Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr "Límite máximo + Home A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home U"
 msgstr "Límite máximo + Home U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home V"
 msgstr "Límite máximo + Home V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr "Ambos límites + Home X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr "Ambos límites + Home Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr "Ambos límites + Home Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr "Ambos límites + Home A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home U"
 msgstr "Ambos límites + Home U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home V"
 msgstr "Ambos límites + Home V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Ambos límites + Home X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Ambos límites + Home Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr "Límite mínimo X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr "Límite mínimo Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:228
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem X"
+msgstr "Límite mínimo X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem Y"
+msgstr "Límite mínimo Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr "Límite mínimo Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:228
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr "Límite mínimo A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit U"
 msgstr "Límite mínimo U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit V"
 msgstr "Límite mínimo V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr "Límite máximo X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr "Límite máximo Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem X"
+msgstr "Límite máximo X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem Y"
+msgstr "Límite máximo Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr "Límite máximo Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr "Límite máximo A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit U"
 msgstr "Límite máximo U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit V"
 msgstr "Límite máximo V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr "Ambos límites X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr "Ambos límites Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr "Ambos límites Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr "Ambos límites A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit U"
 msgstr "Ambos límites U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit V"
 msgstr "Ambos límites V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Ambos límites X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Ambos límites Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr "Todos los límites"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr "Home Todo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits + homes"
 msgstr "Todos los límites + Home"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr "Digital en 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr "Digital en 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr "Digital en 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr "Digital en 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-#: src/emc/usr_intf/pncconf/private_data.py:990
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Up"
+msgstr "Subir"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "Mover hacia abajo"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 msgid "Forward"
 msgstr "Adelante"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-#: src/emc/usr_intf/pncconf/private_data.py:991
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr "Listo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -9835,9 +10111,9 @@ msgstr ""
 "Custom.clp existente pasará a llamarse custom_backup.clp.Cualquier archivo "
 "existente llamado -custom_backup.clp- se perderá\"."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-#: src/emc/usr_intf/pncconf/pages.py:1340
-#: src/emc/usr_intf/pncconf/private_data.py:993
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9849,8 +10125,8 @@ msgstr ""
 "copiarsu archivo de configuración.El programa editado se perderá.\n"
 "¿Estás seguro?  "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-#: src/emc/usr_intf/pncconf/private_data.py:994
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
@@ -9858,7 +10134,7 @@ msgstr ""
 "Debe designar un pin de entrada de parada de emergencia en la página "
 "Configuración de puerto paralelopara este programa\"."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
@@ -9868,19 +10144,19 @@ msgstr ""
 "existente?Custompanel.xml existente se renombrará custompanel_backup.xml.Se "
 "perderá cualquier archivo existente llamado custompanel_backup.xml\"."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr "¿Salir de Stepconf y descartar los cambios?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr "La configuración se ha creado y guardado.¿Quieres renunciar?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
@@ -9888,8 +10164,8 @@ msgstr ""
 "Está utilizando una versión simulada en tiempo real de LinuxCNC, por lo que "
 "está probando / ajustandode hardware no está disponible\"."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9907,16 +10183,16 @@ msgstr ""
 "Estás utilizando el kernel %(actual)s.\n"
 "Necesita usar el kernel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:270
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr "mi-maquina"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:590
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr "El archivo %r se modificó porque lo escribió stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:593
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
@@ -9924,54 +10200,62 @@ msgstr ""
 "Guardar este archivo de configuración descartará los cambios de "
 "configuración realizadosfuera de stepconf\"."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:608
-#: src/emc/usr_intf/pncconf/data.py:877
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr "¿Continuar?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:609
-#: src/emc/usr_intf/pncconf/data.py:878
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr "yY"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:694
-#: src/emc/usr_intf/pncconf/data.py:1058
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr "lanzamiento %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:698
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr "Iniciador de escritorio para LinuxCNC config hecho por Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:873
-#: src/emc/usr_intf/stepconf/pages.py:154
+#: src/emc/usr_intf/stepconf/stepconf.py:826
+#, fuzzy
+msgid ""
+"Loading configuration error:\n"
+"\n"
+"{}"
+msgstr "Selector de Configuraciones de LinuxCNC - ACTUAL: "
+
+#: src/emc/usr_intf/stepconf/stepconf.py:968
+#: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr "Otro"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1385
-#: src/emc/usr_intf/pncconf/tests.py:1025
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr "%s Prueba de eje"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1388
-#: src/emc/usr_intf/stepconf/pages.py:777
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr "deg / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1389
-#: src/emc/usr_intf/stepconf/pages.py:778
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr "deg / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1390
-#: src/emc/usr_intf/stepconf/pages.py:779
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr "deg"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1402
-#: src/emc/usr_intf/stepconf/pages.py:783
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -9986,8 +10270,8 @@ msgstr "deg"
 msgid "mm / s"
 msgstr "mm / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1403
-#: src/emc/usr_intf/stepconf/pages.py:784
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -10002,155 +10286,155 @@ msgstr "mm / s"
 msgid "mm / s²"
 msgstr "mm / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1416
-#: src/emc/usr_intf/stepconf/pages.py:789
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr "en / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1417
-#: src/emc/usr_intf/stepconf/pages.py:790
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr "en / s²"
 
-#: src/emc/usr_intf/stepconf/pages.py:214
+#: src/emc/usr_intf/stepconf/pages.py:235
 msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "Archivos de configuración LinuxCNC 'stepconf'"
 
-#: src/emc/usr_intf/stepconf/pages.py:215
-#: src/emc/usr_intf/pncconf/pncconf.py:856
+#: src/emc/usr_intf/stepconf/pages.py:236
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr "Modificar la configuración existente"
 
-#: src/emc/usr_intf/stepconf/pages.py:776
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr "grado / rev"
 
-#: src/emc/usr_intf/stepconf/pages.py:780
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr "Pasos / grados"
 
-#: src/emc/usr_intf/stepconf/pages.py:782
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
 #: src/emc/usr_intf/stepconf/axisu.glade:292
 #: src/emc/usr_intf/stepconf/axisv.glade:291
 #: src/emc/usr_intf/stepconf/axisa.glade:289
-#: src/emc/usr_intf/pncconf/dialogs.glade:2215
-#: src/emc/usr_intf/pncconf/dialogs.glade:2607
+#: src/emc/usr_intf/pncconf/dialogs.glade:2241
+#: src/emc/usr_intf/pncconf/dialogs.glade:2633
 msgid "mm / rev"
 msgstr "mm / rev"
 
-#: src/emc/usr_intf/stepconf/pages.py:786
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
 #: src/emc/usr_intf/stepconf/axisu.glade:29
 #: src/emc/usr_intf/stepconf/axisv.glade:28
 #: src/emc/usr_intf/stepconf/axisa.glade:28
-#: src/emc/usr_intf/pncconf/dialogs.glade:3040
+#: src/emc/usr_intf/pncconf/dialogs.glade:3066
 msgid "Steps / mm"
 msgstr "Pasos / mm"
 
-#: src/emc/usr_intf/stepconf/pages.py:788
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr "rev / in"
 
-#: src/emc/usr_intf/stepconf/pages.py:792
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr "Pasos / en"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:51
-#: src/emc/usr_intf/stepconf/build_HAL.py:41
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
+#: src/emc/usr_intf/stepconf/build_INI.py:55
+#: src/emc/usr_intf/stepconf/build_HAL.py:42
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr "# Generado por stepconf 1.1 en %s"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:52
-#: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
-#: src/emc/usr_intf/pncconf/build_INI.py:19
-#: src/emc/usr_intf/pncconf/build_HAL.py:55
+#: src/emc/usr_intf/stepconf/build_INI.py:56
+#: src/emc/usr_intf/stepconf/build_HAL.py:43
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
+#: src/emc/usr_intf/pncconf/build_INI.py:20
+#: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
 msgstr "# Si realiza cambios en este archivo, serán"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:53
-#: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_INI.py:57
+#: src/emc/usr_intf/stepconf/build_HAL.py:44
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr "# sobrescrito cuando ejecuta stepconf nuevamente"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:167
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr "# agregar comandos MDI halui aquí (máx. 64)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:287
-#: src/emc/usr_intf/pncconf/build_HAL.py:726
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 "# **** Configuración para el programa de escalera de impedimento externo -"
 "START ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:294
-#: src/emc/usr_intf/pncconf/build_HAL.py:733
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 "# **** Configuración para el programa de escalera de impedimento externo -"
 "END ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:314
-#: src/emc/usr_intf/pncconf/build_HAL.py:760
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 "# Load Classicladder con modbus master incluido (la GUI debe ejecutarse para "
 "Modbus)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:317
-#: src/emc/usr_intf/pncconf/build_HAL.py:765
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr "# Cargar Classicladder sin GUI (puede recargar LADDER GUI en AXIS GUI"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:327
-#: src/emc/usr_intf/pncconf/build_HAL.py:847
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr "Incluya su panel PyVCP aquí.\n"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:340
-#: src/emc/usr_intf/stepconf/build_HAL.py:354
-#: src/emc/usr_intf/stepconf/build_HAL.py:395
-#: src/emc/usr_intf/pncconf/build_HAL.py:860
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 "# Estos archivos se cargan después de la GUI, en el orden en que aparecen"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/pncconf/build_HAL.py:881
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 "# **** Configuración de la pantalla de velocidad del husillo utilizando "
 "pyvcp -START ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:360
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 "# **** Usa la velocidad ACTUAL del cabezal desde el codificador del cabezal"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 "# **** spindle-velocity-feedback-rps rebota así que lo filtramos conpaso bajo"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
@@ -10158,16 +10442,16 @@ msgstr ""
 "# **** spindle-velocity-feedback-rps está firmado, por lo que utilizamos el "
 "componente absolutopara eliminar el signo"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 "# **** La velocidad REAL está en RPS, no en RPM, así que la escalamos\"."
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:372
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr "# **** configurar el husillo en el indicador de velocidad ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:385
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
@@ -10175,24 +10459,30 @@ msgstr ""
 "# **** Use la velocidad de husillo COMANDO de LinuxCNC porque no hay "
 "husillose especificó el codificador"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:408
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr "# Incluya sus comandos HAL %s aquí"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr "# Este archivo no se sobrescribirá cuando vuelva a ejecutar stepconf"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:453
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 "# Este archivo configura límites simulados / inicio / hardware del "
 "codificador del cabezal\"."
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
 msgstr "# Este es un archivo generado no editar\"."
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+#, fuzzy
+msgid "# Include your custom HAL commands here"
+msgstr "# Incluya sus comandos HAL %s aquí"
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
 msgid "Mach configuration files"
@@ -10200,7 +10490,7 @@ msgstr "Archivos de configuración de Mach"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:23
 #: src/emc/usr_intf/pncconf/main_page.glade:35
-#: src/emc/usr_intf/pncconf/dialogs.glade:3230
+#: src/emc/usr_intf/pncconf/dialogs.glade:3286
 msgid "±"
 msgstr "±"
 
@@ -10209,13 +10499,13 @@ msgid "mm/s"
 msgstr "mm / s"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:337
-#: src/emc/usr_intf/pncconf/dialogs.glade:838
-#: src/emc/usr_intf/pncconf/dialogs.glade:3450
+#: src/emc/usr_intf/pncconf/dialogs.glade:864
+#: src/emc/usr_intf/pncconf/dialogs.glade:3506
 msgid "Jog:"
 msgstr "Jog:"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:349
-#: src/emc/usr_intf/pncconf/dialogs.glade:3465
+#: src/emc/usr_intf/pncconf/dialogs.glade:3521
 msgid "Test Area:"
 msgstr "Área de prueba:"
 
@@ -10224,7 +10514,7 @@ msgid "mm/s^2"
 msgstr "mm / s ^ 2"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:400
-#: src/emc/usr_intf/pncconf/dialogs.glade:3719
+#: src/emc/usr_intf/pncconf/dialogs.glade:3775
 msgid "Acceleration:"
 msgstr "Aceleración:"
 
@@ -10254,18 +10544,23 @@ msgstr "Asistente de configuración Stepconf -Stepper"
 #: src/emc/usr_intf/pncconf/y_motor.glade:384
 #: src/emc/usr_intf/pncconf/z_motor.glade:384
 #: src/emc/usr_intf/pncconf/a_motor.glade:384
-#: src/emc/usr_intf/pncconf/dialogs.glade:4638
-#: src/emc/usr_intf/pncconf/dialogs.glade:4651
-#: src/emc/usr_intf/pncconf/dialogs.glade:4664
-#: src/emc/usr_intf/pncconf/dialogs.glade:4677
+#: src/emc/usr_intf/pncconf/dialogs.glade:4814
+#: src/emc/usr_intf/pncconf/dialogs.glade:4827
+#: src/emc/usr_intf/pncconf/dialogs.glade:4840
+#: src/emc/usr_intf/pncconf/dialogs.glade:4853
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr "etiqueta"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "Volver"
 
@@ -10310,17 +10605,6 @@ msgstr "XY (especial)"
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
 msgstr "MM"
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
-msgstr "ns"
 
 #: src/emc/usr_intf/stepconf/base.glade:209
 msgid "Step _Time:"
@@ -10447,152 +10731,117 @@ msgstr ""
 "Si ha realizado modificaciones a una configuración fuera de este programa, "
 "se perderán cuando seleccione \"Modificar una configuración\""
 
-#: src/emc/usr_intf/stepconf/pport1.glade:35
+#: src/emc/usr_intf/stepconf/pport1.glade:32
+#: src/emc/usr_intf/stepconf/pport2.glade:37
+msgid "0x0378"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/pport1.glade:46
 msgid "Xylotex"
 msgstr "Xylotex"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:38
+#: src/emc/usr_intf/stepconf/pport1.glade:49
 msgid "TB6560 3 axes"
 msgstr "TB6560 3 ejes"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:41
+#: src/emc/usr_intf/stepconf/pport1.glade:52
 msgid "TB6560 4 axes"
 msgstr "TB6560 4 ejes"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:57
-msgid "Pin _1:"
+#: src/emc/usr_intf/stepconf/pport1.glade:74
+#: src/emc/usr_intf/stepconf/pport2.glade:74
+#, fuzzy
+msgid " Pin _1:"
 msgstr "Pin _1:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:70
-#: src/emc/usr_intf/stepconf/pport2.glade:1006
-#: src/emc/usr_intf/pncconf/pport1.glade:1066
-#: src/emc/usr_intf/pncconf/pport2.glade:1069
-msgid "Pin _2:"
+#: src/emc/usr_intf/stepconf/pport1.glade:132
+#: src/emc/usr_intf/stepconf/pport2.glade:131
+#: src/emc/usr_intf/stepconf/pport2.glade:973
+#, fuzzy
+msgid " Pin _2:"
 msgstr "Pin _2:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:83
-#: src/emc/usr_intf/stepconf/pport2.glade:1063
-#: src/emc/usr_intf/pncconf/pport1.glade:1126
-#: src/emc/usr_intf/pncconf/pport2.glade:1129
-msgid "Pin _3:"
-msgstr "Pin _3:"
-
-#: src/emc/usr_intf/stepconf/pport1.glade:96
-#: src/emc/usr_intf/stepconf/pport2.glade:1120
-#: src/emc/usr_intf/pncconf/pport1.glade:1186
-#: src/emc/usr_intf/pncconf/pport2.glade:1189
-msgid "Pin _4:"
+#: src/emc/usr_intf/stepconf/pport1.glade:190
+#: src/emc/usr_intf/stepconf/pport2.glade:188
+#: src/emc/usr_intf/stepconf/pport2.glade:1089
+#, fuzzy
+msgid " Pin _4:"
 msgstr "Pin _4:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:109
-#: src/emc/usr_intf/stepconf/pport2.glade:1177
-#: src/emc/usr_intf/pncconf/pport1.glade:1246
-#: src/emc/usr_intf/pncconf/pport2.glade:1249
-msgid "Pin _5:"
+#: src/emc/usr_intf/stepconf/pport1.glade:248
+#: src/emc/usr_intf/stepconf/pport2.glade:245
+#: src/emc/usr_intf/stepconf/pport2.glade:1031
+#, fuzzy
+msgid " Pin _3:"
+msgstr "Pin _3:"
+
+#: src/emc/usr_intf/stepconf/pport1.glade:306
+#: src/emc/usr_intf/stepconf/pport2.glade:302
+#: src/emc/usr_intf/stepconf/pport2.glade:1147
+#, fuzzy
+msgid " Pin _5:"
 msgstr "Pin _5:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:122
-#: src/emc/usr_intf/stepconf/pport2.glade:1234
-#: src/emc/usr_intf/pncconf/pport1.glade:1306
-#: src/emc/usr_intf/pncconf/pport2.glade:1309
-msgid "Pin _6:"
+#: src/emc/usr_intf/stepconf/pport1.glade:364
+#: src/emc/usr_intf/stepconf/pport2.glade:359
+#: src/emc/usr_intf/stepconf/pport2.glade:1205
+#, fuzzy
+msgid " Pin _6:"
 msgstr "Pin _6:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:135
-#: src/emc/usr_intf/stepconf/pport2.glade:1291
-#: src/emc/usr_intf/pncconf/pport1.glade:1366
-#: src/emc/usr_intf/pncconf/pport2.glade:1369
-msgid "Pin _7:"
+#: src/emc/usr_intf/stepconf/pport1.glade:422
+#: src/emc/usr_intf/stepconf/pport2.glade:416
+#: src/emc/usr_intf/stepconf/pport2.glade:1263
+#, fuzzy
+msgid " Pin _7:"
 msgstr "Pin _7:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:148
-#: src/emc/usr_intf/stepconf/pport2.glade:1348
-#: src/emc/usr_intf/pncconf/pport1.glade:1426
-#: src/emc/usr_intf/pncconf/pport2.glade:1429
-msgid "Pin _8:"
+#: src/emc/usr_intf/stepconf/pport1.glade:480
+#: src/emc/usr_intf/stepconf/pport2.glade:473
+#: src/emc/usr_intf/stepconf/pport2.glade:1321
+#, fuzzy
+msgid " Pin _8:"
 msgstr "Pin _8:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:161
-#: src/emc/usr_intf/stepconf/pport2.glade:1405
-#: src/emc/usr_intf/pncconf/pport1.glade:1486
-#: src/emc/usr_intf/pncconf/pport2.glade:1489
-msgid "Pin _9:"
+#: src/emc/usr_intf/stepconf/pport1.glade:538
+#: src/emc/usr_intf/stepconf/pport2.glade:530
+#: src/emc/usr_intf/stepconf/pport2.glade:1379
+#, fuzzy
+msgid " Pin _9:"
 msgstr "Pin _9:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:174
-#: src/emc/usr_intf/stepconf/pport2.glade:1463
+#: src/emc/usr_intf/stepconf/pport1.glade:596
+#: src/emc/usr_intf/stepconf/pport2.glade:588
 #: src/emc/usr_intf/pncconf/pport1.glade:1547
 #: src/emc/usr_intf/pncconf/pport2.glade:1550
 msgid "_Pin 14:"
 msgstr "_Pin 14:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:187
-#: src/emc/usr_intf/stepconf/pport2.glade:1521
+#: src/emc/usr_intf/stepconf/pport1.glade:654
+#: src/emc/usr_intf/stepconf/pport2.glade:646
 #: src/emc/usr_intf/pncconf/pport1.glade:1608
 #: src/emc/usr_intf/pncconf/pport2.glade:1611
 msgid "P_in 16:"
 msgstr "P_in 16:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:200
-#: src/emc/usr_intf/stepconf/pport2.glade:1579
+#: src/emc/usr_intf/stepconf/pport1.glade:712
+#: src/emc/usr_intf/stepconf/pport2.glade:704
 #: src/emc/usr_intf/pncconf/pport1.glade:1669
 #: src/emc/usr_intf/pncconf/pport2.glade:1672
 msgid "Pi_n 17:"
 msgstr "Pi_n 17:"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:400
-#: src/emc/usr_intf/stepconf/pport2.glade:911
+#: src/emc/usr_intf/stepconf/pport1.glade:770
+#: src/emc/usr_intf/stepconf/pport2.glade:762
 #: src/emc/usr_intf/pncconf/pport1.glade:969
 #: src/emc/usr_intf/pncconf/pport2.glade:972
 msgid "Outputs (PC to Mill):"
 msgstr "Salidas (PC a máquina):"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:413
-#: src/emc/usr_intf/stepconf/pport2.glade:584
-#: src/emc/usr_intf/pncconf/pport1.glade:628
-#: src/emc/usr_intf/pncconf/pport2.glade:631
-msgid "Pin 1_0:"
-msgstr "Pin 1_0:"
-
-#: src/emc/usr_intf/stepconf/pport1.glade:426
-#: src/emc/usr_intf/stepconf/pport2.glade:643
-#: src/emc/usr_intf/pncconf/pport1.glade:690
-#: src/emc/usr_intf/pncconf/pport2.glade:693
-msgid "Pin 1_1:"
-msgstr "Pin 1_1:"
-
-#: src/emc/usr_intf/stepconf/pport1.glade:439
-#: src/emc/usr_intf/stepconf/pport2.glade:702
-#: src/emc/usr_intf/pncconf/pport1.glade:752
-#: src/emc/usr_intf/pncconf/pport2.glade:755
-msgid "Pin 1_2:"
-msgstr "Pin 1_2:"
-
-#: src/emc/usr_intf/stepconf/pport1.glade:452
-#: src/emc/usr_intf/stepconf/pport2.glade:761
-#: src/emc/usr_intf/pncconf/pport1.glade:814
-#: src/emc/usr_intf/pncconf/pport2.glade:817
-msgid "Pin 1_3:"
-msgstr "Pin 1_3:"
-
-#: src/emc/usr_intf/stepconf/pport1.glade:465
-#: src/emc/usr_intf/stepconf/pport2.glade:820
-#: src/emc/usr_intf/pncconf/pport1.glade:876
-#: src/emc/usr_intf/pncconf/pport2.glade:879
-msgid "Pin 1_5:"
-msgstr "Pin 1_5:"
-
-#: src/emc/usr_intf/stepconf/pport1.glade:496
-#: src/emc/usr_intf/stepconf/pport2.glade:77
-#: src/emc/usr_intf/pncconf/pport1.glade:100
-#: src/emc/usr_intf/pncconf/pport2.glade:103
-msgid "Inputs (Mill to PC):"
-msgstr "Entradas (Máquina a PC):"
-
-#: src/emc/usr_intf/stepconf/pport1.glade:521
-#: src/emc/usr_intf/stepconf/pport1.glade:534
-#: src/emc/usr_intf/stepconf/pport2.glade:90
-#: src/emc/usr_intf/stepconf/pport2.glade:924
+#: src/emc/usr_intf/stepconf/pport1.glade:795
+#: src/emc/usr_intf/stepconf/pport1.glade:1159
+#: src/emc/usr_intf/stepconf/pport2.glade:787
+#: src/emc/usr_intf/stepconf/pport2.glade:949
 #: src/emc/usr_intf/pncconf/pport1.glade:114
 #: src/emc/usr_intf/pncconf/pport1.glade:982
 #: src/emc/usr_intf/pncconf/pport2.glade:117
@@ -10600,81 +10849,71 @@ msgstr "Entradas (Máquina a PC):"
 msgid "Invert"
 msgstr "Invertir"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:861
+#: src/emc/usr_intf/stepconf/pport1.glade:839
+#: src/emc/usr_intf/stepconf/pport2.glade:1443
+#: src/emc/usr_intf/pncconf/pport1.glade:628
+#: src/emc/usr_intf/pncconf/pport2.glade:631
+msgid "Pin 1_0:"
+msgstr "Pin 1_0:"
+
+#: src/emc/usr_intf/stepconf/pport1.glade:898
+#: src/emc/usr_intf/stepconf/pport2.glade:1503
+#: src/emc/usr_intf/pncconf/pport1.glade:690
+#: src/emc/usr_intf/pncconf/pport2.glade:693
+msgid "Pin 1_1:"
+msgstr "Pin 1_1:"
+
+#: src/emc/usr_intf/stepconf/pport1.glade:957
+#: src/emc/usr_intf/stepconf/pport2.glade:1563
+#: src/emc/usr_intf/pncconf/pport1.glade:752
+#: src/emc/usr_intf/pncconf/pport2.glade:755
+msgid "Pin 1_2:"
+msgstr "Pin 1_2:"
+
+#: src/emc/usr_intf/stepconf/pport1.glade:1016
+#: src/emc/usr_intf/stepconf/pport2.glade:1623
+#: src/emc/usr_intf/pncconf/pport1.glade:814
+#: src/emc/usr_intf/pncconf/pport2.glade:817
+msgid "Pin 1_3:"
+msgstr "Pin 1_3:"
+
+#: src/emc/usr_intf/stepconf/pport1.glade:1075
+#: src/emc/usr_intf/stepconf/pport2.glade:1683
+#: src/emc/usr_intf/pncconf/pport1.glade:876
+#: src/emc/usr_intf/pncconf/pport2.glade:879
+msgid "Pin 1_5:"
+msgstr "Pin 1_5:"
+
+#: src/emc/usr_intf/stepconf/pport1.glade:1134
+#: src/emc/usr_intf/stepconf/pport2.glade:924
+#: src/emc/usr_intf/pncconf/pport1.glade:100
+#: src/emc/usr_intf/pncconf/pport2.glade:103
+msgid "Inputs (Mill to PC):"
+msgstr "Entradas (Máquina a PC):"
+
+#: src/emc/usr_intf/stepconf/pport1.glade:1222
+#: src/emc/usr_intf/stepconf/pport2.glade:817
+#, fuzzy
+msgid "Parport _Number:"
+msgstr "Número siguiente:"
+
+#: src/emc/usr_intf/stepconf/pport1.glade:1273
 msgid "Output pinout presets:"
 msgstr "Pinouts de salida preajustados :"
 
-#: src/emc/usr_intf/stepconf/pport1.glade:910
-msgid "Parport _Base Address:"
-msgstr "Dirección _Base del Puerto :"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:37
+#: src/emc/usr_intf/stepconf/pport2.glade:48
 #: src/emc/usr_intf/pncconf/base.glade:38
 #: src/emc/usr_intf/pncconf/pport1.glade:40
 #: src/emc/usr_intf/pncconf/pport2.glade:40
 msgid "Out"
 msgstr "Salida"
 
-#: src/emc/usr_intf/stepconf/pport2.glade:40
+#: src/emc/usr_intf/stepconf/pport2.glade:51
 #: src/emc/usr_intf/pncconf/base.glade:35
 #: src/emc/usr_intf/pncconf/pport1.glade:37
 #: src/emc/usr_intf/pncconf/pport2.glade:37
 msgid "In"
 msgstr "Entrada"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:114
-#: src/emc/usr_intf/pncconf/pport1.glade:135
-#: src/emc/usr_intf/pncconf/pport2.glade:138
-msgid "Pin 2:"
-msgstr "Pin 2:"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:172
-#: src/emc/usr_intf/pncconf/pport1.glade:196
-#: src/emc/usr_intf/pncconf/pport2.glade:199
-msgid "Pin 3:"
-msgstr "Pin 3:"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:230
-#: src/emc/usr_intf/pncconf/pport1.glade:257
-#: src/emc/usr_intf/pncconf/pport2.glade:260
-msgid "Pin 4:"
-msgstr "Pin 4:"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:288
-#: src/emc/usr_intf/pncconf/pport1.glade:318
-#: src/emc/usr_intf/pncconf/pport2.glade:321
-msgid "Pin 5:"
-msgstr "Pin 5:"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:346
-#: src/emc/usr_intf/pncconf/pport1.glade:379
-#: src/emc/usr_intf/pncconf/pport2.glade:382
-msgid "Pin 6:"
-msgstr "Pin 6:"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:404
-#: src/emc/usr_intf/pncconf/pport1.glade:440
-#: src/emc/usr_intf/pncconf/pport2.glade:443
-msgid "Pin 7:"
-msgstr "Pin 7:"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:462
-#: src/emc/usr_intf/pncconf/pport1.glade:501
-#: src/emc/usr_intf/pncconf/pport2.glade:504
-msgid "Pin 8:"
-msgstr "Pin 8:"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:520
-#: src/emc/usr_intf/pncconf/pport1.glade:562
-#: src/emc/usr_intf/pncconf/pport2.glade:565
-msgid "Pin 9:"
-msgstr "Pin 9:"
-
-#: src/emc/usr_intf/stepconf/pport2.glade:949
-#: src/emc/usr_intf/pncconf/pport1.glade:1006
-#: src/emc/usr_intf/pncconf/pport2.glade:1009
-msgid "Pin _1: "
-msgstr "Pin _1:"
 
 #: src/emc/usr_intf/stepconf/spindle.glade:29
 msgid "_PWM 1:"
@@ -10724,53 +10963,153 @@ msgstr "Usar husillo a velocidad:"
 msgid "Scale %"
 msgstr "Escala %"
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr "Eje"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
-msgstr "Usar gui AXIS"
+msgid "Gmoccapy"
+msgstr "Gmoccapy"
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
-msgstr "Usar gui Gmoccapy"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
+msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+#, fuzzy
+msgid "Screen:  "
+msgstr "Pantalla"
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr "0.000"
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Offset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Offset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+#, fuzzy
+msgid "Alignment Laser:"
+msgstr "corriente de alineación"
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+#, fuzzy
+msgid "Screen Aspect:"
+msgstr "Pantalla"
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Estop ON"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+#, fuzzy
+msgid "Hidden"
+msgstr "¡HiddenColNbr!"
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Botón izquierdo"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "Modo"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr "_ Solicitud en pantalla para cambio manual de herramienta"
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr "Incluir componente de interfaz de usuario Halui"
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr "Incluir panel GUI PyVCP personalizado"
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr "Programa en blanco"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 msgid "Spindle speed display  "
 msgstr "Visualización de la velocidad del husillo"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr "Programa personalizado existente"
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr "Incluir conexiones a HAL"
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10782,68 +11121,68 @@ msgstr ""
 "muestra\n"
 "de panel"
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr "Establecer opciones pyVCP"
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr "Incluir PLC _Classicladder"
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr "Número de pines digitales IN:"
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr "Número de pines digitales OUT:"
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr " Número de pines analógicos IN (s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr " Número de pines analógicos OUT (s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr " Número de pines analógicos IN (float):"
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr " Número de pines analógicos OUT (float):"
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr "Configuración del numero de pines externos"
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr "Incluir soporte del maestro modbus"
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr "Programa ladder en blanco"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr "Programa ladder de Estop"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr "Programa Modbus serie"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
@@ -10852,9 +11191,13 @@ msgstr ""
 "Editar programa\n"
 "ladder"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 msgid "Set Ladder Options"
 msgstr "Establecer opciones de escalera"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr "Incluir componente de interfaz de usuario Halui"
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10872,16 +11215,168 @@ msgstr "ELIMINAR"
 msgid "Move UP"
 msgstr "Subir"
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+#, fuzzy
+msgid "NUM"
+msgstr "NML"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr "10"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+#, fuzzy
+msgid "11"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+#, fuzzy
+msgid "12"
+msgstr "2"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+#, fuzzy
+msgid "13"
+msgstr "3"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+#, fuzzy
+msgid "14"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+#, fuzzy
+msgid "15"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+#, fuzzy
+msgid "16"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+#, fuzzy
+msgid "18"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+#, fuzzy
+msgid "19"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+#, fuzzy
+msgid "20"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+#, fuzzy
+msgid "IDX"
+msgstr "PID"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+#, fuzzy
+msgid "32"
+msgstr "3"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+#, fuzzy
+msgid "64"
+msgstr "6"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+#, fuzzy
+msgid "300"
+msgstr "500"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "Modo"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr "Mismo"
 
@@ -10891,10 +11386,10 @@ msgstr "Mismo"
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 msgid "Opposite"
 msgstr "Opuesto"
 
@@ -10904,13 +11399,13 @@ msgstr "Opuesto"
 #: src/emc/usr_intf/stepconf/axisu.glade:167
 #: src/emc/usr_intf/stepconf/axisv.glade:166
 #: src/emc/usr_intf/stepconf/axisa.glade:166
-#: src/emc/usr_intf/pncconf/dialogs.glade:1243
-#: src/emc/usr_intf/pncconf/dialogs.glade:1307
-#: src/emc/usr_intf/pncconf/dialogs.glade:1517
-#: src/emc/usr_intf/pncconf/dialogs.glade:2032
-#: src/emc/usr_intf/pncconf/dialogs.glade:2098
-#: src/emc/usr_intf/pncconf/dialogs.glade:2412
-#: src/emc/usr_intf/pncconf/dialogs.glade:2503
+#: src/emc/usr_intf/pncconf/dialogs.glade:1269
+#: src/emc/usr_intf/pncconf/dialogs.glade:1333
+#: src/emc/usr_intf/pncconf/dialogs.glade:1543
+#: src/emc/usr_intf/pncconf/dialogs.glade:2058
+#: src/emc/usr_intf/pncconf/dialogs.glade:2124
+#: src/emc/usr_intf/pncconf/dialogs.glade:2438
+#: src/emc/usr_intf/pncconf/dialogs.glade:2529
 msgid "_:"
 msgstr "_:"
 
@@ -10922,15 +11417,6 @@ msgstr "_:"
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
 msgstr "t_o"
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
-msgstr "s"
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
 #: src/emc/usr_intf/stepconf/axisy.glade:402
@@ -11056,7 +11542,7 @@ msgstr "Dirección La_tch Home:"
 #: src/emc/usr_intf/stepconf/axisu.glade:620
 #: src/emc/usr_intf/stepconf/axisv.glade:629
 #: src/emc/usr_intf/stepconf/axisa.glade:609
-#: src/emc/usr_intf/pncconf/dialogs.glade:2859
+#: src/emc/usr_intf/pncconf/dialogs.glade:2885
 msgid "Time to accelerate to max speed:"
 msgstr "Tiempo para acelerar hasta velocidad máxima:"
 
@@ -11075,7 +11561,7 @@ msgstr "Distancia para acelerar hasta velocidad máxima:"
 #: src/emc/usr_intf/stepconf/axisu.glade:648
 #: src/emc/usr_intf/stepconf/axisv.glade:657
 #: src/emc/usr_intf/stepconf/axisa.glade:635
-#: src/emc/usr_intf/pncconf/dialogs.glade:2889
+#: src/emc/usr_intf/pncconf/dialogs.glade:2915
 msgid "Pulse rate at max speed:"
 msgstr "Frecuencia de pulsos a velocidad máxima:"
 
@@ -11132,7 +11618,7 @@ msgstr ""
 msgid " Simulator: will not run hardware "
 msgstr "Simulador: no ejecutará hardware"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:96
+#: src/emc/usr_intf/pncconf/pncconf.py:97
 msgid ""
 "PNCconf encountered an error.  The following information may be useful in "
 "troubleshooting:\n"
@@ -11141,32 +11627,32 @@ msgstr ""
 "PNCconf encontró un error. La siguiente información puede ser útil en "
 "solución de problemas:\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:260
+#: src/emc/usr_intf/pncconf/pncconf.py:264
 msgid "**** PNCCONF ERROR:    custom firmware loading error"
 msgstr "**** ERROR PNCCONF: error de carga de firmware personalizado"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:263
+#: src/emc/usr_intf/pncconf/pncconf.py:267
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr "**** INFORMACIÓN PNCCONF: Se encontró firmware adicional en el archivo"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:327
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr "Actualización de metadatos de descubrimiento"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:361
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr "%s actualización de metadatos"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:381
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr "Configuración de Pncconf"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:393
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr "Se está configurando Pncconf"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:407
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
@@ -11174,15 +11660,15 @@ msgstr ""
 "\n"
 "**** Pausa de depuración! ****"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:480
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr "La página de ayuda específica no está disponible\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:482
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr "Páginas de ayuda"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:538
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11193,11 +11679,11 @@ msgstr ""
 "%s\n"
 "PNCconf usará datos internos del firmware"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:855
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "Archivos de configuración LinuxCNC 'PNCconf'"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:885
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
@@ -11206,11 +11692,11 @@ msgstr ""
 "Parece que los datos en este archivo son demasiado antiguos de una versión "
 "de PNCConf paracontinuar.."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1241
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr "No se encontró ninguna placa\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1279
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11225,32 +11711,32 @@ msgstr ""
 "\n"
 " %s"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1293
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr "El descubrimiento no está disponible\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1545
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr "Búsqueda de información del dispositivo USB"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1559
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr "La página del dispositivo USB no está disponible\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1624
-#: src/emc/usr_intf/pncconf/tests.py:86
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
+#: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr "Los nombres de los pines no están disponibles\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1647
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr "Los nombres de los dispositivos no están disponibles\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1650
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr "No se encontraron reglas de dispositivo hechas por Pncconf\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1695
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11264,7 +11750,7 @@ msgstr ""
 "opciones relacionadas más tarde, como la retroalimentación del husillo, la "
 "conexión HALno se actualizará"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1702
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
@@ -11275,37 +11761,37 @@ msgstr ""
 "seguridad'Al hacer clic en 'programa personalizado existente' se anulará "
 "esta advertencia\"."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3475
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr "Canal no utilizado"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3746
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr "No puede tener señales paso a paso y pwm para el control del cabezal\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3750
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr "Olvidó designar una señal paso a paso o pwm para el eje %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3753
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 "Olvidó designar una señal de codificador / resolutor para el eje %s servo\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3756
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr "Olvidó designar una señal pwm o una señal paso a paso para el eje %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3759
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr "No puede tener señales paso a paso y pwm para el eje %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
@@ -11314,19 +11800,19 @@ msgstr ""
 "Si utiliza un stepper de eje en tándem, debe seleccionar un stepgen maestro "
 "para el eje%s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3770
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr "Touchy requiere una señal externa de inicio de ciclo\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3773
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr "Touchy requiere una señal externa de cancelación\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3776
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr "Touchy requiere una señal externa de paso-sencillo\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3779
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
@@ -11334,7 +11820,7 @@ msgstr ""
 "Touchy requiere una señal externa de codificador MPG con volante manual "
 "múltiple en la mesa página\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3782
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
@@ -11342,15 +11828,15 @@ msgstr ""
 "Touchy requiere 'jogging externo mpg' para ser seleccionado en la pagina "
 "externa del control\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3785
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
-"Touchy requiere que el mpg externo esté en modo 'mpg compartido' en "
-"la página externa del control\n"
+"Touchy requiere que el mpg externo esté en modo 'mpg compartido' en la "
+"página externa del control\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3788
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
@@ -11358,7 +11844,7 @@ msgstr ""
 "Touchy requiere que los incrementos seleccionables no estén marcados en la "
 "página externa del contro\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
@@ -11366,7 +11852,7 @@ msgstr ""
 "La placa secundaria 7i29 requiere generadores de tipo PWM y una base "
 "PWMfrecuencia de 20 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
@@ -11374,7 +11860,7 @@ msgstr ""
 "La placa secundaria 7i30 requiere generadores tipo PWM y una base "
 "PWMfrecuencia de 20 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3807
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
@@ -11382,7 +11868,7 @@ msgstr ""
 "La placa secundaria 7i33 requiere generadores de tipo PDM y una base "
 "PDMfrecuencia de 6 Mhz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3810
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
@@ -11390,7 +11876,7 @@ msgstr ""
 "La placa secundaria 7i40 requiere generadores de tipo PWM y una base "
 "PWMfrecuencia de 50 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3813
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
@@ -11398,96 +11884,99 @@ msgstr ""
 "La placa secundaria 7i48 requiere generadores de tipo UDM y una base "
 "PWMfrecuencia de 24 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3961
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr "Relación de reducción de la caja de cambios"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3964
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr "Relación de reducción"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3967
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr "Paso de husillo"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3970
-#: src/emc/usr_intf/pncconf/dialogs.glade:1978
-#: src/emc/usr_intf/pncconf/dialogs.glade:2359
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
+#: src/emc/usr_intf/pncconf/dialogs.glade:2004
+#: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr "Leadscrew TPI"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3974
-#: src/emc/usr_intf/pncconf/pncconf.py:3975
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr "("
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3976
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
-#: src/emc/usr_intf/pncconf/pncconf.py:3987
-#: src/emc/usr_intf/pncconf/pncconf.py:3988
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr "/ min"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr "/ sec²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 msgid " / Step"
 msgstr "/ Paso"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3981
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 msgid "Steps / "
 msgstr "Pasos /"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr "/ pulso codificador"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3984
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr "Pulsos de codificador /"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 msgid "Resolver Scale:"
 msgstr "Escala de resolución:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4325
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 msgid "Spindle Scale Calculation"
 msgstr "Cálculo de escala de husillo"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4437
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr "Cálculo de escala de eje"
 
-#: src/emc/usr_intf/pncconf/pages.py:239 src/emc/usr_intf/pncconf/pages.py:290
+#: src/emc/usr_intf/pncconf/pages.py:241 src/emc/usr_intf/pncconf/pages.py:292
 #, python-format
 msgid "Point and click configuration - %s.pncconf "
 msgstr "Configuración de apuntar y hacer clic - %s.pncconf"
 
-#: src/emc/usr_intf/pncconf/pages.py:322
+#: src/emc/usr_intf/pncconf/pages.py:324
 msgid ""
 "You need to designate a parport and/or mesa I/O device before continuing."
 msgstr ""
 "Debe designar un parport y / o dispositivo de E / S de mesa antes de "
 "continuar."
 
-#: src/emc/usr_intf/pncconf/pages.py:385
+#: src/emc/usr_intf/pncconf/pages.py:387
 msgid "PCI search page is unavailable\n"
 msgstr "La página de búsqueda de PCI no está disponible\n"
 
-#: src/emc/usr_intf/pncconf/pages.py:433
+#: src/emc/usr_intf/pncconf/pages.py:436
 msgid "in / min"
 msgstr "en / min"
 
-#: src/emc/usr_intf/pncconf/pages.py:436
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr "mm / min"
 
-#: src/emc/usr_intf/pncconf/pages.py:890
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11497,7 +11986,7 @@ msgstr ""
 " Elija el tipo de placa, firmware, cantidades de componentes y presione el "
 "boton' 'Aceptar cambios de componentes"
 
-#: src/emc/usr_intf/pncconf/pages.py:893
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
@@ -11505,7 +11994,7 @@ msgstr ""
 "El tablero Mesa0 elegido es diferente del actual que se muestra.presione el "
 "botón 'Aceptar cambios de componentes' '"
 
-#: src/emc/usr_intf/pncconf/pages.py:942
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11515,7 +12004,7 @@ msgstr ""
 "cantidades de componentes y presione el boton 'Aceptar cambios de "
 "componentes'"
 
-#: src/emc/usr_intf/pncconf/pages.py:945
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
@@ -11523,18 +12012,18 @@ msgstr ""
 "La placa Mesa1 elegida es diferente de la actual que se muestra.presione el "
 "botón 'Aceptar cambios de componentes' '"
 
-#: src/emc/usr_intf/pncconf/pages.py:1313
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 "Debe designar un pin de entrada de parada de emergencia para este programa "
 "de escalera\"."
 
-#: src/emc/usr_intf/pncconf/pages.py:1324
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 "Debe designar un pin de entrada de sonda para este programa de escalera."
 
-#: src/emc/usr_intf/pncconf/pages.py:1334
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11546,110 +12035,115 @@ msgstr ""
 "Cualquier archivo existente llamado -custom_backup.clp- se perderá. "
 "Seleccionando 'programa de escalera existente' evitará esta advertencia "
 
-#: src/emc/usr_intf/pncconf/build_INI.py:17
-#: src/emc/usr_intf/pncconf/build_HAL.py:53
-#: src/emc/usr_intf/pncconf/build_HAL.py:979
-#: src/emc/usr_intf/pncconf/build_HAL.py:999
+#: src/emc/usr_intf/pncconf/build_INI.py:18
+#: src/emc/usr_intf/pncconf/build_HAL.py:54
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr "# Generado por PNCconf en %s"
 
-#: src/emc/usr_intf/pncconf/build_INI.py:18
-#: src/emc/usr_intf/pncconf/build_HAL.py:54
+#: src/emc/usr_intf/pncconf/build_INI.py:19
+#: src/emc/usr_intf/pncconf/build_HAL.py:55
 #, python-format
 msgid "# Using LinuxCNC version:  %s"
 msgstr "# Utilizando la versión LinuxCNC: %s"
 
-#: src/emc/usr_intf/pncconf/build_INI.py:20
-#: src/emc/usr_intf/pncconf/build_HAL.py:56
+#: src/emc/usr_intf/pncconf/build_INI.py:21
+#: src/emc/usr_intf/pncconf/build_HAL.py:57
 msgid "# overwritten when you run PNCconf again"
 msgstr "# sobrescrito cuando ejecuta PNCconf nuevamente"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:407
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr "# conecta señales varias"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:410
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr "# --- Señales HALUI ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:438
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr "# --- señales de la bomba de carga ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:442
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr "# --- señales de refrigerante ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:447
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr "# --- señal de sonda ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:452
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr "# --- señales del botón de desplazamiento ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:457
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr "# --- Señales del botón de avance del dispositivo USB ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:498
-#: src/emc/usr_intf/pncconf/build_HAL.py:524
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr "# --- señales mpg ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:706
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr "# --- señales de control de movimiento ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:711
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr "# --- señales digitales de entrada / salida ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:721
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr "# --- señales de parada ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:740
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr "# --- señales de cambio de herramienta manual ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:749
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+#, fuzzy
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr "# --- señales de cambio de herramienta manual ---"
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 "# --- señales de cambio de herramienta para cambiador de herramientas "
 "personalizado ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:771
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 "# --- Señales Classicladder para el eje Z Programa de toque automático ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:790
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 "# Estos archivos se cargan después de gladeVCP, en el orden en que aparecen"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:804
-#: src/emc/usr_intf/pncconf/build_HAL.py:877
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr "# _DO NOT_ incluye tus comandos HAL aquí\"."
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr "# Colocar comandos HAL personalizados en custom_gvcp.hal"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:808
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 "# **** Configuración de la pantalla de velocidad del husillo utilizando "
 "gladevcp ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:817
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr "# **** Configurar los botones GLADE MDI ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:830
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
@@ -11657,93 +12151,94 @@ msgstr ""
 "# **** Botón de contacto del eje Z - requiere la clásica clásica de "
 "contactoprograma ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr "# Colocar comandos HAL personalizados en custom_postgui.hal"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 "# Los comandos en este archivo se ejecutan después de que se carga la GUI"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:889
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 "# **** Configuración de la pantalla de velocidad del husillo utilizando "
 "pyvcp -END ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:901
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr "# Este archivo no se sobrescribirá cuando vuelva a ejecutar PNCconf"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:907
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
 msgstr "# Estos comandos son necesarios para la GUI Touchy"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1007
+#: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
 msgid "Generated by PNCconf at %s"
 msgstr "Generado por PNCconf en %s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1019
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
 msgid "configures LinuxCNC as:\n"
 msgstr "configura LinuxCNC como:\n"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
 msgid "type CNC\n"
 msgstr "tipo CNC\n"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
 msgid "will be used as the frontend display"
 msgstr "se usará como pantalla de interfaz"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1030
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
 msgid " connector"
 msgstr "conector"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1042
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
 msgid "invrt"
 msgstr "invrt"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1051
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
 #, python-format
 msgid "%(name)s Parport"
 msgstr "%(name)s Parport"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1056
-#: src/emc/usr_intf/pncconf/build_HAL.py:1064
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
 msgid "-> inverted"
 msgstr "-> invertido"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1058
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
 #, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 "pin# %(pinnum)d está conectado a la señal de entrada:'%(data)s' %(mesag)s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1066
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 "pin# %(pinnum)d está conectado a la señal de salida:'%(data)s' %(mesag)s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1466
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 "# Usar la velocidad ACTUAL del cabezal desde el codificador del cabezal"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1467
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr "# la velocidad del husillo rebota, así que la filtramos con paso bajo"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1468
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 "# spindle-velocity está firmado, por lo que usamos un componente absoluto "
 "para eliminar el signo"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1469
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr "# La velocidad REAL está en RPS, no en RPM, así que la escalamos\"."
 
@@ -11759,1503 +12254,1559 @@ msgstr "Pantalla"
 msgid "VCP"
 msgstr "VCP"
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 msgid "External Controls"
 msgstr "Controles externos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr "Tarjeta Mesa 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr "Mesa Card 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 msgid "Parallel Port"
 msgstr "Puerto paralelo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 msgid "X Motor"
 msgstr "Motor X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "X Axis"
 msgstr "Eje X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 msgid "Y Motor"
 msgstr "Motor Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Y Axis"
 msgstr "Eje Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 msgid "Z Motor"
 msgstr "Motor Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Z Axis"
 msgstr "Eje Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 msgid "A Motor"
 msgstr "Un motor"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "A Axis"
 msgstr "Un eje"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 msgid "Spindle Motor"
 msgstr "Motor de husillo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr "Tiempo real"
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr "No utilizado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr "Dummy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr "Unidad servo 8i20"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr "Salida POT"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
 msgstr "Habilitar POT"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Dir"
 msgstr "POT Dir"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Input"
 msgstr "Entrada GPIO"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Output"
 msgstr "Salida GPIO"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO O Drain"
 msgstr "GPIO O Drain"
 
-#: src/emc/usr_intf/pncconf/private_data.py:113
+#: src/emc/usr_intf/pncconf/private_data.py:117
 msgid "SSR Output"
 msgstr "Salida SSR"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr "Quad Enc-A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr "Quad Enc-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr "Quad Enc-I"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr "Quad Enc-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 0"
 msgstr "Muxed Enc 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 1"
 msgstr "Muxed Enc 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "muxed Enc I"
 msgstr "enc. enm. I"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc M"
 msgstr "Muxed Enc M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr "seleccionar mux"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr "Resolver 0 Encoder"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr "Encoder Resolver 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr "Resolver 2 Encoder"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr "Resolver 3 Encoder"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr "Resolver 4 Encoder"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr "Resolver 5 Encoder"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step Gen-A"
 msgstr "Paso Gen-A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr "Dir Gen-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr "Paso / Dir Gen-C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr "Paso / Dir Gen-D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr "Paso / Dir Gen-E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr "Paso / dir Gen-F"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr "PWM Gen-P"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr "PWM Gen-D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr "PWM Gen-E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr "PDM Gen-P"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr "PDM Gen-D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr "PDM Gen-E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr "UDM -Up"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-Down"
 msgstr "UDM-Down"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr "UDM-E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr "Fase del motor A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr "Fase del motor B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr "Fase del motor C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr "Motor Fase A no"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr "Fase del motor B no"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr "Fase del motor C no"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr "Motor habilitado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr "Falla del motor"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr "SSERIAL-P0-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr "SSERIAL-P0-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr "SSERIAL-P0-ES"
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr "SSERIAL-P1-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr "SSERIAL-P1-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr "SSERIAL-P1-ES"
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr "SSERIAL-P2-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr "SSERIAL-P2-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr "SSERIAL-P2-ES"
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr "SSERIAL-P3-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr "SSERIAL-P3-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr "SSERIAL-P3-ES"
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr "SSERIAL-P4-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr "SSERIAL-P4-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr "SSERIAL-P4-ES"
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr "SSERIAL-P5-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr "SSERIAL-P5-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr "SSERIAL-P5-ES"
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr "SSERIAL-P6-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr "SSERIAL-P6-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr "SSERIAL-P6-ES"
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr "SSERIAL-P7-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr "SSERIAL-P7-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr "SSERIAL-P7-ES"
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr "E / S 7i76 (SS0)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr "E / S 7i76 (SS2)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr "E / S 7i76 (SS3)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr "7i77 I / O-SS0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr "7i77 Analog-SS1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr "7i77 I / O-SS3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr "7i77 Analog-SS4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Analog Input"
 msgstr "Entrada analógica"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "X Home"
 msgstr "X Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Y Home"
 msgstr "Y Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Z Home"
 msgstr "Z Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "A Home"
 msgstr "Un hogar"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "All Home"
 msgstr "Todo en casa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "X2 Tandem Home"
 msgstr "X2 Tandem Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Y2 Tandem Home"
 msgstr "Y2 Tandem Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Z2 Tandem Home"
 msgstr "Z2 Tandem Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "A2 Tandem Home"
 msgstr "A2 Tandem Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr "Límite mínimo X + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr "Límite mínimo Y + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr "Límite mínimo Z + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr "Un límite mínimo + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr "Límite máximo X + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr "Y ambos límites + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr "Límite Z Ambos + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr "Un límite de ambos + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr "X Límite de ambos + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr "Y ambos límites + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr "Límite Z Ambos + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr "Un límite de ambos + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "All Limits + Home"
 msgstr "Todos los límites + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr "Límite mínimo X2 + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr "Límite mínimo de Y2 + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr "Límite mínimo Z2 + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr "Límite mínimo A2 + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr "Límite máximo X2 + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr "Límite máximo Y2 + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr "Límite máximo Z2 + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr "Límite máximo A2 + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr "X2 Both Limit + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr "Y2 Both Limit + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr "Z2 Both Limit + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 msgid "A2 Both Limit + Home"
 msgstr "A2 Ambos Límite + Inicio"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr "Selección articulacion A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr "Selección articulacion B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr "Selección articulacion C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr "Selección articulacion D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr "Jog incr A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr "Jog incr B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr "Jog incr C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr "Jog incr D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr A"
 msgstr "Feed Override incr A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr B"
 msgstr "Ajuste de alimentación incr B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr C"
 msgstr "Feed Override incr C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr D"
 msgstr "Feed Override incr D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Spindle Override incr A"
 msgstr "Ajuste del husillo incr A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr B"
 msgstr "Ajuste del husillo incr B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr C"
 msgstr "Ajuste de husillo incr C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr D"
 msgstr "Ajuste del husilloincr D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr "Max Vel Override incr A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr "Max Vel Override incr B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr "Max Vel Override incr C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr "Max Vel Override incr D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Feed Override enable"
 msgstr "Activar ajuste de alimentación"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Spindle Override enable"
 msgstr "Activación de ajuste de husillo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 msgid "Max Vel Override enable"
 msgstr "Max Vel Override enable"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CW"
 msgstr "Husillo manual CW"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CCW"
 msgstr "Husillo manual CCW"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle Stop"
 msgstr "Parada manual del husillo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Spindle Up-To-Speed"
 msgstr "Eje hasta velocidad"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Gear Select A"
 msgstr "Gear Select A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr "Inicio del ciclo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr "Abortar"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Single Step"
 msgstr "Paso único"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr "Jog X +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr "Jog X -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr "Jog Y +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr "Jog Y -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr "Jog Z +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr "Jog Z -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr "Jog A +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr "Jog A -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr "Botón Jog seleccionado +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr "Botón Jog seleccionado -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr "X HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr "X HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr "X HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr "X Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr "X C2 gris"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr "X Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr "X C8 gris"
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr "Y HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr "Y HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr "Y HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr "Y Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr "Y C2 gris"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr "Y gris C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr "Y gris C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr "Z HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr "Z HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr "Z HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr "Z Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr "Z Grey C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr "Z Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr "Z Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr "A HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr "A HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr "A HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr "Un C1 gris"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr "Un C2 gris"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr "Un C4 gris"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr "Un C8 gris"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr "S HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr "S HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr "S HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr "S Gris C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr "S gris C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr "S gris C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr "S gris C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr "Límite mínimo X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr "Límite mínimo Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr "Límite mínimo Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr "Un límite mínimo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr "Límite máximo X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr "Límite máximo Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr "Límite máximo Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr "Un límite máximo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr "X Límite de ambos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr "Y ambos límites"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr "Límite de ambos Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr "Un límite de ambos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr "Todos los límites"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr "Límite mínimo X2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr "Límite mínimo de Y2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr "Límite mínimo de Z2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr "Límite mínimo A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr "Límite máximo X2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr "Límite máximo de Y2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr "Límite máximo de Z2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr "Límite máximo A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr "X2 Ambos límites"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr "Límite de Y2 Ambos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr "Límite de Z2 Ambos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "A2 Both Limit"
 msgstr "Límite de ambos A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 msgid "Main Axis"
 msgstr "Eje principal"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 msgid "Tandem Axis"
 msgstr "Eje en tándem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Arc OK"
+msgstr "Arco CW"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Ohmic Probe"
+msgstr "Sonda"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "Interruptores"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr "Entrada no utilizada"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Limits"
 msgstr "Límites"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr "Límites / Inicio compartido"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr "Digital"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:797
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr "Selección del eje"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 msgid "Overrides"
 msgstr "Anulaciones"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "Operation"
 msgstr "Operación"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "External Control"
 msgstr "Control externo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 msgid "Axis rapid"
 msgstr "Eje rápido"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr "Control X BLDC"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr "Control Y BLDC"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr "Control de Z BLDC"
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr "Un control BLDC"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr "Control S BLDC"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr "Señales personalizadas"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr "X2 Tandem PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr "Y2 Tandem PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr "Z2 Tándem PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr "A2 Tandem PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "X Axis PWM"
 msgstr "Eje X PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "Y Axis PWM"
 msgstr "Y Axis PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "Z Axis PWM"
 msgstr "Eje Z PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "A Axis PWM"
 msgstr "Un eje PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Unused PWM Gen"
 msgstr "Gen PWM no utilizado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Axis PWM"
 msgstr "Eje PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 msgid "X Axis StepGen"
 msgstr "X Axis StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Y Axis StepGen"
 msgstr "Y Axis StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Z Axis StepGen"
 msgstr "Z Axis StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 msgid "A Axis StepGen"
 msgstr "Un eje StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "X2 Tandem StepGen"
 msgstr "X2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "Y2 Tandem StepGen"
 msgstr "Y2 StepGen en tándem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 msgid "Z2 Tandem StepGen"
 msgstr "Z2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 msgid "Unused StepGen"
 msgstr "StepGen no utilizado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr "Eje"
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr "Bomba de carga StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Spindle StepGen"
 msgstr "Spindle StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr "Codificador X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr "Codificador Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr "Codificador Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr "Un codificador"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 msgid "X2 Tandem Encoder"
 msgstr "Codificador en tándem X2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 msgid "Y2 Tandem Encoder"
 msgstr "Codificador en tándem Y2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 msgid "Z2 Tandem Encoder"
 msgstr "Codificador en tándem Z2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 msgid "A2 Tandem Encoder"
 msgstr "Codificador en tándem A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr "Volante X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr "Rueda manual Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr "Rueda de mano Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr "Una rueda de mano"
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr "Rueda manual múltiple"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Feed Override"
 msgstr "Ajuste de feed"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "spindle Override"
 msgstr "ajuste del husillo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Max Vel Override"
 msgstr "Ajuste de Vel Vel"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr "Codificador no utilizado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr "Codificador de eje"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Spindle Encoder"
 msgstr "Codificador de husillo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr "Controles de desplazamiento de MPG"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr "Anular el control MPG"
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Codificador X"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 msgid "Unused Unused"
 msgstr "Sin usar Sin usar"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Enable"
 msgstr "Activar eje"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "Machine Is Enabled"
 msgstr "La máquina está habilitada"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr "Amplificador X habilitado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr "Amplificador Y habilitado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr "Amplificador Z habilitado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr "Un amplificador habilitado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr "Pin de fuerza verdadero"
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Habilitar POT"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Máquina On"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "Touch Off"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr "Salida no utilizada"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Coolant"
 msgstr "Refrigerante"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr "Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr "Control S BLDC"
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr "8I20 sin usar"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr "Resolución no utilizada"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr "Resolver X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr "Y Resolver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr "Resolver Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr "Un solucionador"
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr "S Resolver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr "Salida analógica no utilizada"
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Spindle Output"
 msgstr "Salida de husillo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr "Gen TPPWM no utilizado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr "Controlador X Axis BL"
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr "Controlador Y Axis BL"
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr "Controlador Z Axis BL"
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr "Un controlador Axis BL"
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr "Controlador S Axis BL"
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr "Tarjeta amplificadora 8i20"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr "Tarjeta de E / S 7i64"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr "Tarjeta de E / S 7i69"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr "Tarjeta de E / S 7i70"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr "Tarjeta de E / S 7i71"
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr "Tarjeta de E / S modo 0 7i76"
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr "Tarjeta de E / S 7i76 Modo 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr "Tarjeta de E / S del modo 0 7i77"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr "Tarjeta de E / S del Modo 3 7i77"
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr "Tarjeta colgante 7i73 Modo 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr "Tarjeta de E / S del Modo 1 7i84"
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr "Tarjeta de E / S del Modo 3 7i84"
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Unused Analog In"
 msgstr "Entrada analógica no utilizada"
 
-#: src/emc/usr_intf/pncconf/private_data.py:805
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr "Entrada 7i64P3 y P4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:805
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr "Salida 7i64P2 y P5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:805
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr "7i64-Entrada analógica"
 
-#: src/emc/usr_intf/pncconf/private_data.py:818
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr "7i69P2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:818
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr "7i69P3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:830
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr "Entrada 7i70TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:830
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr "Entrada 7i70TB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:842
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr "Salida 7i71TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:842
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr "Salida 7i71TB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:854
-#: src/emc/usr_intf/pncconf/private_data.py:866
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr "7i76-I / OTB6"
 
-#: src/emc/usr_intf/pncconf/private_data.py:854
-#: src/emc/usr_intf/pncconf/private_data.py:866
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr "7i76-I / OTB5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:854
-#: src/emc/usr_intf/pncconf/private_data.py:866
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr "Salida analógica 7i76TB4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:878
-#: src/emc/usr_intf/pncconf/private_data.py:890
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr "7i77-I / OTB8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:878
-#: src/emc/usr_intf/pncconf/private_data.py:890
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr "7i77-I / OTB7"
 
-#: src/emc/usr_intf/pncconf/private_data.py:878
-#: src/emc/usr_intf/pncconf/private_data.py:890
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr "Salida analógica 7i77TB5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:902
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr "7i73-I/O\n"
 
-#: src/emc/usr_intf/pncconf/private_data.py:915
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr "7i84-I / OTB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:915
-#: src/emc/usr_intf/pncconf/private_data.py:930
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr "7i84-I / OTB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:930
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr "7i84-I / O-MPGTB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:995
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13269,16 +13820,16 @@ msgstr ""
 "existente llamado custompanel_backup.xml y custom_postgui.hal lo haráestar "
 "perdido. "
 
-#: src/emc/usr_intf/pncconf/private_data.py:996
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr "¿Salir de PNCconf y descartar cambios?"
 
-#: src/emc/usr_intf/pncconf/private_data.py:997
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 #, fuzzy
 msgid "Do you want to quit?"
 msgstr "¿Realmente quiere salir?\n"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13292,7 +13843,7 @@ msgstr ""
 "Elegir no significará opciones de AXIS como tamaño / posición y fuerza "
 "máximapodría no ser el solicitado\n"
 
-#: src/emc/usr_intf/pncconf/tests.py:159
+#: src/emc/usr_intf/pncconf/tests.py:160
 msgid ""
 "You specified there is an existing gladefile, But there is not one in the "
 "machine-named folder.."
@@ -13300,68 +13851,77 @@ msgstr ""
 "Usted especificó que hay un archivo glade existente, pero no hay ninguno en "
 "elcarpeta con nombre de máquina..."
 
-#: src/emc/usr_intf/pncconf/tests.py:487
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr "El ajuste del servo aún no se ha probado en PNCconf\n"
 
-#: src/emc/usr_intf/pncconf/tests.py:496
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr "grados"
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr "grados / minuto"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr "grados / segundo²"
 
-#: src/emc/usr_intf/pncconf/tests.py:501
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr "revoluciones"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr "rpm"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr "rev / segundo²"
 
-#: src/emc/usr_intf/pncconf/tests.py:507
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr "mm / minuto"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr "mm / segundo²"
 
-#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr "pulgadas / minuto"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr "pulgadas / segundo²"
 
-#: src/emc/usr_intf/pncconf/tests.py:713
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr "Sintonización del eje %s"
 
-#: src/emc/usr_intf/pncconf/tests.py:907
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
@@ -13369,7 +13929,7 @@ msgstr ""
 "Debe designar una señal ENCODER / RESOLVER y una señal ANALOG SPINDLE para "
 "esta prueba de eje"
 
-#: src/emc/usr_intf/pncconf/tests.py:911
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
@@ -13377,7 +13937,7 @@ msgstr ""
 "Debe designar una señal ENCODER / RESOLVER y una señal PWM para esta prueba "
 "de eje"
 
-#: src/emc/usr_intf/pncconf/tests.py:1200
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13391,11 +13951,11 @@ msgstr ""
 "Idude en permitir su uso, pero a veces es muy útil.¿Desea continuar la "
 "prueba?"
 
-#: src/emc/usr_intf/pncconf/data.py:110
+#: src/emc/usr_intf/pncconf/data.py:116
 msgid "my_LinuxCNC_machine"
 msgstr "my_LinuxCNC_machine"
 
-#: src/emc/usr_intf/pncconf/data.py:849
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13410,12 +13970,12 @@ msgstr ""
 "configuración REALMENTE grande que desea convertir a esta nuevaversión de "
 "PNConf - pregunte en el foro LinuxCNC - puede ser posible .."
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr "El archivo %r fue modificado ya que fue escrito por PNCconf"
 
-#: src/emc/usr_intf/pncconf/data.py:859
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
@@ -13423,7 +13983,7 @@ msgstr ""
 "Guardar este archivo de configuración descartará los cambios de "
 "configuración realizadosfuera de PNCconf\"."
 
-#: src/emc/usr_intf/pncconf/data.py:1062
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
 "Iniciador de escritorio para la configuración LinuxCNC realizada por PNCconf"
@@ -13455,12 +14015,12 @@ msgstr ""
 "husillo VFDo límite avanzado / control del hogar, etc."
 
 #: src/emc/usr_intf/pncconf/main_page.glade:312
-#: src/emc/usr_intf/pncconf/mesa0.glade:22146
-#: src/emc/usr_intf/pncconf/mesa0.glade:27796
-#: src/emc/usr_intf/pncconf/mesa0.glade:33446
-#: src/emc/usr_intf/pncconf/mesa0.glade:39096
-#: src/emc/usr_intf/pncconf/mesa0.glade:44746
-#: src/emc/usr_intf/pncconf/mesa0.glade:50396
+#: src/emc/usr_intf/pncconf/mesa0.glade:22128
+#: src/emc/usr_intf/pncconf/mesa0.glade:27778
+#: src/emc/usr_intf/pncconf/mesa0.glade:33428
+#: src/emc/usr_intf/pncconf/mesa0.glade:39078
+#: src/emc/usr_intf/pncconf/mesa0.glade:44728
+#: src/emc/usr_intf/pncconf/mesa0.glade:50378
 #: src/emc/usr_intf/pncconf/mesa1.glade:22088
 #: src/emc/usr_intf/pncconf/mesa1.glade:27738
 #: src/emc/usr_intf/pncconf/mesa1.glade:33388
@@ -13891,50 +14451,50 @@ msgstr "Configuración     Página"
 #: src/emc/usr_intf/pncconf/mesa0.glade:1449
 #: src/emc/usr_intf/pncconf/mesa0.glade:3405
 #: src/emc/usr_intf/pncconf/mesa0.glade:3677
-#: src/emc/usr_intf/pncconf/mesa0.glade:7213
-#: src/emc/usr_intf/pncconf/mesa0.glade:7484
-#: src/emc/usr_intf/pncconf/mesa0.glade:9319
-#: src/emc/usr_intf/pncconf/mesa0.glade:9581
-#: src/emc/usr_intf/pncconf/mesa0.glade:11405
-#: src/emc/usr_intf/pncconf/mesa0.glade:11676
-#: src/emc/usr_intf/pncconf/mesa0.glade:13498
-#: src/emc/usr_intf/pncconf/mesa0.glade:13769
-#: src/emc/usr_intf/pncconf/mesa0.glade:13900
-#: src/emc/usr_intf/pncconf/mesa0.glade:14172
-#: src/emc/usr_intf/pncconf/mesa0.glade:15993
-#: src/emc/usr_intf/pncconf/mesa0.glade:16265
-#: src/emc/usr_intf/pncconf/mesa0.glade:18086
-#: src/emc/usr_intf/pncconf/mesa0.glade:18358
-#: src/emc/usr_intf/pncconf/mesa0.glade:20195
-#: src/emc/usr_intf/pncconf/mesa0.glade:20458
-#: src/emc/usr_intf/pncconf/mesa0.glade:23952
-#: src/emc/usr_intf/pncconf/mesa0.glade:24214
-#: src/emc/usr_intf/pncconf/mesa0.glade:24495
-#: src/emc/usr_intf/pncconf/mesa0.glade:25845
-#: src/emc/usr_intf/pncconf/mesa0.glade:26108
-#: src/emc/usr_intf/pncconf/mesa0.glade:29602
-#: src/emc/usr_intf/pncconf/mesa0.glade:29864
-#: src/emc/usr_intf/pncconf/mesa0.glade:30145
-#: src/emc/usr_intf/pncconf/mesa0.glade:31495
-#: src/emc/usr_intf/pncconf/mesa0.glade:31758
-#: src/emc/usr_intf/pncconf/mesa0.glade:35252
-#: src/emc/usr_intf/pncconf/mesa0.glade:35514
-#: src/emc/usr_intf/pncconf/mesa0.glade:35795
-#: src/emc/usr_intf/pncconf/mesa0.glade:37145
-#: src/emc/usr_intf/pncconf/mesa0.glade:37408
-#: src/emc/usr_intf/pncconf/mesa0.glade:40902
-#: src/emc/usr_intf/pncconf/mesa0.glade:41164
-#: src/emc/usr_intf/pncconf/mesa0.glade:41445
-#: src/emc/usr_intf/pncconf/mesa0.glade:42795
-#: src/emc/usr_intf/pncconf/mesa0.glade:43058
-#: src/emc/usr_intf/pncconf/mesa0.glade:46552
-#: src/emc/usr_intf/pncconf/mesa0.glade:46814
-#: src/emc/usr_intf/pncconf/mesa0.glade:47095
-#: src/emc/usr_intf/pncconf/mesa0.glade:48445
-#: src/emc/usr_intf/pncconf/mesa0.glade:48708
-#: src/emc/usr_intf/pncconf/mesa0.glade:52202
-#: src/emc/usr_intf/pncconf/mesa0.glade:52464
-#: src/emc/usr_intf/pncconf/mesa0.glade:52745
+#: src/emc/usr_intf/pncconf/mesa0.glade:7195
+#: src/emc/usr_intf/pncconf/mesa0.glade:7466
+#: src/emc/usr_intf/pncconf/mesa0.glade:9301
+#: src/emc/usr_intf/pncconf/mesa0.glade:9563
+#: src/emc/usr_intf/pncconf/mesa0.glade:11387
+#: src/emc/usr_intf/pncconf/mesa0.glade:11658
+#: src/emc/usr_intf/pncconf/mesa0.glade:13480
+#: src/emc/usr_intf/pncconf/mesa0.glade:13751
+#: src/emc/usr_intf/pncconf/mesa0.glade:13882
+#: src/emc/usr_intf/pncconf/mesa0.glade:14154
+#: src/emc/usr_intf/pncconf/mesa0.glade:15975
+#: src/emc/usr_intf/pncconf/mesa0.glade:16247
+#: src/emc/usr_intf/pncconf/mesa0.glade:18068
+#: src/emc/usr_intf/pncconf/mesa0.glade:18340
+#: src/emc/usr_intf/pncconf/mesa0.glade:20177
+#: src/emc/usr_intf/pncconf/mesa0.glade:20440
+#: src/emc/usr_intf/pncconf/mesa0.glade:23934
+#: src/emc/usr_intf/pncconf/mesa0.glade:24196
+#: src/emc/usr_intf/pncconf/mesa0.glade:24477
+#: src/emc/usr_intf/pncconf/mesa0.glade:25827
+#: src/emc/usr_intf/pncconf/mesa0.glade:26090
+#: src/emc/usr_intf/pncconf/mesa0.glade:29584
+#: src/emc/usr_intf/pncconf/mesa0.glade:29846
+#: src/emc/usr_intf/pncconf/mesa0.glade:30127
+#: src/emc/usr_intf/pncconf/mesa0.glade:31477
+#: src/emc/usr_intf/pncconf/mesa0.glade:31740
+#: src/emc/usr_intf/pncconf/mesa0.glade:35234
+#: src/emc/usr_intf/pncconf/mesa0.glade:35496
+#: src/emc/usr_intf/pncconf/mesa0.glade:35777
+#: src/emc/usr_intf/pncconf/mesa0.glade:37127
+#: src/emc/usr_intf/pncconf/mesa0.glade:37390
+#: src/emc/usr_intf/pncconf/mesa0.glade:40884
+#: src/emc/usr_intf/pncconf/mesa0.glade:41146
+#: src/emc/usr_intf/pncconf/mesa0.glade:41427
+#: src/emc/usr_intf/pncconf/mesa0.glade:42777
+#: src/emc/usr_intf/pncconf/mesa0.glade:43040
+#: src/emc/usr_intf/pncconf/mesa0.glade:46534
+#: src/emc/usr_intf/pncconf/mesa0.glade:46796
+#: src/emc/usr_intf/pncconf/mesa0.glade:47077
+#: src/emc/usr_intf/pncconf/mesa0.glade:48427
+#: src/emc/usr_intf/pncconf/mesa0.glade:48690
+#: src/emc/usr_intf/pncconf/mesa0.glade:52184
+#: src/emc/usr_intf/pncconf/mesa0.glade:52446
+#: src/emc/usr_intf/pncconf/mesa0.glade:52727
 #: src/emc/usr_intf/pncconf/mesa1.glade:1171
 #: src/emc/usr_intf/pncconf/mesa1.glade:1443
 #: src/emc/usr_intf/pncconf/mesa1.glade:3369
@@ -13990,50 +14550,50 @@ msgstr "Tipo de pin"
 #: src/emc/usr_intf/pncconf/mesa0.glade:1255
 #: src/emc/usr_intf/pncconf/mesa0.glade:3419
 #: src/emc/usr_intf/pncconf/mesa0.glade:3483
-#: src/emc/usr_intf/pncconf/mesa0.glade:7406
-#: src/emc/usr_intf/pncconf/mesa0.glade:7471
-#: src/emc/usr_intf/pncconf/mesa0.glade:9503
-#: src/emc/usr_intf/pncconf/mesa0.glade:9568
-#: src/emc/usr_intf/pncconf/mesa0.glade:11598
-#: src/emc/usr_intf/pncconf/mesa0.glade:11663
-#: src/emc/usr_intf/pncconf/mesa0.glade:13691
-#: src/emc/usr_intf/pncconf/mesa0.glade:13756
-#: src/emc/usr_intf/pncconf/mesa0.glade:13914
-#: src/emc/usr_intf/pncconf/mesa0.glade:13978
-#: src/emc/usr_intf/pncconf/mesa0.glade:16007
-#: src/emc/usr_intf/pncconf/mesa0.glade:16071
-#: src/emc/usr_intf/pncconf/mesa0.glade:18100
-#: src/emc/usr_intf/pncconf/mesa0.glade:18164
-#: src/emc/usr_intf/pncconf/mesa0.glade:20209
-#: src/emc/usr_intf/pncconf/mesa0.glade:20273
-#: src/emc/usr_intf/pncconf/mesa0.glade:24136
-#: src/emc/usr_intf/pncconf/mesa0.glade:24201
-#: src/emc/usr_intf/pncconf/mesa0.glade:24509
-#: src/emc/usr_intf/pncconf/mesa0.glade:25859
-#: src/emc/usr_intf/pncconf/mesa0.glade:25923
-#: src/emc/usr_intf/pncconf/mesa0.glade:29786
-#: src/emc/usr_intf/pncconf/mesa0.glade:29851
-#: src/emc/usr_intf/pncconf/mesa0.glade:30159
-#: src/emc/usr_intf/pncconf/mesa0.glade:31509
-#: src/emc/usr_intf/pncconf/mesa0.glade:31573
-#: src/emc/usr_intf/pncconf/mesa0.glade:35436
-#: src/emc/usr_intf/pncconf/mesa0.glade:35501
-#: src/emc/usr_intf/pncconf/mesa0.glade:35809
-#: src/emc/usr_intf/pncconf/mesa0.glade:37159
-#: src/emc/usr_intf/pncconf/mesa0.glade:37223
-#: src/emc/usr_intf/pncconf/mesa0.glade:41086
-#: src/emc/usr_intf/pncconf/mesa0.glade:41151
-#: src/emc/usr_intf/pncconf/mesa0.glade:41459
-#: src/emc/usr_intf/pncconf/mesa0.glade:42809
-#: src/emc/usr_intf/pncconf/mesa0.glade:42873
-#: src/emc/usr_intf/pncconf/mesa0.glade:46736
-#: src/emc/usr_intf/pncconf/mesa0.glade:46801
-#: src/emc/usr_intf/pncconf/mesa0.glade:47109
-#: src/emc/usr_intf/pncconf/mesa0.glade:48459
-#: src/emc/usr_intf/pncconf/mesa0.glade:48523
-#: src/emc/usr_intf/pncconf/mesa0.glade:52386
-#: src/emc/usr_intf/pncconf/mesa0.glade:52451
-#: src/emc/usr_intf/pncconf/mesa0.glade:52759
+#: src/emc/usr_intf/pncconf/mesa0.glade:7388
+#: src/emc/usr_intf/pncconf/mesa0.glade:7453
+#: src/emc/usr_intf/pncconf/mesa0.glade:9485
+#: src/emc/usr_intf/pncconf/mesa0.glade:9550
+#: src/emc/usr_intf/pncconf/mesa0.glade:11580
+#: src/emc/usr_intf/pncconf/mesa0.glade:11645
+#: src/emc/usr_intf/pncconf/mesa0.glade:13673
+#: src/emc/usr_intf/pncconf/mesa0.glade:13738
+#: src/emc/usr_intf/pncconf/mesa0.glade:13896
+#: src/emc/usr_intf/pncconf/mesa0.glade:13960
+#: src/emc/usr_intf/pncconf/mesa0.glade:15989
+#: src/emc/usr_intf/pncconf/mesa0.glade:16053
+#: src/emc/usr_intf/pncconf/mesa0.glade:18082
+#: src/emc/usr_intf/pncconf/mesa0.glade:18146
+#: src/emc/usr_intf/pncconf/mesa0.glade:20191
+#: src/emc/usr_intf/pncconf/mesa0.glade:20255
+#: src/emc/usr_intf/pncconf/mesa0.glade:24118
+#: src/emc/usr_intf/pncconf/mesa0.glade:24183
+#: src/emc/usr_intf/pncconf/mesa0.glade:24491
+#: src/emc/usr_intf/pncconf/mesa0.glade:25841
+#: src/emc/usr_intf/pncconf/mesa0.glade:25905
+#: src/emc/usr_intf/pncconf/mesa0.glade:29768
+#: src/emc/usr_intf/pncconf/mesa0.glade:29833
+#: src/emc/usr_intf/pncconf/mesa0.glade:30141
+#: src/emc/usr_intf/pncconf/mesa0.glade:31491
+#: src/emc/usr_intf/pncconf/mesa0.glade:31555
+#: src/emc/usr_intf/pncconf/mesa0.glade:35418
+#: src/emc/usr_intf/pncconf/mesa0.glade:35483
+#: src/emc/usr_intf/pncconf/mesa0.glade:35791
+#: src/emc/usr_intf/pncconf/mesa0.glade:37141
+#: src/emc/usr_intf/pncconf/mesa0.glade:37205
+#: src/emc/usr_intf/pncconf/mesa0.glade:41068
+#: src/emc/usr_intf/pncconf/mesa0.glade:41133
+#: src/emc/usr_intf/pncconf/mesa0.glade:41441
+#: src/emc/usr_intf/pncconf/mesa0.glade:42791
+#: src/emc/usr_intf/pncconf/mesa0.glade:42855
+#: src/emc/usr_intf/pncconf/mesa0.glade:46718
+#: src/emc/usr_intf/pncconf/mesa0.glade:46783
+#: src/emc/usr_intf/pncconf/mesa0.glade:47091
+#: src/emc/usr_intf/pncconf/mesa0.glade:48441
+#: src/emc/usr_intf/pncconf/mesa0.glade:48505
+#: src/emc/usr_intf/pncconf/mesa0.glade:52368
+#: src/emc/usr_intf/pncconf/mesa0.glade:52433
+#: src/emc/usr_intf/pncconf/mesa0.glade:52741
 #: src/emc/usr_intf/pncconf/mesa1.glade:1185
 #: src/emc/usr_intf/pncconf/mesa1.glade:1249
 #: src/emc/usr_intf/pncconf/mesa1.glade:3383
@@ -14087,12 +14647,12 @@ msgstr "Inv"
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1269
 #: src/emc/usr_intf/pncconf/mesa0.glade:3497
-#: src/emc/usr_intf/pncconf/mesa0.glade:7392
-#: src/emc/usr_intf/pncconf/mesa0.glade:11584
-#: src/emc/usr_intf/pncconf/mesa0.glade:13677
-#: src/emc/usr_intf/pncconf/mesa0.glade:13992
-#: src/emc/usr_intf/pncconf/mesa0.glade:16085
-#: src/emc/usr_intf/pncconf/mesa0.glade:18178
+#: src/emc/usr_intf/pncconf/mesa0.glade:7374
+#: src/emc/usr_intf/pncconf/mesa0.glade:11566
+#: src/emc/usr_intf/pncconf/mesa0.glade:13659
+#: src/emc/usr_intf/pncconf/mesa0.glade:13974
+#: src/emc/usr_intf/pncconf/mesa0.glade:16067
+#: src/emc/usr_intf/pncconf/mesa0.glade:18160
 #: src/emc/usr_intf/pncconf/mesa1.glade:1263
 #: src/emc/usr_intf/pncconf/mesa1.glade:3461
 #: src/emc/usr_intf/pncconf/mesa1.glade:7333
@@ -14106,12 +14666,12 @@ msgstr "  1:"
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1284
 #: src/emc/usr_intf/pncconf/mesa0.glade:3512
-#: src/emc/usr_intf/pncconf/mesa0.glade:7377
-#: src/emc/usr_intf/pncconf/mesa0.glade:11569
-#: src/emc/usr_intf/pncconf/mesa0.glade:13662
-#: src/emc/usr_intf/pncconf/mesa0.glade:14007
-#: src/emc/usr_intf/pncconf/mesa0.glade:16100
-#: src/emc/usr_intf/pncconf/mesa0.glade:18193
+#: src/emc/usr_intf/pncconf/mesa0.glade:7359
+#: src/emc/usr_intf/pncconf/mesa0.glade:11551
+#: src/emc/usr_intf/pncconf/mesa0.glade:13644
+#: src/emc/usr_intf/pncconf/mesa0.glade:13989
+#: src/emc/usr_intf/pncconf/mesa0.glade:16082
+#: src/emc/usr_intf/pncconf/mesa0.glade:18175
 #: src/emc/usr_intf/pncconf/mesa1.glade:1278
 #: src/emc/usr_intf/pncconf/mesa1.glade:3476
 #: src/emc/usr_intf/pncconf/mesa1.glade:7318
@@ -14125,12 +14685,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1299
 #: src/emc/usr_intf/pncconf/mesa0.glade:3527
-#: src/emc/usr_intf/pncconf/mesa0.glade:7362
-#: src/emc/usr_intf/pncconf/mesa0.glade:11554
-#: src/emc/usr_intf/pncconf/mesa0.glade:13647
-#: src/emc/usr_intf/pncconf/mesa0.glade:14022
-#: src/emc/usr_intf/pncconf/mesa0.glade:16115
-#: src/emc/usr_intf/pncconf/mesa0.glade:18208
+#: src/emc/usr_intf/pncconf/mesa0.glade:7344
+#: src/emc/usr_intf/pncconf/mesa0.glade:11536
+#: src/emc/usr_intf/pncconf/mesa0.glade:13629
+#: src/emc/usr_intf/pncconf/mesa0.glade:14004
+#: src/emc/usr_intf/pncconf/mesa0.glade:16097
+#: src/emc/usr_intf/pncconf/mesa0.glade:18190
 #: src/emc/usr_intf/pncconf/mesa1.glade:1293
 #: src/emc/usr_intf/pncconf/mesa1.glade:3491
 #: src/emc/usr_intf/pncconf/mesa1.glade:7303
@@ -14144,12 +14704,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1314
 #: src/emc/usr_intf/pncconf/mesa0.glade:3542
-#: src/emc/usr_intf/pncconf/mesa0.glade:7347
-#: src/emc/usr_intf/pncconf/mesa0.glade:11539
-#: src/emc/usr_intf/pncconf/mesa0.glade:13632
-#: src/emc/usr_intf/pncconf/mesa0.glade:14037
-#: src/emc/usr_intf/pncconf/mesa0.glade:16130
-#: src/emc/usr_intf/pncconf/mesa0.glade:18223
+#: src/emc/usr_intf/pncconf/mesa0.glade:7329
+#: src/emc/usr_intf/pncconf/mesa0.glade:11521
+#: src/emc/usr_intf/pncconf/mesa0.glade:13614
+#: src/emc/usr_intf/pncconf/mesa0.glade:14019
+#: src/emc/usr_intf/pncconf/mesa0.glade:16112
+#: src/emc/usr_intf/pncconf/mesa0.glade:18205
 #: src/emc/usr_intf/pncconf/mesa1.glade:1308
 #: src/emc/usr_intf/pncconf/mesa1.glade:3506
 #: src/emc/usr_intf/pncconf/mesa1.glade:7288
@@ -14163,12 +14723,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1329
 #: src/emc/usr_intf/pncconf/mesa0.glade:3557
-#: src/emc/usr_intf/pncconf/mesa0.glade:7332
-#: src/emc/usr_intf/pncconf/mesa0.glade:11524
-#: src/emc/usr_intf/pncconf/mesa0.glade:13617
-#: src/emc/usr_intf/pncconf/mesa0.glade:14052
-#: src/emc/usr_intf/pncconf/mesa0.glade:16145
-#: src/emc/usr_intf/pncconf/mesa0.glade:18238
+#: src/emc/usr_intf/pncconf/mesa0.glade:7314
+#: src/emc/usr_intf/pncconf/mesa0.glade:11506
+#: src/emc/usr_intf/pncconf/mesa0.glade:13599
+#: src/emc/usr_intf/pncconf/mesa0.glade:14034
+#: src/emc/usr_intf/pncconf/mesa0.glade:16127
+#: src/emc/usr_intf/pncconf/mesa0.glade:18220
 #: src/emc/usr_intf/pncconf/mesa1.glade:1323
 #: src/emc/usr_intf/pncconf/mesa1.glade:3521
 #: src/emc/usr_intf/pncconf/mesa1.glade:7273
@@ -14182,12 +14742,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1344
 #: src/emc/usr_intf/pncconf/mesa0.glade:3572
-#: src/emc/usr_intf/pncconf/mesa0.glade:7317
-#: src/emc/usr_intf/pncconf/mesa0.glade:11509
-#: src/emc/usr_intf/pncconf/mesa0.glade:13602
-#: src/emc/usr_intf/pncconf/mesa0.glade:14067
-#: src/emc/usr_intf/pncconf/mesa0.glade:16160
-#: src/emc/usr_intf/pncconf/mesa0.glade:18253
+#: src/emc/usr_intf/pncconf/mesa0.glade:7299
+#: src/emc/usr_intf/pncconf/mesa0.glade:11491
+#: src/emc/usr_intf/pncconf/mesa0.glade:13584
+#: src/emc/usr_intf/pncconf/mesa0.glade:14049
+#: src/emc/usr_intf/pncconf/mesa0.glade:16142
+#: src/emc/usr_intf/pncconf/mesa0.glade:18235
 #: src/emc/usr_intf/pncconf/mesa1.glade:1338
 #: src/emc/usr_intf/pncconf/mesa1.glade:3536
 #: src/emc/usr_intf/pncconf/mesa1.glade:7258
@@ -14201,12 +14761,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1359
 #: src/emc/usr_intf/pncconf/mesa0.glade:3587
-#: src/emc/usr_intf/pncconf/mesa0.glade:7302
-#: src/emc/usr_intf/pncconf/mesa0.glade:11494
-#: src/emc/usr_intf/pncconf/mesa0.glade:13587
-#: src/emc/usr_intf/pncconf/mesa0.glade:14082
-#: src/emc/usr_intf/pncconf/mesa0.glade:16175
-#: src/emc/usr_intf/pncconf/mesa0.glade:18268
+#: src/emc/usr_intf/pncconf/mesa0.glade:7284
+#: src/emc/usr_intf/pncconf/mesa0.glade:11476
+#: src/emc/usr_intf/pncconf/mesa0.glade:13569
+#: src/emc/usr_intf/pncconf/mesa0.glade:14064
+#: src/emc/usr_intf/pncconf/mesa0.glade:16157
+#: src/emc/usr_intf/pncconf/mesa0.glade:18250
 #: src/emc/usr_intf/pncconf/mesa1.glade:1353
 #: src/emc/usr_intf/pncconf/mesa1.glade:3551
 #: src/emc/usr_intf/pncconf/mesa1.glade:7243
@@ -14220,12 +14780,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1374
 #: src/emc/usr_intf/pncconf/mesa0.glade:3602
-#: src/emc/usr_intf/pncconf/mesa0.glade:7287
-#: src/emc/usr_intf/pncconf/mesa0.glade:11479
-#: src/emc/usr_intf/pncconf/mesa0.glade:13572
-#: src/emc/usr_intf/pncconf/mesa0.glade:14097
-#: src/emc/usr_intf/pncconf/mesa0.glade:16190
-#: src/emc/usr_intf/pncconf/mesa0.glade:18283
+#: src/emc/usr_intf/pncconf/mesa0.glade:7269
+#: src/emc/usr_intf/pncconf/mesa0.glade:11461
+#: src/emc/usr_intf/pncconf/mesa0.glade:13554
+#: src/emc/usr_intf/pncconf/mesa0.glade:14079
+#: src/emc/usr_intf/pncconf/mesa0.glade:16172
+#: src/emc/usr_intf/pncconf/mesa0.glade:18265
 #: src/emc/usr_intf/pncconf/mesa1.glade:1368
 #: src/emc/usr_intf/pncconf/mesa1.glade:3566
 #: src/emc/usr_intf/pncconf/mesa1.glade:7228
@@ -14239,12 +14799,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1389
 #: src/emc/usr_intf/pncconf/mesa0.glade:3617
-#: src/emc/usr_intf/pncconf/mesa0.glade:7272
-#: src/emc/usr_intf/pncconf/mesa0.glade:11464
-#: src/emc/usr_intf/pncconf/mesa0.glade:13557
-#: src/emc/usr_intf/pncconf/mesa0.glade:14112
-#: src/emc/usr_intf/pncconf/mesa0.glade:16205
-#: src/emc/usr_intf/pncconf/mesa0.glade:18298
+#: src/emc/usr_intf/pncconf/mesa0.glade:7254
+#: src/emc/usr_intf/pncconf/mesa0.glade:11446
+#: src/emc/usr_intf/pncconf/mesa0.glade:13539
+#: src/emc/usr_intf/pncconf/mesa0.glade:14094
+#: src/emc/usr_intf/pncconf/mesa0.glade:16187
+#: src/emc/usr_intf/pncconf/mesa0.glade:18280
 #: src/emc/usr_intf/pncconf/mesa1.glade:1383
 #: src/emc/usr_intf/pncconf/mesa1.glade:3581
 #: src/emc/usr_intf/pncconf/mesa1.glade:7213
@@ -14258,12 +14818,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1404
 #: src/emc/usr_intf/pncconf/mesa0.glade:3632
-#: src/emc/usr_intf/pncconf/mesa0.glade:7257
-#: src/emc/usr_intf/pncconf/mesa0.glade:11449
-#: src/emc/usr_intf/pncconf/mesa0.glade:13542
-#: src/emc/usr_intf/pncconf/mesa0.glade:14127
-#: src/emc/usr_intf/pncconf/mesa0.glade:16220
-#: src/emc/usr_intf/pncconf/mesa0.glade:18313
+#: src/emc/usr_intf/pncconf/mesa0.glade:7239
+#: src/emc/usr_intf/pncconf/mesa0.glade:11431
+#: src/emc/usr_intf/pncconf/mesa0.glade:13524
+#: src/emc/usr_intf/pncconf/mesa0.glade:14109
+#: src/emc/usr_intf/pncconf/mesa0.glade:16202
+#: src/emc/usr_intf/pncconf/mesa0.glade:18295
 #: src/emc/usr_intf/pncconf/mesa1.glade:1398
 #: src/emc/usr_intf/pncconf/mesa1.glade:3596
 #: src/emc/usr_intf/pncconf/mesa1.glade:7198
@@ -14277,12 +14837,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1419
 #: src/emc/usr_intf/pncconf/mesa0.glade:3647
-#: src/emc/usr_intf/pncconf/mesa0.glade:7242
-#: src/emc/usr_intf/pncconf/mesa0.glade:11434
-#: src/emc/usr_intf/pncconf/mesa0.glade:13527
-#: src/emc/usr_intf/pncconf/mesa0.glade:14142
-#: src/emc/usr_intf/pncconf/mesa0.glade:16235
-#: src/emc/usr_intf/pncconf/mesa0.glade:18328
+#: src/emc/usr_intf/pncconf/mesa0.glade:7224
+#: src/emc/usr_intf/pncconf/mesa0.glade:11416
+#: src/emc/usr_intf/pncconf/mesa0.glade:13509
+#: src/emc/usr_intf/pncconf/mesa0.glade:14124
+#: src/emc/usr_intf/pncconf/mesa0.glade:16217
+#: src/emc/usr_intf/pncconf/mesa0.glade:18310
 #: src/emc/usr_intf/pncconf/mesa1.glade:1413
 #: src/emc/usr_intf/pncconf/mesa1.glade:3611
 #: src/emc/usr_intf/pncconf/mesa1.glade:7183
@@ -14296,12 +14856,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1434
 #: src/emc/usr_intf/pncconf/mesa0.glade:3662
-#: src/emc/usr_intf/pncconf/mesa0.glade:7227
-#: src/emc/usr_intf/pncconf/mesa0.glade:11419
-#: src/emc/usr_intf/pncconf/mesa0.glade:13512
-#: src/emc/usr_intf/pncconf/mesa0.glade:14157
-#: src/emc/usr_intf/pncconf/mesa0.glade:16250
-#: src/emc/usr_intf/pncconf/mesa0.glade:18343
+#: src/emc/usr_intf/pncconf/mesa0.glade:7209
+#: src/emc/usr_intf/pncconf/mesa0.glade:11401
+#: src/emc/usr_intf/pncconf/mesa0.glade:13494
+#: src/emc/usr_intf/pncconf/mesa0.glade:14139
+#: src/emc/usr_intf/pncconf/mesa0.glade:16232
+#: src/emc/usr_intf/pncconf/mesa0.glade:18325
 #: src/emc/usr_intf/pncconf/mesa1.glade:1428
 #: src/emc/usr_intf/pncconf/mesa1.glade:3626
 #: src/emc/usr_intf/pncconf/mesa1.glade:7168
@@ -14315,12 +14875,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1890
 #: src/emc/usr_intf/pncconf/mesa0.glade:4118
-#: src/emc/usr_intf/pncconf/mesa0.glade:6769
-#: src/emc/usr_intf/pncconf/mesa0.glade:10948
-#: src/emc/usr_intf/pncconf/mesa0.glade:13041
-#: src/emc/usr_intf/pncconf/mesa0.glade:14626
-#: src/emc/usr_intf/pncconf/mesa0.glade:16719
-#: src/emc/usr_intf/pncconf/mesa0.glade:18812
+#: src/emc/usr_intf/pncconf/mesa0.glade:6751
+#: src/emc/usr_intf/pncconf/mesa0.glade:10930
+#: src/emc/usr_intf/pncconf/mesa0.glade:13023
+#: src/emc/usr_intf/pncconf/mesa0.glade:14608
+#: src/emc/usr_intf/pncconf/mesa0.glade:16701
+#: src/emc/usr_intf/pncconf/mesa0.glade:18794
 #: src/emc/usr_intf/pncconf/mesa1.glade:1884
 #: src/emc/usr_intf/pncconf/mesa1.glade:4082
 #: src/emc/usr_intf/pncconf/mesa1.glade:6710
@@ -14334,12 +14894,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1954
 #: src/emc/usr_intf/pncconf/mesa0.glade:4182
-#: src/emc/usr_intf/pncconf/mesa0.glade:6711
-#: src/emc/usr_intf/pncconf/mesa0.glade:10891
-#: src/emc/usr_intf/pncconf/mesa0.glade:12984
-#: src/emc/usr_intf/pncconf/mesa0.glade:14683
-#: src/emc/usr_intf/pncconf/mesa0.glade:16776
-#: src/emc/usr_intf/pncconf/mesa0.glade:18869
+#: src/emc/usr_intf/pncconf/mesa0.glade:6693
+#: src/emc/usr_intf/pncconf/mesa0.glade:10873
+#: src/emc/usr_intf/pncconf/mesa0.glade:12966
+#: src/emc/usr_intf/pncconf/mesa0.glade:14665
+#: src/emc/usr_intf/pncconf/mesa0.glade:16758
+#: src/emc/usr_intf/pncconf/mesa0.glade:18851
 #: src/emc/usr_intf/pncconf/mesa1.glade:1942
 #: src/emc/usr_intf/pncconf/mesa1.glade:4140
 #: src/emc/usr_intf/pncconf/mesa1.glade:6652
@@ -14353,12 +14913,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1971
 #: src/emc/usr_intf/pncconf/mesa0.glade:4199
-#: src/emc/usr_intf/pncconf/mesa0.glade:6694
-#: src/emc/usr_intf/pncconf/mesa0.glade:10874
-#: src/emc/usr_intf/pncconf/mesa0.glade:12967
-#: src/emc/usr_intf/pncconf/mesa0.glade:14700
-#: src/emc/usr_intf/pncconf/mesa0.glade:16793
-#: src/emc/usr_intf/pncconf/mesa0.glade:18886
+#: src/emc/usr_intf/pncconf/mesa0.glade:6676
+#: src/emc/usr_intf/pncconf/mesa0.glade:10856
+#: src/emc/usr_intf/pncconf/mesa0.glade:12949
+#: src/emc/usr_intf/pncconf/mesa0.glade:14682
+#: src/emc/usr_intf/pncconf/mesa0.glade:16775
+#: src/emc/usr_intf/pncconf/mesa0.glade:18868
 #: src/emc/usr_intf/pncconf/mesa1.glade:1959
 #: src/emc/usr_intf/pncconf/mesa1.glade:4157
 #: src/emc/usr_intf/pncconf/mesa1.glade:6635
@@ -14372,12 +14932,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:1988
 #: src/emc/usr_intf/pncconf/mesa0.glade:4216
-#: src/emc/usr_intf/pncconf/mesa0.glade:6677
-#: src/emc/usr_intf/pncconf/mesa0.glade:10857
-#: src/emc/usr_intf/pncconf/mesa0.glade:12950
-#: src/emc/usr_intf/pncconf/mesa0.glade:14717
-#: src/emc/usr_intf/pncconf/mesa0.glade:16810
-#: src/emc/usr_intf/pncconf/mesa0.glade:18903
+#: src/emc/usr_intf/pncconf/mesa0.glade:6659
+#: src/emc/usr_intf/pncconf/mesa0.glade:10839
+#: src/emc/usr_intf/pncconf/mesa0.glade:12932
+#: src/emc/usr_intf/pncconf/mesa0.glade:14699
+#: src/emc/usr_intf/pncconf/mesa0.glade:16792
+#: src/emc/usr_intf/pncconf/mesa0.glade:18885
 #: src/emc/usr_intf/pncconf/mesa1.glade:1976
 #: src/emc/usr_intf/pncconf/mesa1.glade:4174
 #: src/emc/usr_intf/pncconf/mesa1.glade:6618
@@ -14391,12 +14951,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:2005
 #: src/emc/usr_intf/pncconf/mesa0.glade:4233
-#: src/emc/usr_intf/pncconf/mesa0.glade:6660
-#: src/emc/usr_intf/pncconf/mesa0.glade:10840
-#: src/emc/usr_intf/pncconf/mesa0.glade:12933
-#: src/emc/usr_intf/pncconf/mesa0.glade:14734
-#: src/emc/usr_intf/pncconf/mesa0.glade:16827
-#: src/emc/usr_intf/pncconf/mesa0.glade:18920
+#: src/emc/usr_intf/pncconf/mesa0.glade:6642
+#: src/emc/usr_intf/pncconf/mesa0.glade:10822
+#: src/emc/usr_intf/pncconf/mesa0.glade:12915
+#: src/emc/usr_intf/pncconf/mesa0.glade:14716
+#: src/emc/usr_intf/pncconf/mesa0.glade:16809
+#: src/emc/usr_intf/pncconf/mesa0.glade:18902
 #: src/emc/usr_intf/pncconf/mesa1.glade:1993
 #: src/emc/usr_intf/pncconf/mesa1.glade:4191
 #: src/emc/usr_intf/pncconf/mesa1.glade:6601
@@ -14410,12 +14970,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:2022
 #: src/emc/usr_intf/pncconf/mesa0.glade:4250
-#: src/emc/usr_intf/pncconf/mesa0.glade:6643
-#: src/emc/usr_intf/pncconf/mesa0.glade:10823
-#: src/emc/usr_intf/pncconf/mesa0.glade:12916
-#: src/emc/usr_intf/pncconf/mesa0.glade:14751
-#: src/emc/usr_intf/pncconf/mesa0.glade:16844
-#: src/emc/usr_intf/pncconf/mesa0.glade:18937
+#: src/emc/usr_intf/pncconf/mesa0.glade:6625
+#: src/emc/usr_intf/pncconf/mesa0.glade:10805
+#: src/emc/usr_intf/pncconf/mesa0.glade:12898
+#: src/emc/usr_intf/pncconf/mesa0.glade:14733
+#: src/emc/usr_intf/pncconf/mesa0.glade:16826
+#: src/emc/usr_intf/pncconf/mesa0.glade:18919
 #: src/emc/usr_intf/pncconf/mesa1.glade:2010
 #: src/emc/usr_intf/pncconf/mesa1.glade:4208
 #: src/emc/usr_intf/pncconf/mesa1.glade:6584
@@ -14429,12 +14989,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:2039
 #: src/emc/usr_intf/pncconf/mesa0.glade:4267
-#: src/emc/usr_intf/pncconf/mesa0.glade:6626
-#: src/emc/usr_intf/pncconf/mesa0.glade:10806
-#: src/emc/usr_intf/pncconf/mesa0.glade:12899
-#: src/emc/usr_intf/pncconf/mesa0.glade:14768
-#: src/emc/usr_intf/pncconf/mesa0.glade:16861
-#: src/emc/usr_intf/pncconf/mesa0.glade:18954
+#: src/emc/usr_intf/pncconf/mesa0.glade:6608
+#: src/emc/usr_intf/pncconf/mesa0.glade:10788
+#: src/emc/usr_intf/pncconf/mesa0.glade:12881
+#: src/emc/usr_intf/pncconf/mesa0.glade:14750
+#: src/emc/usr_intf/pncconf/mesa0.glade:16843
+#: src/emc/usr_intf/pncconf/mesa0.glade:18936
 #: src/emc/usr_intf/pncconf/mesa1.glade:2027
 #: src/emc/usr_intf/pncconf/mesa1.glade:4225
 #: src/emc/usr_intf/pncconf/mesa1.glade:6567
@@ -14448,12 +15008,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:2056
 #: src/emc/usr_intf/pncconf/mesa0.glade:4284
-#: src/emc/usr_intf/pncconf/mesa0.glade:6609
-#: src/emc/usr_intf/pncconf/mesa0.glade:10789
-#: src/emc/usr_intf/pncconf/mesa0.glade:12882
-#: src/emc/usr_intf/pncconf/mesa0.glade:14785
-#: src/emc/usr_intf/pncconf/mesa0.glade:16878
-#: src/emc/usr_intf/pncconf/mesa0.glade:18971
+#: src/emc/usr_intf/pncconf/mesa0.glade:6591
+#: src/emc/usr_intf/pncconf/mesa0.glade:10771
+#: src/emc/usr_intf/pncconf/mesa0.glade:12864
+#: src/emc/usr_intf/pncconf/mesa0.glade:14767
+#: src/emc/usr_intf/pncconf/mesa0.glade:16860
+#: src/emc/usr_intf/pncconf/mesa0.glade:18953
 #: src/emc/usr_intf/pncconf/mesa1.glade:2044
 #: src/emc/usr_intf/pncconf/mesa1.glade:4242
 #: src/emc/usr_intf/pncconf/mesa1.glade:6550
@@ -14467,12 +15027,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:2384
 #: src/emc/usr_intf/pncconf/mesa0.glade:4588
-#: src/emc/usr_intf/pncconf/mesa0.glade:6305
-#: src/emc/usr_intf/pncconf/mesa0.glade:10492
-#: src/emc/usr_intf/pncconf/mesa0.glade:12585
-#: src/emc/usr_intf/pncconf/mesa0.glade:15082
-#: src/emc/usr_intf/pncconf/mesa0.glade:17175
-#: src/emc/usr_intf/pncconf/mesa0.glade:19268
+#: src/emc/usr_intf/pncconf/mesa0.glade:6287
+#: src/emc/usr_intf/pncconf/mesa0.glade:10474
+#: src/emc/usr_intf/pncconf/mesa0.glade:12567
+#: src/emc/usr_intf/pncconf/mesa0.glade:15064
+#: src/emc/usr_intf/pncconf/mesa0.glade:17157
+#: src/emc/usr_intf/pncconf/mesa0.glade:19250
 #: src/emc/usr_intf/pncconf/mesa1.glade:2348
 #: src/emc/usr_intf/pncconf/mesa1.glade:4546
 #: src/emc/usr_intf/pncconf/mesa1.glade:6246
@@ -14486,12 +15046,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:2401
 #: src/emc/usr_intf/pncconf/mesa0.glade:4605
-#: src/emc/usr_intf/pncconf/mesa0.glade:6288
-#: src/emc/usr_intf/pncconf/mesa0.glade:10475
-#: src/emc/usr_intf/pncconf/mesa0.glade:12568
-#: src/emc/usr_intf/pncconf/mesa0.glade:15099
-#: src/emc/usr_intf/pncconf/mesa0.glade:17192
-#: src/emc/usr_intf/pncconf/mesa0.glade:19285
+#: src/emc/usr_intf/pncconf/mesa0.glade:6270
+#: src/emc/usr_intf/pncconf/mesa0.glade:10457
+#: src/emc/usr_intf/pncconf/mesa0.glade:12550
+#: src/emc/usr_intf/pncconf/mesa0.glade:15081
+#: src/emc/usr_intf/pncconf/mesa0.glade:17174
+#: src/emc/usr_intf/pncconf/mesa0.glade:19267
 #: src/emc/usr_intf/pncconf/mesa1.glade:2365
 #: src/emc/usr_intf/pncconf/mesa1.glade:4563
 #: src/emc/usr_intf/pncconf/mesa1.glade:6229
@@ -14505,12 +15065,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:2418
 #: src/emc/usr_intf/pncconf/mesa0.glade:4622
-#: src/emc/usr_intf/pncconf/mesa0.glade:6271
-#: src/emc/usr_intf/pncconf/mesa0.glade:10458
-#: src/emc/usr_intf/pncconf/mesa0.glade:12551
-#: src/emc/usr_intf/pncconf/mesa0.glade:15116
-#: src/emc/usr_intf/pncconf/mesa0.glade:17209
-#: src/emc/usr_intf/pncconf/mesa0.glade:19302
+#: src/emc/usr_intf/pncconf/mesa0.glade:6253
+#: src/emc/usr_intf/pncconf/mesa0.glade:10440
+#: src/emc/usr_intf/pncconf/mesa0.glade:12533
+#: src/emc/usr_intf/pncconf/mesa0.glade:15098
+#: src/emc/usr_intf/pncconf/mesa0.glade:17191
+#: src/emc/usr_intf/pncconf/mesa0.glade:19284
 #: src/emc/usr_intf/pncconf/mesa1.glade:2382
 #: src/emc/usr_intf/pncconf/mesa1.glade:4580
 #: src/emc/usr_intf/pncconf/mesa1.glade:6212
@@ -14524,12 +15084,12 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:2435
 #: src/emc/usr_intf/pncconf/mesa0.glade:4639
-#: src/emc/usr_intf/pncconf/mesa0.glade:6254
-#: src/emc/usr_intf/pncconf/mesa0.glade:10441
-#: src/emc/usr_intf/pncconf/mesa0.glade:12534
-#: src/emc/usr_intf/pncconf/mesa0.glade:15133
-#: src/emc/usr_intf/pncconf/mesa0.glade:17226
-#: src/emc/usr_intf/pncconf/mesa0.glade:19319
+#: src/emc/usr_intf/pncconf/mesa0.glade:6236
+#: src/emc/usr_intf/pncconf/mesa0.glade:10423
+#: src/emc/usr_intf/pncconf/mesa0.glade:12516
+#: src/emc/usr_intf/pncconf/mesa0.glade:15115
+#: src/emc/usr_intf/pncconf/mesa0.glade:17208
+#: src/emc/usr_intf/pncconf/mesa0.glade:19301
 #: src/emc/usr_intf/pncconf/mesa1.glade:2399
 #: src/emc/usr_intf/pncconf/mesa1.glade:4597
 #: src/emc/usr_intf/pncconf/mesa1.glade:6195
@@ -14545,50 +15105,50 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/mesa0.glade:2628
 #: src/emc/usr_intf/pncconf/mesa0.glade:4819
 #: src/emc/usr_intf/pncconf/mesa0.glade:4832
-#: src/emc/usr_intf/pncconf/mesa0.glade:6057
-#: src/emc/usr_intf/pncconf/mesa0.glade:6070
-#: src/emc/usr_intf/pncconf/mesa0.glade:8133
-#: src/emc/usr_intf/pncconf/mesa0.glade:8146
-#: src/emc/usr_intf/pncconf/mesa0.glade:10277
-#: src/emc/usr_intf/pncconf/mesa0.glade:10290
-#: src/emc/usr_intf/pncconf/mesa0.glade:12370
-#: src/emc/usr_intf/pncconf/mesa0.glade:12383
-#: src/emc/usr_intf/pncconf/mesa0.glade:15286
-#: src/emc/usr_intf/pncconf/mesa0.glade:15299
-#: src/emc/usr_intf/pncconf/mesa0.glade:17379
-#: src/emc/usr_intf/pncconf/mesa0.glade:17392
-#: src/emc/usr_intf/pncconf/mesa0.glade:19472
-#: src/emc/usr_intf/pncconf/mesa0.glade:19485
-#: src/emc/usr_intf/pncconf/mesa0.glade:21630
-#: src/emc/usr_intf/pncconf/mesa0.glade:21643
-#: src/emc/usr_intf/pncconf/mesa0.glade:22766
-#: src/emc/usr_intf/pncconf/mesa0.glade:22779
-#: src/emc/usr_intf/pncconf/mesa0.glade:25436
-#: src/emc/usr_intf/pncconf/mesa0.glade:27280
-#: src/emc/usr_intf/pncconf/mesa0.glade:27293
-#: src/emc/usr_intf/pncconf/mesa0.glade:28416
-#: src/emc/usr_intf/pncconf/mesa0.glade:28429
-#: src/emc/usr_intf/pncconf/mesa0.glade:31086
-#: src/emc/usr_intf/pncconf/mesa0.glade:32930
-#: src/emc/usr_intf/pncconf/mesa0.glade:32943
-#: src/emc/usr_intf/pncconf/mesa0.glade:34066
-#: src/emc/usr_intf/pncconf/mesa0.glade:34079
-#: src/emc/usr_intf/pncconf/mesa0.glade:36736
-#: src/emc/usr_intf/pncconf/mesa0.glade:38580
-#: src/emc/usr_intf/pncconf/mesa0.glade:38593
-#: src/emc/usr_intf/pncconf/mesa0.glade:39716
-#: src/emc/usr_intf/pncconf/mesa0.glade:39729
-#: src/emc/usr_intf/pncconf/mesa0.glade:42386
-#: src/emc/usr_intf/pncconf/mesa0.glade:44230
-#: src/emc/usr_intf/pncconf/mesa0.glade:44243
-#: src/emc/usr_intf/pncconf/mesa0.glade:45366
-#: src/emc/usr_intf/pncconf/mesa0.glade:45379
-#: src/emc/usr_intf/pncconf/mesa0.glade:48036
-#: src/emc/usr_intf/pncconf/mesa0.glade:49880
-#: src/emc/usr_intf/pncconf/mesa0.glade:49893
-#: src/emc/usr_intf/pncconf/mesa0.glade:51016
-#: src/emc/usr_intf/pncconf/mesa0.glade:51029
-#: src/emc/usr_intf/pncconf/mesa0.glade:53686
+#: src/emc/usr_intf/pncconf/mesa0.glade:6045
+#: src/emc/usr_intf/pncconf/mesa0.glade:6058
+#: src/emc/usr_intf/pncconf/mesa0.glade:8115
+#: src/emc/usr_intf/pncconf/mesa0.glade:8128
+#: src/emc/usr_intf/pncconf/mesa0.glade:10259
+#: src/emc/usr_intf/pncconf/mesa0.glade:10272
+#: src/emc/usr_intf/pncconf/mesa0.glade:12352
+#: src/emc/usr_intf/pncconf/mesa0.glade:12365
+#: src/emc/usr_intf/pncconf/mesa0.glade:15268
+#: src/emc/usr_intf/pncconf/mesa0.glade:15281
+#: src/emc/usr_intf/pncconf/mesa0.glade:17361
+#: src/emc/usr_intf/pncconf/mesa0.glade:17374
+#: src/emc/usr_intf/pncconf/mesa0.glade:19454
+#: src/emc/usr_intf/pncconf/mesa0.glade:19467
+#: src/emc/usr_intf/pncconf/mesa0.glade:21612
+#: src/emc/usr_intf/pncconf/mesa0.glade:21625
+#: src/emc/usr_intf/pncconf/mesa0.glade:22748
+#: src/emc/usr_intf/pncconf/mesa0.glade:22761
+#: src/emc/usr_intf/pncconf/mesa0.glade:25418
+#: src/emc/usr_intf/pncconf/mesa0.glade:27262
+#: src/emc/usr_intf/pncconf/mesa0.glade:27275
+#: src/emc/usr_intf/pncconf/mesa0.glade:28398
+#: src/emc/usr_intf/pncconf/mesa0.glade:28411
+#: src/emc/usr_intf/pncconf/mesa0.glade:31068
+#: src/emc/usr_intf/pncconf/mesa0.glade:32912
+#: src/emc/usr_intf/pncconf/mesa0.glade:32925
+#: src/emc/usr_intf/pncconf/mesa0.glade:34048
+#: src/emc/usr_intf/pncconf/mesa0.glade:34061
+#: src/emc/usr_intf/pncconf/mesa0.glade:36718
+#: src/emc/usr_intf/pncconf/mesa0.glade:38562
+#: src/emc/usr_intf/pncconf/mesa0.glade:38575
+#: src/emc/usr_intf/pncconf/mesa0.glade:39698
+#: src/emc/usr_intf/pncconf/mesa0.glade:39711
+#: src/emc/usr_intf/pncconf/mesa0.glade:42368
+#: src/emc/usr_intf/pncconf/mesa0.glade:44212
+#: src/emc/usr_intf/pncconf/mesa0.glade:44225
+#: src/emc/usr_intf/pncconf/mesa0.glade:45348
+#: src/emc/usr_intf/pncconf/mesa0.glade:45361
+#: src/emc/usr_intf/pncconf/mesa0.glade:48018
+#: src/emc/usr_intf/pncconf/mesa0.glade:49862
+#: src/emc/usr_intf/pncconf/mesa0.glade:49875
+#: src/emc/usr_intf/pncconf/mesa0.glade:50998
+#: src/emc/usr_intf/pncconf/mesa0.glade:51011
+#: src/emc/usr_intf/pncconf/mesa0.glade:53668
 #: src/emc/usr_intf/pncconf/mesa1.glade:2579
 #: src/emc/usr_intf/pncconf/mesa1.glade:2592
 #: src/emc/usr_intf/pncconf/mesa1.glade:4777
@@ -14642,13 +15202,13 @@ msgstr "función"
 
 #: src/emc/usr_intf/pncconf/mesa0.glade:2639
 #: src/emc/usr_intf/pncconf/mesa0.glade:4843
-#: src/emc/usr_intf/pncconf/mesa0.glade:6040
-#: src/emc/usr_intf/pncconf/mesa0.glade:8116
-#: src/emc/usr_intf/pncconf/mesa0.glade:10259
-#: src/emc/usr_intf/pncconf/mesa0.glade:12353
-#: src/emc/usr_intf/pncconf/mesa0.glade:15310
-#: src/emc/usr_intf/pncconf/mesa0.glade:17403
-#: src/emc/usr_intf/pncconf/mesa0.glade:19496
+#: src/emc/usr_intf/pncconf/mesa0.glade:6028
+#: src/emc/usr_intf/pncconf/mesa0.glade:8098
+#: src/emc/usr_intf/pncconf/mesa0.glade:10241
+#: src/emc/usr_intf/pncconf/mesa0.glade:12335
+#: src/emc/usr_intf/pncconf/mesa0.glade:15292
+#: src/emc/usr_intf/pncconf/mesa0.glade:17385
+#: src/emc/usr_intf/pncconf/mesa0.glade:19478
 #: src/emc/usr_intf/pncconf/mesa1.glade:2603
 #: src/emc/usr_intf/pncconf/mesa1.glade:4801
 #: src/emc/usr_intf/pncconf/mesa1.glade:5987
@@ -14665,50 +15225,50 @@ msgstr "Iniciar panel de prueba"
 #: src/emc/usr_intf/pncconf/mesa0.glade:3143
 #: src/emc/usr_intf/pncconf/mesa0.glade:5334
 #: src/emc/usr_intf/pncconf/mesa0.glade:5347
-#: src/emc/usr_intf/pncconf/mesa0.glade:5541
-#: src/emc/usr_intf/pncconf/mesa0.glade:5556
-#: src/emc/usr_intf/pncconf/mesa0.glade:7617
-#: src/emc/usr_intf/pncconf/mesa0.glade:7632
-#: src/emc/usr_intf/pncconf/mesa0.glade:9760
-#: src/emc/usr_intf/pncconf/mesa0.glade:9775
-#: src/emc/usr_intf/pncconf/mesa0.glade:11854
-#: src/emc/usr_intf/pncconf/mesa0.glade:11869
-#: src/emc/usr_intf/pncconf/mesa0.glade:15802
-#: src/emc/usr_intf/pncconf/mesa0.glade:15815
-#: src/emc/usr_intf/pncconf/mesa0.glade:17895
-#: src/emc/usr_intf/pncconf/mesa0.glade:17908
-#: src/emc/usr_intf/pncconf/mesa0.glade:19988
-#: src/emc/usr_intf/pncconf/mesa0.glade:20001
-#: src/emc/usr_intf/pncconf/mesa0.glade:22117
-#: src/emc/usr_intf/pncconf/mesa0.glade:22130
-#: src/emc/usr_intf/pncconf/mesa0.glade:22265
-#: src/emc/usr_intf/pncconf/mesa0.glade:22280
-#: src/emc/usr_intf/pncconf/mesa0.glade:25670
-#: src/emc/usr_intf/pncconf/mesa0.glade:27767
-#: src/emc/usr_intf/pncconf/mesa0.glade:27780
-#: src/emc/usr_intf/pncconf/mesa0.glade:27915
-#: src/emc/usr_intf/pncconf/mesa0.glade:27930
-#: src/emc/usr_intf/pncconf/mesa0.glade:31320
-#: src/emc/usr_intf/pncconf/mesa0.glade:33417
-#: src/emc/usr_intf/pncconf/mesa0.glade:33430
-#: src/emc/usr_intf/pncconf/mesa0.glade:33565
-#: src/emc/usr_intf/pncconf/mesa0.glade:33580
-#: src/emc/usr_intf/pncconf/mesa0.glade:36970
-#: src/emc/usr_intf/pncconf/mesa0.glade:39067
-#: src/emc/usr_intf/pncconf/mesa0.glade:39080
-#: src/emc/usr_intf/pncconf/mesa0.glade:39215
-#: src/emc/usr_intf/pncconf/mesa0.glade:39230
-#: src/emc/usr_intf/pncconf/mesa0.glade:42620
-#: src/emc/usr_intf/pncconf/mesa0.glade:44717
-#: src/emc/usr_intf/pncconf/mesa0.glade:44730
-#: src/emc/usr_intf/pncconf/mesa0.glade:44865
-#: src/emc/usr_intf/pncconf/mesa0.glade:44880
-#: src/emc/usr_intf/pncconf/mesa0.glade:48270
-#: src/emc/usr_intf/pncconf/mesa0.glade:50367
-#: src/emc/usr_intf/pncconf/mesa0.glade:50380
-#: src/emc/usr_intf/pncconf/mesa0.glade:50515
-#: src/emc/usr_intf/pncconf/mesa0.glade:50530
-#: src/emc/usr_intf/pncconf/mesa0.glade:53920
+#: src/emc/usr_intf/pncconf/mesa0.glade:5529
+#: src/emc/usr_intf/pncconf/mesa0.glade:5544
+#: src/emc/usr_intf/pncconf/mesa0.glade:7599
+#: src/emc/usr_intf/pncconf/mesa0.glade:7614
+#: src/emc/usr_intf/pncconf/mesa0.glade:9742
+#: src/emc/usr_intf/pncconf/mesa0.glade:9757
+#: src/emc/usr_intf/pncconf/mesa0.glade:11836
+#: src/emc/usr_intf/pncconf/mesa0.glade:11851
+#: src/emc/usr_intf/pncconf/mesa0.glade:15784
+#: src/emc/usr_intf/pncconf/mesa0.glade:15797
+#: src/emc/usr_intf/pncconf/mesa0.glade:17877
+#: src/emc/usr_intf/pncconf/mesa0.glade:17890
+#: src/emc/usr_intf/pncconf/mesa0.glade:19970
+#: src/emc/usr_intf/pncconf/mesa0.glade:19983
+#: src/emc/usr_intf/pncconf/mesa0.glade:22099
+#: src/emc/usr_intf/pncconf/mesa0.glade:22112
+#: src/emc/usr_intf/pncconf/mesa0.glade:22247
+#: src/emc/usr_intf/pncconf/mesa0.glade:22262
+#: src/emc/usr_intf/pncconf/mesa0.glade:25652
+#: src/emc/usr_intf/pncconf/mesa0.glade:27749
+#: src/emc/usr_intf/pncconf/mesa0.glade:27762
+#: src/emc/usr_intf/pncconf/mesa0.glade:27897
+#: src/emc/usr_intf/pncconf/mesa0.glade:27912
+#: src/emc/usr_intf/pncconf/mesa0.glade:31302
+#: src/emc/usr_intf/pncconf/mesa0.glade:33399
+#: src/emc/usr_intf/pncconf/mesa0.glade:33412
+#: src/emc/usr_intf/pncconf/mesa0.glade:33547
+#: src/emc/usr_intf/pncconf/mesa0.glade:33562
+#: src/emc/usr_intf/pncconf/mesa0.glade:36952
+#: src/emc/usr_intf/pncconf/mesa0.glade:39049
+#: src/emc/usr_intf/pncconf/mesa0.glade:39062
+#: src/emc/usr_intf/pncconf/mesa0.glade:39197
+#: src/emc/usr_intf/pncconf/mesa0.glade:39212
+#: src/emc/usr_intf/pncconf/mesa0.glade:42602
+#: src/emc/usr_intf/pncconf/mesa0.glade:44699
+#: src/emc/usr_intf/pncconf/mesa0.glade:44712
+#: src/emc/usr_intf/pncconf/mesa0.glade:44847
+#: src/emc/usr_intf/pncconf/mesa0.glade:44862
+#: src/emc/usr_intf/pncconf/mesa0.glade:48252
+#: src/emc/usr_intf/pncconf/mesa0.glade:50349
+#: src/emc/usr_intf/pncconf/mesa0.glade:50362
+#: src/emc/usr_intf/pncconf/mesa0.glade:50497
+#: src/emc/usr_intf/pncconf/mesa0.glade:50512
+#: src/emc/usr_intf/pncconf/mesa0.glade:53902
 #: src/emc/usr_intf/pncconf/mesa1.glade:3094
 #: src/emc/usr_intf/pncconf/mesa1.glade:3107
 #: src/emc/usr_intf/pncconf/mesa1.glade:5293
@@ -14778,7 +15338,7 @@ msgstr ""
 "      I/O\n"
 "Conector 2"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:7502
+#: src/emc/usr_intf/pncconf/mesa0.glade:7484
 #: src/emc/usr_intf/pncconf/mesa1.glade:7443
 msgid ""
 "       I/O\n"
@@ -14787,63 +15347,63 @@ msgstr ""
 "       I/O\n"
 " Conector 3"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:9445
-#: src/emc/usr_intf/pncconf/mesa0.glade:9460
-#: src/emc/usr_intf/pncconf/mesa0.glade:9489
-#: src/emc/usr_intf/pncconf/mesa0.glade:20287
-#: src/emc/usr_intf/pncconf/mesa0.glade:20316
-#: src/emc/usr_intf/pncconf/mesa0.glade:20331
-#: src/emc/usr_intf/pncconf/mesa0.glade:24078
-#: src/emc/usr_intf/pncconf/mesa0.glade:24093
-#: src/emc/usr_intf/pncconf/mesa0.glade:24122
-#: src/emc/usr_intf/pncconf/mesa0.glade:24586
-#: src/emc/usr_intf/pncconf/mesa0.glade:24615
-#: src/emc/usr_intf/pncconf/mesa0.glade:24630
-#: src/emc/usr_intf/pncconf/mesa0.glade:25937
-#: src/emc/usr_intf/pncconf/mesa0.glade:25966
-#: src/emc/usr_intf/pncconf/mesa0.glade:25981
-#: src/emc/usr_intf/pncconf/mesa0.glade:29728
-#: src/emc/usr_intf/pncconf/mesa0.glade:29743
-#: src/emc/usr_intf/pncconf/mesa0.glade:29772
-#: src/emc/usr_intf/pncconf/mesa0.glade:30236
-#: src/emc/usr_intf/pncconf/mesa0.glade:30265
-#: src/emc/usr_intf/pncconf/mesa0.glade:30280
-#: src/emc/usr_intf/pncconf/mesa0.glade:31587
-#: src/emc/usr_intf/pncconf/mesa0.glade:31616
-#: src/emc/usr_intf/pncconf/mesa0.glade:31631
-#: src/emc/usr_intf/pncconf/mesa0.glade:35378
-#: src/emc/usr_intf/pncconf/mesa0.glade:35393
-#: src/emc/usr_intf/pncconf/mesa0.glade:35422
-#: src/emc/usr_intf/pncconf/mesa0.glade:35886
-#: src/emc/usr_intf/pncconf/mesa0.glade:35915
-#: src/emc/usr_intf/pncconf/mesa0.glade:35930
-#: src/emc/usr_intf/pncconf/mesa0.glade:37237
-#: src/emc/usr_intf/pncconf/mesa0.glade:37266
-#: src/emc/usr_intf/pncconf/mesa0.glade:37281
-#: src/emc/usr_intf/pncconf/mesa0.glade:41028
-#: src/emc/usr_intf/pncconf/mesa0.glade:41043
-#: src/emc/usr_intf/pncconf/mesa0.glade:41072
-#: src/emc/usr_intf/pncconf/mesa0.glade:41536
-#: src/emc/usr_intf/pncconf/mesa0.glade:41565
-#: src/emc/usr_intf/pncconf/mesa0.glade:41580
-#: src/emc/usr_intf/pncconf/mesa0.glade:42887
-#: src/emc/usr_intf/pncconf/mesa0.glade:42916
-#: src/emc/usr_intf/pncconf/mesa0.glade:42931
-#: src/emc/usr_intf/pncconf/mesa0.glade:46678
-#: src/emc/usr_intf/pncconf/mesa0.glade:46693
-#: src/emc/usr_intf/pncconf/mesa0.glade:46722
-#: src/emc/usr_intf/pncconf/mesa0.glade:47186
-#: src/emc/usr_intf/pncconf/mesa0.glade:47215
-#: src/emc/usr_intf/pncconf/mesa0.glade:47230
-#: src/emc/usr_intf/pncconf/mesa0.glade:48537
-#: src/emc/usr_intf/pncconf/mesa0.glade:48566
-#: src/emc/usr_intf/pncconf/mesa0.glade:48581
-#: src/emc/usr_intf/pncconf/mesa0.glade:52328
-#: src/emc/usr_intf/pncconf/mesa0.glade:52343
-#: src/emc/usr_intf/pncconf/mesa0.glade:52372
-#: src/emc/usr_intf/pncconf/mesa0.glade:52836
-#: src/emc/usr_intf/pncconf/mesa0.glade:52865
-#: src/emc/usr_intf/pncconf/mesa0.glade:52880
+#: src/emc/usr_intf/pncconf/mesa0.glade:9427
+#: src/emc/usr_intf/pncconf/mesa0.glade:9442
+#: src/emc/usr_intf/pncconf/mesa0.glade:9471
+#: src/emc/usr_intf/pncconf/mesa0.glade:20269
+#: src/emc/usr_intf/pncconf/mesa0.glade:20298
+#: src/emc/usr_intf/pncconf/mesa0.glade:20313
+#: src/emc/usr_intf/pncconf/mesa0.glade:24060
+#: src/emc/usr_intf/pncconf/mesa0.glade:24075
+#: src/emc/usr_intf/pncconf/mesa0.glade:24104
+#: src/emc/usr_intf/pncconf/mesa0.glade:24568
+#: src/emc/usr_intf/pncconf/mesa0.glade:24597
+#: src/emc/usr_intf/pncconf/mesa0.glade:24612
+#: src/emc/usr_intf/pncconf/mesa0.glade:25919
+#: src/emc/usr_intf/pncconf/mesa0.glade:25948
+#: src/emc/usr_intf/pncconf/mesa0.glade:25963
+#: src/emc/usr_intf/pncconf/mesa0.glade:29710
+#: src/emc/usr_intf/pncconf/mesa0.glade:29725
+#: src/emc/usr_intf/pncconf/mesa0.glade:29754
+#: src/emc/usr_intf/pncconf/mesa0.glade:30218
+#: src/emc/usr_intf/pncconf/mesa0.glade:30247
+#: src/emc/usr_intf/pncconf/mesa0.glade:30262
+#: src/emc/usr_intf/pncconf/mesa0.glade:31569
+#: src/emc/usr_intf/pncconf/mesa0.glade:31598
+#: src/emc/usr_intf/pncconf/mesa0.glade:31613
+#: src/emc/usr_intf/pncconf/mesa0.glade:35360
+#: src/emc/usr_intf/pncconf/mesa0.glade:35375
+#: src/emc/usr_intf/pncconf/mesa0.glade:35404
+#: src/emc/usr_intf/pncconf/mesa0.glade:35868
+#: src/emc/usr_intf/pncconf/mesa0.glade:35897
+#: src/emc/usr_intf/pncconf/mesa0.glade:35912
+#: src/emc/usr_intf/pncconf/mesa0.glade:37219
+#: src/emc/usr_intf/pncconf/mesa0.glade:37248
+#: src/emc/usr_intf/pncconf/mesa0.glade:37263
+#: src/emc/usr_intf/pncconf/mesa0.glade:41010
+#: src/emc/usr_intf/pncconf/mesa0.glade:41025
+#: src/emc/usr_intf/pncconf/mesa0.glade:41054
+#: src/emc/usr_intf/pncconf/mesa0.glade:41518
+#: src/emc/usr_intf/pncconf/mesa0.glade:41547
+#: src/emc/usr_intf/pncconf/mesa0.glade:41562
+#: src/emc/usr_intf/pncconf/mesa0.glade:42869
+#: src/emc/usr_intf/pncconf/mesa0.glade:42898
+#: src/emc/usr_intf/pncconf/mesa0.glade:42913
+#: src/emc/usr_intf/pncconf/mesa0.glade:46660
+#: src/emc/usr_intf/pncconf/mesa0.glade:46675
+#: src/emc/usr_intf/pncconf/mesa0.glade:46704
+#: src/emc/usr_intf/pncconf/mesa0.glade:47168
+#: src/emc/usr_intf/pncconf/mesa0.glade:47197
+#: src/emc/usr_intf/pncconf/mesa0.glade:47212
+#: src/emc/usr_intf/pncconf/mesa0.glade:48519
+#: src/emc/usr_intf/pncconf/mesa0.glade:48548
+#: src/emc/usr_intf/pncconf/mesa0.glade:48563
+#: src/emc/usr_intf/pncconf/mesa0.glade:52310
+#: src/emc/usr_intf/pncconf/mesa0.glade:52325
+#: src/emc/usr_intf/pncconf/mesa0.glade:52354
+#: src/emc/usr_intf/pncconf/mesa0.glade:52818
+#: src/emc/usr_intf/pncconf/mesa0.glade:52847
+#: src/emc/usr_intf/pncconf/mesa0.glade:52862
 #: src/emc/usr_intf/pncconf/mesa1.glade:9386
 #: src/emc/usr_intf/pncconf/mesa1.glade:9401
 #: src/emc/usr_intf/pncconf/mesa1.glade:9430
@@ -14901,11 +15461,10 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/mesa1.glade:52778
 #: src/emc/usr_intf/pncconf/mesa1.glade:52807
 #: src/emc/usr_intf/pncconf/mesa1.glade:52822
-#: src/emc/usr_intf/pncconf/dialogs.glade:41
 msgid " "
 msgstr " "
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:9599
+#: src/emc/usr_intf/pncconf/mesa0.glade:9581
 #: src/emc/usr_intf/pncconf/mesa1.glade:9540
 msgid ""
 "       I/O\n"
@@ -14914,7 +15473,7 @@ msgstr ""
 "       I/O\n"
 " Conector 4"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:11694
+#: src/emc/usr_intf/pncconf/mesa0.glade:11676
 #: src/emc/usr_intf/pncconf/mesa1.glade:11635
 msgid ""
 "       I/O\n"
@@ -14923,7 +15482,7 @@ msgstr ""
 "       I/O\n"
 " Conector 5"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:13787
+#: src/emc/usr_intf/pncconf/mesa0.glade:13769
 #: src/emc/usr_intf/pncconf/mesa1.glade:13728
 msgid ""
 "      I/O\n"
@@ -14932,7 +15491,7 @@ msgstr ""
 "      I/O\n"
 "Conector 6"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:15880
+#: src/emc/usr_intf/pncconf/mesa0.glade:15862
 #: src/emc/usr_intf/pncconf/mesa1.glade:15821
 msgid ""
 "      I/O\n"
@@ -14941,7 +15500,7 @@ msgstr ""
 "      I/O\n"
 "Conector 7"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:17973
+#: src/emc/usr_intf/pncconf/mesa0.glade:17955
 #: src/emc/usr_intf/pncconf/mesa1.glade:17915
 msgid ""
 "      I/O\n"
@@ -14950,7 +15509,7 @@ msgstr ""
 "      I/O\n"
 "Conector 8"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:20066
+#: src/emc/usr_intf/pncconf/mesa0.glade:20048
 #: src/emc/usr_intf/pncconf/mesa1.glade:20008
 msgid ""
 "      I/O\n"
@@ -14959,12 +15518,12 @@ msgstr ""
 "      I/O\n"
 " Conector 9"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:24232
-#: src/emc/usr_intf/pncconf/mesa0.glade:29882
-#: src/emc/usr_intf/pncconf/mesa0.glade:35532
-#: src/emc/usr_intf/pncconf/mesa0.glade:41182
-#: src/emc/usr_intf/pncconf/mesa0.glade:46832
-#: src/emc/usr_intf/pncconf/mesa0.glade:52482
+#: src/emc/usr_intf/pncconf/mesa0.glade:24214
+#: src/emc/usr_intf/pncconf/mesa0.glade:29864
+#: src/emc/usr_intf/pncconf/mesa0.glade:35514
+#: src/emc/usr_intf/pncconf/mesa0.glade:41164
+#: src/emc/usr_intf/pncconf/mesa0.glade:46814
+#: src/emc/usr_intf/pncconf/mesa0.glade:52464
 #: src/emc/usr_intf/pncconf/mesa1.glade:24174
 #: src/emc/usr_intf/pncconf/mesa1.glade:29824
 #: src/emc/usr_intf/pncconf/mesa1.glade:35474
@@ -14974,12 +15533,12 @@ msgstr ""
 msgid "page 2"
 msgstr "pagina 2"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:25701
-#: src/emc/usr_intf/pncconf/mesa0.glade:31351
-#: src/emc/usr_intf/pncconf/mesa0.glade:37001
-#: src/emc/usr_intf/pncconf/mesa0.glade:42651
-#: src/emc/usr_intf/pncconf/mesa0.glade:48301
-#: src/emc/usr_intf/pncconf/mesa0.glade:53951
+#: src/emc/usr_intf/pncconf/mesa0.glade:25683
+#: src/emc/usr_intf/pncconf/mesa0.glade:31333
+#: src/emc/usr_intf/pncconf/mesa0.glade:36983
+#: src/emc/usr_intf/pncconf/mesa0.glade:42633
+#: src/emc/usr_intf/pncconf/mesa0.glade:48283
+#: src/emc/usr_intf/pncconf/mesa0.glade:53933
 #: src/emc/usr_intf/pncconf/mesa1.glade:25643
 #: src/emc/usr_intf/pncconf/mesa1.glade:31293
 #: src/emc/usr_intf/pncconf/mesa1.glade:36943
@@ -14989,32 +15548,32 @@ msgstr "pagina 2"
 msgid "page 3"
 msgstr "pagina 3"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:25717
+#: src/emc/usr_intf/pncconf/mesa0.glade:25699
 #: src/emc/usr_intf/pncconf/mesa1.glade:25659
 msgid "Smart Serial 0"
 msgstr "Smart Serial 0"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:31367
+#: src/emc/usr_intf/pncconf/mesa0.glade:31349
 #: src/emc/usr_intf/pncconf/mesa1.glade:31309
 msgid "Smart Serial 1"
 msgstr "Smart Serial 1"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:37017
+#: src/emc/usr_intf/pncconf/mesa0.glade:36999
 #: src/emc/usr_intf/pncconf/mesa1.glade:36959
 msgid "Smart Serial 2"
 msgstr "Smart Serial 2"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:42667
+#: src/emc/usr_intf/pncconf/mesa0.glade:42649
 #: src/emc/usr_intf/pncconf/mesa1.glade:42609
 msgid "Smart Serial 3"
 msgstr "Smart Serial 3"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:48317
+#: src/emc/usr_intf/pncconf/mesa0.glade:48299
 #: src/emc/usr_intf/pncconf/mesa1.glade:48259
 msgid "Smart Serial 4"
 msgstr "Smart Serial 4"
 
-#: src/emc/usr_intf/pncconf/mesa0.glade:53967
+#: src/emc/usr_intf/pncconf/mesa0.glade:53949
 #: src/emc/usr_intf/pncconf/mesa1.glade:53909
 msgid "Smart Serial 5"
 msgstr "Smart Serial 5"
@@ -15207,9 +15766,9 @@ msgid "Z"
 msgstr "Z"
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15364,6 +15923,13 @@ msgstr "use debounce"
 #: src/emc/usr_intf/pncconf/external.glade:5401
 msgid "Mux options"
 msgstr "Opciones de Mux"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "Sec"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15541,176 +16107,194 @@ msgstr "Restaurar la posición articulacion después del apagado"
 msgid "<b>Defaults and Options</b>"
 msgstr "<b> Valores predeterminados y opciones </b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr "<b> Lista de pantallas GUI </b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr "Position_offset"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr "Position_feedback"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr "Ajuste máxima del husillo"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr "Ajuste mínima del husillo"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr "Ajuste de alimentación máxima"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr "xyzabc"
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr "Mostrar geometría"
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr "<b> Valores predeterminados de la GUI general </b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr "Velocidad lineal predeterminada"
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr "Velocidad lineal mínima"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr "Velocidad lineal máxima"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr "Velocidad angular predeterminada"
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr "gedit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr "Velocidad angular mínima"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr "Incrementos"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr "5 mm 1 mm .5 mm .1 mm .05 mm .01 mm .005 mm"
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr "Velocidad angular máxima"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr "Deg / min"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr "tamaño"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr "Posición"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr "X"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr "W"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr "H"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr "Forzar eje para maximizar"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr "Valores predeterminados de AXIS"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr "Forzar Touchy para maximizar después del posicionamiento"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr "Tema GTK"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr "Color de texto absoluto"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr "Color de texto absoluto"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 msgid "Relative Textcolor"
 msgstr "Color de texto relativo"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr "DTG Textcolor"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr "Error Textcolor"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr "Valores predeterminados Touchy"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr "Forzar Gmoccapy para maximizar después del posicionamiento"
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr "Valores predeterminados de Gmoccapy"
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Opciones de muestra"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15800,138 +16384,157 @@ msgstr "Detalles de Gladevcp"
 msgid "Include custom GladeVCP GUI panel"
 msgstr "Incluir panel de GUI GladeVCP personalizado"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
-msgstr "Tipo 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
+msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
-msgstr "Tipo 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
+msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr "Hacia el Límite Negativo"
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Codificador X"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr "Hacia el Límite Positivo"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr "Usar el índice del codificador para home:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr "Velocidad final a home:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr "Dirección de latch de home:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr "Dirección de búsqueda de home:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr "Velocidad de latch de home:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr "nombre de archivo:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
 msgstr "Usar archivo de compensación:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr "Usar compensación de contragolpe:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+#, fuzzy
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 "Ubicación de la posición home (offset desde el origen de la máquina cero):"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 "Distancia de recorrido negativa (origen de máquina cero al final del "
 "recorrido):"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+#, fuzzy
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 "Ubicación del interruptor de inicio (offset desde el origen de la máquina "
 "cero):"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr "Velocidad de búsqueda de home:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 "Distancia de recorrido positiva (origen de máquina cero al final del "
 "recorrido +):"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 msgid "Home Search Sequence:"
 msgstr "Secuencia de búsqueda de inicio:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+#, fuzzy
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+"Ubicación del interruptor de inicio (offset desde el origen de la máquina "
+"cero):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr "Tipo 1"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr "Tipo 2"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr "Hacia el Límite Negativo"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
+msgstr "Hacia el Límite Positivo"
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -15946,7 +16549,7 @@ msgstr "Salida máxima"
 #: src/emc/usr_intf/pncconf/z_motor.glade:116
 #: src/emc/usr_intf/pncconf/a_motor.glade:116
 #: src/emc/usr_intf/pncconf/s_motor.glade:297
-#: src/emc/usr_intf/pncconf/dialogs.glade:3949
+#: src/emc/usr_intf/pncconf/dialogs.glade:4005
 msgid "FF2"
 msgstr "FF2"
 
@@ -15955,7 +16558,7 @@ msgstr "FF2"
 #: src/emc/usr_intf/pncconf/z_motor.glade:129
 #: src/emc/usr_intf/pncconf/a_motor.glade:129
 #: src/emc/usr_intf/pncconf/s_motor.glade:311
-#: src/emc/usr_intf/pncconf/dialogs.glade:3938
+#: src/emc/usr_intf/pncconf/dialogs.glade:3994
 msgid "FF1"
 msgstr "FF1"
 
@@ -15964,7 +16567,7 @@ msgstr "FF1"
 #: src/emc/usr_intf/pncconf/z_motor.glade:142
 #: src/emc/usr_intf/pncconf/a_motor.glade:142
 #: src/emc/usr_intf/pncconf/s_motor.glade:325
-#: src/emc/usr_intf/pncconf/dialogs.glade:3927
+#: src/emc/usr_intf/pncconf/dialogs.glade:3983
 msgid "FF0"
 msgstr "FF0"
 
@@ -15981,7 +16584,7 @@ msgstr "Banda muerta"
 #: src/emc/usr_intf/pncconf/z_motor.glade:204
 #: src/emc/usr_intf/pncconf/a_motor.glade:204
 #: src/emc/usr_intf/pncconf/s_motor.glade:397
-#: src/emc/usr_intf/pncconf/dialogs.glade:4179
+#: src/emc/usr_intf/pncconf/dialogs.glade:4235
 msgid "Bias"
 msgstr "Sesgo"
 
@@ -16364,9 +16967,9 @@ msgstr "Rango:"
 #: src/emc/usr_intf/pncconf/z_motor.glade:1478
 #: src/emc/usr_intf/pncconf/a_motor.glade:1478
 #: src/emc/usr_intf/pncconf/s_motor.glade:2449
-#: src/emc/usr_intf/pncconf/dialogs.glade:1765
-#: src/emc/usr_intf/pncconf/dialogs.glade:1776
-#: src/emc/usr_intf/pncconf/dialogs.glade:3071
+#: src/emc/usr_intf/pncconf/dialogs.glade:1791
+#: src/emc/usr_intf/pncconf/dialogs.glade:1802
+#: src/emc/usr_intf/pncconf/dialogs.glade:3097
 msgid "RPM"
 msgstr "RPM"
 
@@ -16663,6 +17266,91 @@ msgstr "Comando de subprocesos"
 msgid "<b>Custom Components Commands</b>"
 msgstr "<b> Comandos de componentes personalizados </b>"
 
+#: src/emc/usr_intf/pncconf/pport1.glade:135
+#: src/emc/usr_intf/pncconf/pport2.glade:138
+msgid "Pin 2:"
+msgstr "Pin 2:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:196
+#: src/emc/usr_intf/pncconf/pport2.glade:199
+msgid "Pin 3:"
+msgstr "Pin 3:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:257
+#: src/emc/usr_intf/pncconf/pport2.glade:260
+msgid "Pin 4:"
+msgstr "Pin 4:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:318
+#: src/emc/usr_intf/pncconf/pport2.glade:321
+msgid "Pin 5:"
+msgstr "Pin 5:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:379
+#: src/emc/usr_intf/pncconf/pport2.glade:382
+msgid "Pin 6:"
+msgstr "Pin 6:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:440
+#: src/emc/usr_intf/pncconf/pport2.glade:443
+msgid "Pin 7:"
+msgstr "Pin 7:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:501
+#: src/emc/usr_intf/pncconf/pport2.glade:504
+msgid "Pin 8:"
+msgstr "Pin 8:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:562
+#: src/emc/usr_intf/pncconf/pport2.glade:565
+msgid "Pin 9:"
+msgstr "Pin 9:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:1006
+#: src/emc/usr_intf/pncconf/pport2.glade:1009
+msgid "Pin _1: "
+msgstr "Pin _1:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:1066
+#: src/emc/usr_intf/pncconf/pport2.glade:1069
+msgid "Pin _2:"
+msgstr "Pin _2:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:1126
+#: src/emc/usr_intf/pncconf/pport2.glade:1129
+msgid "Pin _3:"
+msgstr "Pin _3:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:1186
+#: src/emc/usr_intf/pncconf/pport2.glade:1189
+msgid "Pin _4:"
+msgstr "Pin _4:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:1246
+#: src/emc/usr_intf/pncconf/pport2.glade:1249
+msgid "Pin _5:"
+msgstr "Pin _5:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:1306
+#: src/emc/usr_intf/pncconf/pport2.glade:1309
+msgid "Pin _6:"
+msgstr "Pin _6:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:1366
+#: src/emc/usr_intf/pncconf/pport2.glade:1369
+msgid "Pin _7:"
+msgstr "Pin _7:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:1426
+#: src/emc/usr_intf/pncconf/pport2.glade:1429
+msgid "Pin _8:"
+msgstr "Pin _8:"
+
+#: src/emc/usr_intf/pncconf/pport1.glade:1486
+#: src/emc/usr_intf/pncconf/pport2.glade:1489
+msgid "Pin _9:"
+msgstr "Pin _9:"
+
 #: src/emc/usr_intf/pncconf/pport1.glade:1800
 #: src/emc/usr_intf/pncconf/pport2.glade:1803
 msgid ""
@@ -16682,17 +17370,22 @@ msgid "--addr"
 msgstr "--addr"
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:40
-#: src/emc/usr_intf/pncconf/dialogs.glade:282
 #: src/emc/usr_intf/pncconf/dialogs.glade:308
+#: src/emc/usr_intf/pncconf/dialogs.glade:334
 msgid "Pci"
 msgstr "Pci"
+
+#: src/emc/usr_intf/pncconf/dialogs.glade:41
+#, fuzzy
+msgid "PCI"
+msgstr "PID"
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:45
 msgid "--epp"
 msgstr "--epp"
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:74
-#: src/emc/usr_intf/pncconf/dialogs.glade:447
+#: src/emc/usr_intf/pncconf/dialogs.glade:473
 msgid "Interface type:"
 msgstr "Tipo de interfaz:"
 
@@ -16721,57 +17414,57 @@ msgstr "192.168.1.121"
 msgid "Card Name:"
 msgstr "Nombre de la tarjeta:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:181
+#: src/emc/usr_intf/pncconf/dialogs.glade:177
+msgid "Read hostmot2 PIN file From help's input tab"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/dialogs.glade:195
 msgid "Mesa Board Disvovery<"
 msgstr "Mesa Table Disvovery <"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:279
 #: src/emc/usr_intf/pncconf/dialogs.glade:305
+#: src/emc/usr_intf/pncconf/dialogs.glade:331
 msgid "hm2_eth"
 msgstr "hm2_eth"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:283
 #: src/emc/usr_intf/pncconf/dialogs.glade:309
+#: src/emc/usr_intf/pncconf/dialogs.glade:335
 msgid "hm2_pci"
 msgstr "hm2_pci"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:286
 #: src/emc/usr_intf/pncconf/dialogs.glade:312
+#: src/emc/usr_intf/pncconf/dialogs.glade:338
 msgid "Parallel Port -7i43"
 msgstr "Puerto paralelo -7i43"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:287
 #: src/emc/usr_intf/pncconf/dialogs.glade:313
+#: src/emc/usr_intf/pncconf/dialogs.glade:339
 msgid "hm2_4i43"
 msgstr "hm2_4i43"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:290
 #: src/emc/usr_intf/pncconf/dialogs.glade:316
+#: src/emc/usr_intf/pncconf/dialogs.glade:342
 msgid "Parellel Port- 7i90"
 msgstr "Puerto Parellel- 7i90"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:291
 #: src/emc/usr_intf/pncconf/dialogs.glade:317
+#: src/emc/usr_intf/pncconf/dialogs.glade:343
 msgid "hm2_7i90"
 msgstr "hm2_7i90"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:345
+#: src/emc/usr_intf/pncconf/dialogs.glade:371
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:348
-msgid "17"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:425
+#: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr "Número de conectores:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:436
+#: src/emc/usr_intf/pncconf/dialogs.glade:462
 msgid "Number of pins per connector:"
 msgstr "Número de pines por conector:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:478
+#: src/emc/usr_intf/pncconf/dialogs.glade:504
 msgid ""
 "Pncconf doesn't recognize the board name.\n"
 "Please set the data and press ok"
@@ -16779,22 +17472,22 @@ msgstr ""
 "Pncconf no reconoce el nombre de la placa.Por favor configure los datos y "
 "presione ok"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:511
+#: src/emc/usr_intf/pncconf/dialogs.glade:537
 msgid "<b>frame2</b>"
 msgstr "<b> marco2 </b>"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:561
+#: src/emc/usr_intf/pncconf/dialogs.glade:587
 #, fuzzy
 msgid "Save & Quit"
 msgstr "Guardar y salir"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:629
+#: src/emc/usr_intf/pncconf/dialogs.glade:655
 msgid ""
 "Save entered data and quit\n"
 "or discard changes and quit?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:718
+#: src/emc/usr_intf/pncconf/dialogs.glade:744
 msgid ""
 "<b>  Motor Encoder Openloop Test\n"
 "      Warning limits switches \n"
@@ -16803,257 +17496,253 @@ msgstr ""
 "<b> Prueba de bucle abierto del codificador del motorLímites de advertencia "
 "de interruptoresNo será obedecido </b>"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:806
+#: src/emc/usr_intf/pncconf/dialogs.glade:832
 msgid "Slow Dac Speed"
 msgstr "Velocidad lenta de dac"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:820
+#: src/emc/usr_intf/pncconf/dialogs.glade:846
 msgid "Fast Dac Speed"
 msgstr "Velocidad rápida de dac"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:930
+#: src/emc/usr_intf/pncconf/dialogs.glade:956
 msgid "Dac Offset:"
 msgstr "Compensación de Dac:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:941
+#: src/emc/usr_intf/pncconf/dialogs.glade:967
 msgid "Encoder Scale:"
 msgstr "Escala de codificador:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:970
+#: src/emc/usr_intf/pncconf/dialogs.glade:996
 msgid "Reset Encoder"
 msgstr "Restablecer codificador"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:984
+#: src/emc/usr_intf/pncconf/dialogs.glade:1010
 msgid "Enable Amp"
 msgstr "Habilitar amplificador"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:997
+#: src/emc/usr_intf/pncconf/dialogs.glade:1023
 msgid "Invert Encoder"
 msgstr "Invertir codificador"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1013
+#: src/emc/usr_intf/pncconf/dialogs.glade:1039
 msgid "Invert Motor"
 msgstr "Invertir motor"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1345
+#: src/emc/usr_intf/pncconf/dialogs.glade:1371
 msgid "Pulley teeth (motor:gearbox):"
 msgstr "Dientes de polea (motor: caja de cambios):"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1354
+#: src/emc/usr_intf/pncconf/dialogs.glade:1380
 msgid "Gear ratio 1 (Input:Output)"
 msgstr "Relación de engranaje 1 (Entrada: Salida)"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1367
-#: src/emc/usr_intf/pncconf/dialogs.glade:2159
+#: src/emc/usr_intf/pncconf/dialogs.glade:1393
+#: src/emc/usr_intf/pncconf/dialogs.glade:2185
 msgid "Microstep Multiplication Factor:"
 msgstr "Factor de multiplicación Microstep:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1383
-#: src/emc/usr_intf/pncconf/dialogs.glade:2234
+#: src/emc/usr_intf/pncconf/dialogs.glade:1409
+#: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr "Pasos del motor por revolución:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1417
-msgid "10"
-msgstr "10"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1459
+#: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
 msgstr "Voltaje para RPM máx .:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1468
+#: src/emc/usr_intf/pncconf/dialogs.glade:1494
 msgid "Use Negative voltage for reverse:"
 msgstr "Usar voltaje negativo para reversa:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1481
+#: src/emc/usr_intf/pncconf/dialogs.glade:1507
 msgid "Gear ratio 2 (Input:Output)"
 msgstr "Relación de engranaje 2 (Entrada: Salida)"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1560
+#: src/emc/usr_intf/pncconf/dialogs.glade:1586
 msgid "      <b>MOTOR</b> RPM at Max Voltage"
 msgstr "<b> MOTOR </b> RPM a voltaje máximo"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1592
+#: src/emc/usr_intf/pncconf/dialogs.glade:1618
 msgid "<b>Spindle Drive Motor</b>"
 msgstr "<b> Motor de accionamiento del husillo </b>"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1634
-#: src/emc/usr_intf/pncconf/dialogs.glade:2455
+#: src/emc/usr_intf/pncconf/dialogs.glade:1660
+#: src/emc/usr_intf/pncconf/dialogs.glade:2481
 msgid "X 4 = Pulses/Rev"
 msgstr "X 4 = Pulsos / Rev"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1646
-#: src/emc/usr_intf/pncconf/dialogs.glade:2469
+#: src/emc/usr_intf/pncconf/dialogs.glade:1672
+#: src/emc/usr_intf/pncconf/dialogs.glade:2495
 msgid "Encoder lines per revolution:"
 msgstr "Líneas de codificador por revolución:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1655
-#: src/emc/usr_intf/pncconf/dialogs.glade:2627
+#: src/emc/usr_intf/pncconf/dialogs.glade:1681
+#: src/emc/usr_intf/pncconf/dialogs.glade:2653
 msgid "<b>Encoder Scale</b>"
 msgstr "<b> Escala de codificador </b>"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1723
+#: src/emc/usr_intf/pncconf/dialogs.glade:1749
 msgid "Spindle RPM at Max Motor Speed -gear 1:"
 msgstr "RPM del husillo a la velocidad máxima del motor - engranaje 1:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1730
+#: src/emc/usr_intf/pncconf/dialogs.glade:1756
 msgid "Spindle RPM at Max Motor Speed -gear 2:"
 msgstr "RPM del husillo a la velocidad máxima del motor - engranaje 2:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1741
+#: src/emc/usr_intf/pncconf/dialogs.glade:1767
 msgid "500"
 msgstr "500"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1752
+#: src/emc/usr_intf/pncconf/dialogs.glade:1778
 msgid "1000"
 msgstr "1000"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1793
-#: src/emc/usr_intf/pncconf/dialogs.glade:3198
+#: src/emc/usr_intf/pncconf/dialogs.glade:1819
+#: src/emc/usr_intf/pncconf/dialogs.glade:3254
 msgid "<b>Motion Data</b>"
 msgstr "<b> Datos de movimiento </b>"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:1937
+#: src/emc/usr_intf/pncconf/dialogs.glade:1963
 msgid "TPI "
 msgstr "TPI"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2137
+#: src/emc/usr_intf/pncconf/dialogs.glade:2163
 msgid "Pulley teeth (motor:Leadscrew):"
 msgstr "Dientes de polea (motor: tornillo):"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2146
-#: src/emc/usr_intf/pncconf/dialogs.glade:2542
+#: src/emc/usr_intf/pncconf/dialogs.glade:2172
+#: src/emc/usr_intf/pncconf/dialogs.glade:2568
 msgid "Worm turn ratio (Input:Outputl)"
 msgstr "Relación de giro del gusano (Entrada: Salidal)"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2180
-#: src/emc/usr_intf/pncconf/dialogs.glade:2572
+#: src/emc/usr_intf/pncconf/dialogs.glade:2206
+#: src/emc/usr_intf/pncconf/dialogs.glade:2598
 msgid "Leadscrew Metric Pitch"
 msgstr "Paso métrico del tornillo prisionero"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2268
+#: src/emc/usr_intf/pncconf/dialogs.glade:2294
 msgid "<b>Step Motor Scale</b>"
 msgstr "<b> Escala de motor paso a paso </b>"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2318
+#: src/emc/usr_intf/pncconf/dialogs.glade:2344
 msgid "TPI"
 msgstr "TPI"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2555
+#: src/emc/usr_intf/pncconf/dialogs.glade:2581
 msgid "Pulley teeth (encoder:Leadscrew):"
 msgstr "Dientes de polea (codificador: tornillo prisionero):"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2671
+#: src/emc/usr_intf/pncconf/dialogs.glade:2697
 msgid "                    "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2717
+#: src/emc/usr_intf/pncconf/dialogs.glade:2743
 msgid "encoder pulses per unit:"
 msgstr "pulsos del codificador por unidad:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2730
+#: src/emc/usr_intf/pncconf/dialogs.glade:2756
 msgid "motor steps per unit:"
 msgstr "pasos del motor por unidad:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2744
+#: src/emc/usr_intf/pncconf/dialogs.glade:2770
 msgid "<b>Calculated Scale</b>"
 msgstr "<b> Escala calculada </b>"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2813
+#: src/emc/usr_intf/pncconf/dialogs.glade:2839
 msgid "mm / encoder pulse"
 msgstr "mm / pulso codificador"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2845
+#: src/emc/usr_intf/pncconf/dialogs.glade:2871
 msgid "Resolution:"
 msgstr "Resolución:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2874
+#: src/emc/usr_intf/pncconf/dialogs.glade:2900
 msgid "Distance to acheave max speed:"
 msgstr "Distancia para alcanzar la velocidad máxima:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2976
+#: src/emc/usr_intf/pncconf/dialogs.glade:3002
 msgid "sec"
 msgstr "sec"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:2992
+#: src/emc/usr_intf/pncconf/dialogs.glade:3018
 msgid "Khz"
 msgstr "Khz"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3008
+#: src/emc/usr_intf/pncconf/dialogs.glade:3034
 msgid "Calculated Axis SCALE:"
 msgstr "ESCALA calculada del eje:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3059
+#: src/emc/usr_intf/pncconf/dialogs.glade:3085
 msgid "Motor RPM at max speed:"
 msgstr "RPM del motor a la velocidad máxima:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3106
+#: src/emc/usr_intf/pncconf/dialogs.glade:3147
 msgid "xmaxrpm"
 msgstr "xmaxrpm"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3580
+#: src/emc/usr_intf/pncconf/dialogs.glade:3636
 msgid "Seconds"
 msgstr "Segundos"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3635
+#: src/emc/usr_intf/pncconf/dialogs.glade:3691
 msgid "Enable"
 msgstr "Habilitar"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3757
+#: src/emc/usr_intf/pncconf/dialogs.glade:3813
 msgid "mm/minute^2"
 msgstr "mm / minuto ^ 2"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3804
+#: src/emc/usr_intf/pncconf/dialogs.glade:3860
 msgid "mm/minute"
 msgstr "mm / minuto"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3883
-#: src/emc/usr_intf/pncconf/dialogs.glade:4525
+#: src/emc/usr_intf/pncconf/dialogs.glade:3939
+#: src/emc/usr_intf/pncconf/dialogs.glade:4701
 msgid "Current"
 msgstr "Actual"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3894
+#: src/emc/usr_intf/pncconf/dialogs.glade:3950
 msgid "P:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3905
+#: src/emc/usr_intf/pncconf/dialogs.glade:3961
 msgid "I:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3916
+#: src/emc/usr_intf/pncconf/dialogs.glade:3972
 msgid "D:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:3970
-#: src/emc/usr_intf/pncconf/dialogs.glade:4538
+#: src/emc/usr_intf/pncconf/dialogs.glade:4026
+#: src/emc/usr_intf/pncconf/dialogs.glade:4714
 msgid "Original"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:4190
+#: src/emc/usr_intf/pncconf/dialogs.glade:4246
 msgid "DeadBand"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:4269
+#: src/emc/usr_intf/pncconf/dialogs.glade:4325
 msgid "PID Tuning"
 msgstr "Ajuste de PID"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:4492
+#: src/emc/usr_intf/pncconf/dialogs.glade:4668
 msgid "Step Time:"
 msgstr "Tiempo de paso:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:4503
+#: src/emc/usr_intf/pncconf/dialogs.glade:4679
 msgid "Step Space:"
 msgstr "Espacio de paso:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:4514
+#: src/emc/usr_intf/pncconf/dialogs.glade:4690
 msgid "Direction Hold:"
 msgstr "Retención de dirección:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:4551
+#: src/emc/usr_intf/pncconf/dialogs.glade:4727
 msgid "Direction Setup:"
 msgstr "Configuración de dirección:"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:4764
+#: src/emc/usr_intf/pncconf/dialogs.glade:4940
 msgid "Step Timing"
 msgstr "Tiempo de paso"
 
@@ -17094,50 +17783,52 @@ msgstr ""
 "prueba de latencia más completa como se describe en el wiki de linuxcnc.org:"
 "http://wiki.linuxcnc.org/cgi-bin/wiki.pl?TroubleShooting"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:62
+#: src/emc/usr_intf/gscreen/gscreen.py:63
 msgid ""
 "**** WARNING GSCREEN: could not import vte terminal - is package installed?"
 msgstr ""
-"**** ADVERTENCIA GSCREEN: no se pudo importar el terminal vte - ¿está instalado el paquete?"
+"**** ADVERTENCIA GSCREEN: no se pudo importar el terminal vte - ¿está "
+"instalado el paquete?"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:270
+#: src/emc/usr_intf/gscreen/gscreen.py:271
 msgid "Manual Mode"
 msgstr "Modo manual"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:270
+#: src/emc/usr_intf/gscreen/gscreen.py:271
 msgid "MDI Mode"
 msgstr "Modo MDI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:270
+#: src/emc/usr_intf/gscreen/gscreen.py:271
 msgid "Auto Mode"
 msgstr "Modo Auto"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:385
+#: src/emc/usr_intf/gscreen/gscreen.py:386
 #, python-format
 msgid "adding import dir %s"
 msgstr "agregando el directorio de importación %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:391
+#: src/emc/usr_intf/gscreen/gscreen.py:392
 #, python-format
 msgid "module '%s' imported OK"
 msgstr "módulo '%s' importado OK"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:470
+#: src/emc/usr_intf/gscreen/gscreen.py:471
 msgid ""
 "**** GSCREEN ERROR: INI file path missing from Gscreen launch command ****\n"
 msgstr ""
-"**** ERROR GSGSCREEN: falta la ruta del archivo INI en el comando de inicio de Gscreen ****\n"
+"**** ERROR GSGSCREEN: falta la ruta del archivo INI en el comando de inicio "
+"de Gscreen ****\n"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:478
+#: src/emc/usr_intf/gscreen/gscreen.py:479
 msgid "**** GSCREEN INFO: CUSTOM locale name ="
 msgstr "**** INFORMACIÓN GSGSCREEN: nombre local personalizado ="
 
-#: src/emc/usr_intf/gscreen/gscreen.py:484
+#: src/emc/usr_intf/gscreen/gscreen.py:485
 msgid "**** GSCREEN INFO: SKIN locale name ="
 msgstr ""
 "**** INFORMACIÓN GSGSCREEN: nombre de la configuración regional de la SKIN ="
 
-#: src/emc/usr_intf/gscreen/gscreen.py:496
+#: src/emc/usr_intf/gscreen/gscreen.py:497
 #, python-format
 msgid ""
 "\n"
@@ -17146,7 +17837,7 @@ msgstr ""
 "\n"
 "**** INFORMACIÓN GSGSCREEN: Usando archivo glade PERSONALIZADO desde %s ****"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:501
+#: src/emc/usr_intf/gscreen/gscreen.py:502
 #, python-format
 msgid ""
 "\n"
@@ -17155,7 +17846,7 @@ msgstr ""
 "\n"
 "**** INFORMACIÓN GSGSCREEN: Usando el archivo glade SKIN desde %s ****"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:504
+#: src/emc/usr_intf/gscreen/gscreen.py:505
 #, python-format
 msgid ""
 "\n"
@@ -17164,26 +17855,28 @@ msgstr ""
 "\n"
 "**** INFORMACIÓN GSGSCREEN: utilizando el archivo glade STOCK desde: %s ****"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:517
+#: src/emc/usr_intf/gscreen/gscreen.py:519
 #, python-format
 msgid "**** Gscreen GLADE ERROR:    With main screen xml file: %s"
-msgstr "**** Gscreen GLADE ERROR: Con el archivo xml de la pantalla principal: %s"
+msgstr ""
+"**** Gscreen GLADE ERROR: Con el archivo xml de la pantalla principal: %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:522
+#: src/emc/usr_intf/gscreen/gscreen.py:524
 #, python-format
 msgid ""
 "\n"
 "**** GSCREEN INFO:  Screen 2 -Using CUSTOM glade file from %s ****"
 msgstr ""
 "\n"
-"**** INFORMACIÓN GSGSCREEN: Pantalla 2 -Usando el archivo glade PERSONALIZADO desde %s ****"
+"**** INFORMACIÓN GSGSCREEN: Pantalla 2 -Usando el archivo glade "
+"PERSONALIZADO desde %s ****"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:528
+#: src/emc/usr_intf/gscreen/gscreen.py:530
 #, python-format
 msgid "**** Gscreen GLADE ERROR:    With screen 2's xml file: %s"
 msgstr "**** Gscreen ERROR DE GLADE: Con archivo xml de pantalla 2: %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:530
+#: src/emc/usr_intf/gscreen/gscreen.py:532
 msgid ""
 "\n"
 "**** GSCREEN INFO:  No Screen 2 glade file present"
@@ -17191,29 +17884,31 @@ msgstr ""
 "\n"
 "**** INFORMACIÓN GSGSCREEN: No hay archivo Glade de pantalla 2 presente"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:574
+#: src/emc/usr_intf/gscreen/gscreen.py:576
 msgid "No UNITS entry found in [TRAJ] or [AXIS_X] of INI file"
 msgstr "No se encontró una entrada UNITS en [TRAJ] o [AXIS_X] del archivo INI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:587
+#: src/emc/usr_intf/gscreen/gscreen.py:589
 msgid ""
 "*** Gscreen ERROR:    Asking for a HAL component using a name that already "
 "exists."
 msgstr ""
-"*** ERROR de Gscreen: pidiendo un componente HAL usando un nombre que "
-"ya existe."
+"*** ERROR de Gscreen: pidiendo un componente HAL usando un nombre que ya "
+"existe."
 
-#: src/emc/usr_intf/gscreen/gscreen.py:662
+#: src/emc/usr_intf/gscreen/gscreen.py:664
 msgid "No default jog increments entry found in [DISPLAY] of INI file"
 msgstr ""
-"No se encontró una entrada predeterminada de incrementos de jog en [DISPLAY] del archivo INI"
+"No se encontró una entrada predeterminada de incrementos de jog en [DISPLAY] "
+"del archivo INI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:675
+#: src/emc/usr_intf/gscreen/gscreen.py:677
 msgid "No default angular jog increments entry found in [DISPLAY] of INI file"
 msgstr ""
-"No se encontró una entrada de incrementos de jog angular predeterminada en [DISPLAY] del archivo INI"
+"No se encontró una entrada de incrementos de jog angular predeterminada en "
+"[DISPLAY] del archivo INI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:684
+#: src/emc/usr_intf/gscreen/gscreen.py:686
 #, python-format
 msgid ""
 "No DEFAULT_LINEAR_VELOCITY entry found in [DISPLAY] of INI file: using "
@@ -17222,7 +17917,7 @@ msgstr ""
 "No se encontró ninguna entrada DEFAULT_LINEAR_VELOCITY en [DISPLAY] del "
 "archivo INI: usando valor predeterminado interno de %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:695
+#: src/emc/usr_intf/gscreen/gscreen.py:697
 #, python-format
 msgid ""
 "No MAX_LINEAR_VELOCITY entry found in [DISPLAY] of INI file: using internal "
@@ -17231,11 +17926,11 @@ msgstr ""
 "No se encontró la entrada MAX_LINEAR_VELOCITY en [DISPLAY] del archivo INI: "
 "usando valor predeterminado interno de %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:702
+#: src/emc/usr_intf/gscreen/gscreen.py:704
 msgid "No MAX_LINEAR_VELOCITY found in [TRAJ] of the INI file"
 msgstr "No se encontró MAX_LINEAR_VELOCITY en [TRAJ] del archivo INI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:715
+#: src/emc/usr_intf/gscreen/gscreen.py:717
 #, python-format
 msgid ""
 "No DEFAULT_ANGULAR_VELOCITY entry found in [DISPLAY] of INI file: using "
@@ -17244,7 +17939,7 @@ msgstr ""
 "No se encontró ninguna entrada DEFAULT_ANGULAR_VELOCITY en [DISPLAY] del "
 "archivo INI: usandovalor predeterminado interno de %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:726
+#: src/emc/usr_intf/gscreen/gscreen.py:728
 #, python-format
 msgid ""
 "No MAX_ANGULAR_VELOCITY entry found in [DISPLAY] of INI file: using internal "
@@ -17253,48 +17948,48 @@ msgstr ""
 "No se encontró la entrada MAX_ANGULAR_VELOCITY en [DISPLAY] del archivo INI: "
 "usando valor interno predeterminado de %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:734
+#: src/emc/usr_intf/gscreen/gscreen.py:736
 msgid "No MAX_SPINDLE_OVERRIDE entry found in [DISPLAY] of INI file"
 msgstr ""
 "No se encontró la entrada MAX_SPINDLE_OVERRIDE en [DISPLAY] del archivo INI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:740
+#: src/emc/usr_intf/gscreen/gscreen.py:742
 msgid "No MIN_SPINDLE_OVERRIDE entry found in [DISPLAY] of INI file"
 msgstr ""
 "No se encontró ninguna entrada MIN_SPINDLE_OVERRIDE en [DISPLAY] del archivo "
 "INI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:746
+#: src/emc/usr_intf/gscreen/gscreen.py:748
 msgid "No MAX_FEED_OVERRIDE entry found in [DISPLAY] of INI file"
 msgstr ""
 "No se encontró la entrada MAX_FEED_OVERRIDE en [DISPLAY] del archivo INI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:751
+#: src/emc/usr_intf/gscreen/gscreen.py:753
 msgid "This screen will be orientated for Lathe options"
 msgstr "Esta pantalla estará orientada para las opciones de Torno"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:804
+#: src/emc/usr_intf/gscreen/gscreen.py:807
 msgid "CYCLE_TIME in [DISPLAY] of INI file is missing: defaulting to 100ms"
 msgstr ""
 "Falta CYCLE_TIME en [DISPLAY] del archivo INI: el valor predeterminado es "
 "100 ms"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:807
+#: src/emc/usr_intf/gscreen/gscreen.py:810
 msgid "CYCLE_TIME in [DISPLAY] of INI file is too small: defaulting to 100ms"
 msgstr ""
 "CYCLE_TIME en [DISPLAY] del archivo INI es demasiado pequeño: el valor "
 "predeterminado es 100 ms"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:809
+#: src/emc/usr_intf/gscreen/gscreen.py:812
 #, python-format
 msgid "timeout %d"
 msgstr "tiempo de espera %d"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1257
+#: src/emc/usr_intf/gscreen/gscreen.py:1260
 msgid "Ready For Homing"
 msgstr "Listo para Homing"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1308
+#: src/emc/usr_intf/gscreen/gscreen.py:1311
 msgid ""
 "**** WARNING GSCREEN: could not initialize vte terminal - is package vte "
 "installed? Is widget: terminal_window in GLADE file?"
@@ -17303,11 +17998,11 @@ msgstr ""
 "paquete vte¿está instalado? ¿El widget: terminal_window está en el archivo "
 "GLADE?"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1324
+#: src/emc/usr_intf/gscreen/gscreen.py:1327
 msgid "Local Config Theme"
 msgstr "Tema de configuración local"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1380
+#: src/emc/usr_intf/gscreen/gscreen.py:1383
 msgid ""
 "**** WARNING GSCREEN: could not understand the window geometry info in "
 "hidden preference file"
@@ -17315,145 +18010,146 @@ msgstr ""
 "**** ADVERTENCIA GSCREEN: no se pudo entender la información de geometría de "
 "la ventana enarchivo de preferencias ocultas"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1510
+#: src/emc/usr_intf/gscreen/gscreen.py:1513
 msgid "Control powered up and initialized"
 msgstr "Control encendido e inicializado"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1884
+#: src/emc/usr_intf/gscreen/gscreen.py:1887
 msgid "Cycle start pressed in AUTO mode"
 msgstr "Inicio de ciclo presionado en modo AUTO"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1887
+#: src/emc/usr_intf/gscreen/gscreen.py:1890
 msgid "Cycle start pressed in MDI mode"
 msgstr "Inicio de ciclo presionado en modo MDI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1922
+#: src/emc/usr_intf/gscreen/gscreen.py:1925
 #, python-format
 msgid "Please change to tool # %s, then click OK."
 msgstr "Cambie a la herramienta # %s, luego haga clic en Aceptar."
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1923
-#: src/emc/usr_intf/gscreen/gscreen.py:1935
+#: src/emc/usr_intf/gscreen/gscreen.py:1926
 #: src/emc/usr_intf/gscreen/gscreen.py:1938
-#: src/emc/usr_intf/gscreen/gscreen.py:1954
+#: src/emc/usr_intf/gscreen/gscreen.py:1941
 #: src/emc/usr_intf/gscreen/gscreen.py:1957
-#: src/emc/usr_intf/gscreen/gscreen.py:1963
-#: src/emc/usr_intf/gscreen/gscreen.py:2352
-#: src/emc/usr_intf/gscreen/gscreen.py:2676
-#: src/emc/usr_intf/gscreen/gscreen.py:4088
+#: src/emc/usr_intf/gscreen/gscreen.py:1960
+#: src/emc/usr_intf/gscreen/gscreen.py:1966
+#: src/emc/usr_intf/gscreen/gscreen.py:2354
+#: src/emc/usr_intf/gscreen/gscreen.py:2678
 #: src/emc/usr_intf/gscreen/gscreen.py:4091
-#: src/emc/usr_intf/gscreen/gscreen.py:4135
-#: src/emc/usr_intf/gscreen/gscreen.py:4155
+#: src/emc/usr_intf/gscreen/gscreen.py:4094
+#: src/emc/usr_intf/gscreen/gscreen.py:4138
 #: src/emc/usr_intf/gscreen/gscreen.py:4158
-#: src/emc/usr_intf/gscreen/gscreen.py:4228
+#: src/emc/usr_intf/gscreen/gscreen.py:4161
 #: src/emc/usr_intf/gscreen/gscreen.py:4231
-#: src/emc/usr_intf/gscreen/gscreen.py:4238
+#: src/emc/usr_intf/gscreen/gscreen.py:4234
 #: src/emc/usr_intf/gscreen/gscreen.py:4241
-#: src/emc/usr_intf/gscreen/gscreen.py:4250
-#: src/emc/usr_intf/gscreen/gscreen.py:4261
-#: src/emc/usr_intf/gscreen/gscreen.py:4267
+#: src/emc/usr_intf/gscreen/gscreen.py:4244
+#: src/emc/usr_intf/gscreen/gscreen.py:4253
+#: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
+#: src/emc/usr_intf/gscreen/gscreen.py:4273
 msgid "INFO:"
 msgstr "INFO:"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1935
-#: src/emc/usr_intf/gscreen/gscreen.py:1954
+#: src/emc/usr_intf/gscreen/gscreen.py:1938
+#: src/emc/usr_intf/gscreen/gscreen.py:1957
 msgid "Can't start spindle manually while MDI busy"
 msgstr "No se puede iniciar el husillo manualmente mientras MDI está ocupado"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1938
-#: src/emc/usr_intf/gscreen/gscreen.py:1957
+#: src/emc/usr_intf/gscreen/gscreen.py:1941
+#: src/emc/usr_intf/gscreen/gscreen.py:1960
 msgid "can't start spindle manually in Auto mode"
 msgstr "no se puede iniciar el husillo manualmente en modo auto"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1963
-#: src/emc/usr_intf/gscreen/gscreen.py:4135
+#: src/emc/usr_intf/gscreen/gscreen.py:1966
+#: src/emc/usr_intf/gscreen/gscreen.py:4138
 msgid "No direction selected for spindle"
 msgstr "No hay dirección seleccionada para el husillo"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:1975
-#: src/emc/usr_intf/gscreen/gscreen.py:1977
+#: src/emc/usr_intf/gscreen/gscreen.py:1978
+#: src/emc/usr_intf/gscreen/gscreen.py:1980
 msgid "Spindle Speed Preset Entry"
 msgstr "Entrada de preajuste de velocidad del husillo"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2011
-#: src/emc/usr_intf/gscreen/gscreen.py:2016
+#: src/emc/usr_intf/gscreen/gscreen.py:2014
+#: src/emc/usr_intf/gscreen/gscreen.py:2019
 msgid "Manual Tool Index Entry"
 msgstr "Entrada manual de índice de herramienta"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2184
+#: src/emc/usr_intf/gscreen/gscreen.py:2187
 msgid "Entry dialog"
 msgstr "Diálogo de entrada"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2352
+#: src/emc/usr_intf/gscreen/gscreen.py:2354
 msgid "Classicladder realtime component not detected"
 msgstr "Componente en tiempo real Classicladder no detectado"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2353
+#: src/emc/usr_intf/gscreen/gscreen.py:2355
 msgid "ladder not available - is the realtime component loaded?"
 msgstr "ladder no disponible: ¿está cargado el componente en tiempo real?"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2503
+#: src/emc/usr_intf/gscreen/gscreen.py:2505
 msgid "Override Entry"
 msgstr "Ajustar entrada"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2547
+#: src/emc/usr_intf/gscreen/gscreen.py:2549
 msgid "Machine powered on"
 msgstr "Máquina encendida"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2552
+#: src/emc/usr_intf/gscreen/gscreen.py:2554
 msgid "Machine Estopped!"
 msgstr "¡Máquina detenida!"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2558
+#: src/emc/usr_intf/gscreen/gscreen.py:2560
 msgid "Calculator"
 msgstr "Calculadora"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2784
+#: src/emc/usr_intf/gscreen/gscreen.py:2786
 #, python-format
 msgid "Axes %s are homed"
 msgstr "Los ejes %s tienen home"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2798
+#: src/emc/usr_intf/gscreen/gscreen.py:2800
 msgid "All the axes have been homed"
 msgstr "Todos los ejes tienen home"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2811
+#: src/emc/usr_intf/gscreen/gscreen.py:2813
 #, python-format
 msgid "There are unhomed axes: %s"
 msgstr "Hay ejes sin home: %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2820
+#: src/emc/usr_intf/gscreen/gscreen.py:2822
 #, python-format
 msgid "Program loaded: %s"
 msgstr "Programa cargado: %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:2973
+#: src/emc/usr_intf/gscreen/gscreen.py:2975
 msgid "Manual Spindle Control"
 msgstr "Control Manual del husillo"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3051
-#: src/emc/usr_intf/gscreen/gscreen.py:3052
+#: src/emc/usr_intf/gscreen/gscreen.py:3053
+#: src/emc/usr_intf/gscreen/gscreen.py:3054
 msgid "Error with launching on-screen keyboard program -can't find program."
-msgstr "Error al iniciar el programa de teclado en pantalla: no se puede encontrar el programa."
+msgstr ""
+"Error al iniciar el programa de teclado en pantalla: no se puede encontrar "
+"el programa."
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3062
+#: src/emc/usr_intf/gscreen/gscreen.py:3064
 msgid "Keyboard"
 msgstr "Teclado"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3095
+#: src/emc/usr_intf/gscreen/gscreen.py:3097
 #, python-format
 msgid "Error with launching 'Onboard' on-screen keyboard program %s"
 msgstr "Error al iniciar el programa de teclado en pantalla 'Onboard' %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3244
+#: src/emc/usr_intf/gscreen/gscreen.py:3246
 #, python-format
 msgid "**** GSCREEN INFO: Overriding internal signal call to %s"
 msgstr ""
 "**** INFORMACIÓN GSCREEN: anulación de la llamada de señal interna a %s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3675
+#: src/emc/usr_intf/gscreen/gscreen.py:3678
 msgid ""
 "Zero\n"
 " "
@@ -17461,7 +18157,7 @@ msgstr ""
 "Cero\n"
 " "
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3676
+#: src/emc/usr_intf/gscreen/gscreen.py:3679
 msgid ""
 "Set At\n"
 " "
@@ -17469,16 +18165,16 @@ msgstr ""
 "Establecer en\n"
 " "
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3680
+#: src/emc/usr_intf/gscreen/gscreen.py:3683
 msgid " Zero Origin"
 msgstr "Origen cero"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3681
+#: src/emc/usr_intf/gscreen/gscreen.py:3684
 #: src/emc/usr_intf/gscreen/gscreen.glade:2573
 msgid "Offset Origin"
 msgstr "Offset de Origen"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3696
+#: src/emc/usr_intf/gscreen/gscreen.py:3699
 msgid ""
 "**** Gscreen ERROR:    Invalid message configuration (missing text or type) "
 "in INI File [DISPLAY] section"
@@ -17486,7 +18182,7 @@ msgstr ""
 "**** ERROR de Gscreen: configuración de mensaje no válida (falta texto o "
 "tipo)en la sección del archivo INI [DISPLAY]"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3698
+#: src/emc/usr_intf/gscreen/gscreen.py:3701
 msgid ""
 "**** Gscreen ERROR:    Invalid message configuration (missing pinname) in "
 "INI File [DISPLAY] section"
@@ -17494,7 +18190,7 @@ msgstr ""
 "**** ERROR de Gscreen: configuración de mensaje no válida (falta el pinname) "
 "enSección del archivo INI [DISPLAY]"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3700
+#: src/emc/usr_intf/gscreen/gscreen.py:3703
 msgid ""
 "**** Gscreen ERROR:    Invalid message configuration (missing boldtext) in "
 "INI File [DISPLAY] section"
@@ -17502,7 +18198,7 @@ msgstr ""
 "**** Gscreen ERROR: configuración de mensaje no válida (falta texto en "
 "negrita) enSección del archivo INI [DISPLAY]"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3704
+#: src/emc/usr_intf/gscreen/gscreen.py:3707
 #, python-format
 msgid ""
 "**** Gscreen ERROR:    invalid message type (%s)in INI File [DISPLAY] section"
@@ -17510,146 +18206,138 @@ msgstr ""
 "**** ERROR de Gscreen: tipo de mensaje no válido (%s) en la sección "
 "[DISPLAY] del archivo INI"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3736
+#: src/emc/usr_intf/gscreen/gscreen.py:3739
 msgid "Dialog error - Is the dialog handler missing from the handler file?"
 msgstr ""
 "Error de diálogo: ¿falta el controlador de diálogo en el archivo del "
 "controlador?"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3738
+#: src/emc/usr_intf/gscreen/gscreen.py:3741
 msgid "Manual Toolchange"
 msgstr "Cambio Manual de Herramientas"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3740
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
+#: src/emc/usr_intf/gscreen/gscreen.py:3743
 msgid "Operator Message"
 msgstr "Mensaje del operador"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3774
-#: src/emc/usr_intf/gscreen/gscreen.py:3778
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
+#: src/emc/usr_intf/gscreen/gscreen.py:3777
+#: src/emc/usr_intf/gscreen/gscreen.py:3781
 msgid "Restart Entry"
 msgstr "Reiniciar entrada"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3787
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
+#: src/emc/usr_intf/gscreen/gscreen.py:3790
 msgid "Up"
 msgstr "Arriba"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3789
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
+#: src/emc/usr_intf/gscreen/gscreen.py:3792
 msgid "Enter"
 msgstr "Entrar"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3791
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
+#: src/emc/usr_intf/gscreen/gscreen.py:3794
 msgid "Down"
 msgstr "Abajo"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3811
+#: src/emc/usr_intf/gscreen/gscreen.py:3814
 #, python-format
 msgid "Ready to Restart program from line %d"
 msgstr "Listo para reiniciar el programa desde la línea %d"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:3844
+#: src/emc/usr_intf/gscreen/gscreen.py:3847
 msgid "Invalid embeded tab configuration"
 msgstr "Configuración de pestaña embebida no válida"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4088
-#: src/emc/usr_intf/gscreen/gscreen.py:4155
+#: src/emc/usr_intf/gscreen/gscreen.py:4091
+#: src/emc/usr_intf/gscreen/gscreen.py:4158
 msgid "Can't jog multiple axis"
 msgstr "No se puede mover varios ejes"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4091
+#: src/emc/usr_intf/gscreen/gscreen.py:4094
 msgid "No axis selected to jog"
 msgstr "Ningún eje seleccionado para jog"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4158
+#: src/emc/usr_intf/gscreen/gscreen.py:4161
 msgid "No axis selected to move"
 msgstr "No se seleccionó ningún eje para mover"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4228
+#: src/emc/usr_intf/gscreen/gscreen.py:4231
 msgid "Can't home multiple axis - select HOME ALL instead"
 msgstr "No se puede hacer home en varios ejes: seleccione HOME TODO"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4231
+#: src/emc/usr_intf/gscreen/gscreen.py:4234
 msgid "No axis selected to home"
 msgstr "Ningún eje seleccionado para home"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4238
+#: src/emc/usr_intf/gscreen/gscreen.py:4241
 msgid "Can't unhome multiple axis"
 msgstr "No se puede hacer unhome en ejes múltiples"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4241
+#: src/emc/usr_intf/gscreen/gscreen.py:4244
 msgid "No axis selected to unhome"
 msgstr "No se seleccionó ningún eje para unhome"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4250
+#: src/emc/usr_intf/gscreen/gscreen.py:4253
 msgid "No axis selected for origin zeroing"
 msgstr "No se seleccionó ningún eje para la puesta a cero de origen"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4261
+#: src/emc/usr_intf/gscreen/gscreen.py:4264
 msgid "No axis selected for origin touch-off"
 msgstr "No se seleccionó ningún eje para touch-off de origen"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4267
+#: src/emc/usr_intf/gscreen/gscreen.py:4270
 msgid "Can't tool touch-off multiple axes"
 msgstr "No se pueden hacer touch-off en varios ejes"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4270
+#: src/emc/usr_intf/gscreen/gscreen.py:4273
 msgid "No axis selected for tool touch-off"
 msgstr "No se seleccionó ningún eje para touch-off"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4329
-#: src/emc/usr_intf/gscreen/gscreen.py:4414
+#: src/emc/usr_intf/gscreen/gscreen.py:4332
+#: src/emc/usr_intf/gscreen/gscreen.py:4417
 msgid "Error Message"
 msgstr "Mensaje de error"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4329
+#: src/emc/usr_intf/gscreen/gscreen.py:4332
 #, python-format
 msgid "Tool editor error - is the %s editor available?"
 msgstr "Error del editor de herramientas: ¿está disponible el editor %s?"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4416
-#: src/emc/usr_intf/gscreen/gscreen.py:4418
+#: src/emc/usr_intf/gscreen/gscreen.py:4419
+#: src/emc/usr_intf/gscreen/gscreen.py:4421
 msgid "Message"
 msgstr "Mensaje"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4448
+#: src/emc/usr_intf/gscreen/gscreen.py:4451
 #, python-format
 msgid "%d RPM"
 msgstr "%d RPM"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4563
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr "Herramienta %(t)s    %(l)s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4595
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr "%4.2f mm/min"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4597
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr "%3.2f IPM"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4600
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr "%4.2f DPM"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4609
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr "%(n)s   Vista-%(v)s               %(t)s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4618
-#: src/emc/usr_intf/gscreen/gscreen.py:4619
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
+#: src/emc/usr_intf/gscreen/gscreen.py:4622
 msgid " mm "
 msgstr "mm"
 
@@ -17764,7 +18452,6 @@ msgid "<b>Status</b>"
 msgstr "<b>Estado</b>"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
@@ -17773,7 +18460,6 @@ msgstr ""
 " Texto:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 msgid ""
 "Replace\n"
 "  Text:"
@@ -17782,7 +18468,6 @@ msgstr ""
 "    Texto:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 msgid ""
 "Replace\n"
 "   All"
@@ -17791,7 +18476,6 @@ msgstr ""
 "   Todas"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17808,7 +18492,6 @@ msgid "Main Level"
 msgstr "Nivel principal"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr "Temas"
 
@@ -17821,12 +18504,10 @@ msgid "DTG Text Color"
 msgstr "Color de texto DTG"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr "Audio de advertencia"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr "Audio de alerta"
 
@@ -17835,7 +18516,6 @@ msgid "Grid Size"
 msgstr "Tamaño de cuadrícula"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 msgid "Starting RPM"
 msgstr "Iniciando RPM"
 
@@ -17896,7 +18576,7 @@ msgstr ""
 msgid ""
 " On M8 Use\n"
 "Aux Coolant"
-msgstr  ""
+msgstr ""
 " En M8 Use\n"
 "refrigerante Aux"
 
@@ -17930,7 +18610,6 @@ msgstr ""
 "Halshow"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 msgid "Calibration"
 msgstr "Calibración"
 
@@ -17980,7 +18659,7 @@ msgstr "Configuración de herramienta"
 msgid ""
 "Single\n"
 " Step"
-msgstr  ""
+msgstr ""
 "Paso\n"
 " Sencillo"
 
@@ -18065,7 +18744,7 @@ msgstr ""
 msgid ""
 "Toggle\n"
 "Readout"
-msgstr  ""
+msgstr ""
 "Alternar\n"
 "Lectura"
 
@@ -18226,12 +18905,10 @@ msgid ""
 msgstr "BuscarFwd"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "Deshacer"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "Rehacer"
 
@@ -18260,6 +18937,8 @@ msgstr ""
 "estado"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr "G54"
 
@@ -18326,1649 +19005,1555 @@ msgstr "REV"
 msgid "screen 2"
 msgstr "pantalla 2"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr "**** GMOCCAPY INI Entry **** \n"
+#: lib/python/gladevcp/iconview.py:112
+msgid "Move to your home directory"
+msgstr "Mover a su directorio de inicio"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-msgid "user mode selected"
-msgstr "modo usuario seleccionado"
+#: lib/python/gladevcp/iconview.py:120
+#, fuzzy
+msgid "Move to parent directory"
+msgstr "Mover al directorio de padres"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr "logotipo de entrada encontrado = {0}"
+#: lib/python/gladevcp/iconview.py:128
+#, fuzzy
+msgid "Select the previous file"
+msgstr "Seleccione el archivo previos"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr "**** GMOCCAPY INI Error de entrada **** \n"
+#: lib/python/gladevcp/iconview.py:136
+msgid "Select the next file"
+msgstr "Seleccione el siguiente archivo"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr "Se encontró la entrada del archivo de registro, pero no se pudo convertir a la ruta.\n"
+#: lib/python/gladevcp/iconview.py:160
+msgid "Jump to user defined directory"
+msgstr "Saltar al directorio definido por el usuario"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr "La ruta del archivo no debe contener espacios"
+#: lib/python/gladevcp/iconview.py:168
+msgid "select the highlighted file and return the path"
+msgstr "seleccione el archivo resaltado y devuelva la ruta"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr "Presione para iniciar todos {0}"
+#: lib/python/gladevcp/iconview.py:176
+msgid "Close without returning a file path"
+msgstr "Cerrar sin devolver una ruta de archivo"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr "Presione para mostrar el botón de homing anterior"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr "Presione para home {0} {1}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr "Presione para mostrar el siguiente botón de homing"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr "Presione para unhome todos {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr "Presione para volver a la lista de principal botones"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr "**** ERROR DE GMOCCAPY ****\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
+#: lib/python/gladevcp/offsetpage_widget.py:142
 msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
 msgstr ""
-"**** no pudo resolver la ruta de la imagen '{0}' dada para el botón macro '{1}' ****"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
 msgstr ""
-"  editar\n"
-"offsets"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr "Presione para editar offsets"
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr "Presione para establecer el valor touch off para el eje {0}"
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+#, fuzzy
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr "Offset todos los sistemas de coordenadas"
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "recargar la tabla de herramientas desde el archivo"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+#, fuzzy
+msgid "Tool file was modified since it was last read"
+msgstr "El archivo %r se modificó porque lo escribió stepconf"
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Botón de rueda"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+#, fuzzy
+msgid "button"
+msgstr "sin botón aquí"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "Conmutar envío automático"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Herramienta:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "negro"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+#, fuzzy
+msgid "G5x"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "Rotación XY:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+#, fuzzy
+msgid "G92"
+msgstr "_G92"
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+#, fuzzy
+msgid "G55"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+#, fuzzy
+msgid "G56"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+#, fuzzy
+msgid "G57"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+#, fuzzy
+msgid "G58"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+#, fuzzy
+msgid "G59"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+#, fuzzy
+msgid "G59.1"
+msgstr "P7 G59._1"
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+#, fuzzy
+msgid "G59.2"
+msgstr "P8 G59._2"
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+#, fuzzy
+msgid "G59.3"
+msgstr "P9 G59._3"
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Offset:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Página de offset"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+#, fuzzy
 msgid ""
-"zero\n"
-" G92"
+"Zero\n"
+"G92"
 msgstr ""
 "cero\n"
 " G92"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr "Presione para restablecer todas los offsets G92"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
 msgid ""
-" Block\n"
-"Height"
-msgstr ""
-" Altura\n"
-"Bloque"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr "Presione para ingresar un nuevo valor para la altura del bloque"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-"    set\n"
-"seleccionado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr "Presione para configurar el sistema de coordenadas seleccionado como activo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr "**** INFORMACIÓN DE GMOCCAPY ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr "**** sin configuración de sonda válida en archivo INI ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr "**** medición de herramienta deshabilitada ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr "**** encontrada configuración de sonda válida en archivo INI ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr "**** utilizará la medición automática de herramientas ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr "**** GMOCCAPY build_GUI INFO ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr "**** Demasiados incrementos en archivo INI para esta pantalla ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr "**** Solo los primeros 10 serán accesibles en esta pantalla ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "comando jog desconocido {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr "Presione para jog del eje {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr "Presione para jog de articulación {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr "**** INFORMACIÓN DE GMOCCAPY ****\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr "**** encontradas más de 16 macros, se usará solo las primeras 16 ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr "Presione para mostrar el botón de macro anterior"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr "Presione para ejecutar la macro {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr "Presione para mostrar el siguiente botón de macro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr "Presione para mostrar el teclado virtual"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr "***** ERROR DE GMOCCAPY *****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr "esto no es un torno, ya que un torno debe tener al menos\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr "un eje X y un eje Z\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr "Configuración incorrecta del torno, salimos de aquí"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr "Situación muy crítica"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr "***** INFO GMOCCAPY *****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr "esta no es una configuración habitual\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr "falta uno de los ejes X, Y o Z\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr "Usaremos el botón de jog ordenado por axisletter"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr "mm/min"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr "pulgadas/min"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr "**** Configuración de pestaña incrustada no válida ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr "**** ¡No se agregarán pestañas! ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-"ERROR, al intentar inicializar las pestañas o paneles del usuario, buscar errores tipográficos"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr "**** No se encontró un archivo de herramientas en [EMCIO] TOOL_TABLE ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr "**** audio disponible! ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr "**** no hay audio disponible! ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr "**** ¿PYGST libray no está instalado? ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr "**** ¿está instalado python-gstX.XX? ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr "**** Entrando en init gremlin ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-msgid ""
-" Joint\n"
-"mode"
-msgstr ""
-" Modo\n"
-"Articulacion"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr "**** programa de teclado virtual encontrado : <onboard>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr "**** programa de teclado virtual encontrado : <matchbox-keyboard>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-"**** No hay ningún teclado virtual instalado, verificamos <onboard> "
-"y <matchbox-keyboard>."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr "**** ERROR DE GMOCCAPY ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr "**** Error al iniciar el teclado virtual"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr "**** ¿está instalado onboard o matchbox? ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr "interrumpir la ejecución de macro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr "**** No se encontró un archivo de parámetros en [RS274NGC] PARAMETER_FILE ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr "Seleccione el archivo que desea cargar al inicio del programa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr "**** ERROR DE GMOCCAPY **** / n Tipo de mensaje {0} no compatible"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr "Tipo de error desconocido sin texto de error"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr "Advertencia importante"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr "ERROR: ¡ESTOP externo activado, no se pudo cambiar el estado!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr "ERROR: No se pudo encender la máquina, ¿está activado el interruptor de límite?"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr "No es posible cambiar al modo MDI en este momento"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr "No es posible cambiar al modo Auto en este momento"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr "Ingrese el valor:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "Establezca el parámetro {0} en:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr "error de conversión"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr "¡Error de conversión!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr "Este botón mostrará u ocultará el teclado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr "¡El cambio de modo solo está permitido si el intérprete está inactivo!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr "**** {0} ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr "**** Ningún widget llamado: {0} para sensibilizar ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr "No hay descripción de herramienta disponible"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr "Hola, bienvenido al mensaje de prueba {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr "Pin Hal bajo, acceso denegado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr "ingresado código incorrecto, acceso denegado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr "Solo como advertencia"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr "ERROR: No hay interruptor de límite activo, ignorar los límites, no se establecerán."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-msgid "Classicladder real-time component not detected"
-msgstr "Componente en tiempo real Classicladder no detectado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr "Algo salió mal, tenemos un widget de husillo desconocido {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr "¿Realmente desea eliminar el historial MDI?\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr "esto no eliminará el archivo  de historial MDI, pero puede\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr "eliminar las entradas del cuadro de lista para esta sesión"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr "¡Atención!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-msgid "Enter value for diameter"
-msgstr "Ingrese el valor para el diámetro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-msgid "Set diameter to:"
-msgstr "Establecer el diámetro en:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-msgid "Enter value for radius"
-msgstr "Ingrese el valor para el radio"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-msgid "Set radius to:"
-msgstr "Establecer el radio en:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr "Ingrese el valor para el eje {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "Establecer eje {0} en:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr "Error de conversión en btn_set_value"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr "¡Error de conversión en btn_set_value!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr "Ingrese solo valores numéricos. No se han aplicado valores"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-"no seleccionó un sistema para cambiarlo, por lo que no se cambiará nada"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr "¡Advertencia importante!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr "Ingrese la altura del bloque"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr "Altura del bloque medida desde la tabla base"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr "¡Error de conversión en btn_block_height!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr "Ingrese solo valores numéricos\n"
-"No se han aplicado valores"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr "Retire la herramienta montada y presione OK cuando haya terminado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-"Por favor, cambie a herramienta\n"
-"\n"
-"# {0: d}    {1}\n"
-"luego haga clic en Aceptar\"."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-msgid "Manual Tool change"
-msgstr "Cambio manual de herramienta"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr "¡Se ha abortado el cambio de herramienta!\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr "¡La herramienta anterior permanecerá configurada!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr "Está intentando eliminar la herramienta montada en el husillo\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr "Esto no está permitido, cambie la herramienta antes de eliminarla"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr "¡Advertencia, la herramienta no se puede eliminar!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr "Ninguna o mas de una herramientas seleccionadas en la tabla de herramientas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr "Seleccione solo una herramienta en la tabla"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr "¡Advertencia, No es posible Touch off!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr "no se puede hacer touch of de una herramienta no montada en el husillo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr "su selección se ha restablecido a la herramienta en el husillo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-"¡No es posible touch off de herramienta con compensación de radio de corte activada!\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr "Por favor, emita un G40 antes de touch off de la herramienta"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr "¡Gran error!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-"Has logrado llegar a un lugar que no es posible en on_btn_tool_touchoff"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr "Ingrese el valor a establecer para el eje {0}:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr "Establezca el parámetro de la herramienta {0:d} y el eje {1} en:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr "Error de conversión debido a una entrada incorrecta para touch off en eje {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr "Ingrese el número de herramienta como entero "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-msgid "Select the tool to change"
-msgstr "Seleccione la herramienta a cambiar"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-"Error de conversión debido a una entrada incorrecta para el número de herramienta\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr "ingrese solo números enteros"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr "La herramienta seleccionada ya está en el eje, no se necesitan cambios."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-"seleccionó ninguna o más de una herramienta, la selección de la herramienta debe ser única"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr "No se pudo entender el número de herramienta ingresado. No cambiará nada"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-msgid ""
-"World\n"
-"mode"
-msgstr ""
-"Modo\n"
-"Universal"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr "El jog de eje solo está permitido en modo universal, ¡pero usted está en modo articulacion!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr "Recibida una señal no clasificada del pin {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr "No se pudo traducir {0} a número"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-msgid "no button here"
-msgstr "sin botón aquí"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr "el botón no es sensible"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr "El botón {0} se ha conmutado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr "Se ha presionado el botón {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr "Se ha hecho clic en el botón {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr "tiene una ubicación incorrecta para ubicar childs"
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr "Ingrese el código de desbloqueo del sistema"
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr "Introducir valor"
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr "Ingrese el valor para establecer"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr "**** GMOCCAPY GETINIINFO: ****"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-"**** gmoccapy solo puede manejar 9 ejes, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr "**** gmoccapy no se iniciará ****\n"
-"\n"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr "**** GMOCCAPY GETINIINFO ****\n"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-"**** Sin carpeta de subrutina o prefijo de programa en el archivo ini ****\n"
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr "Error al intentar borrar el mensaje con número %s"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr "izquierda rotar, medio mover, derecha zoom"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr "izquierda zoom, medio mover, derecha rotar"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr "izquierda mover, medio rotar, derecha zoom"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr "izquierda zoom, medio rotar, derecha mover"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr "izquierda mover, medio zoom, derecha rotar"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr "izquierda rotar, medio zoom, derecha mover"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-msgid "No Program loaded"
-msgstr "No hay programa cargado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr "blockheight = 0.0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-msgid "clear plot"
-msgstr "limpiar plot"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-msgid "view perspective"
-msgstr "vista perspectiva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr "vista a lo largo del eje X de positivo a negativo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr "vista a lo largo del eje Y de positivo a negativo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr "ver a lo largo del eje Z de positivo a negativo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr "Mostrar u ocultar la ruta de la herramienta"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr "Mostrar u ocultar dimensiones"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-"vista a lo largo del eje Y de positivo a negativo como vista para herramienta "
-"trasera de torno"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-msgid "Offset Page"
-msgstr "Página de offset"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-msgid "Tooledit"
-msgstr "Tooledit"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-msgid "File Selection"
-msgstr "Selección de archivo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr "jog de ejes"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-msgid "jog joints"
-msgstr "jog de articulaciones"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr "Logo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-msgid "Ignore limits"
-msgstr "Ignorar límites"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-msgid "<b>Jogging</b>"
-msgstr "<b>Jogging</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr "Información sobre la herramienta en el husillo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-msgid "Tool no."
-msgstr "Herramienta no."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
+"    Zero\n"
+"Rotational"
+msgstr "RotarHoriontal"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "_Seleccionar"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Herramienta:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+#, fuzzy
+msgid "Pocket"
+msgstr "Ranuras:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
 msgid "Diameter"
 msgstr "Diámetro"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-msgid "offset z"
-msgstr "offset z"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-msgid "offset x"
-msgstr "offset x"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr "Vc = 0.00"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-msgid "<b>Tool information</b>"
-msgstr "<b>Información de la herramienta</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr "Información de código G y M, así como velocidad y avance"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-msgid "active_mcodes_label"
-msgstr "active_mcodes_label"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-msgid "active_gcodes_label"
-msgstr "active_gcodes_label"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-msgid "<b>G-Code</b>"
-msgstr "<b>Código G</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-msgid "<b>Cooling</b>"
-msgstr "<b>Refrigeración</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-msgid "<b>Spindle [rpm]</b>"
-msgstr "<b>Husillo [rpm]</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr "Vel."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr "Muestra la velocidad actual"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-msgid "<b>Rapid Override</b>"
-msgstr "<b>Ajuste Rápidos</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr "Muestra la velocidad de avance programada"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-msgid "reset feed override to 100 %"
-msgstr "restablecer ajuste de alimentación al 100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-msgid "<b>Feed Override</b>"
-msgstr "<b>Ajuste de alimentación</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-"Buscar\n"
-" atras"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-"Buscar\n"
-"adelante"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr "Reemplazar"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr "Iniciar como pantalla completa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr "Iniciar maximizado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr "Iniciar como ventana"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-msgid "X Pos."
-msgstr "X Pos."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-msgid "Y Pos."
-msgstr "Y Pos."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr "Ancho"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr "Altura"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr "ocultar cursor"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-msgid "<b>Main Window</b>"
-msgstr "<b>Ventana principal</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-msgid "Show keyboard on offset"
-msgstr "Mostrar teclado en offset"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr "Mostrar teclado en tooledit"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr "Mostrar teclado en MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr "Mostrar teclado en EDITAR"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr "Mostrar teclado en carga de archivo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-msgid "<b>Keyboard</b>"
-msgstr "<b> Teclado </b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-msgid "show preview"
-msgstr "mostrar vista previa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-msgid "show offsets"
-msgstr "mostrar offsets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr "<b>On Touch off</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-msgid "Relative Color"
-msgstr "Color relativo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-msgid "Absolute Color"
-msgstr "Color absoluto"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr "Color DTG"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-msgid "Homed color"
-msgstr "Color Homed"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-msgid "Unhomed color"
-msgstr "Color Unhomed"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr "Dígitos"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-"alternar el modo DRO \n"
-"haciendo clic en el DRO"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-msgid "<b>DRO</b>"
-msgstr "<b>DRO</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-msgid "Grid size"
-msgstr "Tamaño de cuadrícula"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-msgid "Show DRO"
-msgstr "Mostrar DRO"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-msgid "Show offsets"
-msgstr "Mostrar compensaciones"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-msgid "Show DTG"
-msgstr "Mostrar DTG"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-msgid "<b>Mouse Button mode</b>"
-msgstr "<b>Modo de botón del mouse</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-msgid "<b>Preview</b>"
-msgstr "<b>Vista previa</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-msgid ""
-"current\n"
-"   file"
-msgstr ""
-"archivo\n"
-"   actual"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr "<b> Archivo a cargar al inicio </b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-msgid "Select user dir"
-msgstr "Seleccionar dir usuario"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-msgid "<b>Select jump to dir</b>"
-msgstr "<b> Seleccione saltar al directorio </b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr "<b> Temas y sonido </b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr "Apariencia"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-msgid "Scale rapid override"
-msgstr "Escala ajuste rápidos"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-msgid "Scale jog velocity"
-msgstr "Escala velocidad de jog"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-msgid "Scale feed override"
-msgstr "Escala Ajuste de alimentación"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-msgid "Scale spindle override"
-msgstr "Escala Ajuste de husillo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "<b> Escala MPG hardware </b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr "Usar métodos abreviados de teclado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr "<b> Métodos abreviados de teclado </b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-msgid "Use unlock code"
-msgstr "Usar código de desbloqueo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr "No use el código de desbloqueo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr "Usar pin hal para desbloquear"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-msgid "<b>Unlock settings</b>"
-msgstr "<b>Configuración de desbloqueo</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-msgid "Spindle bar min"
-msgstr "Barra de husillo min"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-msgid "Spindle bar max"
-msgstr "Barra de husillo máx"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr "Ocultar el botón Jog tortuga"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr "Factor jog de tortuga"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-msgid "<b>Turtle Jog</b>"
-msgstr "<b>Jog tortuga</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr "Hardware"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr "Usar medición automática de herramienta"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr "Sonda de Altura"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr "0.000"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-msgid "Z Pos."
-msgstr "Pos. Z"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr "Sonda máx."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-msgid "<b>Probe Informations</b>"
-msgstr "<b>Información de la sonda</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-msgid "Search Vel."
-msgstr "Buscar Vel."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr "Sonda Vel."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr "<b>Sonda de Velocidades</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-"Sin configuración válida\n"
-"encontrado en su archivo INI,\n"
-"por favor, eche un vistazo a\n"
-"la WIKI para comprobar cómo\n"
-"configurar los ajustes."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-msgid "<b>Tool Measurement</b>"
-msgstr "<b> Medición de herramientas </b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-msgid "Reload Tool on Start"
-msgstr "Recargar Herramienta al arranque"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-"Si está marcado, la herramienta en\n"
-"el husillo se guardará en cada cambio\n"
-"y la última herramienta se volverá a cargar\n"
-"al arranque de la GUI. También se volvera\n"
-"a cargar el offset de longitud.\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-"Ha usado NO_FORCE_HOMING,\n"
-"así que la recarga de una herramienta\n"
-"al inicio no es posible."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-msgid "<b>Reload Tool</b>"
-msgstr "<b>Recarga de Herramienta</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr "No utilice ejecutar desde la línea"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-msgid "Use run from line"
-msgstr "Usar ejecución desde línea"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-msgid "<b>Run from line</b>"
-msgstr "<b>Ejecutar desde línea</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr "Usar marcos"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-"Si está marcado, los mensajes\n"
-"estará en un marco\"."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr "máx."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr "La fuente a usar"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr "Máximo de mensajes que desea que se muestren\t"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr "Ancho de los mensajes"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr "Posición X en píxeles desde la esquina superior izquierda de la pantalla"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr "Posición Y en píxeles desde la esquina superior izquierda de la pantalla"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr "Iniciar mensaje de prueba"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-"Presione aquí para lanzar un mensaje\n"
-"de prueba para su configuración."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-"<b>      mensaje gmoccapy\n"
-" comportamiento y apariencia </b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr ""
-"Configuraciones\n"
-"Avanzadas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr "Pestaña Usuario 1"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr "Pestañas de usuario"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-"Estop de máquina\n"
-"[F1]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr ""
-"Encender/apagar la máquina\n"
-"[F2]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-"ingrese el modo manual para jog del eje o touch off\n"
-"[F3]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-"ingrese al modo MDI para iniciar comandos de código g\n"
-"[F5]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-msgid "enter auto mode to run programs"
-msgstr "ingrese al modo auto para ejecutar programas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr "Ingrese a la página de configuración, el código predeterminado es \"123\""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-msgid "show user tabs"
-msgstr "mostrar pestañas de usuario"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr "abrir la lista de botones de referencia"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr "abrir lista de botones de touch off"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr "Abrir la página de tooleditor"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-msgid ""
-"World\n"
-"Mode"
-msgstr "MundoModo estoy aqui"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-"Cambiar el modo de movimiento entre el modo articulacion y MundialLa tecla "
-"F12 o $ hace lo mismo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr "haga que la vista previa sea lo más grande posible"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr "Cerrar gmoccapy / salir del programa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-msgid "Load a new program"
-msgstr "Cargar un nuevo programa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-msgid "Run the loaded program"
-msgstr "Ejecuta el programa cargado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-msgid "Stop the running program"
-msgstr "Detener el programa en ejecución"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-msgid "Pause the running program"
-msgstr "Pausa el programa en ejecución"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-msgid "pause the running program"
-msgstr "pausa el programa en ejecución"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr "Ejecute el programa cargado paso a paso"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-"ejecuta el programa desde una determinada línea, atención, eso es peligroso, "
-"porque¡las líneas anteriores no mejorarán!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-"Máquina o no los bloques opcionales del programa. Si se presiona el botónlos "
-"bloques opcionales no serán mecanizados. El botón lo indicará mediante "
-"unfondo amarillo\"."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-msgid "Edit the loaded program"
-msgstr "Editar el programa cargado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-msgid "delete MDI"
-msgstr "eliminar MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-msgid "delete MDI history"
-msgstr "eliminar el historial de MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr "Cl.-escalera"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr "Abrir classicladder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-msgid "Hal-Scope"
-msgstr "Hal-Scope"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr "lanzamiento hal alcance"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr "lanzar estado de linuxcnc"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr "iniciar hal meter"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-msgid "launch calibration"
-msgstr "iniciar calibración"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr "Halshow"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr "abre la herramienta show hal"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr "guardar el archivo con el nombre original"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr "guardar el archivo con un nuevo nombre"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr "borra el campo de edición y crea un nuevo archivo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr "Mostrar u ocultar el teclado virtual"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr "Volver a la lista de botones principal"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr "eliminar herramienta o herramientas seleccionadas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-msgid "add a new tool to tool table"
-msgstr "agrega una nueva herramienta a la tabla de herramientas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "frontal"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "Operación"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "Comentario"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
 msgid "Reload"
 msgstr "Recargar"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-msgid "reload tool table from file"
-msgstr "recargar la tabla de herramientas desde el archivo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
 msgstr ""
-"aplique los cambios que realizó, G43 se ejecutará solo si está activo el "
-"código g"
+"Offset\n"
+"%s"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-msgid "Select a tool by number"
-msgstr "Seleccione una herramienta por número"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
 msgstr ""
-"¿Cambiar herramienta con el comando M61 Q ?, no se realizará ningún "
-"movimiento de máquina"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr "cambia la herramienta a la seleccionada"
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr "touchoffherramienta x"
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "Diámetro"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr "toque la herramienta y establezca el valor en la tabla de herramientas"
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "Offsets de trabajo:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr "touchoffherramienta z"
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Herramienta:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
-msgid "Move to your home directory"
-msgstr "Mover a su directorio de inicio"
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Herramienta:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
-msgid "Move to parrent directory"
-msgstr "Mover al directorio de padres"
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Establecer offset de herramienta"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
-msgid "Select the previos file"
-msgstr "Seleccione el archivo previos"
+#~ msgid "next search: %d\n"
+#~ msgstr "siguiente búsqueda: %d\n"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
-msgid "Select the next file"
-msgstr "Seleccione el siguiente archivo"
+#~ msgid "search: %d (wrapped=%d)\n"
+#~ msgstr "buscar: %d (rotativo=%d)\n"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
-msgid "Jump to user defined directory"
-msgstr "Saltar al directorio definido por el usuario"
+#~ msgid "Substituting"
+#~ msgstr "Sustituir"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
-msgid "select the highlighted file and return the path"
-msgstr "seleccione el archivo resaltado y devuelva la ruta"
+#~ msgid "for"
+#~ msgstr "para"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
-msgid "Close without returning a file path"
-msgstr "Cerrar sin devolver una ruta de archivo"
+#~ msgid "unhome_joint <%s> Use joint mode for unhoming"
+#~ msgstr "unhome_joint <%s> Usar el modo articulacion para desconectar"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-msgid "Load File"
-msgstr "Cargar archivo"
+#~ msgid "Parport _Base Address:"
+#~ msgstr "Dirección _Base del Puerto :"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
-msgid "home joints"
-msgstr "articulaciones caseras"
+#~ msgid "Use AXIS Screen"
+#~ msgstr "Usar gui AXIS"
+
+#~ msgid "Use Gmoccapy Screen"
+#~ msgstr "Usar gui Gmoccapy"
+
+#~ msgid "filename:"
+#~ msgstr "nombre de archivo:"
+
+#~ msgid "**** GMOCCAPY INI Entry **** \n"
+#~ msgstr "**** GMOCCAPY INI Entry **** \n"
+
+#~ msgid "user mode selected"
+#~ msgstr "modo usuario seleccionado"
+
+#~ msgid "logo entry found = {0}"
+#~ msgstr "logotipo de entrada encontrado = {0}"
+
+#~ msgid "**** GMOCCAPY INI Entry Error **** \n"
+#~ msgstr "**** GMOCCAPY INI Error de entrada **** \n"
+
+#~ msgid "Logofile entry found, but could not be converted to path.\n"
+#~ msgstr ""
+#~ "Se encontró la entrada del archivo de registro, pero no se pudo convertir "
+#~ "a la ruta.\n"
+
+#~ msgid "The file path should not contain any spaces"
+#~ msgstr "La ruta del archivo no debe contener espacios"
+
+#~ msgid "Press to home all {0}"
+#~ msgstr "Presione para iniciar todos {0}"
+
+#~ msgid "Press to display previous homing button"
+#~ msgstr "Presione para mostrar el botón de homing anterior"
+
+#~ msgid "Press to home {0} {1}"
+#~ msgstr "Presione para home {0} {1}"
+
+#~ msgid "Press to display next homing button"
+#~ msgstr "Presione para mostrar el siguiente botón de homing"
+
+#~ msgid "Press to unhome all {0}"
+#~ msgstr "Presione para unhome todos {0}"
+
+#~ msgid "Press to return to main button list"
+#~ msgstr "Presione para volver a la lista de principal botones"
+
+#~ msgid "**** GMOCCAPY ERROR ****\n"
+#~ msgstr "**** ERROR DE GMOCCAPY ****\n"
+
+#~ msgid ""
+#~ "**** could not resolv the image path '{0}' given for macro button '{1}' "
+#~ "****"
+#~ msgstr ""
+#~ "**** no pudo resolver la ruta de la imagen '{0}' dada para el botón macro "
+#~ "'{1}' ****"
+
+#~ msgid ""
+#~ "  edit\n"
+#~ "offsets"
+#~ msgstr ""
+#~ "  editar\n"
+#~ "offsets"
+
+#~ msgid "Press to edit the offsets"
+#~ msgstr "Presione para editar offsets"
+
+#~ msgid "Press to set touch off value for axis {0}"
+#~ msgstr "Presione para establecer el valor touch off para el eje {0}"
+
+#~ msgid "Press to reset all G92 offsets"
+#~ msgstr "Presione para restablecer todas los offsets G92"
+
+#~ msgid ""
+#~ " Block\n"
+#~ "Height"
+#~ msgstr ""
+#~ " Altura\n"
+#~ "Bloque"
+
+#~ msgid "Press to enter new value for block height"
+#~ msgstr "Presione para ingresar un nuevo valor para la altura del bloque"
+
+#~ msgid ""
+#~ "    set\n"
+#~ "selected"
+#~ msgstr ""
+#~ "    set\n"
+#~ "seleccionado"
+
+#~ msgid "Press to set the selected coordinate system to be the active one"
+#~ msgstr ""
+#~ "Presione para configurar el sistema de coordenadas seleccionado como "
+#~ "activo"
+
+#~ msgid "**** GMOCCAPY INFO ****"
+#~ msgstr "**** INFORMACIÓN DE GMOCCAPY ****"
+
+#~ msgid "**** no valid probe config in INI File ****"
+#~ msgstr "**** sin configuración de sonda válida en archivo INI ****"
+
+#~ msgid "**** disabled tool measurement ****"
+#~ msgstr "**** medición de herramienta deshabilitada ****"
+
+#~ msgid "**** found valid probe config in INI File ****"
+#~ msgstr "**** encontrada configuración de sonda válida en archivo INI ****"
+
+#~ msgid "**** will use auto tool measurement ****"
+#~ msgstr "**** utilizará la medición automática de herramientas ****"
+
+#~ msgid "**** GMOCCAPY build_GUI INFO ****"
+#~ msgstr "**** GMOCCAPY build_GUI INFO ****"
+
+#~ msgid "**** To many increments given in INI File for this screen ****"
+#~ msgstr "**** Demasiados incrementos en archivo INI para esta pantalla ****"
+
+#~ msgid "**** Only the first 10 will be reachable through this screen ****"
+#~ msgstr "**** Solo los primeros 10 serán accesibles en esta pantalla ****"
+
+#~ msgid "unknown jog command {0}"
+#~ msgstr "comando jog desconocido {0}"
+
+#~ msgid "Press to jog axis {0}"
+#~ msgstr "Presione para jog del eje {0}"
+
+#~ msgid "Press to jog joint {0}"
+#~ msgstr "Presione para jog de articulación {0}"
+
+#~ msgid "**** GMOCCAPY INFO ****\n"
+#~ msgstr "**** INFORMACIÓN DE GMOCCAPY ****\n"
+
+#~ msgid "**** found more than 16 macros, will use only the first 16 ****"
+#~ msgstr ""
+#~ "**** encontradas más de 16 macros, se usará solo las primeras 16 ****"
+
+#~ msgid "Press to display previous macro button"
+#~ msgstr "Presione para mostrar el botón de macro anterior"
+
+#~ msgid "Press to run macro {0}"
+#~ msgstr "Presione para ejecutar la macro {0}"
+
+#~ msgid "Press to display next macro button"
+#~ msgstr "Presione para mostrar el siguiente botón de macro"
+
+#~ msgid "Press to display the virtual keyboard"
+#~ msgstr "Presione para mostrar el teclado virtual"
+
+#~ msgid "*****  GMOCCAPY ERROR  *****"
+#~ msgstr "***** ERROR DE GMOCCAPY *****"
+
+#~ msgid "this is not a lathe, as a lathe must have at least\n"
+#~ msgstr "esto no es un torno, ya que un torno debe tener al menos\n"
+
+#~ msgid "an X and an Z axis\n"
+#~ msgstr "un eje X y un eje Z\n"
+
+#~ msgid "Wrong lathe configuration, we will leave here"
+#~ msgstr "Configuración incorrecta del torno, salimos de aquí"
+
+#~ msgid "Very critical situation"
+#~ msgstr "Situación muy crítica"
+
+#~ msgid "*****  GMOCCAPY INFO  *****"
+#~ msgstr "***** INFO GMOCCAPY *****"
+
+#~ msgid "this is not a usual config\n"
+#~ msgstr "esta no es una configuración habitual\n"
+
+#~ msgid "we miss one of X , Y or Z axis\n"
+#~ msgstr "falta uno de los ejes X, Y o Z\n"
+
+#~ msgid "We will use by axisletter ordered jog button"
+#~ msgstr "Usaremos el botón de jog ordenado por axisletter"
+
+#~ msgid "mm/min"
+#~ msgstr "mm/min"
+
+#~ msgid "inch/min"
+#~ msgstr "pulgadas/min"
+
+#~ msgid "**** Invalid embedded tab configuration ****"
+#~ msgstr "**** Configuración de pestaña incrustada no válida ****"
+
+#~ msgid "**** No tabs will be added! ****"
+#~ msgstr "**** ¡No se agregarán pestañas! ****"
+
+#~ msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
+#~ msgstr ""
+#~ "ERROR, al intentar inicializar las pestañas o paneles del usuario, buscar "
+#~ "errores tipográficos"
+
+#~ msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
+#~ msgstr ""
+#~ "**** No se encontró un archivo de herramientas en [EMCIO] TOOL_TABLE ****"
+
+#~ msgid "**** audio available! ****"
+#~ msgstr "**** audio disponible! ****"
+
+#~ msgid "**** no audio available! ****"
+#~ msgstr "**** no hay audio disponible! ****"
+
+#~ msgid "**** PYGST libray not installed? ****"
+#~ msgstr "**** ¿PYGST libray no está instalado? ****"
+
+#~ msgid "**** is python-gstX.XX installed? ****"
+#~ msgstr "**** ¿está instalado python-gstX.XX? ****"
+
+#~ msgid "**** Entering init gremlin ****"
+#~ msgstr "**** Entrando en init gremlin ****"
+
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr ""
+#~ " Modo\n"
+#~ "Articulacion"
+
+#~ msgid "**** virtual keyboard program found : <onboard>"
+#~ msgstr "**** programa de teclado virtual encontrado : <onboard>"
+
+#~ msgid "**** virtual keyboard program found : <matchbox-keyboard>"
+#~ msgstr "**** programa de teclado virtual encontrado : <matchbox-keyboard>"
+
+#~ msgid ""
+#~ "**** No virtual keyboard installed, we checked for <onboard> and "
+#~ "<matchbox-keyboard>."
+#~ msgstr ""
+#~ "**** No hay ningún teclado virtual instalado, verificamos <onboard> y "
+#~ "<matchbox-keyboard>."
+
+#~ msgid "**** GMOCCAPY ERROR ****"
+#~ msgstr "**** ERROR DE GMOCCAPY ****"
+
+#~ msgid "**** Error with launching virtual keyboard,"
+#~ msgstr "**** Error al iniciar el teclado virtual"
+
+#~ msgid "**** is onboard or matchbox-keyboard installed? ****"
+#~ msgstr "**** ¿está instalado onboard o matchbox? ****"
+
+#~ msgid "interrupt running macro"
+#~ msgstr "interrumpir la ejecución de macro"
+
+#~ msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
+#~ msgstr ""
+#~ "**** No se encontró un archivo de parámetros en [RS274NGC] PARAMETER_FILE "
+#~ "****"
+
+#~ msgid "Select the file you want to be loaded at program start"
+#~ msgstr "Seleccione el archivo que desea cargar al inicio del programa"
+
+#~ msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
+#~ msgstr "**** ERROR DE GMOCCAPY **** / n Tipo de mensaje {0} no compatible"
+
+#~ msgid "Unknown error type and no error text given"
+#~ msgstr "Tipo de error desconocido sin texto de error"
+
+#~ msgid "Important Warning"
+#~ msgstr "Advertencia importante"
+
+#~ msgid "ERROR : External ESTOP is set, could not change state!"
+#~ msgstr "ERROR: ¡ESTOP externo activado, no se pudo cambiar el estado!"
+
+#~ msgid "ERROR : Could not switch the machine on, is limit switch activated?"
+#~ msgstr ""
+#~ "ERROR: No se pudo encender la máquina, ¿está activado el interruptor de "
+#~ "límite?"
+
+#~ msgid "It is not possible to change to MDI Mode at the moment"
+#~ msgstr "No es posible cambiar al modo MDI en este momento"
+
+#~ msgid "It is not possible to change to Auto Mode at the moment"
+#~ msgstr "No es posible cambiar al modo Auto en este momento"
+
+#~ msgid "Enter value:"
+#~ msgstr "Ingrese el valor:"
+
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "Establezca el parámetro {0} en:"
+
+#~ msgid "conversion error"
+#~ msgstr "error de conversión"
+
+#~ msgid "Conversion error !"
+#~ msgstr "¡Error de conversión!"
+
+#~ msgid "This button will show or hide the keyboard"
+#~ msgstr "Este botón mostrará u ocultará el teclado"
+
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr ""
+#~ "¡El cambio de modo solo está permitido si el intérprete está inactivo!"
+
+#~ msgid "**** {0} ****"
+#~ msgstr "**** {0} ****"
+
+#~ msgid "**** No widget named: {0} to sensitize ****"
+#~ msgstr "**** Ningún widget llamado: {0} para sensibilizar ****"
+
+#~ msgid "No tool description available"
+#~ msgstr "No hay descripción de herramienta disponible"
+
+#~ msgid "Halo, welcome to the test message {0}"
+#~ msgstr "Hola, bienvenido al mensaje de prueba {0}"
+
+#~ msgid "Hal Pin is low, Access denied"
+#~ msgstr "Pin Hal bajo, acceso denegado"
+
+#~ msgid "wrong code entered, Access denied"
+#~ msgstr "ingresado código incorrecto, acceso denegado"
+
+#~ msgid "Just to warn you"
+#~ msgstr "Solo como advertencia"
+
+#~ msgid "ERROR : No limit switch is active, ignore limits will not be set."
+#~ msgstr ""
+#~ "ERROR: No hay interruptor de límite activo, ignorar los límites, no se "
+#~ "establecerán."
+
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "Componente en tiempo real Classicladder no detectado"
+
+#~ msgid "Something went wrong, we have an unknown spindle widget {0}"
+#~ msgstr "Algo salió mal, tenemos un widget de husillo desconocido {0}"
+
+#~ msgid "Do you really want to delete the MDI history?\n"
+#~ msgstr "¿Realmente desea eliminar el historial MDI?\n"
+
+#~ msgid "this will not delete the MDI History file, but will\n"
+#~ msgstr "esto no eliminará el archivo  de historial MDI, pero puede\n"
+
+#~ msgid "delete the listbox entries for this session"
+#~ msgstr "eliminar las entradas del cuadro de lista para esta sesión"
+
+#~ msgid "Attention!!"
+#~ msgstr "¡Atención!"
+
+#~ msgid "Enter value for diameter"
+#~ msgstr "Ingrese el valor para el diámetro"
+
+#~ msgid "Set diameter to:"
+#~ msgstr "Establecer el diámetro en:"
+
+#~ msgid "Enter value for radius"
+#~ msgstr "Ingrese el valor para el radio"
+
+#~ msgid "Set radius to:"
+#~ msgstr "Establecer el radio en:"
+
+#~ msgid "Enter value for axis {0}"
+#~ msgstr "Ingrese el valor para el eje {0}"
+
+#~ msgid "Set axis {0} to:"
+#~ msgstr "Establecer eje {0} en:"
+
+#~ msgid "Conversion error in btn_set_value"
+#~ msgstr "Error de conversión en btn_set_value"
+
+#~ msgid "Conversion error in btn_set_value!"
+#~ msgstr "¡Error de conversión en btn_set_value!"
+
+#~ msgid "Please enter only numerical values. Values have not been applied"
+#~ msgstr "Ingrese solo valores numéricos. No se han aplicado valores"
+
+#~ msgid ""
+#~ "you did not selected a system to be changed to, so nothing will be changed"
+#~ msgstr ""
+#~ "no seleccionó un sistema para cambiarlo, por lo que no se cambiará nada"
+
+#~ msgid "Important Warning!"
+#~ msgstr "¡Advertencia importante!"
+
+#~ msgid "Enter the block height"
+#~ msgstr "Ingrese la altura del bloque"
+
+#~ msgid "Block height measured from base table"
+#~ msgstr "Altura del bloque medida desde la tabla base"
+
+#~ msgid "Conversion error in btn_block_height!"
+#~ msgstr "¡Error de conversión en btn_block_height!"
+
+#~ msgid ""
+#~ "Please enter only numerical values\n"
+#~ "Values have not been applied"
+#~ msgstr ""
+#~ "Ingrese solo valores numéricos\n"
+#~ "No se han aplicado valores"
+
+#~ msgid "Please remove the mounted tool and press OK when done"
+#~ msgstr "Retire la herramienta montada y presione OK cuando haya terminado"
+
+#~ msgid ""
+#~ "Please change to tool\n"
+#~ "\n"
+#~ "# {0:d}     {1}\n"
+#~ "\n"
+#~ " then click OK."
+#~ msgstr ""
+#~ "Por favor, cambie a herramienta\n"
+#~ "\n"
+#~ "# {0: d}    {1}\n"
+#~ "luego haga clic en Aceptar\"."
+
+#~ msgid "Manual Tool change"
+#~ msgstr "Cambio manual de herramienta"
+
+#~ msgid "Tool Change has been aborted!\n"
+#~ msgstr "¡Se ha abortado el cambio de herramienta!\n"
+
+#~ msgid "The old tool will remain set!"
+#~ msgstr "¡La herramienta anterior permanecerá configurada!"
+
+#~ msgid "You are trying to delete the tool mounted in the spindle\n"
+#~ msgstr "Está intentando eliminar la herramienta montada en el husillo\n"
+
+#~ msgid "This is not allowed, please change tool prior to delete it"
+#~ msgstr "Esto no está permitido, cambie la herramienta antes de eliminarla"
+
+#~ msgid "Warning Tool can not be deleted!"
+#~ msgstr "¡Advertencia, la herramienta no se puede eliminar!"
+
+#~ msgid "No or more than one tool selected in tool table"
+#~ msgstr ""
+#~ "Ninguna o mas de una herramientas seleccionadas en la tabla de "
+#~ "herramientas"
+
+#~ msgid "Please select only one tool in the table"
+#~ msgstr "Seleccione solo una herramienta en la tabla"
+
+#~ msgid "Warning Tool Touch off not possible!"
+#~ msgstr "¡Advertencia, No es posible Touch off!"
+
+#~ msgid "you can not touch of a tool, witch is not mounted in the spindle"
+#~ msgstr ""
+#~ "no se puede hacer touch of de una herramienta no montada en el husillo"
+
+#~ msgid "your selection has been reseted to the tool in spindle"
+#~ msgstr "su selección se ha restablecido a la herramienta en el husillo"
+
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr ""
+#~ "¡No es posible touch off de herramienta con compensación de radio de "
+#~ "corte activada!\n"
+
+#~ msgid "Please emit an G40 before tool touch off"
+#~ msgstr "Por favor, emita un G40 antes de touch off de la herramienta"
+
+#~ msgid "Real big error!"
+#~ msgstr "¡Gran error!"
+
+#~ msgid ""
+#~ "You managed to come to a place that is not possible in "
+#~ "on_btn_tool_touchoff"
+#~ msgstr ""
+#~ "Has logrado llegar a un lugar que no es posible en on_btn_tool_touchoff"
+
+#~ msgid "Enter value for axis {0} to set:"
+#~ msgstr "Ingrese el valor a establecer para el eje {0}:"
+
+#~ msgid "Set parameter of tool {0:d} and axis {1} to:"
+#~ msgstr "Establezca el parámetro de la herramienta {0:d} y el eje {1} en:"
+
+#~ msgid "Conversion error because of wrong entry for touch off axis {0}"
+#~ msgstr ""
+#~ "Error de conversión debido a una entrada incorrecta para touch off en eje "
+#~ "{0}"
+
+#~ msgid "Enter the tool number as integer "
+#~ msgstr "Ingrese el número de herramienta como entero "
+
+#~ msgid "Select the tool to change"
+#~ msgstr "Seleccione la herramienta a cambiar"
+
+#~ msgid "Conversion error because of wrong entry for tool number\n"
+#~ msgstr ""
+#~ "Error de conversión debido a una entrada incorrecta para el número de "
+#~ "herramienta\n"
+
+#~ msgid "enter only integer numbers"
+#~ msgstr "ingrese solo números enteros"
+
+#~ msgid "Selected tool is already in spindle, no change needed."
+#~ msgstr ""
+#~ "La herramienta seleccionada ya está en el eje, no se necesitan cambios."
+
+#~ msgid ""
+#~ "you selected no or more than one tool, the tool selection must be unique"
+#~ msgstr ""
+#~ "seleccionó ninguna o más de una herramienta, la selección de la "
+#~ "herramienta debe ser única"
+
+#~ msgid ""
+#~ "Could not understand the entered tool number. Will not change anything"
+#~ msgstr ""
+#~ "No se pudo entender el número de herramienta ingresado. No cambiará nada"
+
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr ""
+#~ "Modo\n"
+#~ "Universal"
+
+#~ msgid ""
+#~ "Axis jogging is only allowed in world mode, but you are in joint mode!"
+#~ msgstr ""
+#~ "El jog de eje solo está permitido en modo universal, ¡pero usted está en "
+#~ "modo articulacion!"
+
+#~ msgid "Recieved a not clasified signal from pin {0}"
+#~ msgstr "Recibida una señal no clasificada del pin {0}"
+
+#~ msgid "Could not translate {0} to number"
+#~ msgstr "No se pudo traducir {0} a número"
+
+#~ msgid "the button is not sensitive"
+#~ msgstr "el botón no es sensible"
+
+#~ msgid "Button {0} has been toggled"
+#~ msgstr "El botón {0} se ha conmutado"
+
+#~ msgid "Button {0} has been pressed"
+#~ msgstr "Se ha presionado el botón {0}"
+
+#~ msgid "Button {0} has been clicked"
+#~ msgstr "Se ha hecho clic en el botón {0}"
+
+#~ msgid "got wrong location to locate the childs"
+#~ msgstr "tiene una ubicación incorrecta para ubicar childs"
+
+#~ msgid "Enter System Unlock Code"
+#~ msgstr "Ingrese el código de desbloqueo del sistema"
+
+#~ msgid "Enter value"
+#~ msgstr "Introducir valor"
+
+#~ msgid "Enter the value to set"
+#~ msgstr "Ingrese el valor para establecer"
+
+#~ msgid "**** GMOCCAPY GETINIINFO : ****"
+#~ msgstr "**** GMOCCAPY GETINIINFO: ****"
+
+#~ msgid ""
+#~ "**** gmoccapy can only handle 9 axis, ****\n"
+#~ "**** but you have given {0} through your INI file ****\n"
+#~ msgstr ""
+#~ "**** gmoccapy solo puede manejar 9 ejes, ****\n"
+#~ "**** but you have given {0} through your INI file ****\n"
+
+#~ msgid ""
+#~ "**** gmoccapy will not start ****\n"
+#~ "\n"
+#~ msgstr ""
+#~ "**** gmoccapy no se iniciará ****\n"
+#~ "\n"
+
+#~ msgid "**** GMOCCAPY GETINIINFO ****\n"
+#~ msgstr "**** GMOCCAPY GETINIINFO ****\n"
+
+#~ msgid ""
+#~ "**** No subroutine folder or program prefix is given in the ini file "
+#~ "**** \n"
+#~ msgstr ""
+#~ "**** Sin carpeta de subrutina o prefijo de programa en el archivo ini "
+#~ "****\n"
+
+#~ msgid "Error trying to delet the message with number %s"
+#~ msgstr "Error al intentar borrar el mensaje con número %s"
+
+#~ msgid "left rotate,  middle move,  right zoom"
+#~ msgstr "izquierda rotar, medio mover, derecha zoom"
+
+#~ msgid "left zoom,  middle move,  right rotate"
+#~ msgstr "izquierda zoom, medio mover, derecha rotar"
+
+#~ msgid "left move,  middle rotate,  right zoom"
+#~ msgstr "izquierda mover, medio rotar, derecha zoom"
+
+#~ msgid "left zoom,  middle rotate,  right move"
+#~ msgstr "izquierda zoom, medio rotar, derecha mover"
+
+#~ msgid "left move,  middle zoom,  right rotate"
+#~ msgstr "izquierda mover, medio zoom, derecha rotar"
+
+#~ msgid "left rotate,  middle zoom,  right move"
+#~ msgstr "izquierda rotar, medio zoom, derecha mover"
+
+#~ msgid "No Program loaded"
+#~ msgstr "No hay programa cargado"
+
+#~ msgid "blockheight = 0.0"
+#~ msgstr "blockheight = 0.0"
+
+#~ msgid "clear plot"
+#~ msgstr "limpiar plot"
+
+#~ msgid "view perspective"
+#~ msgstr "vista perspectiva"
+
+#~ msgid "view along the X axis from positive to negative"
+#~ msgstr "vista a lo largo del eje X de positivo a negativo"
+
+#~ msgid "view along the Y axis from positive to negative"
+#~ msgstr "vista a lo largo del eje Y de positivo a negativo"
+
+#~ msgid "view along the Z axis from positive to negative"
+#~ msgstr "ver a lo largo del eje Z de positivo a negativo"
+
+#~ msgid "Show or hide tool path"
+#~ msgstr "Mostrar u ocultar la ruta de la herramienta"
+
+#~ msgid "Show or hide dimensions"
+#~ msgstr "Mostrar u ocultar dimensiones"
+
+#~ msgid ""
+#~ "view along the Y axis from positive to negative as viewn for a back tool "
+#~ "lathe"
+#~ msgstr ""
+#~ "vista a lo largo del eje Y de positivo a negativo como vista para "
+#~ "herramienta trasera de torno"
+
+#~ msgid "Tooledit"
+#~ msgstr "Tooledit"
+
+#~ msgid "File Selection"
+#~ msgstr "Selección de archivo"
+
+#~ msgid "jog axes"
+#~ msgstr "jog de ejes"
+
+#~ msgid "jog joints"
+#~ msgstr "jog de articulaciones"
+
+#~ msgid "Logo"
+#~ msgstr "Logo"
+
+#~ msgid "Ignore limits"
+#~ msgstr "Ignorar límites"
+
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "<b>Jogging</b>"
+
+#~ msgid "Information over the tool in spindle"
+#~ msgstr "Información sobre la herramienta en el husillo"
+
+#~ msgid "Tool no."
+#~ msgstr "Herramienta no."
+
+#~ msgid "offset z"
+#~ msgstr "offset z"
+
+#~ msgid "offset x"
+#~ msgstr "offset x"
+
+#~ msgid "Vc= 0.00"
+#~ msgstr "Vc = 0.00"
+
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "<b>Información de la herramienta</b>"
+
+#~ msgid "G and M code information as well as speed and feed"
+#~ msgstr "Información de código G y M, así como velocidad y avance"
+
+#~ msgid "active_mcodes_label"
+#~ msgstr "active_mcodes_label"
+
+#~ msgid "active_gcodes_label"
+#~ msgstr "active_gcodes_label"
+
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "<b>Código G</b>"
+
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "<b>Refrigeración</b>"
+
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "<b>Husillo [rpm]</b>"
+
+#~ msgid "Vel."
+#~ msgstr "Vel."
+
+#~ msgid "Displays the current velocity"
+#~ msgstr "Muestra la velocidad actual"
+
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "<b>Ajuste Rápidos</b>"
+
+#~ msgid "Displayes the programmed feed rate"
+#~ msgstr "Muestra la velocidad de avance programada"
+
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "restablecer ajuste de alimentación al 100%"
+
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "<b>Ajuste de alimentación</b>"
+
+#~ msgid ""
+#~ "Search\n"
+#~ " back"
+#~ msgstr ""
+#~ "Buscar\n"
+#~ " atras"
+
+#~ msgid ""
+#~ "Search\n"
+#~ "  fwd"
+#~ msgstr ""
+#~ "Buscar\n"
+#~ "adelante"
+
+#~ msgid "Replace"
+#~ msgstr "Reemplazar"
+
+#~ msgid "Start as fullscreen"
+#~ msgstr "Iniciar como pantalla completa"
+
+#~ msgid "Start maximized"
+#~ msgstr "Iniciar maximizado"
+
+#~ msgid "Start as window"
+#~ msgstr "Iniciar como ventana"
+
+#~ msgid "X Pos."
+#~ msgstr "X Pos."
+
+#~ msgid "Y Pos."
+#~ msgstr "Y Pos."
+
+#~ msgid "Width"
+#~ msgstr "Ancho"
+
+#~ msgid "Height"
+#~ msgstr "Altura"
+
+#~ msgid "hide cursor"
+#~ msgstr "ocultar cursor"
+
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "<b>Ventana principal</b>"
+
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Mostrar teclado en offset"
+
+#~ msgid "Show keyboard on tooledit"
+#~ msgstr "Mostrar teclado en tooledit"
+
+#~ msgid "Show keyboard on MDI"
+#~ msgstr "Mostrar teclado en MDI"
+
+#~ msgid "Show keyboard on EDIT"
+#~ msgstr "Mostrar teclado en EDITAR"
+
+#~ msgid "Show keyboard on load file"
+#~ msgstr "Mostrar teclado en carga de archivo"
+
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "<b> Teclado </b>"
+
+#~ msgid "show preview"
+#~ msgstr "mostrar vista previa"
+
+#~ msgid "show offsets"
+#~ msgstr "mostrar offsets"
+
+#~ msgid "<b>On Touch off</b>"
+#~ msgstr "<b>On Touch off</b>"
+
+#~ msgid "Relative Color"
+#~ msgstr "Color relativo"
+
+#~ msgid "Absolute Color"
+#~ msgstr "Color absoluto"
+
+#~ msgid "DTG Color"
+#~ msgstr "Color DTG"
+
+#~ msgid "Homed color"
+#~ msgstr "Color Homed"
+
+#~ msgid "Unhomed color"
+#~ msgstr "Color Unhomed"
+
+#~ msgid "Digits"
+#~ msgstr "Dígitos"
+
+#~ msgid ""
+#~ "toggle DRO mode \n"
+#~ "clicking on the DRO"
+#~ msgstr ""
+#~ "alternar el modo DRO \n"
+#~ "haciendo clic en el DRO"
+
+#~ msgid "<b>DRO</b>"
+#~ msgstr "<b>DRO</b>"
+
+#~ msgid "Grid size"
+#~ msgstr "Tamaño de cuadrícula"
+
+#~ msgid "Show DRO"
+#~ msgstr "Mostrar DRO"
+
+#~ msgid "Show offsets"
+#~ msgstr "Mostrar compensaciones"
+
+#~ msgid "Show DTG"
+#~ msgstr "Mostrar DTG"
+
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "<b>Modo de botón del mouse</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Vista previa</b>"
+
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr ""
+#~ "archivo\n"
+#~ "   actual"
+
+#~ msgid "<b>File to load on start</b>"
+#~ msgstr "<b> Archivo a cargar al inicio </b>"
+
+#~ msgid "Select user dir"
+#~ msgstr "Seleccionar dir usuario"
+
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "<b> Seleccione saltar al directorio </b>"
+
+#~ msgid "<b>Themes and sound</b>"
+#~ msgstr "<b> Temas y sonido </b>"
+
+#~ msgid "Appearance"
+#~ msgstr "Apariencia"
+
+#~ msgid "Scale rapid override"
+#~ msgstr "Escala ajuste rápidos"
+
+#~ msgid "Scale jog velocity"
+#~ msgstr "Escala velocidad de jog"
+
+#~ msgid "Scale feed override"
+#~ msgstr "Escala Ajuste de alimentación"
+
+#~ msgid "Scale spindle override"
+#~ msgstr "Escala Ajuste de husillo"
+
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "<b> Escala MPG hardware </b>"
+
+#~ msgid "Use keyboard shortcuts"
+#~ msgstr "Usar métodos abreviados de teclado"
+
+#~ msgid "<b>Keyboard shortcuts</b>"
+#~ msgstr "<b> Métodos abreviados de teclado </b>"
+
+#~ msgid "Use unlock code"
+#~ msgstr "Usar código de desbloqueo"
+
+#~ msgid "Do not use unlock code"
+#~ msgstr "No use el código de desbloqueo"
+
+#~ msgid "Use hal pin to unlock"
+#~ msgstr "Usar pin hal para desbloquear"
+
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "<b>Configuración de desbloqueo</b>"
+
+#~ msgid "Spindle bar min"
+#~ msgstr "Barra de husillo min"
+
+#~ msgid "Spindle bar max"
+#~ msgstr "Barra de husillo máx"
+
+#~ msgid "Hide turtle Jog Button"
+#~ msgstr "Ocultar el botón Jog tortuga"
+
+#~ msgid "Turtle jog Factor"
+#~ msgstr "Factor jog de tortuga"
+
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "<b>Jog tortuga</b>"
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgid "Use auto tool measurement"
+#~ msgstr "Usar medición automática de herramienta"
+
+#~ msgid "Probe Height"
+#~ msgstr "Sonda de Altura"
+
+#~ msgid "Z Pos."
+#~ msgstr "Pos. Z"
+
+#~ msgid "Max. Probe"
+#~ msgstr "Sonda máx."
+
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "<b>Información de la sonda</b>"
+
+#~ msgid "Search Vel."
+#~ msgstr "Buscar Vel."
+
+#~ msgid "Probe Vel."
+#~ msgstr "Sonda Vel."
+
+#~ msgid "<b>Probe velocitys</b>"
+#~ msgstr "<b>Sonda de Velocidades</b>"
+
+#~ msgid ""
+#~ "No valid configuration\n"
+#~ "found in your INI file,\n"
+#~ "please take a look at \n"
+#~ "the WIKI to check how\n"
+#~ "to configure the settings."
+#~ msgstr ""
+#~ "Sin configuración válida\n"
+#~ "encontrado en su archivo INI,\n"
+#~ "por favor, eche un vistazo a\n"
+#~ "la WIKI para comprobar cómo\n"
+#~ "configurar los ajustes."
+
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "<b> Medición de herramientas </b>"
+
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Recargar Herramienta al arranque"
+
+#~ msgid ""
+#~ "If checked, the tool in spindle\n"
+#~ "will be saved on each change\n"
+#~ "and the last tool will be reloaded\n"
+#~ "at start of the GUI. Also it's \n"
+#~ "length offset will be reloaded.\n"
+#~ msgstr ""
+#~ "Si está marcado, la herramienta en\n"
+#~ "el husillo se guardará en cada cambio\n"
+#~ "y la última herramienta se volverá a cargar\n"
+#~ "al arranque de la GUI. También se volvera\n"
+#~ "a cargar el offset de longitud.\n"
+
+#~ msgid ""
+#~ "You use NO_FORCE_HOMING,\n"
+#~ "so the reload of a tool at start\n"
+#~ "is not possible."
+#~ msgstr ""
+#~ "Ha usado NO_FORCE_HOMING,\n"
+#~ "así que la recarga de una herramienta\n"
+#~ "al inicio no es posible."
+
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "<b>Recarga de Herramienta</b>"
+
+#~ msgid "Do not use run from line"
+#~ msgstr "No utilice ejecutar desde la línea"
+
+#~ msgid "Use run from line"
+#~ msgstr "Usar ejecución desde línea"
+
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "<b>Ejecutar desde línea</b>"
+
+#~ msgid "Use frames"
+#~ msgstr "Usar marcos"
+
+#~ msgid ""
+#~ "If checked, the messages\n"
+#~ "will be in a frame."
+#~ msgstr ""
+#~ "Si está marcado, los mensajes\n"
+#~ "estará en un marco\"."
+
+#~ msgid "max."
+#~ msgstr "máx."
+
+#~ msgid "The font to use"
+#~ msgstr "La fuente a usar"
+
+#~ msgid "The maximum messages you want to be shown\t"
+#~ msgstr "Máximo de mensajes que desea que se muestren\t"
+
+#~ msgid "The width of the messages"
+#~ msgstr "Ancho de los mensajes"
+
+#~ msgid "X-position in pixel from top left corner of the screen"
+#~ msgstr ""
+#~ "Posición X en píxeles desde la esquina superior izquierda de la pantalla"
+
+#~ msgid "Y-position in pixel from top left corner of the screen"
+#~ msgstr ""
+#~ "Posición Y en píxeles desde la esquina superior izquierda de la pantalla"
+
+#~ msgid "Launch test message"
+#~ msgstr "Iniciar mensaje de prueba"
+
+#~ msgid ""
+#~ "Push here to launch a test message\n"
+#~ "to test your settings."
+#~ msgstr ""
+#~ "Presione aquí para lanzar un mensaje\n"
+#~ "de prueba para su configuración."
+
+#~ msgid ""
+#~ "<b>      gmoccapy message\n"
+#~ " behavior and appearance </b>"
+#~ msgstr ""
+#~ "<b>      mensaje gmoccapy\n"
+#~ " comportamiento y apariencia </b>"
+
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr ""
+#~ "Configuraciones\n"
+#~ "Avanzadas"
+
+#~ msgid "User tab 1"
+#~ msgstr "Pestaña Usuario 1"
+
+#~ msgid "User tabs"
+#~ msgstr "Pestañas de usuario"
+
+#~ msgid ""
+#~ "Estop the machine\n"
+#~ "[F1]"
+#~ msgstr ""
+#~ "Estop de máquina\n"
+#~ "[F1]"
+
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr ""
+#~ "Encender/apagar la máquina\n"
+#~ "[F2]"
+
+#~ msgid ""
+#~ "enter manual mode to jog axis by hand or touch off\n"
+#~ "[F3]"
+#~ msgstr ""
+#~ "ingrese el modo manual para jog del eje o touch off\n"
+#~ "[F3]"
+
+#~ msgid ""
+#~ "enter MDI mode to launch g-code commands\n"
+#~ "[F5]"
+#~ msgstr ""
+#~ "ingrese al modo MDI para iniciar comandos de código g\n"
+#~ "[F5]"
+
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "ingrese al modo auto para ejecutar programas"
+
+#~ msgid "Enter the settings page, the default code is \"123\""
+#~ msgstr ""
+#~ "Ingrese a la página de configuración, el código predeterminado es \"123\""
+
+#~ msgid "show user tabs"
+#~ msgstr "mostrar pestañas de usuario"
+
+#~ msgid "open homing button list"
+#~ msgstr "abrir la lista de botones de referencia"
+
+#~ msgid "open touch off button list"
+#~ msgstr "abrir lista de botones de touch off"
+
+#~ msgid "Open the tooleditor page"
+#~ msgstr "Abrir la página de tooleditor"
+
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "MundoModo estoy aqui"
+
+#~ msgid ""
+#~ "Switch motion mode between Joint and World mode\n"
+#~ "F12 or $ key does the same"
+#~ msgstr ""
+#~ "Cambiar el modo de movimiento entre el modo articulacion y MundialLa "
+#~ "tecla F12 o $ hace lo mismo"
+
+#~ msgid "make the preview as large as possible"
+#~ msgstr "haga que la vista previa sea lo más grande posible"
+
+#~ msgid "Close gmoccapy / leave the program"
+#~ msgstr "Cerrar gmoccapy / salir del programa"
+
+#~ msgid "Load a new program"
+#~ msgstr "Cargar un nuevo programa"
+
+#~ msgid "Run the loaded program"
+#~ msgstr "Ejecuta el programa cargado"
+
+#~ msgid "Stop the running program"
+#~ msgstr "Detener el programa en ejecución"
+
+#~ msgid "Pause the running program"
+#~ msgstr "Pausa el programa en ejecución"
+
+#~ msgid "pause the running program"
+#~ msgstr "pausa el programa en ejecución"
+
+#~ msgid "Run the  loaded program step by step"
+#~ msgstr "Ejecute el programa cargado paso a paso"
+
+#~ msgid ""
+#~ "run the program from a certain line, attention, that is dangerous, "
+#~ "because the previous lines will not checed!"
+#~ msgstr ""
+#~ "ejecuta el programa desde una determinada línea, atención, eso es "
+#~ "peligroso, porque¡las líneas anteriores no mejorarán!"
+
+#~ msgid ""
+#~ "Machine or not the optional blocks of the program. If the button is "
+#~ "pressed, the optional blocks will not be machined. The button will "
+#~ "indicate this by a yellow background."
+#~ msgstr ""
+#~ "Máquina o no los bloques opcionales del programa. Si se presiona el "
+#~ "botónlos bloques opcionales no serán mecanizados. El botón lo indicará "
+#~ "mediante unfondo amarillo\"."
+
+#~ msgid "Edit the loaded program"
+#~ msgstr "Editar el programa cargado"
+
+#~ msgid "delete MDI"
+#~ msgstr "eliminar MDI"
+
+#~ msgid "delete MDI history"
+#~ msgstr "eliminar el historial de MDI"
+
+#~ msgid "Cl.-ladder"
+#~ msgstr "Cl.-escalera"
+
+#~ msgid "Open classicladder"
+#~ msgstr "Abrir classicladder"
+
+#~ msgid "Hal-Scope"
+#~ msgstr "Hal-Scope"
+
+#~ msgid "launch hal scope"
+#~ msgstr "lanzamiento hal alcance"
+
+#~ msgid "launch linuxcnc status"
+#~ msgstr "lanzar estado de linuxcnc"
+
+#~ msgid "launch hal meter"
+#~ msgstr "iniciar hal meter"
+
+#~ msgid "launch calibration"
+#~ msgstr "iniciar calibración"
+
+#~ msgid "Halshow"
+#~ msgstr "Halshow"
+
+#~ msgid "opens the show hal tool"
+#~ msgstr "abre la herramienta show hal"
+
+#~ msgid "save the file using the original name"
+#~ msgstr "guardar el archivo con el nombre original"
+
+#~ msgid "save the file with a new name"
+#~ msgstr "guardar el archivo con un nuevo nombre"
+
+#~ msgid "clear the edit field and make a new file"
+#~ msgstr "borra el campo de edición y crea un nuevo archivo"
+
+#~ msgid "Show or hide the virtual keyboard"
+#~ msgstr "Mostrar u ocultar el teclado virtual"
+
+#~ msgid "Go back to main button list"
+#~ msgstr "Volver a la lista de botones principal"
+
+#~ msgid "delete selected tool or tools"
+#~ msgstr "eliminar herramienta o herramientas seleccionadas"
+
+#~ msgid "add a new tool to tool table"
+#~ msgstr "agrega una nueva herramienta a la tabla de herramientas"
+
+#~ msgid ""
+#~ "apply the changes you made, G43 will be excecuted only if it is active g-"
+#~ "code"
+#~ msgstr ""
+#~ "aplique los cambios que realizó, G43 se ejecutará solo si está activo el "
+#~ "código g"
+
+#~ msgid "Select a tool by number"
+#~ msgstr "Seleccione una herramienta por número"
+
+#~ msgid "change tool with the command M61 Q?, no machine move will be done"
+#~ msgstr ""
+#~ "¿Cambiar herramienta con el comando M61 Q ?, no se realizará ningún "
+#~ "movimiento de máquina"
+
+#~ msgid "change tool to the selected one"
+#~ msgstr "cambia la herramienta a la seleccionada"
+
+#~ msgid ""
+#~ "touchoff\n"
+#~ "  tool x"
+#~ msgstr "touchoffherramienta x"
+
+#~ msgid "touch off the tool and set the value to the tool table"
+#~ msgstr ""
+#~ "toque la herramienta y establezca el valor en la tabla de herramientas"
+
+#~ msgid ""
+#~ "touchoff\n"
+#~ "  tool z"
+#~ msgstr "touchoffherramienta z"
+
+#~ msgid "Load File"
+#~ msgstr "Cargar archivo"
+
+#~ msgid "home joints"
+#~ msgstr "articulaciones caseras"
 
 #~ msgid "TKLinux"
 #~ msgstr "TKLinux"
-
-#~ msgid "Gmoccapy"
-#~ msgstr "Gmoccapy"
 
 #~ msgid "Touchy"
 #~ msgstr "Touchy"

--- a/src/po/fi.po
+++ b/src/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EMC2 2.5.0-pre2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2011-12-26 10:58-0600\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,66 +17,66 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr ""
 
@@ -186,424 +186,424 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -716,30 +716,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "G53:n kanssa ei voi käyttää polarikoordinaatteja"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -854,102 +854,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, c-format
 msgid "cant open ini file '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 msgid "Parameter file name is missing"
 msgstr ""
 
@@ -1367,7 +1367,7 @@ msgid "Negative spindle speed used"
 msgstr ""
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+msgid "Negative tool id (tool not found)"
 msgstr ""
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1749,24 +1749,23 @@ msgstr ""
 msgid "R less than V in cycle in UW plane"
 msgstr ""
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "Hal-mittari"
 
@@ -1778,93 +1777,111 @@ msgstr ""
 msgid "E_xit"
 msgstr ""
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr ""
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr ""
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr ""
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr ""
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr ""
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 msgstr ""
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr ""
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+msgid "_Cancel"
+msgstr ""
+
+#: src/hal/utils/scope.c:471
+msgid "_Open"
+msgstr ""
+
+#: src/hal/utils/scope.c:491
+msgid "Save Configuration File:"
+msgstr ""
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+msgid "_Save"
+msgstr ""
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr ""
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr ""
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr ""
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr ""
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr ""
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "HAL skooppi"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr ""
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "Valittu kanava"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr ""
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr ""
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr ""
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1872,37 +1889,37 @@ msgstr ""
 msgid "Stop"
 msgstr "Seis"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr ""
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr ""
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "Zoom"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1916,11 +1933,39 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "Lopeta"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1933,105 +1978,81 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "Valitse näytteistysnopeus"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "Lopeta"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2045,56 +2066,64 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
 "record length that supports more channels."
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
 "per div"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
 "at %s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
-msgstr "ns"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
-msgstr "us"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
-msgstr "m"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
-msgstr "s"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2108,90 +2137,71 @@ msgstr "s"
 #: src/emc/usr_intf/pncconf/mesa1.glade:460
 #: src/emc/usr_intf/pncconf/mesa1.glade:473
 msgid "Hz"
-msgstr "Hz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
-msgstr "kHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
-msgstr "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
+msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
 "%s"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "Vahvistus"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 msgid ""
 "Offset\n"
 "----"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
 "for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr ""
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr "AC-kytketty"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2199,172 +2209,163 @@ msgid ""
 "the record length to allow for more channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
 "as the source for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr ""
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "Signaalit"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
 "Chan %2d"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr ""
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr ""
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr ""
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr "G38.4-liike valmis, kosketus ei katkennut"
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr "G38.2-liike valmis, ei kosketusta"
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+#, fuzzy
+msgid "Probe tripped during non-probe move."
 msgstr "Mittapää kosketti ajettaessa mittaukseen liittymätöntä MDI-käskyä"
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr "Mittapään kosketus ajettaessa kotiasemaan"
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 #, fuzzy
 msgid "Probe tripped during a joint jog."
 msgstr "Mittapään kosketus käsiajolla"
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 #, fuzzy
 msgid "Probe tripped during a coordinate jog."
 msgstr "Mittapään kosketus käsiajolla"
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr "'enable'-tulo katkaisi"
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, fuzzy, c-format
 msgid "spindle %d amplifier fault"
 msgstr "vahvistinvika nivelellä %d"
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "virhe, nivel %d rajalla"
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "vahvistinvika nivelellä %d"
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "seurantavirhe nivelellä %d"
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, fuzzy, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr "Nivelen %d positiivinen ohjelmallinen raja ylitetty"
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 #, fuzzy
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 "kaikkien nivelien tulee olla kotiasemissaan ennen koordinoituun tilaan "
 "siirtymistä"
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, fuzzy, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr "Nivelen %d positiivinen ohjelmallinen raja ylitetty"
@@ -2433,177 +2434,177 @@ msgstr ""
 "kaikkien nivelien tulee olla kotiasemissaan ennen koordinoituun tilaan "
 "siirtymistä"
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr "Niveliä ei voi käsiajaa, koska kone on ajamassa kotiasemaan"
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr "Mitään niveltä ei voi käsiajaa samalla kun kone ajaa kotiasemaan."
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr ""
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr ""
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr ""
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr ""
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr ""
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr ""
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr ""
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr ""
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr ""
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2692,26 +2693,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2881,7 +2882,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -2969,19 +2970,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr ""
 
@@ -3031,7 +3032,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr ""
 
@@ -3049,7 +3050,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr ""
 
@@ -3063,7 +3064,6 @@ msgid "Config"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 msgid "Preview"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgid "Edit mode..."
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr ""
 
@@ -3497,7 +3497,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr ""
 
@@ -3507,6 +3507,24 @@ msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
+msgstr ""
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
 msgstr ""
 
 #: src/hal/classicladder/edit_sequential.c:68
@@ -3692,7 +3710,7 @@ msgid "Parameter"
 msgstr ""
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3877,7 +3895,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr ""
 
@@ -3955,11 +3972,13 @@ msgid "Delete section"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Down"
 msgstr ""
 
@@ -4476,6 +4495,7 @@ msgid "Exit"
 msgstr ""
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr ""
 
@@ -4518,7 +4538,6 @@ msgid "Renumber File..."
 msgstr ""
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr ""
 
@@ -4789,15 +4808,15 @@ msgstr ""
 msgid "Test HAL command :"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr ""
 
@@ -4911,21 +4930,21 @@ msgstr ""
 msgid "SIZE :"
 msgstr ""
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr ""
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr ""
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 msgid "Create Report File"
 msgstr ""
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr ""
 
@@ -4999,7 +5018,7 @@ msgstr ""
 msgid "Tool:"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr ""
@@ -5066,18 +5085,18 @@ msgstr ""
 msgid "auto"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5234,7 +5253,7 @@ msgstr ""
 msgid "world"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr ""
 
@@ -5315,16 +5334,15 @@ msgstr ""
 msgid "Optional Stop"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr ""
 
@@ -5433,7 +5451,7 @@ msgid "Coordinate System Control Window"
 msgstr ""
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr ""
 
@@ -5985,9 +6003,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr ""
 
@@ -6007,8 +6025,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr ""
 
@@ -6080,145 +6098,145 @@ msgstr ""
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 msgid "no such file"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 msgid "LinuxCNC"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 msgid "LinuxCNC version"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -6870,220 +6888,218 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
 "produced are shown below:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
 "%(error_str)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
 "%(lines)s gcode lines"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 #, fuzzy
 msgid "File not Writable:"
 msgstr "Tiedosto ei ole avoinna"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7094,58 +7110,58 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Custom Grid"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 msgid "Touch Off (system)"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, python-format
 msgid "Tool %s TouchOff"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7154,7 +7170,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7163,7 +7179,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7172,88 +7188,88 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 msgid "Joints"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, python-format
 msgid "Home All %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, python-format
 msgid "Unhome All %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 msgid "Joint"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 msgid "Home Joint"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr ""
 
@@ -7558,11 +7574,11 @@ msgid "_Properties..."
 msgstr ""
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+msgid "Edit _tool data..."
 msgstr ""
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+msgid "Reload tool _data"
 msgstr ""
 
 #: share/axis/tcl/axis.tcl:96
@@ -7889,11 +7905,11 @@ msgstr ""
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr ""
 
@@ -8070,9 +8086,10 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr ""
 
@@ -8114,7 +8131,7 @@ msgid "Position:"
 msgstr ""
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr ""
 
@@ -8218,21 +8235,20 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr ""
@@ -8572,6 +8588,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8581,43 +8599,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8672,7 +8735,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr ""
 
@@ -8836,7 +8898,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr ""
 
@@ -8895,8 +8956,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9028,10 +9089,10 @@ msgid "Stepconf"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9049,12 +9110,12 @@ msgid "Parallel Port 1"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 msgid "Parallel Port 2"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 msgid "Options"
 msgstr ""
 
@@ -9063,225 +9124,270 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+msgid "User Buttons"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 msgid "Axis X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 msgid "Axis Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 msgid "Axis Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 msgid "Axis U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 msgid "Axis V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 msgid "Axis A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "Spindle"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "U Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "U Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "V Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "V Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+msgid "Tandem X Step"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+msgid "Tandem X Direction"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+msgid "Tandem Y Step"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+msgid "Tandem Y Direction"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9292,249 +9398,329 @@ msgstr ""
 msgid "Unused"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+msgid "Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+msgid "Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-msgid "All limits"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-msgid "All home"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-msgid "All limits + homes"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 0"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 1"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 2"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 3"
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+msgid "Both Limit + Home Tandem X"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
-msgid "Forward"
+msgid "Both Limit + Home Tandem Y"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
-msgid "Done"
+msgid "Minimum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit Y"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+msgid "Minimum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
+msgid "All limits"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
+msgid "All home"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
+msgid "All limits + homes"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 0"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 1"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 2"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Down"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
+msgid "Forward"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
+msgid "Done"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9543,40 +9729,40 @@ msgid ""
 "Are you sure?  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
 "Any existing file named custompanel_backup.xml will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9587,76 +9773,76 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 msgid ""
 "Loading configuration error:\n"
 "\n"
 "{}"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -9671,8 +9857,8 @@ msgstr ""
 msgid "mm / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -9687,13 +9873,13 @@ msgstr ""
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr ""
 
@@ -9702,19 +9888,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -9726,7 +9912,7 @@ msgstr ""
 msgid "mm / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -9737,28 +9923,28 @@ msgstr ""
 msgid "Steps / mm"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -9766,99 +9952,104 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+msgid "# Include your custom HAL commands here"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
@@ -9928,11 +10119,16 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr ""
 
@@ -9972,17 +10168,6 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:209
@@ -10325,53 +10510,144 @@ msgstr ""
 msgid "Scale %"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+msgid "  Y Offset"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+msgid " X Offset"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+msgid "Estop Button:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+msgid "Button"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+msgid "Mode:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 msgid "Spindle speed display  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10380,76 +10656,80 @@ msgid ""
 "panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
 "program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 msgid "Set Ladder Options"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
@@ -10468,16 +10748,153 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+msgid "Model"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10487,10 +10904,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 msgid "Opposite"
 msgstr ""
 
@@ -10517,15 +10934,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisv.glade:249
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
@@ -10724,38 +11132,38 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -10763,22 +11171,22 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -10788,32 +11196,32 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -10822,174 +11230,174 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 msgid " / Step"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 msgid "Steps / "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 msgid "Resolver Scale:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 msgid "Spindle Scale Calculation"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11007,52 +11415,55 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 msgid "in / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11062,8 +11473,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr ""
@@ -11079,169 +11490,174 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
-#, python-format
-msgid "Generated by PNCconf at %s"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
-msgid "configures LinuxCNC as:\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
-msgid "type CNC\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
-msgid "will be used as the frontend display"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
-msgid " connector"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
-msgid "invrt"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
-#, python-format
-msgid "%(name)s Parport"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
-msgid "-> inverted"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
+msgid "Generated by PNCconf at %s"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
+msgid "configures LinuxCNC as:\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
+msgid "type CNC\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
+msgid "will be used as the frontend display"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
+msgid " connector"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
+msgid "invrt"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
+#, python-format
+msgid "%(name)s Parport"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
+msgid "-> inverted"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
+#, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11257,1503 +11673,1552 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 msgid "External Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 msgid "Parallel Port"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
-msgid "X Motor"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
-msgid "X Axis"
+msgid "Mesa THCAD"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:50
-msgid "Y Motor"
+msgid "X Motor"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
-msgid "Y Axis"
+#: src/emc/usr_intf/pncconf/private_data.py:534
+msgid "X Axis"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:52
-msgid "Z Motor"
+msgid "Y Motor"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
-msgid "Z Axis"
+#: src/emc/usr_intf/pncconf/private_data.py:534
+msgid "Y Axis"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:54
-msgid "A Motor"
+msgid "Z Motor"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
-msgid "A Axis"
+#: src/emc/usr_intf/pncconf/private_data.py:534
+msgid "Z Axis"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:56
-msgid "Spindle Motor"
+msgid "A Motor"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
+msgid "A Axis"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:58
+msgid "Spindle Motor"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Dir"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO O Drain"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:113
+#: src/emc/usr_intf/pncconf/private_data.py:117
 msgid "SSR Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "muxed Enc I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step Gen-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-Down"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Analog Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "X Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Y Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Z Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "A Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "All Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "X2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Y2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Z2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "A2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "All Limits + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 msgid "A2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Spindle Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Feed Override enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Spindle Override enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 msgid "Max Vel Override enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CW"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CCW"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle Stop"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Spindle Up-To-Speed"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Gear Select A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Single Step"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "A2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 msgid "Main Axis"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 msgid "Tandem Axis"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Float Switch"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 msgid "Overrides"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "Operation"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "External Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 msgid "Axis rapid"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "X Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "Y Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "Z Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "A Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Unused PWM Gen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 msgid "X Axis StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Y Axis StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Z Axis StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 msgid "A Axis StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "X2 Tandem StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "Y2 Tandem StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 msgid "Z2 Tandem StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 msgid "Unused StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Spindle StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 msgid "X2 Tandem Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 msgid "Y2 Tandem Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 msgid "Z2 Tandem Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 msgid "A2 Tandem Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Feed Override"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "spindle Override"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Max Vel Override"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Spindle Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+msgid "Plasma Encoder"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 msgid "Unused Unused"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "Machine Is Enabled"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Coolant"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Spindle Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Unused Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -12762,15 +13227,15 @@ msgid ""
 "be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 msgid "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -12785,80 +13250,89 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -12871,7 +13345,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -12881,18 +13355,18 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
 
@@ -14545,9 +15019,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -14702,6 +15176,13 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/external.glade:5401
 msgid "Mux options"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "s"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -14879,175 +15360,192 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 msgid "Relative Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+msgid "QtPlasmaC Options"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
@@ -15138,130 +15636,142 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+msgid "Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+msgid "Use Compensation Filename:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 msgid "Home Search Sequence:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
@@ -16179,10 +16689,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr ""
@@ -16266,10 +16772,6 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:1409
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
@@ -16714,7 +17216,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -16867,31 +17368,23 @@ msgid "Manual Toolchange"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 msgid "Restart Entry"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr ""
 
@@ -16969,33 +17462,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17110,28 +17603,24 @@ msgid "<b>Status</b>"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 msgid ""
 "Replace\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 msgid ""
 "Replace\n"
 "   All"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17146,7 +17635,6 @@ msgid "Main Level"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17159,12 +17647,10 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17173,7 +17659,6 @@ msgid "Grid Size"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 msgid "Starting RPM"
 msgstr ""
 
@@ -17250,7 +17735,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 msgid "Calibration"
 msgstr ""
 
@@ -17497,12 +17981,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr ""
 
@@ -17525,6 +18007,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -17587,1565 +18071,282 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-msgid "user mode selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, python-brace-format
-msgid "unknown jog command {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-msgid ""
-" Joint\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-msgid "Classicladder real-time component not detected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-msgid "Enter value for diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-msgid "Set diameter to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-msgid "Enter value for radius"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr "0-säteinen kaari"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, python-brace-format
-msgid "Set axis {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-msgid "Manual Tool change"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-msgid "Select the tool to change"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-msgid ""
-"World\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-msgid "no button here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-msgid "No Program loaded"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-msgid "clear plot"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-msgid "view perspective"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-msgid "Offset Page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-msgid "Tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-msgid "File Selection"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-msgid "jog joints"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-msgid "Ignore limits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-msgid "<b>Jogging</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-msgid "Tool no."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-msgid "Diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-msgid "offset z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-msgid "offset x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-msgid "<b>Tool information</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-msgid "active_mcodes_label"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-msgid "active_gcodes_label"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-msgid "<b>G-Code</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-msgid "<b>Cooling</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-msgid "<b>Spindle [rpm]</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-msgid "<b>Rapid Override</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-msgid "reset feed override to 100 %"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-msgid "<b>Feed Override</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-msgid "X Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-msgid "Y Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-msgid "<b>Main Window</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-msgid "Show keyboard on offset"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-msgid "<b>Keyboard</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-msgid "show preview"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-msgid "show offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-msgid "Relative Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-msgid "Absolute Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-msgid "Homed color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-msgid "Unhomed color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-msgid "<b>DRO</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-msgid "Grid size"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-msgid "Show DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-msgid "Show offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-msgid "Show DTG"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-msgid "<b>Mouse Button mode</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-msgid "<b>Preview</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-msgid ""
-"current\n"
-"   file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-msgid "Select user dir"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-msgid "<b>Select jump to dir</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-msgid "Scale rapid override"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-msgid "Scale jog velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-msgid "Scale feed override"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-msgid "Scale spindle override"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-msgid "<b>Hardware MPG Scale</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-msgid "Use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-msgid "<b>Unlock settings</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-msgid "Spindle bar min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-msgid "Spindle bar max"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-msgid "<b>Turtle Jog</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-msgid "Z Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-msgid "<b>Probe Informations</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-msgid "Search Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-msgid "<b>Tool Measurement</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-msgid "Reload Tool on Start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-msgid "<b>Reload Tool</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-msgid "Use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-msgid "<b>Run from line</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-msgid "enter auto mode to run programs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-msgid "show user tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-msgid ""
-"World\n"
-"Mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-msgid "Load a new program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-msgid "Run the loaded program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-msgid "Stop the running program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-msgid "Pause the running program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-msgid "pause the running program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-msgid "Edit the loaded program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-msgid "delete MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-msgid "delete MDI history"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-msgid "Hal-Scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-msgid "launch calibration"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-msgid "add a new tool to tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-msgid "Reload"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-msgid "reload tool table from file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-msgid "Select a tool by number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
-msgid "Move to parrent directory"
+#: lib/python/gladevcp/iconview.py:120
+msgid "Move to parent directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
-msgid "Select the previos file"
-msgstr ""
+#: lib/python/gladevcp/iconview.py:128
+#, fuzzy
+msgid "Select the previous file"
+msgstr "Valittu kanava"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Valittu kanava"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-msgid "Load File"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
-msgid "home joints"
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
 msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+msgid "Tool file was modified since it was last read"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+msgid "checkbutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+msgid "button"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+msgid "togglebutton"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+msgid "Tool"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+msgid "black"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+msgid "Rotation of Z"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
+msgid "Offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:416
+msgid "Offset Name"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:442
+msgid ""
+"Zero\n"
+"G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:456
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+msgid "Select"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+msgid "Tool#"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+msgid "Diameter"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+msgid "Front"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+msgid "Orientation"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+msgid "Comments"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+msgid "Reload"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+msgid "All Offsets"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "Hal-mittari"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+msgid "Lathe Wear Offsets"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+msgid "X Tool"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+msgid "Z Tool"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+msgid "Lathe Tool Offsets"
+msgstr ""
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "0-säteinen kaari"
 
 #~ msgid "Exceeded negative soft limit on joint %d"
 #~ msgstr "Nivelen %d negatiivinen ohjelmallinen raja ylitetty"

--- a/src/po/fr.po
+++ b/src/po/fr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2014-07-14 20:06+0100\n"
 "Last-Translator: Francis Tisserant <tissf@free.fr>\n"
 "Language-Team: French translation team <tissf@free.fr>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "X-Poedit-Language: fr\n"
 "X-Poedit-Country: France\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
@@ -24,60 +24,60 @@ msgstr ""
 "La commande (%s) ne peut être exécutée tant que la machine n'est pas sortie "
 "de l'arrêt d'urgence et mise en marche"
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "Commande (%s) impossible en mode manuel"
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr "(%s) impossible en mode auto avec l'interpréteur en charge"
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr "(%s) impossible en mode auto avec l'interpréteur en lecture"
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr "(%s) impossible en mode auto avec l'interpréteur en pause"
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr "(%s) impossible en mode auto avec l'interpréteur en attente"
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "Commande (%s) impossible en mode MDI"
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr "Impossible de quitter le mode AUTO si l'interpréteur est en charge"
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 #, fuzzy
 msgid "failed to close file"
 msgstr "Impossible d'ouvrir le fichier <%s>"
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "Impossible d'ouvrir %s"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr "Pas de commande MDI avant la prise d'origine machine"
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "Pas de commande MDI hors du mode MDI"
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr "Pas de départ cycle avant la prise d'origine machine"
 
@@ -209,30 +209,30 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 "Vous devez spécifier les coordonnées X et Y pour les points de contrôle"
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 "Possibilité de spécifier P sans X et Y, seulement pour le premier point de "
 "contrôle"
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr "Un poids P positif doit être spécifié pour chaque point de contrôle"
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr "Impossible de faire un NURBS avec une vitesse nulle"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr "Impossible d'utiliser G5.3 sans G5.2 en premier"
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
@@ -241,32 +241,32 @@ msgstr ""
 "Vous devez spécifier un nombre de points de contrôle au moins égal à l'ordre "
 "L = %d"
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr ""
 "Impossible de convertir une spline avec la compensation de rayon d'outil"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr "Les splines doivent être dans le plan XY"
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr "Splines may not have motion in Z, A, B, or C"
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr "I et J doivent être spécifiés tous les deux avec G5.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr "I et J doivent être spécifiés tous les deux, ou aucun"
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr "P et Q doivent être spécifiés tous les deux avec G5"
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
@@ -274,47 +274,47 @@ msgstr ""
 "Le premier mouvement après l'arrêt de la compensation de rayon d'outil doit "
 "être une droite, pas un arc"
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr "Un arc est impossible dans les plans G17.1, G18.1 ou G19.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 "Mouvement impossible en mode longueur par tour avec une vitesse de broche à "
 "zéro"
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr "Mot %c manquant en centre d'arc absolu"
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 "L'arc d'entrée de compensation de rayon d'outil est plus petit que le rayon "
 "de l'outil"
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 "Le mouvement en arc dans l'angle intérieur ne peut pas s'achever sans que "
 "l'outil n'interfère avec la pièce"
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr "Mouvement d'arc en arc impossible, les deux arcs ayant le même centre"
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
@@ -322,340 +322,340 @@ msgstr ""
 "Mouvement d'arc en arc, pour initier la compensation d'outil, ne pouvant pas "
 "être suivi sans interférer avec la pièce"
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr "Position absolue %5.2f invalide pour l'axe rotatif wrapped %c"
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 "Changement de mode de contrôle impossible avec la compensation de rayon "
 "d'outil activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 "Changement de système de coordonnées impossible avec la compensation de "
 "rayon d'outil activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr "G%d.1 sans mot D"
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr "G%d.1 avec mot L, mais le plan n'est pas G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr "G%d exige que le mot D soit un nombre entier"
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr "G%d avec outil de tour, mais le plan n'est pas G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 "Réglage de point de référence impossible avec la compensation d'outil activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 "Réglage de sortie mouvement impossible avec la compensation de rayon d'outil "
 "activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr "Pas de mot P valide avec M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 "Réglage de sortie numérique impossible avec la compensation de rayon d'outil "
 "activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr "Pas de mot P valide avec M63"
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 "Réglage de sortie numérique auxiliaire impossible avec la compensation de "
 "rayon d'outil activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr "Pas de mot P valide avec M64"
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr "Pas de mot P valide avec M65"
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr "Mot P valide avec M66"
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 "Attente d'une entrée numérique impossible avec la compensation de rayon "
 "d'outil activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 "Attente d'une entrée analogique impossible avec la compensation de rayon "
 "d'outil activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 "Réglage de sortie analogique impossible avec la compensation de rayon "
 "d'outil activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr "Index analogique invalide avec M67"
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 "Réglage de sortie analogique auxiliaire impossible avec la compensation de "
 "rayon d'outil activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr "Index analogique invalide avec M68"
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 #, fuzzy
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr "Avec M61, un mot Q positif doit spécifier le numéro de l'outil"
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 "Activation des correcteurs impossible avec la compensation de rayon d'outil"
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 "Désactivation des correcteurs impossible avec la compensation de rayon "
 "d'outil"
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr "Indexing axis %c can only be moved with G0"
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr "Indexing axis %c can only be moved alone"
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr "Mesure impossible dans le mode vitesse en unités par tour"
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 "Changement de mode de retrait impossible avec la compensation de rayon "
 "d'outil"
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr "G10 L1 sans offsets n'a aucun effet"
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr "Le nombre Q dans G10 n'est pas un entier"
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr "Orientation d'outil invalide"
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr "Mots I J non permis avec G10 L2"
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 "Changement de système de coordonnées impossible avec la compensation de "
 "rayon d'outil activée"
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr "R n'est pas permis avec G10 L20"
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr "Broche pas en rotation en G33"
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr "Broche pas en rotation en G33.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, fuzzy, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "Broche pas en rotation en G33"
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr "BUG: An axis incorrectly moved along with an indexer"
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr "BUG: trying to index incorrect axis"
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr "Cycle de filetage G76 impossible avec la compensation de rayon d'outil"
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr "I ne peut pas être à 0 dans G76"
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr "J doit être supérieur à 0 dans G76"
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr "K doit être plus grand que J dans G76"
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 "Le mouvement d'entrée en compensation de longueur d'outil doit être plus "
 "grand que le rayon d'outil"
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 "Un angle interne de zéro degré est invalide pour la compensation de rayon "
 "d'outil"
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
@@ -663,22 +663,22 @@ msgstr ""
 "Mouvement d'arc vers une droite, pour initier la compensation d'outil, ne "
 "pouvant pas être suivi sans interférer avec la pièce"
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 "Changement d'outil impossible avec la compensation de rayon d'outil active"
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 "Changement d'offsetd'outil impossible avec la compensation de rayon d'outil "
 "active"
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -800,33 +800,33 @@ msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
 #
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "Coordonnées polaires inutilisables avec G53"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr "Impossible de spécifier les mots X et Y avec des coordonnées polaires"
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr "Un angle en coordonnées polaires doit être spécifié si à l'origine"
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 "Un mouvement incrémental avec des coordonnées polaires est indéterminé si à "
 "l'origine"
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 "Un mouvement G91 avec des coordonnées polaires est indéterminé si à l'origine"
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr "L'outil demandé %d n'est pas dans la table d'outils"
@@ -950,102 +950,102 @@ msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 "Fichier:%s ligne:%d redéfinition sub: o|%s| déjà défini dans le fichier:%s"
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, fuzzy, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "Pas dans une définition de sous-programmme"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "Paramètre nommé #<%s> non défini"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, fuzzy, c-format
 msgid "cant open ini file '%s'"
 msgstr "Le format pour le fichier ini est"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, fuzzy, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "Paramètre nommé #<%s> non défini"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr "Erreur interne: Ne peut assigner #<%s>"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "La queue n'est pas vide après changement d'outil"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "Impossible d'ouvrir le fichier de paramètres:'%s'"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 #, fuzzy
 msgid "Parameter file name is missing"
 msgstr "Fichier de paramètres %s"
@@ -1473,7 +1473,8 @@ msgid "Negative spindle speed used"
 msgstr "Utilisation d'une vitesse de broche négative"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "Utilisation d'un index d'outil négatif"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1861,17 +1862,17 @@ msgstr "R inférieur à U dans un cycle dans le plan VW"
 msgid "R less than V in cycle in UW plane"
 msgstr "R inférieur à V dans un cycle dans le plan UW"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "ERREUR: '%s' n'est pas un type de sonde valide\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "ERREUR: aucun nom de pin/signal/paramètre\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
@@ -1879,8 +1880,7 @@ msgstr ""
 "ERREUR: l'option -s requiert un type de sonde et un nom de pin/signal/"
 "paramètre\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "HalMeter"
 
@@ -1892,27 +1892,27 @@ msgstr "_Sélectionner"
 msgid "E_xit"
 msgstr "Quitter"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "Choisir l'item à mesurer"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr " _Pins "
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr " _Signaux "
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr " Para_mètres "
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr " Fermer"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
@@ -1920,67 +1920,89 @@ msgstr ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "Ouvrir un fichier de configuration:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Annuler"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "Ouvrir..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Ouvrir un fichier de configuration:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "Enregistrer"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "_Ouvrir la configuration..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "Enregi_strer la configuration..."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "Ouvrir un fichier de données..."
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "Enregistrer d_ans un fichier de données"
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "_Quitter"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "_A propos de Halscope"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "_Fichier"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "Aide"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "Oscilloscope HAL"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "Canal sélectionné"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "Mode \"Run\""
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "Trigger"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "Vertical"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1988,39 +2010,40 @@ msgstr "Vertical"
 msgid "Stop"
 msgstr "Stopper"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "Normal"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "Simple"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "Boucle"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "Zoom"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr " Pos "
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "----- Échantil.\n"
 "à ---- kHz"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "Composant temps réel non chargé"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -2046,11 +2069,39 @@ msgstr ""
 "ou\n"
 "Cliquer 'Quitter' pour sortir de HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "Quitter"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "Fonction temps réel non liée"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -2072,11 +2123,11 @@ msgstr ""
 "ou\n"
 "Cliquer 'Quitter' pour sortir de HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "Sélectionner un taux d'échantillonnage"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
@@ -2086,94 +2137,70 @@ msgstr ""
 "ou\n"
 "Cliquer 'Quitter' pour sortir de HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr "Thread:"
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr "Période d'échantillonnage:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr "Taux d'échantillonnage:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr "Thread"
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "Période"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "Multiplicateur:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr "Durée d'enregistrement"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d échantillons (1 canal)"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d échantillons (2 canaux)"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d échantillons (4 canaux)"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d échantillons (8 canaux)"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d échantillons (16 canaux)"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "Quitter"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr "Thread temps réel non lancé"
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2197,15 +2224,15 @@ msgstr ""
 "ou\n"
 "Cliquer 'Quitter' pour sortir de HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr "Choisir le fichier dans lequel écrire:"
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr "Pas assez de canaux"
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
@@ -2215,7 +2242,7 @@ msgstr ""
 "contenir tous les canaux validés.  Réduire\n"
 "l'enregistrement supportera plus de canaux."
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
@@ -2224,7 +2251,7 @@ msgstr ""
 "%s\n"
 "par div"
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
@@ -2233,27 +2260,35 @@ msgstr ""
 "%s échantil.\n"
 "à %s"
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
-msgstr "ns"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
-msgstr "us"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
-msgstr "ms"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
-msgstr "s"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2267,17 +2302,17 @@ msgstr "s"
 #: src/emc/usr_intf/pncconf/mesa1.glade:460
 #: src/emc/usr_intf/pncconf/mesa1.glade:473
 msgid "Hz"
-msgstr "Hz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
-msgstr "kHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
-msgstr "MHz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
+msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
@@ -2286,24 +2321,25 @@ msgstr ""
 "Offset\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "Gain"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr "Pos"
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr "Échelle"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
@@ -2312,15 +2348,11 @@ msgstr ""
 "Offset\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr "Canal Off"
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "Ajuster l'offset"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
@@ -2329,35 +2361,19 @@ msgstr ""
 "Ajuster l'offset vertical\n"
 "pour le canal %d."
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "Ajuster l'offset"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr "AC Couplé"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Annuler"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr "Trop de canaux"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2369,21 +2385,7 @@ msgstr ""
 "Soit désactiver un ou plusieurs canaux, soit\n"
 "raccourcir la durée d'enregistrement"
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr "Sélectionner le canal source"
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
@@ -2392,29 +2394,33 @@ msgstr ""
 "Sélectionner la pin, signal, ou paramètre\n"
 "qui sera la source du canal %d."
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "Sélectionner le canal source"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "Pins"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "Signaux"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "Paramètres"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr "Descendant"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr "Montant"
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
@@ -2422,7 +2428,7 @@ msgstr ""
 "Source\n"
 "Sans"
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
@@ -2431,117 +2437,118 @@ msgstr ""
 "Source\n"
 "Canal %2d"
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "Auto"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr "Forcer"
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr "Niveau"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr "Trigger Source"
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr "Sélectionner le canal de déclenchement."
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "Trigger Source"
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr "Canal"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr "Source"
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, fuzzy, c-format
 msgid "fault %d during orient in progress"
 msgstr "prise d'origine déjà en cours"
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr "mouvement G38.4 terminé sans quitter le contact."
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr "mouvement G38.2 terminé sans obtenir le contact."
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+#, fuzzy
+msgid "Probe tripped during non-probe move."
 msgstr ""
 "La sonde à touché pendant une commande MDI ne faisant pas appel à elle."
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr "La sonde à touché pendant un mouvement de prise d'origine."
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 #, fuzzy
 msgid "Probe tripped during a joint jog."
 msgstr "La sonde à touché pendant un mouvement à la manivelle."
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 #, fuzzy
 msgid "Probe tripped during a coordinate jog."
 msgstr "La sonde à touché pendant un mouvement à la manivelle."
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr "mouvement stoppé par enable input"
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, fuzzy, c-format
 msgid "spindle %d amplifier fault"
 msgstr "amplificateur jointure %d en défaut"
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "jointure %d en erreur sur un contact de limite"
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "amplificateur jointure %d en défaut"
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "Erreur de suivi jointure %d:"
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, fuzzy, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr "La jointure %d à dépassé la limite logicielle positive"
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 #, fuzzy
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 "La prise d'origine de toutes les jointures doit être faite avant d'aller en "
 "mode teleop"
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, fuzzy, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr "La jointure %d à dépassé la limite logicielle positive"
@@ -2622,182 +2629,182 @@ msgstr ""
 "La prise d'origine de toutes les jointures doit être faite avant d'aller en "
 "mode coordonné"
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr "Jog d'articulation impossible quand elle n'est pas activée."
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr "Jog d'articulations impossible avant la prise d'origine."
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr "Jog d'articulation impossible avant la prise d'origine."
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr "doit être activé en mode coordonné pour mouvement linéaire"
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr "mouvement linéaire impossible avec des limites dépassées"
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, fuzzy, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr "mouvement linéaire impossible avec des limites dépassées"
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr "doit être activé en mode coordonné pour un mouvement circulaire"
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr "mouvement circulaire impossible avec des limites dépassées"
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, fuzzy, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr "mouvement circulaire impossible avec des limites dépassées"
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr "MOTION: can't STEP while already executing"
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr "ne peut pas activer le mouvement, l'entrée activation est false"
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr "doit être en mode jointure pour la prise d'origine"
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr "séquence de prise d'origine déjà en cours"
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr "doit être en mode jointure ou désactivé pour effacer l'origine"
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr "impossible d'effacer l'origine pendant la prise d'origine, jointure %d"
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr "impossible d'effacer l'origine pendant un mouvement, jointure %d"
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, fuzzy, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr "Jog d'articulation impossible quand elle n'est pas activée."
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr "impossible d'effacer l'origine d'une jointure inactive, jointure %d"
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr "impossible d'effacer l'origine de la jointure invalide %d (max %d)"
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr "doit être activé, en mode coordonné pour un mouvement avec sonde"
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr "mouvement avec sonde impossible avec des limites dépassées"
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr "la sonde est déjà clair au début du mouvement G38.4 ou G38.5"
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr "la sonde est enfoncée au début du mouvement G38.2 ou G38.3"
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr "ne peut pas ajouter de mouvement avec sonde"
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 "doit être activé, en mode coordonné pour un mouvement de taraudage rigide"
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 "ne peut pas lancer un mouvement de taraudage rigide avec des limites "
 "dépassées"
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, fuzzy, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 "ne peut pas lancer un mouvement de taraudage rigide avec des limites "
 "dépassées"
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, fuzzy, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr "Tentative d'élever un nombre négatif à une puissance non entière"
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr "jointure %d: trop d'entrées de compensation"
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr "jointure %d: les valeurs de compensations doivent augmenter"
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr "commande %d inconnue"
@@ -2888,27 +2895,27 @@ msgstr "MOTION:défaut hal_exit(), a retourné %d\n"
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr "MOTION: défaut emcmot_hal_data malloc\n"
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, fuzzy, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr "MOTION: défaut joint %d pin/param export\n"
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr "MOTION: défaut joint %d pin/param export\n"
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 #, fuzzy
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr "MOTION: défaut init_hal_io()\n"
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, fuzzy, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr "MOTION: défaut joint %d pin/param export\n"
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, fuzzy, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr "MOTION: défaut joint %d pin/param export\n"
@@ -3084,7 +3091,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr "Ok"
 
@@ -3174,19 +3181,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "Oui"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 #, fuzzy
 msgid "No"
 msgstr "Aucun"
@@ -3240,7 +3247,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -3259,7 +3266,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "Éditeur"
 
@@ -3274,7 +3281,6 @@ msgid "Config"
 msgstr "Configuration HAL"
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 msgid "Preview"
 msgstr "Parcours d'outil"
 
@@ -3713,7 +3719,7 @@ msgid "Edit mode..."
 msgstr "Éditer.."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "Effacer"
 
@@ -3722,7 +3728,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "Ajouter"
 
@@ -3733,6 +3739,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "Modifier"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Annuler"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3922,7 +3946,7 @@ msgid "Parameter"
 msgstr "Paramètres"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -4113,7 +4137,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "Manuel"
 
@@ -4199,11 +4222,13 @@ msgid "Delete section"
 msgstr "Position relative"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 #, fuzzy
 msgid "Move Down"
 msgstr "Bas"
@@ -4728,6 +4753,7 @@ msgid "Exit"
 msgstr "Quitter"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "Éditer"
 
@@ -4770,7 +4796,6 @@ msgid "Renumber File..."
 msgstr "Re-numéroter le fichier..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "Réglages"
 
@@ -5062,15 +5087,15 @@ msgstr "Arborescence"
 msgid "Test HAL command :"
 msgstr "Tester une commande HAL :"
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr "Charger une liste de watch"
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr "Enregistrer liste de watch courante"
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "Ces commandes peuvent être testées ici mais ne seront PAS enregistrées"
 
@@ -5198,11 +5223,11 @@ msgstr "DIRECTION"
 msgid "SIZE :"
 msgstr "TAILLE:"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr "Erreurs de LinuxCNC"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 #, fuzzy
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
@@ -5211,12 +5236,12 @@ msgstr ""
 "LinuxCNC s'est terminé avec une erreur.  Si vous rapportez le problème, "
 "merci d'inclure toutes les informations suivantes dans votre message."
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 #, fuzzy
 msgid "Create Report File"
 msgstr "Créer ou éditer"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "Fermer"
 
@@ -5295,7 +5320,7 @@ msgstr "Ajuster l'offset d'outil"
 msgid "Tool:"
 msgstr "Outil:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Tous les fichiers"
@@ -5362,18 +5387,18 @@ msgstr "Unités"
 msgid "auto"
 msgstr "auto"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "pouces"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5531,7 +5556,7 @@ msgstr "jointure"
 msgid "world"
 msgstr "global"
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "origine"
 
@@ -5612,16 +5637,15 @@ msgstr "Vérifier"
 msgid "Optional Stop"
 msgstr "Arrêt optionnel"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "Choisir police"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "Police"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "Taille"
 
@@ -5730,7 +5754,7 @@ msgid "Coordinate System Control Window"
 msgstr "Fenêtre de contrôle des coordonnées système"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "Axe"
 
@@ -6286,9 +6310,9 @@ msgstr "enlever"
 msgid "move"
 msgstr "déplacer"
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr "Personnalisé"
 
@@ -6308,8 +6332,8 @@ msgstr "Trouve plusieurs occurrences pour"
 msgid "using path"
 msgstr "utiliser le chemin"
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr "Attention"
 
@@ -6382,119 +6406,119 @@ msgstr "fichier ini"
 msgid "not found"
 msgstr "introuvable"
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr "truetype-tracer v4 trouvé -OK"
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr "Note truetype-tracer v4 est requis"
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr "Note: truetype-tracer v4 est requis"
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr "ngcgui_app.tcl doit être chargé avant"
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr "Crée un fichier sous-programme avec truetype-tracer (V4.requis)"
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr "problème avec"
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr "Aucune entrée pour"
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr "mauvaise version de truetype-tracer"
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr "Pas accessible en écriture, en utilisant"
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr "and setting expandsub"
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr "Texte"
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr "Graduation"
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr "Aucun"
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr "Subdivision"
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr "défaut"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr "Mode"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr "normal"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr "date"
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr "nom de police"
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr "Switches"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr "Unicode"
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr "Rotation permise"
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr "Crée un sous-fichier compatible ngcgui dans nouvel onglet"
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr "Texte Null"
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr "Utilise la font par défaut avec truetype-tracer"
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 msgid "no such file"
 msgstr "aucun fichier"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr "fichier illisible"
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr "Créer un nouvel onglet"
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
@@ -6502,27 +6526,27 @@ msgstr ""
 "nécessite une commande inifindall\n"
 "depuis axis.py (LinuxCNC 2.5) ou"
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr "illisible"
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr "Inattendu: startups multiples pour ngcgui"
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 msgid "LinuxCNC"
 msgstr "LinuxCNC"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr "pour LinuxCNC 2.5.xxx. Ne pas inclure tkapp.py dans le fichier ini"
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 msgid "LinuxCNC version"
 msgstr "LinuxCNC version"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr "pour LinuxCNC 2.5.xxx. Ne pas inclure tkapp.py dans le fichier ini"
 
@@ -7195,34 +7219,34 @@ msgstr ""
 msgid "Open a Menu"
 msgstr "Ouvrir un nouveau sous-fichier"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Outil %d inconnu"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Pas d'outil"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Outil %(tool)d, offset %(zo)g, diamètre %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "Outil %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "Filtrage..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "Le filtrage a échoué"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
@@ -7231,12 +7255,12 @@ msgstr ""
 "Le programme %(program)r s'est arrêté avec le code %(code)d.  Si des "
 "messages ont été produits, ils sont ci-dessous:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "Erreur de G-code en %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7245,130 +7269,128 @@ msgstr ""
 "Vers la ligne %(seq)d de %(f)s:\n"
 "%(error_str)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "Continu"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr "T    Table d'outils"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "en"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr "rayon"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr "diamètre"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr "°"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "Décalage origine pièce"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr "porte-pièce"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr "la pièce"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "Nom:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "Taille:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "Outil N°:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "Distance en vitesse rapide:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "Distance en vitesse travail:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "Distance totale:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "Run time:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "Limites X:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Limites Y:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Limites Z:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "Limites A:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "Limites B:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "Limites C:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "Le programme dépasse la limite mini sur l'axe %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "Le programme dépasse la limite maxi sur l'axe %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "Le programme excède les limites machine"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Exécuter tout de même"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "Aucun fichier chargé"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "produit depuis %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
@@ -7377,45 +7399,45 @@ msgstr ""
 "%(size)s octets\n"
 "%(lines)s lignes de gcode"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr "% 1f minutes"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr "%d secondes"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%(a)f à %(b)f = %(diff)f %(units)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "Propriétés du G-code"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "Tous les fichiers d'usinage"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "Fichiers rs274ngc"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 "les axes n'acceptent pas de commande à distance pendant leur fonctionnement"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 #, fuzzy
 msgid "File not Writable:"
 msgstr "fichier illisible"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7426,66 +7448,66 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Custom Grid"
 msgstr "Personnalisé"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 #, fuzzy
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 "Les axes sont déjà référencés, vous êtes sûr de vouloir relancer une prise "
 "d'origine générale ?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, fuzzy, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr "doit être en mode jointure pour la prise d'origine"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 #, fuzzy
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 "Cet axe est déjà référencé, êtes vous sûr de vouloir relancer une prise "
 "d'origine ?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 #, fuzzy
 msgid "Touch Off (system)"
 msgstr "Toucher"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "Coordonnée %s relative à %%s:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, fuzzy, python-format
 msgid "Tool %s TouchOff"
 msgstr "Toucher"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "Erreur d'enregistrement du fichier"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7494,7 +7516,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7503,7 +7525,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7512,91 +7534,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "Jointure:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "Prise d'origine générale"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, fuzzy, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "Prise d'origine machine générale [Ctrl+origine]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "Prise d'origine générale"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "Annulation OM de tous les axes"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "Jointure:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "Emplacement de l'origine mac_hine:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, fuzzy, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "Annulation OM de l'axe _%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "Démarrer depuis ici"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "Erreur dans ~/.axisrc"
 
@@ -7909,11 +7931,13 @@ msgid "_Properties..."
 msgstr "_Propriétés..."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "Éditer la _table d'outils"
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+#, fuzzy
+msgid "Reload tool _data"
 msgstr "Recharger la ta_ble d'outils"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8242,11 +8266,11 @@ msgstr "Sauter ou non les lignes avec '/' [Alt-M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "Avec ou sans pause optionnelle [Alt-M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "Zoom plus [+]"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "Zoom moins [-]"
 
@@ -8425,9 +8449,10 @@ msgstr "Correction vitesse de broche:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr "%"
 
@@ -8479,7 +8504,7 @@ msgid "Position:"
 msgstr "Position:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr "Machine"
 
@@ -8585,22 +8610,21 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Mouvement temporaire hors limites [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 #, fuzzy
 msgid "Follow System Theme"
 msgstr "Suit le thème du système\n"
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "Broche en sens horaire"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "Broche en sens anti-horaire"
@@ -8943,6 +8967,8 @@ msgid "."
 msgstr "."
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8952,43 +8978,88 @@ msgstr "."
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr "0"
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr "3"
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr "2"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr "1"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr "6"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr "5"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr "4"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr "9"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr "8"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr "7"
 
@@ -9043,7 +9114,6 @@ msgid "label26"
 msgstr "label26"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr "<b>Broche</b>"
 
@@ -9213,7 +9283,6 @@ msgstr ""
 "3"
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr "Statut:"
 
@@ -9272,8 +9341,8 @@ msgstr "<b>Options d'affichage</b>"
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr "pouce"
@@ -9409,10 +9478,10 @@ msgid "Stepconf"
 msgstr "Pas à pas"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9433,13 +9502,13 @@ msgid "Parallel Port 1"
 msgstr "Réglage port parallèle"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 #, fuzzy
 msgid "Parallel Port 2"
 msgstr "Réglage port parallèle"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "Options des interfaces graphiques"
@@ -9449,235 +9518,286 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Bouton X à zéro"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Axe"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Axe"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Axe"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Axe"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Axe"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Axe"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "Spindle"
 msgstr "Broche"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr "Gecko 201"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr "Gecko 202"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr "Gecko 203v"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr "Gecko 210"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr "Gecko 212"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr "Gecko 320"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr "Gecko 540"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr "L297"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr "PMDX-150"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr "Sherline"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr "Xylotex 8S-3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr "Parker-Compumotor oem750"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr "JVL-SMD41 ou 42"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr "Hobbycnc Pro Chopper"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr "Keling 4030"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr "Pas en X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr "Direction X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr "Pas en Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr "Direction Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr "Pas en Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr "Direction Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr "Pas en A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr "Direction A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "Pas en X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "Direction X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "Pas en X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "Direction X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "X2 Tandem StepGen"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "Direction X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "X2 Tandem StepGen"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Direction Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr "Marche broche"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr "PWM broche"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr "Frein de broche"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr "Gouttelettes"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr "Arrosage"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr "Sortie arrêt d'urgence"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr "Activation ampli (enable)"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr "Pompe de charge"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr "Sortie numérique 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr "Sortie numérique 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr "Sortie numérique 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr "Sortie numérique 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+#, fuzzy
+msgid "Plasma Ohmic Enable"
+msgstr "Validation POT"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9688,255 +9808,350 @@ msgstr "Sortie numérique 3"
 msgid "Unused"
 msgstr "Inutilisé"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr "Entrée A/U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr "Entrée palpeur"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr "Index broche"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr "Phase A broche"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr "Phase B broche"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr "Origine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr "Origine Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr "Origine Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr "Origine A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "Origine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "Origine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Origine X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Origine Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr "Limite mini + origine machine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr "Limite mini + origine machine Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem X"
+msgstr "Limite mini + origine machine X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem Y"
+msgstr "Limite mini + origine machine Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr "Limite mini + origine machine Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr "Limite mini + origine machine A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home U"
 msgstr "Limite mini + origine machine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home V"
 msgstr "Limite mini + origine machine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr "Limite maxi + origine machine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr "Limite maxi + origine machine Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem X"
+msgstr "Limite maxi + origine machine X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem Y"
+msgstr "Limite maxi + origine machine Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr "Limite maxi + origine machine Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr "Limite maxi + origine machine A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home U"
 msgstr "Limite maxi + origine machine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home V"
 msgstr "Limite maxi + origine machine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr "Les deux limites + origine machine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr "Les deux limites + origine machine Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr "Les deux limites + origine machine Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr "Les deux limites + origine machine A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home U"
 msgstr "Les deux limites + origine machine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home V"
 msgstr "Les deux limites + origine machine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Les deux limites + origine machine X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Les deux limites + origine machine Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr "Limite mini X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr "Limite mini Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem X"
+msgstr "Limite mini X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem Y"
+msgstr "Limite mini Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr "Limite mini Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr "Limite mini A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit U"
 msgstr "Limite mini X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit V"
 msgstr "Limite mini X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr "Limite maxi X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr "Limite maxi Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem X"
+msgstr "Limite maxi X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem Y"
+msgstr "Limite maxi Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr "Limite maxi Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr "Limite maxi A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit U"
 msgstr "Limite maxi X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit V"
 msgstr "Limite maxi X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr "Toutes les limites X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr "Toutes les limites Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr "Toutes les limites Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr "Toutes les limites A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit U"
 msgstr "Toutes les limites X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit V"
 msgstr "Toutes les limites X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Toutes les limites X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Toutes les limites Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr "Toutes les limites"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr "Toutes les origines"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits + homes"
 msgstr "Toutes les limites + origines"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr "Entrée numérique 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr "Entrée numérique 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr "Entrée numérique 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr "Entrée numérique 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "Bas"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Broche sens horaire"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -9946,9 +10161,9 @@ msgstr ""
 "Le fichier custom.clp existant sera renommé custom_backup.clp \n"
 "Tout autre fichier custom_backup.clp précédent sera perdu."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9962,8 +10177,8 @@ msgstr ""
 "\n"
 "Etes-vous sûr de ce choix ? "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
@@ -9971,7 +10186,7 @@ msgstr ""
 "Pour ce programme, vous devez indiquer une broche d'entrée pour l'arrêt "
 "d'urgence dans la page de réglage du port parallèle."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
@@ -9982,19 +10197,19 @@ msgstr ""
 "Le fichier custom.clp existant sera renommé custom_backup.clp \n"
 "Tout autre fichier custom_backup.clp précédent sera perdu."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr "Quitter Stepconf et perdre les modifications ?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
@@ -10002,8 +10217,8 @@ msgstr ""
 "Vous utilisez une version de LinuxCNC temps réel simulé, / les réglages du "
 "matériel n'y sont pas disponibles."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, fuzzy, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -10019,16 +10234,16 @@ msgstr ""
 "C'est peut-être provoqué par une mise à jour de l'OS qui empêche désormais "
 "le chargement automatique du kernel RTAI.\n"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr "ma-machine"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr "Le fichier %r a été modifié depuis qu'il a été écrit par Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
@@ -10036,28 +10251,28 @@ msgstr ""
 "Enregistrer cette configuration va écraser les modifications faites à "
 "l'extérieur de Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr "Continuer ?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr "yY"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr "lancer %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr ""
 "Lanceur de bureau pour LinuxCNC avec la configuration faite par Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -10065,34 +10280,34 @@ msgid ""
 "{}"
 msgstr "Sélecteur de configuration de LinuxCNC "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr "Autre"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr "Test axe %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr "deg / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr "degré / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr "deg"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -10107,8 +10322,8 @@ msgstr "deg"
 msgid "mm / s"
 msgstr "mm / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -10123,13 +10338,13 @@ msgstr "mm / s"
 msgid "mm / s²"
 msgstr "mm / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr "pouces / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr "pouces / s²"
 
@@ -10138,19 +10353,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "Fichiers de configuration 'stepconf' de LinuxCNC "
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr "Modifier configuration existante"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr "degrés / tour"
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr "Pas / degré"
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10162,7 +10377,7 @@ msgstr "Pas / degré"
 msgid "mm / rev"
 msgstr "mm / tour"
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10173,28 +10388,28 @@ msgstr "mm / tour"
 msgid "Steps / mm"
 msgstr "Pas / mm"
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr "tour / pouce"
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr "Pas / pouce"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, fuzzy, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr "# Généré par Stepconf le %s"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10202,71 +10417,71 @@ msgstr "# Si vous modifiez ce fichier, il sera"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr "# écrasé quand vous relancerez Stepconf"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr "# ajoutez ici les commandes MDI halui (maximum 64) "
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr "# **** Paramètre -START pour l'A/U externe du programme ladder ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr "# **** Paramètre -END pour l'A/U externe du programme ladder ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 "# Chargement de Classicladder avec modbus maître inclus (La GUI doit tourner "
 "avec Modbus)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 "# Chargement de Classicladder sans GUI (peut recharger la GUI LADDER dans la "
 "GUI AXIS)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr "Inclure son propre panneau PyVCP ici.\n"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr "# Ces fichiers sont chargés après la GUI, dans leur ordre d'apparition"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr "# **** Réglage de l'affichage de vitesse broche avec pyvcp -START ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 "# **** Utiliser la vitesse de broche actuelle depuis le codeur de broche"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 #, fuzzy
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr "# **** filtre passe-bas sur la vitesse de broche"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 #, fuzzy
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
@@ -10275,17 +10490,17 @@ msgstr ""
 "# **** utilisation du composant absolu pour enlever le signe si vitesse "
 "broche avec signe"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 "# **** La vitesse ACTUELLE est en tr/s et non en tr/mn, elle peut, si "
 "besoin, être mise à l'échelle."
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr "# **** ajuster vitesse max broche selon l'indicateur de vitesse ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
@@ -10293,22 +10508,28 @@ msgstr ""
 "# **** Utilise la vitesse de broche COMMANDÉE depuis LinuxCNC puisqu'aucun "
 "codeur de broche n'a été spécifié"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, fuzzy, python-format
 msgid "# Include your %s HAL commands here"
 msgstr "# Inclure vos commandes HAL personnalisées ici"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr "# Ce fichier ne sera pas écrasé si vous relancez Stepconf"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
 msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+#, fuzzy
+msgid "# Include your custom HAL commands here"
+msgstr "# Inclure vos commandes HAL personnalisées ici"
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
 #, fuzzy
@@ -10379,11 +10600,16 @@ msgstr "Configuration de LinuxCNC pour moteurs pas à pas"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr "label"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "Arrière"
 
@@ -10436,17 +10662,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
 msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
-msgstr "ns"
 
 #: src/emc/usr_intf/stepconf/base.glade:209
 msgid "Step _Time:"
@@ -10811,56 +11026,155 @@ msgstr "Utiliser vitesse-broche-atteinte:"
 msgid "Scale %"
 msgstr "Echelle %"
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr "Axis"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+#, fuzzy
+msgid "0.000"
+msgstr ".0001"
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Offset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Offset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+#, fuzzy
+msgid "Alignment Laser:"
+msgstr "Alignement courant"
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "A/U engagé"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+#, fuzzy
+msgid "4:3"
+msgstr "47:"
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Bouton gauche"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "Mode"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 #, fuzzy
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 "Dialogue à l'écran pour\n"
 "le changement d'outil"
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr "Inclure l'interface utilisateur Halui"
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr "Inclure un panneau PyVCP personnalisé"
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr "Programme vierge"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 msgid "Spindle speed display  "
 msgstr "Afficheur vitesse broche"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr "Programme personnalisé existant"
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr "Inclure les connections à HAL"
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10872,69 +11186,69 @@ msgstr ""
 "panneau\n"
 "simple"
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 #, fuzzy
 msgid "Set pyVCP options"
 msgstr "Options de géomètrie"
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr "Inclure l'API _Classicladder"
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr "Nombre de broches d'entrée numérique:"
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr "Nombre de broches de sortie numérique:"
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr "Nombre de broches d'entrée analogique (s32)"
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr "Nombre de broches de sortie analogique (s32)"
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr "Nombre de broches d'entrée analogique (float)"
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr "Nombre de broches de sortie analogique (float)"
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr "Nombre de broches externes"
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr "Inclure le support modbus maître"
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr "Programme ladder vierge"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr "Programme ladder d'arrêt d'urgence"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr "Programme Modbus série"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
@@ -10943,10 +11257,14 @@ msgstr ""
 "Editer prog.\n"
 "ladder"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "Echantillon d'options"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr "Inclure l'interface utilisateur Halui"
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10964,16 +11282,169 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+#, fuzzy
+msgid "NUM"
+msgstr "NML"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+#, fuzzy
+msgid "10"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+#, fuzzy
+msgid "11"
+msgstr "11:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+#, fuzzy
+msgid "12"
+msgstr "2"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+#, fuzzy
+msgid "13"
+msgstr "13:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+#, fuzzy
+msgid "14"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+#, fuzzy
+msgid "15"
+msgstr "15:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+#, fuzzy
+msgid "16"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+#, fuzzy
+msgid "17"
+msgstr "17:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+#, fuzzy
+msgid "18"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+#, fuzzy
+msgid "19"
+msgstr "19:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+#, fuzzy
+msgid "20"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+#, fuzzy
+msgid "IDX"
+msgstr "PID"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+#, fuzzy
+msgid "32"
+msgstr "3"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+#, fuzzy
+msgid "64"
+msgstr "6"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "Mode"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10983,10 +11454,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr ""
@@ -11017,15 +11488,6 @@ msgstr "_:"
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
 msgstr " à "
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
-msgstr "s"
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
 #: src/emc/usr_intf/stepconf/axisy.glade:402
@@ -11241,39 +11703,39 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 #, fuzzy
 msgid "Specific Help page is unavailable\n"
 msgstr "Page d'aide indisponible\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr "Pages d'aide"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, fuzzy, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11285,11 +11747,11 @@ msgstr ""
 "PNCconf utilisera un micro-logiciel échantillon,\n"
 "les tests en direct ne seront pas possible."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "Fichiers de configuration 'PNCconf' pour LinuxCNC "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
@@ -11299,11 +11761,11 @@ msgstr ""
 "ancienne de PNCConf, impossible de continuer.\n"
 "."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11313,33 +11775,33 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 #, fuzzy
 msgid "Discovery is  unavailable\n"
 msgstr "Nom de dispositif indisponible\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr "Recherche informations dispositif USB"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr "La page du dispositif USB est indisponible\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr "Nom de broche indisponible\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr "Nom de dispositif indisponible\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr "Aucune règle créée par Pncconf n'a été trouvée\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11353,7 +11815,7 @@ msgstr ""
 "mais si vous changez ces options plus tard -comme le retour de vitesse "
 "broche- la connexion ne sera plus à jour"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
@@ -11363,44 +11825,44 @@ msgstr ""
 "Le fichier pyvcp-panel.xml sera renommé et ajouté au dossier 'backup'. \n"
 "Cliquez 'programme utilisateur existant' pour éviter cet avertissement."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr "Voie inutilisée"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 "Il est impossible d'avoir simultanément les signaux PWM et de pas à pas pour "
 "contrôler la broche\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr "Vous avez omis de déclarer un signal PWM ou pas à pas pour l'axe %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 "Vous avez omis de déclarer un signal de codeur/résolveur pour le servo de "
 "l'axe %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 "Vous avez omis de déclarer un signal PWM ou un signal pas à pas pour l'axe "
 "%s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 "Vous ne pouvez pas avoir simultanément des signaux PWM et de pas à pas pour "
 "l'axe %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
@@ -11409,19 +11871,19 @@ msgstr ""
 "Si un tandem de moteur pas à pas est utilisé, vous devez choisir un stepgen "
 "maître pour l'axe %s \n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr "Touchy requiert un signal de départ cycle externe\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr "Touchy requiert un signal d'abandon externe\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr "Touchy requiert un signal d'avance par pas externe\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
@@ -11429,7 +11891,7 @@ msgstr ""
 "Touchy requiert le signal du codeur de manivelle multi-axes sur la page "
 "mesa\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
@@ -11437,7 +11899,7 @@ msgstr ""
 "Touchy requiert qu'une 'Manivelle de jog externe' soit sélectionnée sur la "
 "page des contrôles externes\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
@@ -11445,7 +11907,7 @@ msgstr ""
 "Touchy requiert que la manivelle externe soit en mode 'Manivelle partagée' "
 "sur la page des contrôles externes\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
@@ -11453,7 +11915,7 @@ msgstr ""
 "Touchy requiert que la case 'Incréments de manivelle sélectionnables' soit "
 "décochée sur la page des contrôles externes\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
@@ -11461,7 +11923,7 @@ msgstr ""
 "La carte fille 7i29 requiert des générateurs de type PWM et une fréquence "
 "PWM de base de 20 kHz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
@@ -11469,7 +11931,7 @@ msgstr ""
 "La carte fille 7i30 requiert des générateurs de type PWM et une fréquence "
 "PWM de base de 20 kHz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
@@ -11477,7 +11939,7 @@ msgstr ""
 "La carte fille 7i33 requiert des générateurs de type PDM et une fréquence "
 "PDM de base de 6 MHz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
@@ -11485,7 +11947,7 @@ msgstr ""
 "La carte fille 7i40 requiert des générateurs de type PWM et une fréquence "
 "PWM de base de 50 kHz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
@@ -11493,66 +11955,66 @@ msgstr ""
 "La carte fille 7i48 requiert des générateurs de type UDM et une fréquence "
 "PWM de base de 24 kHz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr "Rapport de réduction des pignons"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr "Rapport de réduction"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr "Pas de la vis"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr "Filets de la vis par pouce"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr "("
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr " / mn"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr " / s²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 msgid " / Step"
 msgstr " / pas"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 msgid "Steps / "
 msgstr "Pas / "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr " / impulsion codeur"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr "Impulsions de codeur / "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 msgid "Resolver Scale:"
 msgstr "Échelle codeur:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Calcul d'échelle d'axe"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr "Calcul d'échelle d'axe"
 
@@ -11571,19 +12033,22 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr "Page de recherche PCI indisponible\n"
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr " / mn"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr "mm / mn"
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11593,7 +12058,7 @@ msgstr ""
 "Choisir le type de carte, de micro-logiciel, de composants et presser le "
 "bouton 'Accepter les changements de composants'"
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
@@ -11601,7 +12066,7 @@ msgstr ""
 "La carte Mesa0 choisie est différente de celle affichée.\n"
 "Presser le bouton 'Accepter les changements de composants'"
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11611,7 +12076,7 @@ msgstr ""
 "Choisir le type de carte, de micro-logiciel, de composants et presser le "
 "bouton 'Accepter les changements de composants'"
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
@@ -11619,19 +12084,19 @@ msgstr ""
 "La carte Mesa1 choisie est différente de celle affichée.\n"
 "Presser le bouton 'Accepter les changements de composants'"
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 "Pour ce programme ladder, vous devez indiquer une broche d'entrée pour "
 "l'arrêt d'urgence."
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 "Pour ce programme ladder, vous devez indiquer une broche d'entrée pour le "
 "palpeur."
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11645,8 +12110,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr "# Généré par PNCconf le %s"
@@ -11662,87 +12127,92 @@ msgstr "LinuxCNC version"
 msgid "# overwritten when you run PNCconf again"
 msgstr "# écrasé quand vous relancerez PNCconf"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr "#connections de signaux divers"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr "#  ---signaux HALUI---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr "#  ---signaux pompe de charge---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr "#  ---signaux d'arrosage---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr "#  ---signal de sonde---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr "#  ---signaux de boutons de jog---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr "# ---signaux de boutons de jog sur dispositif USB---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr "#  ---signaux manivelle---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr "#  ---signaux contrôle mouvement---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr "#  ---signaux entrée / sortie numérique---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr "#  ---signaux d'A/U---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr "#  ---signaux changeur manuel d'outil---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+#, fuzzy
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr "#  ---signaux changeur manuel d'outil---"
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr "#  ---signaux pour changeur d'outil personnalisé---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 "#  --- signaux Classicladder programme de toucher automatique pour l'axe Z---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 "# Ces fichiers sont chargés après gladeVCP, dans leur ordre d'apparition"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr "# _NE PAS_ inclure vos commandes HAL ici"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr "# Placez vos commandes HAL personnalisées dans custom_gvcp.hal"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr "# **** Réglage de vitesse broche affiché avec gladevcp ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr "# **** Boutons de réglage GLADE MDI ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
@@ -11750,89 +12220,90 @@ msgstr ""
 "# **** Bouton toucher de l'axe Z - requiert le programme de toucher de "
 "classicladder ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr "# Placez vos commandes HAL personnalisées dans custom_postgui.hal"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 "# Les commandes de ce fichier seront exécutées après le chargement de la GUI"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr "# **** Réglage de vitesse broche affiché avec pyvcp -END ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr "# Ce fichier ne sera pas écrasé si vous relancez PNCconf"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
 msgstr "# Ces commandes sont requises par la GUI Touchy"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
+#: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
 msgid "Generated by PNCconf at %s"
 msgstr "Généré par PNCconf le %s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
 msgid "configures LinuxCNC as:\n"
 msgstr "configurer LinuxCNC comme:\n"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
 msgid "type CNC\n"
 msgstr "type de CNC\n"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
 msgid "will be used as the frontend display"
 msgstr "sera utilisé en façade de l'affichage"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
 msgid " connector"
 msgstr " connecteur"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
 msgid "invrt"
 msgstr "Inverser"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
 #, python-format
 msgid "%(name)s Parport"
 msgstr "%(name)s Parport"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
 msgid "-> inverted"
 msgstr "-> inversé"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1059
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
 #, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr "pin# %(pinnum)d est connectée au signal d'entrée:'%(data)s' %(mesag)s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr "pin# %(pinnum)d est connectée au signal de sortie:'%(data)s' %(mesag)s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr "#  Utiliser la vitesse de broche actuelle depuis le codeur de broche"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 "#  les variations parasites de la vitesse de broche seront filtrées par un "
 "filtre passe-bas"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 "#  le signe de la vitesse de broche sera enlevé par un composant absolu"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 "#  La vitesse ACTUELLE est en tr/s et non en tr/mn elle doit être mise à "
@@ -11850,1484 +12321,1540 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 msgid "External Controls"
 msgstr "Contrôles externes"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 #, fuzzy
 msgid "Parallel Port"
 msgstr "Réglage port parallèle"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 #, fuzzy
 msgid "X Motor"
 msgstr "Inverser moteur"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "X Axis"
 msgstr "Axe X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 #, fuzzy
 msgid "Y Motor"
 msgstr "Inverser moteur"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Y Axis"
 msgstr "Axe Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 #, fuzzy
 msgid "Z Motor"
 msgstr "Inverser moteur"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Z Axis"
 msgstr "Axe Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 #, fuzzy
 msgid "A Motor"
 msgstr "Inverser moteur"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "A Axis"
 msgstr "Axe A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Arrêt de broche"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr "Inutilisé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr "Factice"
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr "8i20 Pilote Servo "
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr "Sortie POT"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
 msgstr "Validation POT"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
 msgid "POT Dir"
 msgstr "Direction POT"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Input"
 msgstr "Entrée GPIO"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Output"
 msgstr "Sortie GPIO"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO O Drain"
 msgstr "GPIO O Drain"
 
-#: src/emc/usr_intf/pncconf/private_data.py:113
+#: src/emc/usr_intf/pncconf/private_data.py:117
 #, fuzzy
 msgid "SSR Output"
 msgstr "Sortie"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-A"
 msgstr "Codeur quad.-A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-B"
 msgstr "Codeur quad.-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-I"
 msgstr "Codeur quad.-I"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-M"
 msgstr "Codeur quad.-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 0"
 msgstr "Codeur multiplexé-0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 1"
 msgstr "Codeur multiplexé-A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "muxed Enc I"
 msgstr "Codeur multiplexé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc M"
 msgstr "Codeur multiplexé-0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr "mux select"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr "Résolveur encoder 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr "Résolveur encoder 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr "Résolveur encoder 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr "Résolveur encoder 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr "Résolveur encoder 4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr "Résolveur encoder 5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step Gen-A"
 msgstr "Géné step-A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr "Géné dir-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr "Géné Step/Dir -C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr "Géné Step/Dir -D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr "Géné Step/Dir -E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr "Géné Step/Dir -F"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-P"
 msgstr "Géné Pulse Width-P"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-D"
 msgstr "Géné Pulse Width-D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-E"
 msgstr "Géné Pulse Width-E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 #, fuzzy
 msgid "PDM Gen-P"
 msgstr "Géné dir-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 #, fuzzy
 msgid "PDM Gen-D"
 msgstr "Géné dir-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 #, fuzzy
 msgid "PDM Gen-E"
 msgstr "Géné dir-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 #, fuzzy
 msgid "UDM -Up"
 msgstr "Up/Down Mode -Up"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 #, fuzzy
 msgid "UDM-Down"
 msgstr "Bas"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr "Moteur phase A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr "Moteur phase B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr "Moteur phase C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr "Moteur phase A Not"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr "Moteur phase B Not"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr "Moteur phase C Not"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr "Activation moteur"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr "Défaut moteur"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 #, fuzzy
 msgid "SSERIAL-P0-TX"
 msgstr "SMARTSERIAL-P0-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 #, fuzzy
 msgid "SSERIAL-P0-RX"
 msgstr "SMARTSERIAL-P0-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 #, fuzzy
 msgid "SSERIAL-P0-EN"
 msgstr "SMARTSERIAL-P0-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 #, fuzzy
 msgid "SSERIAL-P1-TX"
 msgstr "SMARTSERIAL-P1-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 #, fuzzy
 msgid "SSERIAL-P1-RX"
 msgstr "SMARTSERIAL-P1-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 #, fuzzy
 msgid "SSERIAL-P1-EN"
 msgstr "SMARTSERIAL-P1-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 #, fuzzy
 msgid "SSERIAL-P2-TX"
 msgstr "SMARTSERIAL-P2-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 #, fuzzy
 msgid "SSERIAL-P2-RX"
 msgstr "SMARTSERIAL-P2-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 #, fuzzy
 msgid "SSERIAL-P2-EN"
 msgstr "SMARTSERIAL-P2-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 #, fuzzy
 msgid "SSERIAL-P3-TX"
 msgstr "SMARTSERIAL-P3-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 #, fuzzy
 msgid "SSERIAL-P3-RX"
 msgstr "SMARTSERIAL-P3-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 #, fuzzy
 msgid "SSERIAL-P3-EN"
 msgstr "SMARTSERIAL-P3-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 #, fuzzy
 msgid "SSERIAL-P4-TX"
 msgstr "SMARTSERIAL-P4-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 #, fuzzy
 msgid "SSERIAL-P4-RX"
 msgstr "SMARTSERIAL-P4-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 #, fuzzy
 msgid "SSERIAL-P4-EN"
 msgstr "SMARTSERIAL-P4-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 #, fuzzy
 msgid "SSERIAL-P5-TX"
 msgstr "SMARTSERIAL-P5-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 #, fuzzy
 msgid "SSERIAL-P5-RX"
 msgstr "SMARTSERIAL-P5-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 #, fuzzy
 msgid "SSERIAL-P5-EN"
 msgstr "SMARTSERIAL-P5-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 #, fuzzy
 msgid "SSERIAL-P6-TX"
 msgstr "SMARTSERIAL-P6-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 #, fuzzy
 msgid "SSERIAL-P6-RX"
 msgstr "SMARTSERIAL-P6-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 #, fuzzy
 msgid "SSERIAL-P6-EN"
 msgstr "SMARTSERIAL-P6-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 #, fuzzy
 msgid "SSERIAL-P7-TX"
 msgstr "SMARTSERIAL-P7-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 #, fuzzy
 msgid "SSERIAL-P7-RX"
 msgstr "SMARTSERIAL-P7-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 #, fuzzy
 msgid "SSERIAL-P7-EN"
 msgstr "SMARTSERIAL-P7-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr "7i76 E/S (SS0)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr "7i76 E/S (SS2)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr "7i76 E/S (SS3)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 #, fuzzy
 msgid "7i77 I/O-SS0"
 msgstr "7i77 E/S (SS0)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 #, fuzzy
 msgid "7i77 Analog-SS1"
 msgstr "7i77 Analogique   (SS1)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 #, fuzzy
 msgid "7i77 I/O-SS3"
 msgstr "7i77 E/S (SS3)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 #, fuzzy
 msgid "7i77 Analog-SS4"
 msgstr "7i77 Analogique   (SS4)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Analog Input"
 msgstr "Entrée analogique"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "X Home"
 msgstr "Origine X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Y Home"
 msgstr "Origine Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Z Home"
 msgstr "Origine Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "A Home"
 msgstr "Origine A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "All Home"
 msgstr "Toutes les origines"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "X2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "Y2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "Z2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "A2 Tandem Home"
 msgstr "X2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr "Limite mini + origine machine X "
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr "Limite mini + origine machine Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr "Limite mini + origine machine Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr "Limite mini + origine machine A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr "Limite maxi + origine machine X "
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr "Limite maxi + origine machine Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr "Limite maxi + origine machine Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr "Limite maxi + origine machine A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr "Les deux limites + origine machine X "
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr "Les deux limites + origine machine Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr "Les deux limites + origine machine Z "
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr "Les deux limites + origine machine A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Toutes les limites + origines"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 #, fuzzy
 msgid "X2 Minimum Limit + Home"
 msgstr "Limite mini + origine machine X "
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Y2 Minimum Limit + Home"
 msgstr "Limite mini + origine machine Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Z2 Minimum Limit + Home"
 msgstr "Limite mini + origine machine Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "A2 Minimum Limit + Home"
 msgstr "Limite mini + origine machine A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "X2 Maximum Limit + Home"
 msgstr "Limite maxi + origine machine X "
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Y2 Maximum Limit + Home"
 msgstr "Limite maxi + origine machine Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Z2 Maximum Limit + Home"
 msgstr "Limite maxi + origine machine Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "A2 Maximum Limit + Home"
 msgstr "Limite maxi + origine machine A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "X2 Both Limit + Home"
 msgstr "Les deux limites + origine machine X "
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Y2 Both Limit + Home"
 msgstr "Les deux limites + origine machine Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Z2 Both Limit + Home"
 msgstr "Les deux limites + origine machine Z "
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 #, fuzzy
 msgid "A2 Both Limit + Home"
 msgstr "Les deux limites + origine machine A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr "Sélection jointure A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr "Sélection jointure B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr "Sélection jointure C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr "Sélection jointure D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr "Incrément du Jog A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr "Incrément du Jog B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr "Incrément du Jog C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr "Incrément du Jog D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr A"
 msgstr "Incrément correcteur de vitesse A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr B"
 msgstr "Incrément correcteur de vitesse B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr C"
 msgstr "Incrément correcteur de vitesse C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr D"
 msgstr "Incrément correcteur de vitesse D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Spindle Override incr A"
 msgstr "Incrément correcteur de vitesse broche A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr B"
 msgstr "Incrément correcteur de vitesse broche B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr C"
 msgstr "Incrément correcteur de vitesse broche C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr D"
 msgstr "Incrément correcteur de vitesse broche D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr "Incrément correcteur de vitesse maximale A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr "Incrément correcteur de vitesse maximale B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr "Incrément correcteur de vitesse maximale C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr "Incrément correcteur de vitesse maximale D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Feed Override enable"
 msgstr "Correcteur de vitesse activé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Spindle Override enable"
 msgstr "Correction vitesse de broche activé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 msgid "Max Vel Override enable"
 msgstr "Correcteur de vitesse maximale activé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CW"
 msgstr "Marche manuelle broche en sens horaire"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CCW"
 msgstr "Marche manuelle broche en sens anti-horaire"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle Stop"
 msgstr "Arrêt de broche manuel"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Spindle Up-To-Speed"
 msgstr "Broche Up-To-Speed"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "Tout sélectionner"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr "Départ cycle"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr "Abandon"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Single Step"
 msgstr "Pas par pas"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr "Jog X +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr "Jog X -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr "Jog Y +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr "Jog Y -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr "Jog Z +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr "Jog Z -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr "Jog A +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr "Jog A -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr "Bouton + du Jog sélectionné"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr "Bouton - du Jog sélectionné"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr "X HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr "X HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr "X HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr "X Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr "X Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr "X Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr "X Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr "Y HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr "Y HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr "Y HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr "Y Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr "Y Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr "Y Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr "Y Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr "Z HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr "Z HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr "Z HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr "Z Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr "Z Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr "Z Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr "Z Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr "A HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr "A HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr "A HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr "A Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr "A Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr "A Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr "A Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr "S HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr "S HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr "S HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr "S Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr "S Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr "S Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr "S Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr "Limite minimale X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr "Limite minimale Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr "Limite minimale Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr "Limite minimale A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr "Limite maximale X "
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr "Limite maximale Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr "Limite maximale Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr "Limite maximale A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr "Toutes les limites X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr "Toutes les limites Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr "Toutes les limites Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr "Toutes les limites A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr "Toutes les limites"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "X2 Minimum Limit"
 msgstr "Limite minimale X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Y2 Minimum Limit"
 msgstr "Limite minimale Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Z2 Minimum Limit"
 msgstr "Limite minimale Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "A2 Minimum Limit"
 msgstr "Limite minimale A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "X2 Maximum Limit"
 msgstr "Limite maximale X "
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Y2 Maximum Limit"
 msgstr "Limite maximale Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Z2 Maximum Limit"
 msgstr "Limite maximale Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "A2 Maximum Limit"
 msgstr "Limite maximale A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "X2 Both Limit"
 msgstr "Toutes les limites X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Y2 Both Limit"
 msgstr "Toutes les limites Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Z2 Both Limit"
 msgstr "Toutes les limites Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "A2 Both Limit"
 msgstr "Toutes les limites A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "Axe X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "POM des axes"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Arc OK"
+msgstr "Arc sens horaire"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Ohmic Probe"
+msgstr "Palpeur"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "Switches"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr "Entrée inutilisée"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Limits"
 msgstr "Limites"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr "Limites/origines partagées"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr "Numérique"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr "Sélection d'axe"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 msgid "Overrides"
 msgstr "Survitesse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "Operation"
 msgstr "Opération"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "External Control"
 msgstr "Contrôle externe"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 msgid "Axis rapid"
 msgstr "Axe rapide"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr "X BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr "Y BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr "Z BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr "A BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr "S BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr " Signaux personnalisés"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 #, fuzzy
 msgid "X2 Tandem PWM"
 msgstr "X2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 #, fuzzy
 msgid "Y2 Tandem PWM"
 msgstr "Y2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 #, fuzzy
 msgid "Z2 Tandem PWM"
 msgstr "Z2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 #, fuzzy
 msgid "A2 Tandem PWM"
 msgstr "X2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "X Axis PWM"
 msgstr "PWM axe X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "Y Axis PWM"
 msgstr "PWM axe Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "Z Axis PWM"
 msgstr "PWM axe Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "A Axis PWM"
 msgstr "PWM axe A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Unused PWM Gen"
 msgstr "Géné PWM inutilisé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Axis PWM"
 msgstr "PWM axe X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 msgid "X Axis StepGen"
 msgstr "Géné. de pas axe X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Y Axis StepGen"
 msgstr "Géné. de pas axe Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Z Axis StepGen"
 msgstr "Géné. de pas axe Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 msgid "A Axis StepGen"
 msgstr "Géné. de pas axe A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "X2 Tandem StepGen"
 msgstr "X2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "Y2 Tandem StepGen"
 msgstr "Y2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 msgid "Z2 Tandem StepGen"
 msgstr "Z2 Tandem StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 msgid "Unused StepGen"
 msgstr "Géné. de pas inutilisé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr "Axis"
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr "Pompe de charge StepGen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Spindle StepGen"
 msgstr "Géné. de pas de la broche"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr "Codeur X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr "Codeur Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr "Codeur Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr "Codeur A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "Codeur X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "Codeur Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "Codeur Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "Codeur A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr "Manivelle X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr "Manivelle Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr "Manivelle Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr "Manivelle A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr "Manivelle multi-axes"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Feed Override"
 msgstr "Correcteur de vitesse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "spindle Override"
 msgstr "Correcteur de vitesse broche"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Max Vel Override"
 msgstr "Correcteur de vitesse maximale"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr "Codeur inutilisé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr "Codeur d'axe"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Spindle Encoder"
 msgstr "Codeur broche"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr "Contrôles sur manivelle de jog"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr "Contrôle correcteur par manivelle"
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Codeur X"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 msgid "Unused Unused"
 msgstr "Inutilisé Inutilisé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Codeur broche"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "Machine Is Enabled"
 msgstr "Machine activée"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr "Activation ampli X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr "Activation ampli Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr "Activation ampli Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr "Activation ampli A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr "Force la pin à True"
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Validation POT"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Marche machine"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "Toucher"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr "Sortie inutilisée"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Coolant"
 msgstr "Arrosage"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr "Contrôle"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr " S BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr "8I20 inutilisé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr "Résolveur inutilisé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr "Résolveur X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr "Résolveur Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr "Résolveur Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr "Résolveur A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr "Résolveur S"
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr "Sortie analogique inutilisée"
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Spindle Output"
 msgstr "Sortie broche"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr "TPPWM Gen inutilisé"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr "X Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr "Y Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr "Z Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr "A Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr "S Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr "Carte ampli. 8i20"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr "Carte E/S 7i64"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr "Carte E/S 7i69"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr "Carte E/S 7i70"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr "Carte E/S 7i71 "
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr "Carte E/S 7i76 Mode 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 #, fuzzy
 msgid "7i76 Mode 2 I/O Card"
 msgstr "Carte E/S 7i76 Mode 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr "Carte E/S 7i77 Mode 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 #, fuzzy
 msgid "7i77 Mode 3 I/O Card"
 msgstr "Carte E/S 7i77 Mode 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr "Carte 7i73 Mode 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 #, fuzzy
 msgid "7i84 Mode 1 I/O Card"
 msgstr "Carte E/S 7i76 Mode 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 #, fuzzy
 msgid "7i84 Mode 3 I/O Card"
 msgstr "Carte E/S 7i76 Mode 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Unused Analog In"
 msgstr "Entrée analogique inutilisée"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
@@ -13335,7 +13862,7 @@ msgstr ""
 "Entrée 7i64\n"
 "P3 et P4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
@@ -13343,11 +13870,11 @@ msgstr ""
 "Sortie 7i64\n"
 "P2 et P5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr "7i64-Entrée analogique "
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
@@ -13355,7 +13882,7 @@ msgstr ""
 "7i69\n"
 "P2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
@@ -13363,7 +13890,7 @@ msgstr ""
 "7i69\n"
 "P3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
@@ -13371,7 +13898,7 @@ msgstr ""
 "7i70-Entrée\n"
 "TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
@@ -13379,7 +13906,7 @@ msgstr ""
 "7i70-Entrée\n"
 "TB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
@@ -13387,7 +13914,7 @@ msgstr ""
 "7i71-Sortie\n"
 "TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
@@ -13395,8 +13922,8 @@ msgstr ""
 "7i71-Sortie\n"
 "TB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
@@ -13404,8 +13931,8 @@ msgstr ""
 "7i76-E/S\n"
 "TB6"
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
@@ -13413,8 +13940,8 @@ msgstr ""
 "7i76-E/S\n"
 "TB5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
@@ -13422,8 +13949,8 @@ msgstr ""
 "7i76-Sortie analogique\n"
 "TB4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
@@ -13431,8 +13958,8 @@ msgstr ""
 "7i77-E/S\n"
 "TB8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
@@ -13440,8 +13967,8 @@ msgstr ""
 "7i77-E/S\n"
 "TB7"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
@@ -13449,11 +13976,11 @@ msgstr ""
 "7i77-Sortie analogique\n"
 "TB5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr "7i73-E/S\n"
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 #, fuzzy
 msgid ""
 "7i84-I/O\n"
@@ -13462,8 +13989,8 @@ msgstr ""
 "7i76-E/S\n"
 "TB6"
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 #, fuzzy
 msgid ""
 "7i84-I/O\n"
@@ -13472,7 +13999,7 @@ msgstr ""
 "7i76-E/S\n"
 "TB6"
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 #, fuzzy
 msgid ""
 "7i84-I/O-MPG\n"
@@ -13481,7 +14008,7 @@ msgstr ""
 "7i76-E/S\n"
 "TB6"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13496,17 +14023,17 @@ msgstr ""
 "custompanel_backup.xml et postgui_backup.hal \n"
 "Tout fichier existant portant déjà un de ces noms sera écrasé."
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 #, fuzzy
 msgid "Quit PNCconf and discard changes?"
 msgstr "Quitter PNCconf et perdre les modifications ?"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 #, fuzzy
 msgid "Do you want to quit?"
 msgstr "Que voulez-vous faire:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13523,69 +14050,78 @@ msgstr ""
 "Vous avez spécifié un fichier glade comme existant alors que le dossier "
 "portant le nom de la machine n'en contient pas..."
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 #, fuzzy
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr "Les réglages de servo ne sont pas  opérationnels dans PNCconf \n"
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr "degrés"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr "degrés / minute"
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr "degrés / seconde²"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr "tour"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr "tr/mn"
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr "tours / seconde²"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr "mm / minute"
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr "mm / seconde²"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr "pouces / minute"
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr "pouces / seconde²"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr "Calibration de l'axe %s"
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
@@ -13593,7 +14129,7 @@ msgstr ""
 " Un signal CODEUR / RESOLVEUR et un signal ANALOGIQUE de broche doivent être "
 "déclarés pour tester cet axe"
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
@@ -13601,7 +14137,7 @@ msgstr ""
 " Un signal CODEUR/RESOLVEUR et un signal PWM doivent être déclarés pour "
 "tester cet axe"
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13620,7 +14156,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "ma_machine_LinuxCNC"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13638,12 +14174,12 @@ msgstr ""
 "version, posez la question sur le forum linuxcnc.org,\n"
 "c'est peut être possible..."
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr "Le fichier %r a été modifié depuis qu'il a été écrit par PNCconf"
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
@@ -13651,7 +14187,7 @@ msgstr ""
 "Enregistrer cette configuration va écraser les modifications faites à "
 "l'extérieur de PNCconf"
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
 "Lanceur de bureau pour LinuxCNC avec la configuration faite par PNCconf"
@@ -15408,9 +15944,9 @@ msgid "Z"
 msgstr "Z"
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15565,6 +16101,13 @@ msgstr "utiliser anti-rebonds"
 #: src/emc/usr_intf/pncconf/external.glade:5401
 msgid "Mux options"
 msgstr "Options de multiplexage"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "s"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15754,181 +16297,199 @@ msgstr "Recupération position jointure après arrêt"
 msgid "<b>Defaults and Options</b>"
 msgstr "<b>Défauts et options</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 #, fuzzy
 msgid "<b>GUI Screen list</b>"
 msgstr "<b>Liste des interfaces graphiques</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr "Offset_position"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr "Retour_position"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr "Correcteur de vitesse broche maximale"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr "Correcteur de vitesse broche minimale"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr "Correcteur de vitesse maximale"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr "xyzabc"
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 #, fuzzy
 msgid "Display Geometry"
 msgstr "Géométrie des axes"
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr "<b>Valeurs communes par défauts</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr "Vitesse linéaire par défaut"
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr "Vitesse linéaire minimale"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr "Vitesse linéaire maximale"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr "Vitesse angulaire par défaut"
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr "gedit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr "Vitesse angulaire minimale"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr "Incréments"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr "Vitesse angulaire maximale"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr "degrés / mn"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr "Taille"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr "Position"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr "X"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr "W"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr "H"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr "Forcer Axis à maximiser"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 #, fuzzy
 msgid "AXIS Defaults"
 msgstr "Options par défaut d'AXIS"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr "Force Touchy à maximiser après le positionnement"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr "Thème GTK"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr "Couleur texte Absolu"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr "Couleur texte Absolu"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 msgid "Relative Textcolor"
 msgstr "Couleur texte Relatif"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr "DTG Textcolor"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr "Couleur texte Erreurs"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 #, fuzzy
 msgid "Touchy Defaults"
 msgstr "Utiliser par défaut"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 #, fuzzy
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr "Force Touchy à maximiser après le positionnement"
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Echantillon d'options"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -16018,148 +16579,165 @@ msgstr "Détails Gladevcp"
 msgid "Include custom GladeVCP GUI panel"
 msgstr "Inclure un panneau utilisateur GladeVCP"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Codeur X"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
+msgid "Use Encoder Index For Home:"
+msgstr "Utiliser l'index codeur pour la prise d'origine:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
+msgid "Home Final Velocity:"
+msgstr "Vitesse finale de re_cherche d'origine:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
+msgid "Home Latch Direction:"
+msgstr "Direction de dégagement du contact d'origine:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
+msgid "Home Search Direction:"
+msgstr "Direction de recherche du contact d'origine:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
+msgid "Home latch Velocity:"
+msgstr "Vitesse de dégagement du contact d'origine:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Utiliser un fichier de compensation:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
+msgid "Use Backlash Compensation:"
+msgstr "Utiliser la compensation de jeu:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+#, fuzzy
+msgid "Final Home Position location   (Offset from machine zero Origin):"
+msgstr "Position de l'origine (distance de l'origine machine):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
+msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
+msgstr ""
+"Longueur de course négative  (distance entre l'origine et la fin de la "
+"course en sens négatif): "
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+#, fuzzy
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
+msgstr "Position du contact d'origine   (décalage depuis l'origine machine):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
+msgid "Home Search Velocity:"
+msgstr "Vitesse de recherche de l'origine:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
+msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
+msgstr ""
+"Longueur de course positive  (distance entre l'origine et la fin de la "
+"course en sens positif): "
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
+#, fuzzy
+msgid "Home Search Sequence:"
+msgstr "Vitesse de recherche de l'origine:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+#, fuzzy
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr "Position du contact d'origine   (décalage depuis l'origine machine):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
 #, fuzzy
 msgid "Type 1"
 msgstr ""
 "Type 1\n"
 "Type 2"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
 #, fuzzy
 msgid "Type 2"
 msgstr ""
 "Type 1\n"
 "Type 2"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
 #, fuzzy
 msgid "Towards Negative Limit"
 msgstr ""
 "Limite négative inverse\n"
 "Limite positive inverse"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
 #, fuzzy
 msgid "Towards Positive Limit"
 msgstr ""
 "Limite négative inverse\n"
 "Limite positive inverse"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
-msgid "Use Encoder Index For Home:"
-msgstr "Utiliser l'index codeur pour la prise d'origine:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
-msgid "Home Final Velocity:"
-msgstr "Vitesse finale de re_cherche d'origine:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
-msgid "Home Latch Direction:"
-msgstr "Direction de dégagement du contact d'origine:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
-msgid "Home Search Direction:"
-msgstr "Direction de recherche du contact d'origine:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
-msgid "Home latch Velocity:"
-msgstr "Vitesse de dégagement du contact d'origine:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr "nom de fichier:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr "Utiliser un fichier de compensation:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
-msgid "Use Backlash Compensation:"
-msgstr "Utiliser la compensation de jeu:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
-msgstr "Position de l'origine (distance de l'origine machine):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
-msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
-msgstr ""
-"Longueur de course négative  (distance entre l'origine et la fin de la "
-"course en sens négatif): "
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
-msgstr "Position du contact d'origine   (décalage depuis l'origine machine):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
-msgid "Home Search Velocity:"
-msgstr "Vitesse de recherche de l'origine:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
-msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
-msgstr ""
-"Longueur de course positive  (distance entre l'origine et la fin de la "
-"course en sens positif): "
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
-#, fuzzy
-msgid "Home Search Sequence:"
-msgstr "Vitesse de recherche de l'origine:"
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -17111,11 +17689,6 @@ msgstr ""
 msgid "24"
 msgstr "2"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-#, fuzzy
-msgid "17"
-msgstr "17:"
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 #, fuzzy
 msgid "Number of connectors:"
@@ -17210,11 +17783,6 @@ msgstr "Facteur de multiplication dû aux micropas:"
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr "Nombre de pas moteur par tour:"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-#, fuzzy
-msgid "10"
-msgstr "0"
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17680,7 +18248,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17848,32 +18415,24 @@ msgid "Manual Toolchange"
 msgstr "Changement d'outil manuel d'AXIS"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 #, fuzzy
 msgid "Restart Entry"
 msgstr "Reprise"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr "Haut"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr "Bas"
 
@@ -17954,33 +18513,33 @@ msgstr "Utilisation"
 msgid "%d RPM"
 msgstr "tr/mn maximaux"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, fuzzy, python-format
 msgid "%4.2f mm/min"
 msgstr "mm / mn "
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, fuzzy, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr "                    "
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -18105,7 +18664,6 @@ msgid "<b>Status</b>"
 msgstr "<b>a)</b>"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 #, fuzzy
 msgid ""
 "Search\n"
@@ -18113,7 +18671,6 @@ msgid ""
 msgstr "Chemin de recherche"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -18121,7 +18678,6 @@ msgid ""
 msgstr "Remplacer par:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -18129,7 +18685,6 @@ msgid ""
 msgstr "Remplacer tous"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 #, fuzzy
 msgid ""
 "Ignore\n"
@@ -18147,7 +18702,6 @@ msgid "Main Level"
 msgstr "Niveau"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 #, fuzzy
 msgid "Themes"
 msgstr "Thème:"
@@ -18163,13 +18717,11 @@ msgid "DTG Text Color"
 msgstr "DTG Textcolor"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 #, fuzzy
 msgid "Warning Audio"
 msgstr "Attention"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -18179,7 +18731,6 @@ msgid "Grid Size"
 msgstr "Taille"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 #, fuzzy
 msgid "Starting RPM"
 msgstr "Réglages"
@@ -18262,7 +18813,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "_Calibration"
@@ -18545,12 +19095,10 @@ msgid ""
 msgstr "Chemin de recherche"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "Annuler"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "Rétablir"
 
@@ -18575,6 +19123,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18640,1687 +19190,800 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-#, fuzzy
-msgid "user mode selected"
-msgstr "Prise d'origine axe courant"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "Utilisation d'un G code inconnu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-#, fuzzy
-msgid "this is not a usual config\n"
-msgstr "Axis ne répond pas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-#, fuzzy
-msgid "mm/min"
-msgstr "mm / mn "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-#, fuzzy
-msgid "inch/min"
-msgstr "pouces / minute"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "Mode articulations"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "Pas encore de paramètre"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-#, fuzzy
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr "(%s) impossible en mode auto avec l'interpréteur en charge"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-#, fuzzy
-msgid "No tool description available"
-msgstr "Aucun détail disponible."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-#, fuzzy
-msgid "Classicladder real-time component not detected"
-msgstr "Composant temps réel non chargé"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-#, fuzzy
-msgid "Enter value for diameter"
-msgstr "Valeur non entière pour un entier"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-#, fuzzy
-msgid "Set diameter to:"
-msgstr "diamètre"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-#, fuzzy
-msgid "Enter value for radius"
-msgstr "Valeur non entière pour un entier"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr "rayon"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, fuzzy, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr "Valeur non entière pour un entier"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, fuzzy, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "Ajuster valeurs d'axes"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "Changement d'outil manuel d'AXIS"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-#, fuzzy
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-"Changement d'offsetd'outil impossible avec la compensation de rayon d'outil "
-"active"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "Choisir l'item à mesurer"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "Mode articulations"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-#, fuzzy
-msgid "no button here"
-msgstr "Bouton + du Jog sélectionné"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "Fichier programme"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "Rafraîchir le parcours d'outil"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "Vue en perspective"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-#, fuzzy
-msgid "Show or hide dimensions"
-msgstr "Montrer raccourcis clavier"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "Valeur d'offset"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "Outils"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "Sélection d'axe"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-#, fuzzy
-msgid "jog joints"
-msgstr "jointure"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "Dépassement de limite"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "<b>Prise d'origine</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Informations outil"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-#, fuzzy
-msgid "Diameter"
-msgstr "diamètre"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "Offsets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "Offsets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "<b>Configuration</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Codes actifs:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Codes actifs:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "<b>Puissance</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "<b>Arrosage</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "<b>Broche</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "<b>Correcteur de vitesse broche externe</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Correction de la vitesse entre 0% et 100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "<b>Correcteur de vitesse externe</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-#, fuzzy
-msgid ""
-"Search\n"
-" back"
-msgstr "Chemin de recherche"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-#, fuzzy
-msgid ""
-"Search\n"
-"  fwd"
-msgstr "Chemin de recherche"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr "Remplacer"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-#, fuzzy
-msgid "Start maximized"
-msgstr "Force à maximiser"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-#, fuzzy
-msgid "X Pos."
-msgstr " Pos "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-#, fuzzy
-msgid "Y Pos."
-msgstr " Pos "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "<b>Éléments de base</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "Afficher les offs_ets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "<b>Puissance</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Parcours d'outil"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "Afficher les offs_ets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "Couleur texte Relatif"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-#, fuzzy
-msgid "Absolute Color"
-msgstr "Couleur texte Absolu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-#, fuzzy
-msgid "DTG Color"
-msgstr "DTG Textcolor"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "Prise d'origine générale"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "Annulation OM de tous les axes"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-#, fuzzy
-msgid "Digits"
-msgstr "Numérique"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr "<b>b)</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-#, fuzzy
-msgid "Grid size"
-msgstr "Taille"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "Afficher"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "Afficher les offs_ets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-#, fuzzy
-msgid "Show DTG"
-msgstr "Afficher"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "<b>Boutons de jog externes</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<b>Page</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "on current subfile"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "Sélection de la vitesse de jog"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "Choisir l'item à mesurer"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-#, fuzzy
-msgid "<b>Themes and sound</b>"
-msgstr "<b>Défauts et options</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "Ajuster le correcteur de vitesse de broche"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "Afficher la _vitesse d'avance"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "Ajuster le correcteur de vitesse:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Ajuster le correcteur de vitesse de broche"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "<b>Échelle moteur pas à pas</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-#, fuzzy
-msgid "Use unlock code"
-msgstr "Codeur inutilisé"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "<b>Ajustement outil</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Activation frein de broche"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Frein de broche"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "<b>Frontaux</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-#, fuzzy
-msgid "Probe Height"
-msgstr "Entrée palpeur"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-#, fuzzy
-msgid "0.000"
-msgstr ".0001"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-#, fuzzy
-msgid "Z Pos."
-msgstr " Pos "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-#, fuzzy
-msgid "Max. Probe"
-msgstr "Palpeur"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "<b>Options de programme</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-#, fuzzy
-msgid "Search Vel."
-msgstr "Chemin de recherche"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-#, fuzzy
-msgid "Probe Vel."
-msgstr "Entrée palpeur"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-#, fuzzy
-msgid "<b>Probe velocitys</b>"
-msgstr "<b>Liste des interfaces graphiques</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "<b>Arrosage</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "Recharger table d'outils"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Recharger table d'outils"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "Démarrer à la lig_ne sélectionnée"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "<b>Prise d'origine</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-#, fuzzy
-msgid "Launch test message"
-msgstr "Lancer le panneau de test"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "Options avancées"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Marche machine"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "Programme Modbus série"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "Afficher le statut"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-#, fuzzy
-msgid "open touch off button list"
-msgstr "L'outil touchera le porte-pièce"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "Mode articulations"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Recharger le programme"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Recharger le programme"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Arrêter le programme, ou"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Arrêter le programme, ou"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Arrêter le programme, ou"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr ""
-"Editer prog.\n"
-"ladder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-#, fuzzy
-msgid "delete MDI"
-msgstr "Effacer"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-#, fuzzy
-msgid "delete MDI history"
-msgstr "Vider l'historique du MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-#, fuzzy
-msgid "Open classicladder"
-msgstr "Inclure l'API _Classicladder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "HalScope"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-#, fuzzy
-msgid "launch hal scope"
-msgstr "lancer %s"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "_Calibration"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "Recharger la ta_ble d'outils"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "_Recharger"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "Recharger la ta_ble d'outils"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "Ajuster le numéro d'outil"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-#, fuzzy
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr "L'outil touchera le porte-pièce"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-#, fuzzy
-msgid "touch off the tool and set the value to the tool table"
-msgstr "L'outil demandé %d n'est pas dans la table d'outils"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
+#: lib/python/gladevcp/iconview.py:120
 #, fuzzy
-msgid "Move to parrent directory"
+msgid "Move to parent directory"
 msgstr "Répertoire courant"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "Choisir l'item à mesurer"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Choisir l'item à mesurer"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "Fichier chargé:"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
 #, fuzzy
-msgid "home joints"
-msgstr "jointure"
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr "Décale toutes les coordonnées système"
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+#, fuzzy
+msgid "Toolfile does not exist"
+msgstr "Le fichier d'outils %s"
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "Recharger la ta_ble d'outils"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+#, fuzzy
+msgid "Tool file was modified since it was last read"
+msgstr "Le fichier %r a été modifié depuis qu'il a été écrit par Stepconf"
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Appui molette souris"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+#, fuzzy
+msgid "button"
+msgstr "Bouton + du Jog sélectionné"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "Bascule envoi auto"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Outil:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Noir"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "Rotation XY:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+#, fuzzy
+msgid "G92"
+msgstr "_G92"
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+#, fuzzy
+msgid "G59.1"
+msgstr "P7  G59._1"
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+#, fuzzy
+msgid "G59.2"
+msgstr "P8  G59._2"
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+#, fuzzy
+msgid "G59.3"
+msgstr "P9  G59._3"
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Offset:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Valeur d'offset"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+#, fuzzy
+msgid ""
+"Zero\n"
+"G92"
+msgstr "Tous les G59.2 à zéro"
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "Horizontal"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "_Sélectionner"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Outil N°:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+#, fuzzy
+msgid "Pocket"
+msgstr "Poches:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+#, fuzzy
+msgid "Diameter"
+msgstr "diamètre"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "frontal"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "Opération"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "commentaire"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "_Recharger"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "Offset d'axe"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "diamètre"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "Offsets de travail:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Outil:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Outil:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Ajuster l'offset d'outil"
+
+#~ msgid "filename:"
+#~ msgstr "nom de fichier:"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "Prise d'origine axe courant"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "Utilisation d'un G code inconnu"
+
+#, fuzzy
+#~ msgid "this is not a usual config\n"
+#~ msgstr "Axis ne répond pas"
+
+#, fuzzy
+#~ msgid "mm/min"
+#~ msgstr "mm / mn "
+
+#, fuzzy
+#~ msgid "inch/min"
+#~ msgstr "pouces / minute"
+
+#, fuzzy
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "Mode articulations"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "Pas encore de paramètre"
+
+#, fuzzy
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr "(%s) impossible en mode auto avec l'interpréteur en charge"
+
+#, fuzzy
+#~ msgid "No tool description available"
+#~ msgstr "Aucun détail disponible."
+
+#, fuzzy
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "Composant temps réel non chargé"
+
+#, fuzzy
+#~ msgid "Enter value for diameter"
+#~ msgstr "Valeur non entière pour un entier"
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr "diamètre"
+
+#, fuzzy
+#~ msgid "Enter value for radius"
+#~ msgstr "Valeur non entière pour un entier"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "rayon"
+
+#, fuzzy
+#~ msgid "Enter value for axis {0}"
+#~ msgstr "Valeur non entière pour un entier"
+
+#, fuzzy
+#~ msgid "Set axis {0} to:"
+#~ msgstr "Ajuster valeurs d'axes"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "Changement d'outil manuel d'AXIS"
+
+#, fuzzy
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr ""
+#~ "Changement d'offsetd'outil impossible avec la compensation de rayon "
+#~ "d'outil active"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "Choisir l'item à mesurer"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "Mode articulations"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "Fichier programme"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "Rafraîchir le parcours d'outil"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "Vue en perspective"
+
+#, fuzzy
+#~ msgid "Show or hide dimensions"
+#~ msgstr "Montrer raccourcis clavier"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Outils"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "Sélection d'axe"
+
+#, fuzzy
+#~ msgid "jog joints"
+#~ msgstr "jointure"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "Dépassement de limite"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "<b>Prise d'origine</b>"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Informations outil"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "Offsets"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "Offsets"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "<b>Configuration</b>"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Codes actifs:"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Codes actifs:"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "<b>Puissance</b>"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "<b>Arrosage</b>"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "<b>Broche</b>"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "<b>Correcteur de vitesse broche externe</b>"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Correction de la vitesse entre 0% et 100%"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "<b>Correcteur de vitesse externe</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "Search\n"
+#~ " back"
+#~ msgstr "Chemin de recherche"
+
+#, fuzzy
+#~ msgid ""
+#~ "Search\n"
+#~ "  fwd"
+#~ msgstr "Chemin de recherche"
+
+#~ msgid "Replace"
+#~ msgstr "Remplacer"
+
+#, fuzzy
+#~ msgid "Start maximized"
+#~ msgstr "Force à maximiser"
+
+#, fuzzy
+#~ msgid "X Pos."
+#~ msgstr " Pos "
+
+#, fuzzy
+#~ msgid "Y Pos."
+#~ msgstr " Pos "
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "<b>Éléments de base</b>"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Afficher les offs_ets"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "<b>Puissance</b>"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Parcours d'outil"
+
+#, fuzzy
+#~ msgid "show offsets"
+#~ msgstr "Afficher les offs_ets"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Couleur texte Relatif"
+
+#, fuzzy
+#~ msgid "Absolute Color"
+#~ msgstr "Couleur texte Absolu"
+
+#, fuzzy
+#~ msgid "DTG Color"
+#~ msgstr "DTG Textcolor"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "Prise d'origine générale"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "Annulation OM de tous les axes"
+
+#, fuzzy
+#~ msgid "Digits"
+#~ msgstr "Numérique"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr "<b>b)</b>"
+
+#, fuzzy
+#~ msgid "Grid size"
+#~ msgstr "Taille"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "Afficher"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "Afficher les offs_ets"
+
+#, fuzzy
+#~ msgid "Show DTG"
+#~ msgstr "Afficher"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "<b>Boutons de jog externes</b>"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Page</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "on current subfile"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "Sélection de la vitesse de jog"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "Choisir l'item à mesurer"
+
+#, fuzzy
+#~ msgid "<b>Themes and sound</b>"
+#~ msgstr "<b>Défauts et options</b>"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Ajuster le correcteur de vitesse de broche"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "Afficher la _vitesse d'avance"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Ajuster le correcteur de vitesse:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Ajuster le correcteur de vitesse de broche"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "<b>Échelle moteur pas à pas</b>"
+
+#, fuzzy
+#~ msgid "Use unlock code"
+#~ msgstr "Codeur inutilisé"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "<b>Ajustement outil</b>"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Activation frein de broche"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Frein de broche"
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "<b>Frontaux</b>"
+
+#, fuzzy
+#~ msgid "Probe Height"
+#~ msgstr "Entrée palpeur"
+
+#, fuzzy
+#~ msgid "Z Pos."
+#~ msgstr " Pos "
+
+#, fuzzy
+#~ msgid "Max. Probe"
+#~ msgstr "Palpeur"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "<b>Options de programme</b>"
+
+#, fuzzy
+#~ msgid "Search Vel."
+#~ msgstr "Chemin de recherche"
+
+#, fuzzy
+#~ msgid "Probe Vel."
+#~ msgstr "Entrée palpeur"
+
+#, fuzzy
+#~ msgid "<b>Probe velocitys</b>"
+#~ msgstr "<b>Liste des interfaces graphiques</b>"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "<b>Arrosage</b>"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Recharger table d'outils"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Recharger table d'outils"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "Démarrer à la lig_ne sélectionnée"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "<b>Prise d'origine</b>"
+
+#, fuzzy
+#~ msgid "Launch test message"
+#~ msgstr "Lancer le panneau de test"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "Options avancées"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Marche machine"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "Programme Modbus série"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "Afficher le statut"
+
+#, fuzzy
+#~ msgid "open touch off button list"
+#~ msgstr "L'outil touchera le porte-pièce"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "Mode articulations"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Recharger le programme"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Recharger le programme"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Arrêter le programme, ou"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Arrêter le programme, ou"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Arrêter le programme, ou"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr ""
+#~ "Editer prog.\n"
+#~ "ladder"
+
+#, fuzzy
+#~ msgid "delete MDI"
+#~ msgstr "Effacer"
+
+#, fuzzy
+#~ msgid "delete MDI history"
+#~ msgstr "Vider l'historique du MDI"
+
+#, fuzzy
+#~ msgid "Open classicladder"
+#~ msgstr "Inclure l'API _Classicladder"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "HalScope"
+
+#, fuzzy
+#~ msgid "launch hal scope"
+#~ msgstr "lancer %s"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "_Calibration"
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "Recharger la ta_ble d'outils"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "Ajuster le numéro d'outil"
+
+#, fuzzy
+#~ msgid ""
+#~ "touchoff\n"
+#~ "  tool x"
+#~ msgstr "L'outil touchera le porte-pièce"
+
+#, fuzzy
+#~ msgid "touch off the tool and set the value to the tool table"
+#~ msgstr "L'outil demandé %d n'est pas dans la table d'outils"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "Fichier chargé:"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "jointure"
 
 #~ msgid "Substituting"
 #~ msgstr "Substitution"
@@ -20474,9 +20137,6 @@ msgstr "jointure"
 #~ msgid "Tool File"
 #~ msgstr "Fichier d'outils"
 
-#~ msgid "Tool file is %s"
-#~ msgstr "Le fichier d'outils %s"
-
 #~ msgid "Active G Codes"
 #~ msgstr "G-codes actifs"
 
@@ -20489,9 +20149,6 @@ msgstr "jointure"
 
 #~ msgid "CONTINUE"
 #~ msgstr "CONTINUER"
-
-#~ msgid "Tool #:"
-#~ msgstr "Outil N°:"
 
 #~ msgid "Length :"
 #~ msgstr "Longueur :"
@@ -20662,9 +20319,6 @@ msgstr "jointure"
 #~ msgid "Zero All G59.1"
 #~ msgstr "Tous les G59.1 à zéro"
 
-#~ msgid "Zero All G59.2"
-#~ msgstr "Tous les G59.2 à zéro"
-
 #~ msgid "Zero All G59.3"
 #~ msgstr "Tous les G59.3 à zéro"
 
@@ -20765,9 +20419,6 @@ msgstr "jointure"
 
 #~ msgid "Show Setup"
 #~ msgstr "Afficher les réglages"
-
-#~ msgid "Axis Offset"
-#~ msgstr "Offset d'axe"
 
 #~ msgid "toomany"
 #~ msgstr "trop"

--- a/src/po/hu.po
+++ b/src/po/hu.po
@@ -3,7 +3,7 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <dzsolt@gmail.com>, 2006.
 #
-#  Beta. 
+#  Beta.
 #  Now 100% translation.
 #  Now refinement a few word.
 #
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AXIS Hungarian Translation 0.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2006-01-18 21:22-0000\n"
 "Last-Translator: Dani Zsolt <dzsolt@gmail.com>\n"
 "Language-Team: Hungarian <LL@li.org>\n"
@@ -22,66 +22,66 @@ msgstr ""
 "X-Poedit-Language: Hungarian\n"
 "X-Poedit-Country: HUNGARY\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr ""
 
@@ -191,424 +191,424 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -722,30 +722,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -860,102 +860,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, c-format
 msgid "cant open ini file '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 msgid "Parameter file name is missing"
 msgstr ""
 
@@ -1375,7 +1375,7 @@ msgid "Negative spindle speed used"
 msgstr "Túlhajtás (%):"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+msgid "Negative tool id (tool not found)"
 msgstr ""
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1760,25 +1760,24 @@ msgstr ""
 msgid "R less than V in cycle in UW plane"
 msgstr ""
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "HIBA: '%s' nem érvényes tapintó típus\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "HIBA: láb/jel/paraméter név hiányzik\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr ""
 "HIBA: -s opcióhoz szükséges a tapintó típusa és egy láb/jell/paraméter név\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr ""
 
@@ -1790,27 +1789,27 @@ msgstr ""
 msgid "E_xit"
 msgstr ""
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "Válaszd ki a vizsgálandó elemet"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr " _Lábak "
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr " _Jelek "
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr " Para_méterek "
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr "_Bezárás"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 #, fuzzy
 msgid ""
 "Usage:\n"
@@ -1819,70 +1818,92 @@ msgstr ""
 "Használat:\n"
 "  halscope [-h] [-i ini_fájl] [-o kimeneti_fájl] [mintavétel_száma]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "Konfigurációs fájl megnyitása:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Mégsem"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "_Megnyitás"
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Konfigurációs fájl megnyitása:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "_Fájl"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "Konfiguráció meg_nyitása..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "Konfiguráció el_mentése..."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "Adatfájl meg_nyitása..."
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "Adatfájl el_mentésa..."
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 #, fuzzy
 msgid "_Quit"
 msgstr "_Kilépés"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "_Halszkóp névjegy"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 #, fuzzy
 msgid "_File"
 msgstr "_Fájl"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 #, fuzzy
 msgid "_Help"
 msgstr "_Segítség"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "HAL Oszcilloszkóp"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "Horizontális"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "Kiválasztott csatorna"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "Futási mód"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "Trigger jel"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "Vertikális"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1890,39 +1911,40 @@ msgstr "Vertikális"
 msgid "Stop"
 msgstr "Stop"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "Normál"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "Egyedi"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "Görgetés"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "Közelítés"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr " Poz "
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "----- mintavétel\n"
-"---- KHz-en"
+"---- kHz-en"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "Valós idejű komponens nincs betöltve"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1936,11 +1958,40 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+#, fuzzy
+msgid "Quit"
+msgstr "_Kilépés"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1953,106 +2004,81 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-#, fuzzy
-msgid "Quit"
-msgstr "_Kilépés"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2066,56 +2092,64 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
 "record length that supports more channels."
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
 "per div"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
 "at %s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2131,90 +2165,71 @@ msgstr ""
 msgid "Hz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, fuzzy, c-format
 msgid ""
 "Offset\n"
 "%s"
 msgstr "Eltolás"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
 "----"
 msgstr "Eltolás"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:715
-#, fuzzy
-msgid "Set Offset"
-msgstr "Eltolás"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
 "for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+#, fuzzy
+msgid "Set Offset"
+msgstr "Eltolás"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Mégsem"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2222,167 +2237,157 @@ msgid ""
 "the record length to allow for more channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
 "as the source for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr ""
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
 "Chan %2d"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr ""
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr ""
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr ""
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr ""
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr ""
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+msgid "Probe tripped during non-probe move."
 msgstr ""
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr ""
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr ""
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr ""
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr ""
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr ""
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr ""
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
@@ -2451,177 +2456,177 @@ msgstr ""
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr ""
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr ""
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr ""
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr ""
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr ""
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr ""
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr ""
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr ""
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr ""
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2710,26 +2715,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2899,7 +2904,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -2988,19 +2993,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr ""
 
@@ -3052,7 +3057,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr ""
 
@@ -3071,7 +3076,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 #, fuzzy
 msgid "Editor"
 msgstr "Sz_erkesztés"
@@ -3086,7 +3091,6 @@ msgid "Config"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 #, fuzzy
 msgid "Preview"
 msgstr "Oldal nézet"
@@ -3517,7 +3521,7 @@ msgid "Edit mode..."
 msgstr "Sz_erkesztés"
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr ""
 
@@ -3526,7 +3530,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr ""
 
@@ -3537,6 +3541,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr ""
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Mégsem"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3725,7 +3747,7 @@ msgid "Parameter"
 msgstr " Para_méterek "
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3912,7 +3934,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 #, fuzzy
 msgid "Main"
 msgstr "Gép"
@@ -3993,11 +4014,13 @@ msgid "Delete section"
 msgstr "Mutasd a relatív pozíciót"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Down"
 msgstr ""
 
@@ -4518,6 +4541,7 @@ msgid "Exit"
 msgstr "Sz_erkesztés"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 #, fuzzy
 msgid "Edit"
 msgstr "Sz_erkesztés"
@@ -4564,7 +4588,6 @@ msgid "Renumber File..."
 msgstr ""
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr ""
 
@@ -4841,15 +4864,15 @@ msgstr ""
 msgid "Test HAL command :"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr ""
 
@@ -4966,21 +4989,21 @@ msgstr ""
 msgid "SIZE :"
 msgstr ""
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr ""
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr ""
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 msgid "Create Report File"
 msgstr ""
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr ""
 
@@ -5058,7 +5081,7 @@ msgstr ""
 msgid "Tool:"
 msgstr "Hűtés:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr ""
@@ -5127,18 +5150,18 @@ msgstr ""
 msgid "auto"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5315,7 +5338,7 @@ msgstr ""
 msgid "world"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 #, fuzzy
 msgid "home"
 msgstr "Nullpont"
@@ -5405,16 +5428,15 @@ msgstr ""
 msgid "Optional Stop"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr ""
 
@@ -5524,7 +5546,7 @@ msgid "Coordinate System Control Window"
 msgstr ""
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 #, fuzzy
 msgid "Axis "
 msgstr "Tengely:"
@@ -6087,9 +6109,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr ""
 
@@ -6109,8 +6131,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr ""
 
@@ -6185,146 +6207,146 @@ msgstr "AXIS (Nincs fájl)"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 #, fuzzy
 msgid "no such file"
 msgstr "AXIS (Nincs fájl)"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 msgid "LinuxCNC"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 msgid "LinuxCNC version"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7001,47 +7023,47 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Szerszám %d ismeretlen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Nincs szerszám"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, fuzzy, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Szerszám %d, eltolás %g, atmerő %g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 #, fuzzy
 msgid "Filter failed"
 msgstr "Program_szűrő %r sikertelen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
 "produced are shown below:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "G-kód hiba %s -ben"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, fuzzy, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7050,175 +7072,173 @@ msgstr ""
 "Közel a %d sorhoz, %s -ból:\n"
 "%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "Folytonos"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 #, fuzzy
 msgid "Size:"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "A program meghaladja a gép minimumat: %s tengelyen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "A program meghaladja a gép maximumat: %s tengelyen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "A program túllép a gép korlátain"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Program folytatás"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
 "%(lines)s gcode lines"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, fuzzy, python-format
 msgid "%d seconds"
 msgstr "2. tengely léptetés"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 #, fuzzy
 msgid "G-Code Properties"
 msgstr "G-kód hiba %s -ben"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 msgid "File not Writable:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7229,58 +7249,58 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Custom Grid"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 msgid "Touch Off (system)"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, python-format
 msgid "Tool %s TouchOff"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7289,7 +7309,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7298,7 +7318,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7307,91 +7327,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "Lépés a kiválasztott tengelyen"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 #, fuzzy
 msgid "Home All"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 msgid "Joint"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr ""
 
@@ -7706,11 +7726,12 @@ msgid "_Properties..."
 msgstr "G-kód hiba %s -ben"
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
-msgstr ""
+#, fuzzy
+msgid "Edit _tool data..."
+msgstr "Sz_erkesztés"
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+msgid "Reload tool _data"
 msgstr ""
 
 #: share/axis/tcl/axis.tcl:96
@@ -8061,12 +8082,12 @@ msgstr ""
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 #, fuzzy
 msgid "Zoom in"
 msgstr "Közelítés [+]"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 #, fuzzy
 msgid "Zoom out"
 msgstr "Távolítás [-]"
@@ -8257,9 +8278,10 @@ msgstr "Túlhajtás (%):"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr ""
 
@@ -8315,7 +8337,7 @@ msgid "Position:"
 msgstr "Pozíció:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 #, fuzzy
 msgid "Machine"
 msgstr "Gép"
@@ -8427,22 +8449,21 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Átmenetileg túl léphető határok [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 #, fuzzy
 msgid "Spindle CW"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 #, fuzzy
 msgid "Spindle CCW"
@@ -8797,6 +8818,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8806,43 +8829,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr "0"
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8908,7 +8976,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 #, fuzzy
 msgid "<b>Spindle</b>"
 msgstr "Fő orsó:"
@@ -9079,7 +9146,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr ""
 
@@ -9141,8 +9207,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9276,10 +9342,10 @@ msgid "Stepconf"
 msgstr "Lépé_s"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9298,12 +9364,12 @@ msgid "Parallel Port 1"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 msgid "Parallel Port 2"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "Pozíció:"
@@ -9313,246 +9379,296 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Bal egér gomb"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "Spindle"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "X Step"
 msgstr "Lépé_s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "Y Step"
 msgstr "Lépé_s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "Z Step"
 msgstr "Lépé_s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "A Step"
 msgstr "Lépé_s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "Lépé_s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "Fő orsó fék bekapcsolva"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "Lépé_s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "Fő orsó fék bekapcsolva"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "Fő orsó lassítása [F11]"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "Fő orsó fék bekapcsolva"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "Fő orsó lassítása [F11]"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Fő orsó fék bekapcsolva"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 #, fuzzy
 msgid "Spindle ON"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 #, fuzzy
 msgid "Spindle PWM"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Brake"
 msgstr "Fő orsó fék bekapcsolva"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 #, fuzzy
 msgid "Coolant Mist"
 msgstr "Hűtés:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 #, fuzzy
 msgid "Coolant Flood"
 msgstr "Hűtés:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "ESTOP Out"
 msgstr "ESTOP"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9563,260 +9679,344 @@ msgstr ""
 msgid "Unused"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 #, fuzzy
 msgid "ESTOP In"
 msgstr "ESTOP"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Index"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase A"
 msgstr "Fő orsó fék bekapcsolva"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase B"
 msgstr "Fő orsó fék bekapcsolva"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home X"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Y"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Z"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home A"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Nullpont"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Nullpont"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Nullpont"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Nullpont"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits + homes"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Down"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Fő orsó fék bekapcsolva"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9825,40 +10025,40 @@ msgid ""
 "Are you sure?  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
 "Any existing file named custompanel_backup.xml will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9869,43 +10069,43 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 #, fuzzy
 msgid "Continue? "
 msgstr "Folytonos"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9913,34 +10113,34 @@ msgid ""
 "{}"
 msgstr "Fő orsó fék bekapcsolva"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -9955,8 +10155,8 @@ msgstr ""
 msgid "mm / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -9971,13 +10171,13 @@ msgstr ""
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr ""
 
@@ -9986,19 +10186,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10010,7 +10210,7 @@ msgstr ""
 msgid "mm / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10021,28 +10221,28 @@ msgstr ""
 msgid "Steps / mm"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10050,99 +10250,104 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+msgid "# Include your custom HAL commands here"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
@@ -10214,11 +10419,16 @@ msgstr "Fő orsó fék bekapcsolva"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 #, fuzzy
 msgid "Back"
 msgstr "Fék"
@@ -10259,17 +10469,6 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:209
@@ -10615,55 +10814,152 @@ msgstr ""
 msgid "Scale %"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+#, fuzzy
+msgid "Axis"
+msgstr "Tengely:"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Eltolás"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Eltolás"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Bal egér gomb"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Bal egér gomb"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "Futási mód"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 #, fuzzy
 msgid "Blank program"
 msgstr "Program indítás"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 #, fuzzy
 msgid "Spindle speed display  "
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10672,79 +10968,83 @@ msgid ""
 "panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 #, fuzzy
 msgid "Blank ladder program"
 msgstr "Program szünet"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 #, fuzzy
 msgid "Estop ladder program"
 msgstr "Program megszakítása"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 #, fuzzy
 msgid "Serial modbus program"
 msgstr "Program szünet"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
 "program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 msgid "Set Ladder Options"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
@@ -10763,16 +11063,156 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+#, fuzzy
+msgid "10"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+#, fuzzy
+msgid "20"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "Futási mód"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10782,10 +11222,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr "Pozíció:"
@@ -10813,15 +11253,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisv.glade:249
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
@@ -11022,38 +11453,38 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11061,22 +11492,22 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11086,32 +11517,32 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11120,178 +11551,178 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "Lépé_s"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "Lépé_s"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "Program léptetés"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Fő orsó fék bekapcsolva"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11309,52 +11740,55 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 msgid "in / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11364,8 +11798,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr ""
@@ -11381,169 +11815,174 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
-#, python-format
-msgid "Generated by PNCconf at %s"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
-msgid "configures LinuxCNC as:\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
-msgid "type CNC\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
-msgid "will be used as the frontend display"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
-msgid " connector"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
-msgid "invrt"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
-#, python-format
-msgid "%(name)s Parport"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
-msgid "-> inverted"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
+msgid "Generated by PNCconf at %s"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
+msgid "configures LinuxCNC as:\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
+msgid "type CNC\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
+msgid "will be used as the frontend display"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
+msgid " connector"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
+msgid "invrt"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
+#, python-format
+msgid "%(name)s Parport"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
+msgid "-> inverted"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
+#, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11559,1578 +11998,1629 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 #, fuzzy
 msgid "External Controls"
 msgstr "Kézi vezérlés"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 msgid "Parallel Port"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 msgid "X Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "X Axis"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 msgid "Y Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Y Axis"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 msgid "Z Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Z Axis"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 msgid "A Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "A Axis"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Fő orsó fék kikapcsolva"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Dir"
-msgstr "Fő orsó fék bekapcsolva"
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Input"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO O Drain"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
+msgid "POT Dir"
+msgstr "Fő orsó fék bekapcsolva"
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Input"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Output"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO O Drain"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:117
+#, fuzzy
 msgid "SSR Output"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "muxed Enc I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 #, fuzzy
 msgid "Step Gen-A"
 msgstr "Program léptetés"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-Down"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "Kézi vezérlés"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "X Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Y Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Z Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "A Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "All Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "A2 Tandem Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 msgid "A2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select A"
 msgstr "Lépés a kiválasztott tengelyen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select B"
 msgstr "Lépés a kiválasztott tengelyen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select C"
 msgstr "Lépés a kiválasztott tengelyen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select D"
 msgstr "Lépés a kiválasztott tengelyen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Spindle Override incr A"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr B"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr C"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr D"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CW"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CCW"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle Stop"
 msgstr "Fő orsó lassítása [F11]"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Spindle Up-To-Speed"
 msgstr "Fő orsó lassítása [F11]"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "Lépés a kiválasztott tengelyen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "Fő orsó lassítása [F11]"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected +"
 msgstr "Lépés a kiválasztott tengelyen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected -"
 msgstr "Lépés a kiválasztott tengelyen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "A2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "Nullpont"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Float Switch"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "Határok módosítása"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "Operation"
 msgstr "Ismeretlen hiba %s"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "External Control"
 msgstr "Kézi vezérlés"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "Tengely:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
-msgid "A2 Tandem PWM"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "X Axis PWM"
-msgstr "Tengely:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "Y Axis PWM"
-msgstr "Tengely:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "Z Axis PWM"
-msgstr "Tengely:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "A Axis PWM"
-msgstr "Tengely:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-msgid "Unused PWM Gen"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-#, fuzzy
-msgid "Axis PWM"
-msgstr "Tengely:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:467
-#, fuzzy
-msgid "X Axis StepGen"
-msgstr "Tengely:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Y Axis StepGen"
-msgstr "Tengely:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Z Axis StepGen"
-msgstr "Tengely:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:469
-#, fuzzy
-msgid "A Axis StepGen"
-msgstr "Tengely:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "X2 Tandem StepGen"
-msgstr "Fő orsó lassítása [F11]"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "Y2 Tandem StepGen"
-msgstr "Fő orsó lassítása [F11]"
-
-#: src/emc/usr_intf/pncconf/private_data.py:471
-#, fuzzy
-msgid "Z2 Tandem StepGen"
-msgstr "Fő orsó lassítása [F11]"
-
 #: src/emc/usr_intf/pncconf/private_data.py:473
-msgid "Unused StepGen"
+msgid "A2 Tandem PWM"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
-msgid "Axis"
+msgid "X Axis PWM"
+msgstr "Tengely:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:474
+#, fuzzy
+msgid "Y Axis PWM"
 msgstr "Tengely:"
 
 #: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "Z Axis PWM"
+msgstr "Tengely:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "A Axis PWM"
+msgstr "Tengely:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+msgid "Unused PWM Gen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+#, fuzzy
+msgid "Axis PWM"
+msgstr "Tengely:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:481
+#, fuzzy
+msgid "X Axis StepGen"
+msgstr "Tengely:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Y Axis StepGen"
+msgstr "Tengely:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Z Axis StepGen"
+msgstr "Tengely:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:483
+#, fuzzy
+msgid "A Axis StepGen"
+msgstr "Tengely:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "X2 Tandem StepGen"
+msgstr "Fő orsó lassítása [F11]"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "Y2 Tandem StepGen"
+msgstr "Fő orsó lassítása [F11]"
+
+#: src/emc/usr_intf/pncconf/private_data.py:485
+#, fuzzy
+msgid "Z2 Tandem StepGen"
+msgstr "Fő orsó lassítása [F11]"
+
+#: src/emc/usr_intf/pncconf/private_data.py:487
+msgid "Unused StepGen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Spindle StepGen"
 msgstr "Fő orsó lassítása [F11]"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Feed Override"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "spindle Override"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Spindle Encoder"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Fő orsó:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 msgid "Unused Unused"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "Gép"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Fő orsó:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Gép"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Coolant"
 msgstr "Hűtés:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 #, fuzzy
 msgid "Spindle Output"
 msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Unused Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13139,15 +13629,15 @@ msgid ""
 "be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 msgid "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13162,82 +13652,91 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 #, fuzzy
 msgid "revolutions"
 msgstr "Pozíció:"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 #, fuzzy
 msgid "mm / second²"
 msgstr "2. tengely léptetés"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13251,7 +13750,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "Gép"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13261,18 +13760,18 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
 
@@ -14935,9 +15434,9 @@ msgid "Z"
 msgstr "_Z"
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15098,6 +15597,13 @@ msgstr ""
 #, fuzzy
 msgid "Mux options"
 msgstr "Pozíció:"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 #, fuzzy
@@ -15283,110 +15789,119 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 #, fuzzy
 msgid "Position_offset"
 msgstr "Pozíció:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 #, fuzzy
 msgid "Position_feedback"
 msgstr "Pozíció:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 #, fuzzy
 msgid "Max Spindle Override "
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 #, fuzzy
 msgid "Min Spindle Override"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 #, fuzzy
 msgid "Max Feed Override"
 msgstr "Túlhajtás (%):"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 #, fuzzy
 msgid "Increments "
 msgstr "Lépes növelése"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 #, fuzzy
 msgid "Position"
 msgstr "Pozíció:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
@@ -15394,74 +15909,83 @@ msgstr "Pozíció:"
 msgid "X"
 msgstr "_X"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "Mutasd a relatív pozíciót"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Mértékegység: _Inch"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15558,130 +16082,144 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr ""
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Fő orsó:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr ""
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Konfigurációs fájl megnyitása:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 msgid "Home Search Sequence:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
@@ -16617,10 +17155,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr ""
@@ -16707,11 +17241,6 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr ""
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-#, fuzzy
-msgid "10"
-msgstr "0"
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17163,7 +17692,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17324,31 +17852,23 @@ msgid "Manual Toolchange"
 msgstr "Kézi vezérlés"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 msgid "Restart Entry"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr ""
 
@@ -17426,33 +17946,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17573,14 +18093,12 @@ msgid "<b>Status</b>"
 msgstr "Hűtés:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17588,7 +18106,6 @@ msgid ""
 msgstr "Relatív"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17596,7 +18113,6 @@ msgid ""
 msgstr "Relatív"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17612,7 +18128,6 @@ msgid "Main Level"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17626,12 +18141,10 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17640,7 +18153,6 @@ msgid "Grid Size"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 msgid "Starting RPM"
 msgstr ""
 
@@ -17719,7 +18231,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "Ismeretlen hiba %s"
@@ -17984,12 +18495,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr ""
 
@@ -18014,6 +18523,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18078,1632 +18589,558 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-#, fuzzy
-msgid "user mode selected"
-msgstr "Lépés a kiválasztott tengelyen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "Szerszám %d ismeretlen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-msgid ""
-" Joint\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-#, fuzzy
-msgid "Classicladder real-time component not detected"
-msgstr "Valós idejű komponens nincs betöltve"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-msgid "Enter value for diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-msgid "Set diameter to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-msgid "Enter value for radius"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-msgid "Set radius to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, python-brace-format
-msgid "Set axis {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "Kézi vezérlés"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "Válaszd ki a vizsgálandó elemet"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-msgid ""
-"World\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-#, fuzzy
-msgid "no button here"
-msgstr "Lépés a kiválasztott tengelyen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "_Program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "Grafikus szimuláció törlése"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "Perspektíva nézet"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "Eltolás"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "Hűtés:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "Fő orsó fék bekapcsolva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-msgid "jog joints"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "Határok módosítása"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "Fő orsó fék bekapcsolva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Hűtés:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-msgid "Diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "Eltolás"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "Eltolás"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "Fő orsó fék bekapcsolva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Aktuális G-kódok:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Aktuális G-kódok:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "Fő orsó:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "Hűtés:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "Fő orsó:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "Túlhajtás (%):"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Túlhajtás (%):"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "Túlhajtás (%):"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-#, fuzzy
-msgid "Replace"
-msgstr "Relatív"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-#, fuzzy
-msgid "X Pos."
-msgstr " Poz "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-#, fuzzy
-msgid "Y Pos."
-msgstr " Poz "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "Fő orsó:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "Mutasd a _határokat"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "Hűtés:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Oldal nézet"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "Mutasd a _határokat"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "Mutasd a relatív pozíciót"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-msgid "Absolute Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "Nullpont"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "Nullpont"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-msgid "<b>DRO</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-msgid "Grid size"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "Mutasd a _határokat"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "Mutasd a _határokat"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-msgid "Show DTG"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-msgid "<b>Mouse Button mode</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "Oldal nézet"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "Újratöltés [Control-R]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "Lépes növelése"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "Válaszd ki a vizsgálandó elemet"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "Túlhajtás (%):"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "Mutas_d a grafikus szimulációt"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "Túlhajtás (%):"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Túlhajtás (%):"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-msgid "<b>Hardware MPG Scale</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-msgid "Use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-msgid "<b>Unlock settings</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Fő orsó fék bekapcsolva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Fő orsó fék bekapcsolva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-msgid "<b>Turtle Jog</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-#, fuzzy
-msgid "Z Pos."
-msgstr " Poz "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "Fő orsó fék bekapcsolva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-msgid "Search Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "Hűtés:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-msgid "Reload Tool on Start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Hűtés:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "Nézet mozgatás vagy sor kijelölés"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "Nézet mozgatás vagy sor kijelölés"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Kapcsold be a gépet"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "Program szünet"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "Mutasd a _határokat"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-msgid ""
-"World\n"
-"Mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Program indítás"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Program indítás"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Program megszakítása"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Program megszakítása"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Program megszakítása"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr "Program indítás"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-msgid "delete MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-msgid "delete MDI history"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-msgid "Hal-Scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-msgid "launch calibration"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-msgid "add a new tool to tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "Ú_jratöltés"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-msgid "reload tool table from file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "Válaszd ki a vizsgálandó elemet"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
-msgid "Move to parrent directory"
+#: lib/python/gladevcp/iconview.py:120
+msgid "Move to parent directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "Válaszd ki a vizsgálandó elemet"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Válaszd ki a vizsgálandó elemet"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "_Program"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+msgid "Tool file was modified since it was last read"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
 #, fuzzy
-msgid "home joints"
-msgstr "Muta_sd a programot"
+msgid "checkbutton"
+msgstr "Egér görgő gomb"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+#, fuzzy
+msgid "button"
+msgstr "Lépés a kiválasztott tengelyen"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "Hűtés Ki/Be"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Hűtés:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Fék"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "Pozíció:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Eltolás"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Eltolás"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+msgid ""
+"Zero\n"
+"G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "Horizontális"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "Lépés a kiválasztott tengelyen"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Hűtés:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+msgid "Diameter"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "_Elől nézet"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "Ismeretlen hiba %s"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "Irányított"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "Ú_jratöltés"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "Eltolás"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr " Para_méterek "
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "Eltolás"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Hűtés:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Hűtés:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Mutasd a _határokat"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "Lépés a kiválasztott tengelyen"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "Szerszám %d ismeretlen"
+
+#, fuzzy
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "Valós idejű komponens nincs betöltve"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "Kézi vezérlés"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "Válaszd ki a vizsgálandó elemet"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "_Program"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "Grafikus szimuláció törlése"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "Perspektíva nézet"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Hűtés:"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "Fő orsó fék bekapcsolva"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "Határok módosítása"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "Fő orsó fék bekapcsolva"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Hűtés:"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "Eltolás"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "Eltolás"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "Fő orsó fék bekapcsolva"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Aktuális G-kódok:"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Aktuális G-kódok:"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "Fő orsó:"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "Hűtés:"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "Fő orsó:"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "Túlhajtás (%):"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Túlhajtás (%):"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "Túlhajtás (%):"
+
+#, fuzzy
+#~ msgid "Replace"
+#~ msgstr "Relatív"
+
+#, fuzzy
+#~ msgid "X Pos."
+#~ msgstr " Poz "
+
+#, fuzzy
+#~ msgid "Y Pos."
+#~ msgstr " Poz "
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "Fő orsó:"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Mutasd a _határokat"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "Hűtés:"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Oldal nézet"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Mutasd a relatív pozíciót"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "Nullpont"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "Nullpont"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "Mutasd a _határokat"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "Mutasd a _határokat"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "Oldal nézet"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "Újratöltés [Control-R]"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "Lépes növelése"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "Válaszd ki a vizsgálandó elemet"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Túlhajtás (%):"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "Mutas_d a grafikus szimulációt"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Túlhajtás (%):"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Túlhajtás (%):"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Fő orsó fék bekapcsolva"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Fő orsó fék bekapcsolva"
+
+#, fuzzy
+#~ msgid "Z Pos."
+#~ msgstr " Poz "
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "Fő orsó fék bekapcsolva"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "Hűtés:"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Hűtés:"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "Nézet mozgatás vagy sor kijelölés"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "Nézet mozgatás vagy sor kijelölés"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Kapcsold be a gépet"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "Program szünet"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "Mutasd a _határokat"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Program indítás"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Program indítás"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Program megszakítása"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Program megszakítása"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Program megszakítása"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr "Program indítás"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "Válaszd ki a vizsgálandó elemet"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "_Program"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "Muta_sd a programot"
 
 #, fuzzy
 #~ msgid "Program"
@@ -19748,10 +19185,6 @@ msgstr "Muta_sd a programot"
 #, fuzzy
 #~ msgid "Show Setup"
 #~ msgstr "EMC állapot mutatása"
-
-#, fuzzy
-#~ msgid "Axis Offset"
-#~ msgstr "Eltolás"
 
 #, fuzzy
 #~ msgid "Spindle Motor/Encoder Configuration"

--- a/src/po/it.po
+++ b/src/po/it.po
@@ -3,13 +3,13 @@
 # Copyright (C) 2018 Ernesto Lo Valvo
 # This file is distributed under the same license package as rs274ngc.pot.
 # Ernesto Lo Valvo <ernesto.lovalvo@unipa.it>, 2019.
-# 
-# 
+#
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: it_rs274_err\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2020-05-14 22:22+0200\n"
 "Last-Translator: Ernesto Lo Valvo <ernesto.lovalvo@unipa.it>\n"
 "Language-Team: \n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3.1\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
@@ -28,69 +28,69 @@ msgstr ""
 "il comando (%s) non può essere eseguito finchè la macchina non è in E-Stop "
 "ed accesa"
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "impossibile eseguire questo (%s:%d) in modo manuale"
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr ""
 "impossibile eseguire il comando (%s) in modalità automatica con l'interprete "
 "in stato di libero"
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr ""
 "impossibile eseguire il comando (%s) in modalità automatica con l'interprete "
 "in stato di lettura"
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 "impossibile eseguire il comando (%s) in modalità automatica con l'interprete "
 "in stato di pausa"
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 "impossibile eseguire il comando (%s) in modalità automatica con l'interprete "
 "in stato di attesa"
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "impossibile eseguire il comando (%s:%d) in modalità MDI"
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 "Non è possibile cambiare modo mentre si è in AUTO e l'interprete non è "
 "INATTIVO"
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr "impossibile chiudere il file"
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "non posso aprire %s"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr "Non è possibile usare comandi MDI quando la macchina non è azzerata"
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "Bisogna essere in modalità MDI per eseguire comandi MDI"
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr ""
 "Non è possibile far girare un programma se la macchina non è stata azzerata"
@@ -218,27 +218,27 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr "Il valore di R con M19 deve essere tra 0..360"
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr "Bisogna specificare nei Punti di Controllo sia X che Y"
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr "Puoi specificare P senza X e Y solo sul primo punto di controllo"
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr "Bisogna specificare un peso P positivo per ogni Punto di Controllo"
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr "Impossibile eseguire NURBS con avanzamento nullo"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr "Impossibile usare G5.3 senza G5.2 prima"
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
@@ -247,31 +247,31 @@ msgstr ""
 "Bisogna specificare un numero di punti di controllo almeno uguale all'ordine "
 "L = %d"
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr "Impossibile convertire spline con compensazione raggio utensile"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr "Le spline devono essere sul piano XY"
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr "Le spline non possono avere movimenti in Z, A, B, o C"
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr "Bisogna specificare sia I e J con G5.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr "Bisogna indicare sia I e J oppure nessuno dei due"
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr "Bisogna specificare sia P e Q con G5"
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
@@ -279,49 +279,49 @@ msgstr ""
 "Il movimento subito dopo l'uscita dal modo compensazione utensile deve essre "
 "diritto, non un arco"
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr "Impossibile fare un arco nei piani G17.1, G18.1, o G19.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 "Movimento impossibile con velocità zero del mandrino in modalità avanzamento "
 "per giro"
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr "Parametro %c  mancante in centro arco assoluto"
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 "Il raggio del arco di ingresso della compensazione raggio utensile non è "
 "maggiore del raggio utensile"
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 "Movimento arco in un angolo concavo non può essre raggiungo dall'utensile "
 "senza urto"
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 "Il movimento da arco ad arco non è valido perchè gli archi hanno lo stesso "
 "centro"
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
@@ -329,60 +329,60 @@ msgstr ""
 "Il movimento da arco ad arco genera un angolo concavo che l'utensile "
 "compensato non può essere effettuato senza urto"
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr "Posizione assoluta  %5.2f invalida per asse rotante  %c"
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 "Impossibile cambiare modalità controllo con compensazione raggio utensile "
 "attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 "Impossibile cambiare sistema coordinate con compensazione raggio utensile "
 "attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr "G%d.1 senza parametro D"
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr "G%d.1 con parametro L, ma il piano non è G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr "G%d richiede che il parametro D sia un numero intero"
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr "G%d con utensile da tornio, ma il piano non è G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 "Impossibile impostare punto riferimento con compensazione raggio utensile "
 "attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, fuzzy, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr "M7x: restore_settings G20/G21 errato: '%s'"
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
@@ -390,106 +390,106 @@ msgstr ""
 "BUG: impossibile restore da u basso call level (%d) ad un alto call level "
 "(%d)"
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr "BUG: restore dal  livello %d !?"
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr "BUG: restore al livello %d !?"
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr "M7x: restore_settings G20/G21 errato: '%s'"
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr "M7x: restore_settings errato eseguendo '%s': %s"
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 "Operazione di movimento impossibile con compensazione raggio utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr "Nessun parametro P con M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 "Operazione di movimento digitale impossibile con compensazione raggio "
 "utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr "Nessun parametro P valido con M63"
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 "Impossibile definire output digitali ausiliari con compensazione raggio "
 "utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr "Nessun parametro P valido con M64"
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr "Nessun parametro P valido con M65"
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr "parametro P errato con M66"
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 "Attesa input digitale impossibile con compensazione raggio utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 "Attesa input analogico impossibile con compensazione raggio utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 "Operazione di movimento analogico impossibile con compensazione raggio "
 "utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr "Indice analogico non valido con M67"
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 "Impossibile definire output analogici ausiliari con compensazione raggio "
 "utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr "Indice analogico non valido con M68"
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 "E' necessario un parametro Q non-negativo  per specificare il numero "
 "utensile con M61"
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
@@ -498,7 +498,7 @@ msgstr ""
 "Mandrino ($) numero fuori portata in comando M3\n"
 " num_spindles =% i. $ =% d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, fuzzy, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
@@ -507,7 +507,7 @@ msgstr ""
 "Mandrino ($) numero fuori portata in comando M3\n"
 " num_spindles =% i. $ =% d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, fuzzy, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
@@ -516,161 +516,161 @@ msgstr ""
 "Mandrino ($) numero fuori portata in comando M3\n"
 " num_spindles =% i. $ =% d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr "Mandrino ($) numero fuori range nel comando M19"
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr "Word Q con M19 richiede un valore > 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 "Impossibile riprendere contesto da stack frame invalido - M70/M73 mancante?"
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 "Impossibile abilitare superamento con compensazione raggio utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 "Impossibile disabilitare superamento con compensazione raggio utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr "Numero di mandrino ($) non valido nel comando M51"
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr "Asse Indexato %c può muoversi solo con G0"
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr "Asse Indexato %c può muoversi solo singolarmente"
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr "Operazione di misura impossibile in modalità avanzamento per giro"
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 "Impossibile cambiare modo retract con compensazione raggio utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr "G10 L1 senza offsets non ha effetto"
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr "Il numero Q in G10 non è intero"
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr "Orientazione utensile errata"
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr "Parametri I J non consentiti con G10 L2"
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 "Impossibile cambiare sistema coordinate con compensazione raggio utensile "
 "attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr "R non consentito in G10 L20"
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr "BUG: raggiunto convert_stop () da M99 come ritorno subprogram"
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr "Numero mandrino non valido ($) in G33 Move"
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr "Il mandrino non gira in G33"
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr "Numero di mandrino ($) non valido in G 33.1 Move"
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr "Il mandrino non gira in G33.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr "Numero D non valido nel ciclo G76"
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "Il mandrino (%i) not turning in G76"
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr "BUG: Un movimento asse non corretto con un indexer"
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr "BUG: tentativo di indicare asse non corretto"
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 "Impossibile usare il ciclo di filettatura G76 con compensazione raggio "
 "utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr "In G76, I non può essere 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr "In G76, J deve essere maggiore di 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr "In G76, K deve essere maggiore di J"
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 "La lunghezza del movimento di ingresso con compensazione raggio utensile non "
 "è maggiore del raggio utensile"
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 "Angolo interno di 0 gradi non è consentito con la compensazione utensile "
 "attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
@@ -678,20 +678,20 @@ msgstr ""
 "Il movimento da arco a linea genera un angolo che l'utensile compensato non "
 "può eseguire senza urto"
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr "Impossibile cambiare utensile con compensazione raggio utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 "Impossibile cambiare offset utensile con compensazione raggio utensile attiva"
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 #, fuzzy
 msgid "G43.2: No axes specified and H word missing"
 msgstr "G43.2: H-word mancante"
@@ -812,32 +812,32 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr "Numero mandrino non valido ($) nel comando velocità mandrino"
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "Impossibile usare coordinate polari con G53"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr "Impossibile specificare parametri X e Y con coordinate polari"
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 "Bisogna specificare l'angolo in coordinate polari se riferite all'origine"
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 "Movimento incrementale in coordinate polari è indeterminato nell'origine"
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr "Movimento G91 in coordinate polari è indeterminato nell'origine"
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr "Utensile richiesto %d mancante nella tabella utensili"
@@ -957,107 +957,107 @@ msgstr "File:%s   linea:%d sub: o|%s| trovata in posizione illegale"
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr "File:%s  La linea:%d ridefinisce sub: o|%s| già definita nel file:%s"
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "%d: manca nella definizione subroutine : '%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr "% d: etichetta O-Word duplicata:' %s'-definita nella riga% d"
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr "% d: etichetta O-Word duplicata-già definita nella riga% d:' %s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr "%d: label O-word non definita: '%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 "% d: nessuna corrispondenza ' If ' Label:' %s'(trovato ' %s'nella riga% d)"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 "% d: nessuna etichetta corrispondente:' %s'(trovata ' %s'nella riga% d):' %s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 "% d: nessuna etichetta while/do corrispondente:' %s'(trovato ' %s'nella riga"
 "% d)"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 "% d: nessuna etichetta corrispondente:' %s'(trovato ' %s'nella riga% d)"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "Parametro nominato #<%s> non definito"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, c-format
 msgid "cant open ini file '%s'"
 msgstr "impossibile aprire file ini '%s'"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "Parametro ini nominato #<%s> non definito in inifile '%s': error=0x%x"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr "fetch_hal_param: hal_init(%s): %d"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr "fetch_hal_param: hal_ready(): %d"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr "Errore interno: non posso assegnare #<%s>"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr "Impossibile assegnare  parametro #<%s> read-only"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr "BUG: lookup_named_param(%s): non gestito indice=%fn"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "Coda non vuota dopo un cambio utensile"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "Impossibile aprire il file parametri : '%s'"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 msgid "Parameter file name is missing"
 msgstr "Manca nome file parametri"
 
@@ -1483,7 +1483,8 @@ msgid "Negative spindle speed used"
 msgstr "Uso velocità mandrino negativa"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "Uso indice utensile negativo"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1793,7 +1794,7 @@ msgstr "Parametro P mancante con G76"
 msgid "I J or K words missing with G76"
 msgstr "Parametro I, J o K mancante con G76"
 
-# 
+#
 #: src/emc/rs274ngc/rs274ngc_return.hh:200
 msgid "Cannot move rotary axes with G76"
 msgstr "Impossibile muovere asse rotante con G76"
@@ -1873,17 +1874,17 @@ msgstr "R minore di U in un ciclo nel piano VW"
 msgid "R less than V in cycle in UW plane"
 msgstr "R minore di V in un ciclo nel piano UW"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "ERRORE: '%s' non è un tipo di esame valido\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "ERRORE: nessun nome di pin/segnale/parametro\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
@@ -1891,8 +1892,7 @@ msgstr ""
 "ERRORE:  opzione -s richiede un tipo di esame ed un nome di pin/segnale/"
 "parametro\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "Hal Meter"
 
@@ -1904,27 +1904,27 @@ msgstr "_Seleziona"
 msgid "E_xit"
 msgstr "E_sci"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "Selezione Elemento da Esaminare"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr " _Pins "
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr " _Segnali "
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr " Para_metri "
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr "_Chiudi"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
@@ -1932,67 +1932,89 @@ msgstr ""
 "Uso:\n"
 "  halscope [-h] [-i infile] [-o outfile] [numero_campioni]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "Apri File Configurazione:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Annulla"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "Apri"
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Apri File Configurazione:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "Salva"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "Apri C_onfigurazione..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "_Salva configurazione."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "A_pri File Dati..."
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "S_alva File Dati..."
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "_Esci"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "Inform_azioni su Halscope"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "_File"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "_Aiuto"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "Oscilloscopio HAL"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "Orizzontale"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "Canale Selezionato"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "Modo Operativo"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "Trigger"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "Verticale"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -2000,39 +2022,40 @@ msgstr "Verticale"
 msgid "Stop"
 msgstr "Stop"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "Normale"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "Singolo"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "Roll"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "Zoom"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr " Pos "
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "----- Campioni\n"
-"a ---- KHz"
+"a ---- kHz"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "Componente realtime non caricato"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -2059,11 +2082,39 @@ msgstr ""
 "oppure\n"
 "Cliccare 'Esci' per uscire da HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "Esci"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "Funzione realtime non collegata"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -2085,11 +2136,11 @@ msgstr ""
 "oppure\n"
 "Cliccare 'Esci' per uscire da HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "Seleziona Velocità Campionamento"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
@@ -2099,94 +2150,70 @@ msgstr ""
 "oppure\n"
 "Cliccare 'Esci' per uscire da HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr "Thread:"
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr "Periodo Campionamento:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr "Velocità Campionamento:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr "Thread"
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "Periodo"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "Moltiplicatore:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr "Lunghezza Registrazione"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d campioni (1 canale)"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d campioni (2 canali)"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d campioni (4 canali)"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d campioni (8 canali)"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d campioni (16 canali)"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "Esci"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr "Threads realtime non attivi"
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2210,15 +2237,15 @@ msgstr ""
 "oppure\n"
 "Cliccare 'Esci' per uscire da HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr "Selezionare il file log da scrivere su:"
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr "Canali non sufficienti"
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
@@ -2228,7 +2255,7 @@ msgstr ""
 "che sono attualmente attivati.  Scegliere una lunghezza\n"
 "del record più piccola che supporta più canali."
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
@@ -2237,7 +2264,7 @@ msgstr ""
 "%s\n"
 "per div"
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
@@ -2246,27 +2273,35 @@ msgstr ""
 "%s campioni\n"
 "a %s"
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
-msgstr "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
-msgstr "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
-msgstr "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
-msgstr "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2280,17 +2315,17 @@ msgstr "Sec"
 #: src/emc/usr_intf/pncconf/mesa1.glade:460
 #: src/emc/usr_intf/pncconf/mesa1.glade:473
 msgid "Hz"
-msgstr "Hz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
-msgstr "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
-msgstr "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
+msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
@@ -2299,24 +2334,25 @@ msgstr ""
 "Offset\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "Guadagno"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr "Pos"
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr "Scala"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 msgid ""
 "Offset\n"
 "----"
@@ -2324,15 +2360,11 @@ msgstr ""
 "Offset\n"
 "----"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr "Canale Off"
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "Imposta Offset"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
@@ -2341,37 +2373,21 @@ msgstr ""
 "Imposta l'offset verticale\n"
 "per il canale %d."
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "Imposta Offset"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr "Accoppiamento AC"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Annulla"
-
 # Anmerkung:FJ: Tool max? Was das?
 # Anmerkung:AJ: sollte "Index in tool table file too large" sein
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr "Troppi canali"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2383,21 +2399,7 @@ msgstr ""
 "Disattivare uno o più canali, oppure ridurre\n"
 "la lunghezza del record così da utilizzare più canali"
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr "prossima ricerca: %d\n"
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr "search: %d (wrapped=%d)\n"
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr "Selezionare Sorgente Canale"
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
@@ -2406,29 +2408,33 @@ msgstr ""
 "Selezionare un pin, segnale, o parametro\n"
 "come sorgente per il canale %d."
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "Selezionare Sorgente Canale"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "Pins"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "Segnali"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "Parametri"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr "Discesa"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr "Salita"
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
@@ -2436,7 +2442,7 @@ msgstr ""
 "Sorgente\n"
 "Nessuna"
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
@@ -2445,113 +2451,114 @@ msgstr ""
 "Sorgente\n"
 "Canale %2d"
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "Auto"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr "Forza"
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr "Livello"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr "Sorgente Trigger"
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr "Selezione un canale da usare per il triggering."
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "Sorgente Trigger"
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr "Canale"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr "Sorgente"
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr "errore %d durante orientazione in progress"
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr "Movimento G38.4 concluso senza interruzione contatto."
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr "Movimento G38.2 concluso senza raggiungimento contatto."
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+#, fuzzy
+msgid "Probe tripped during non-probe move."
 msgstr "Contatto sensore durante comando MDI senza-sensore."
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr "Contatto sensore durante movimento azzeramento."
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr "Contatto sensore durante movimento."
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr "Contatto sensore durante movimento."
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr "movimento fermato da enable input"
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr "errore amplificatore mandrino %d"
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "contatto sul limite %d"
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "errore amplificatore asse %d"
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "errore Inseguimento giunto %d"
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr "kinematicsInverse ha dato posizione giunti  non-finita sul giunto% d"
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr "kinematicsInverse fallita"
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr "Limite soft NEGATIVO superato  (%.5f) sull'asse %d\n"
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 #, fuzzy
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 "utti gli assi devono essere azzerati prima di andare in modalità teleop"
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr "Suggerimento: passare alla modalità giunti per jog off soft limit"
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr "Limite soft POSITIVO superato  (%.5f) sull'asse %d\n"
@@ -2621,179 +2628,179 @@ msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 "tutti gli assi devono essere azzerati prima di andare in modalità coordinate"
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr "Impossibile movimentare assi senza abilitazione."
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr "Impossibile movimentare assi durante azzeramento."
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr "Impossibile movimentare nessun asse durante azzeramento."
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr "necessaria abilitazione, per moto lineare in modalità coordinate"
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr "errati parametri in comando lineare"
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr "movimento lineare impossibile in presenza superamento limiti"
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 "impossibile aggiungere movimento lineare alla linea %d, codice errore %d"
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr "necessaria abilitazione, per moto circolare in modalità coordinate"
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr "movimento circolare impossibile in presenza superamento limiti"
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 "impossibile aggiungere movimento circolare alla linea %d, codice errore %d"
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr "MOTION: STEP impossibile in presenza di altre esecuzioni"
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr "impossibile abilitare movimento, input enable è falso"
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr "bisogna essere in modalità assi per eseguire azzeramento"
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr "Homing denied by motion.homing-inhibit joint=%d\n"
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr "sequenza azzeramento già attiva"
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr "bisogna essere in modalità assi oppure scegliere dis-azzeraramento"
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr "Impossibile dis-azzerare durante azzeramento, asse %d"
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr "Impossibile dis-azzerare durante movimento, asse %d"
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr "Impossibile dis-azzerare extrajoint <%d> con movimento abilitato"
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr "Impossibile dis-azzerare asse %d inattivo"
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr "Impossibile dis-azzerare asse invalido %d (max %d)"
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr "necessaria abilitazione, per movimento sonda in modalità coordinate"
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr "impossibile uso sonda in presenza di superamento limiti"
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr "Sonda già inattiva all'inizio del movimento con G38.4 o G38.5"
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr "Sonda già attiva all'inizio del movimento con G38.2 o G38.3"
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr "impossibile aggiungere movimento sonda"
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr "necessaria abilitazione, per movimento rigido in modalità coordinate"
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr "impossibile uso movimento tap rigido in presenza di superamento limiti"
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr "impossibile uso movimento tap rigido  alla linea %d, codice errore %d"
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr "Tentativo di avvio per mandrino inesistente"
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr "Tentativo di stop per mandrino inesistente<%d>"
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr "Tentativo di accelerazione per mandrino inesistente <%d>"
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr "Attempt to increase non-existent spindle <%d>"
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr "Tentativo di decelerazione per mandrino inesistente <%d>"
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr "Tentativo di blocco freno per mandrino inesistente<%d>"
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr "Tentativo di sblocco freno per mandrino inesistente<%d>"
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr "asse %d: troppi parametri compensazione"
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr "asse %d: i valori della compensazione devono crescere"
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr "comando %d sconosciuto"
@@ -2894,26 +2901,26 @@ msgstr "MOTION: hal_exit() fallito, riporta %d\n"
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr "MOTION: emcmot_hal_data malloc fallito\n"
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr "MOTION: asse %d export pin fallito"
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr "MOTION: asse %d pin/param export fallito\n"
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr "MOTION: export_joint_home_pins ) fallito\n"
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr "MOTION: ejoint %d pin/param export fallito\n"
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr "MOTION: asse %c pin/param export fallito\n"
@@ -3096,7 +3103,7 @@ msgstr "Errore caricamento file project..."
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr "Ok"
 
@@ -3190,19 +3197,19 @@ msgstr "Okay"
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "Si"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr "No"
 
@@ -3258,7 +3265,7 @@ msgstr "Carica"
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "Salva"
 
@@ -3276,7 +3283,7 @@ msgstr "Vars"
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "Editore"
 
@@ -3290,7 +3297,6 @@ msgid "Config"
 msgstr "Config"
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 msgid "Preview"
 msgstr "Visualizzare"
 
@@ -3722,7 +3728,7 @@ msgid "Edit mode..."
 msgstr "Modo Modifica..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "Cancella"
 
@@ -3731,7 +3737,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr "Vuoi davvero cancellare il rung corrente?"
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "Aggiungi"
 
@@ -3742,6 +3748,24 @@ msgstr "Inserire"
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "Modifica"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Annulla"
 
 #: src/hal/classicladder/edit_sequential.c:68
 msgid "Step Nbr"
@@ -3934,7 +3958,7 @@ msgid "Parameter"
 msgstr "Parametro"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr "Applica"
 
@@ -4125,7 +4149,6 @@ msgstr "Ladder"
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "Principale"
 
@@ -4203,11 +4226,13 @@ msgid "Delete section"
 msgstr "Cancella Sezione"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr "Muove Sopra"
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Down"
 msgstr "Muove Giù"
 
@@ -4754,6 +4779,7 @@ msgid "Exit"
 msgstr "Esci"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "Modifica"
 
@@ -4796,7 +4822,6 @@ msgid "Renumber File..."
 msgstr "Rinumera File..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "Settaggi"
 
@@ -5085,15 +5110,15 @@ msgstr "Vista ad albero"
 msgid "Test HAL command :"
 msgstr "Prova comando HAL:"
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr "Carica una lista di controllo"
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr "Salva la lista controllo corrente"
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "Possono essere provati i comandi ma essi NON saranno salvati"
 
@@ -5223,11 +5248,11 @@ msgstr "DIREZIONE"
 msgid "SIZE :"
 msgstr "GRANDEZZA :"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr "Errori LinuxCNC"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
@@ -5235,11 +5260,11 @@ msgstr ""
 "LinuxCNC terminato con un errore.  Per segnalare il problema, si prega di "
 "creare un file report da includere nel tuo messaggio."
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 msgid "Create Report File"
 msgstr "Crea File Report"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "Chiudi"
 
@@ -5317,7 +5342,7 @@ msgstr "Imposta Offset Utensili"
 msgid "Tool:"
 msgstr "Utensile:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Tutti i file"
@@ -5384,18 +5409,18 @@ msgstr "Unità"
 msgid "auto"
 msgstr "auto"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "pollici"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5552,7 +5577,7 @@ msgstr "articolazione"
 msgid "world"
 msgstr "globale"
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "origine"
 
@@ -5633,16 +5658,15 @@ msgstr "Verifica"
 msgid "Optional Stop"
 msgstr "Stop Opzionale"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "Imposta font"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "Font"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "Dimensione"
 
@@ -5751,7 +5775,7 @@ msgid "Coordinate System Control Window"
 msgstr "Finestra Controllo Sistema Coordinate"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "Asse "
 
@@ -6305,9 +6329,9 @@ msgstr "rimuove"
 msgid "move"
 msgstr "muove"
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr "Personale"
 
@@ -6327,8 +6351,8 @@ msgstr "Trovati multipli per"
 msgid "using path"
 msgstr "uso percorso"
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr "Attenzione"
 
@@ -6402,119 +6426,119 @@ msgstr "file ini"
 msgid "not found"
 msgstr "non trovato"
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr "trovato  truetype-tracer v4 -OK"
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr "Nota: è richiesto truetype-tracer v4"
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr "Nota: è richiesto truetype-tracer v4"
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr "bisogna caricare prima ngcgui_app.tcl"
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr "Crea un file subroutine da truetype-tracer (V4 richiesta)"
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr "problema con"
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr "Nessuna voce per"
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr "versione errata di truetype-tracer"
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr "non scrivibile, usando"
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr "e imposta expandsub"
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr "Testo"
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr "Scala lineare"
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr "niente"
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr "Subdiv"
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr "default"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr "Modo"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr "normale"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr "data"
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr "nome font"
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr "Switches"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr "Unicode"
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr "Consente Rotazione"
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr "Genera subfile ngcgui-compatibile e nuova pagina tab"
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr "Testo nullo"
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr "Uso default font  truetype-tracer"
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 msgid "no such file"
 msgstr "nessun file"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr "ile non leggibile"
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr "Crea nuova pagina tab"
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
@@ -6522,27 +6546,27 @@ msgstr ""
 "richiede il comando inifindall\n"
 "da axis.py (LinuxCNC 2.5) o"
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr "non leggibile"
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr "Imprevisto: Startup multiple per ngcgui"
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 msgid "LinuxCNC"
 msgstr "LinuxCNC"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr "per linuxCNC 2.5.xxx, Non includere tkapp.py nel file ini"
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 msgid "LinuxCNC version"
 msgstr "Versione LinuxCNC"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr "per LinuxCNC 2.5.xxx, Non includere tkapp.py nel file ini"
 
@@ -7199,34 +7223,34 @@ msgstr "Alt-F, M, V"
 msgid "Open a Menu"
 msgstr "Apri un Menù"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Utensile %d sconosciuto"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Utensile assente"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Utensile %(tool)d, offset %(zo)g, diametro %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "Utensile %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "Filtraggio..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "Filtro fallito"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
@@ -7235,12 +7259,12 @@ msgstr ""
 "Il programma %(program)r termina con codice %(code)d.  Ogni messaggio di "
 "errore prodotto è mostrato sotto:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "Errore codice G in %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7249,130 +7273,128 @@ msgstr ""
 "Vicino la linea  %(seq)d di %(f)s:\n"
 "%(error_str)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "Continuo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr "T     Tabella Utensile"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "in"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr " raggio"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr " diametro"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr "°"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "Sistema Coordinate:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr "fissaggio"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr "pezzo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "Nome:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "Dimensione:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "Ordine utensile:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "Distanza rapido:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "Distanza di lavoro:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "Distanza totale:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "Tempo lavorazione:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "Limiti X:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Limiti Y:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Limiti Z:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "Limiti A:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "Limiti B:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "Limiti C:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "Il programma va oltre il limite inferiore sull'asse %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "Il programma va oltre il limite superiore sull'asse %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "Il programma eccede i limiti macchina"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Esegui comunque"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "Nessun file caricato"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "generato da %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
@@ -7381,43 +7403,43 @@ msgstr ""
 "%(size)s bytes\n"
 "%(lines)s linee gcode"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr "%.1f minuti"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr "%d secondi"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%(a)f a %(b)f = %(diff)f %(units)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "Proprietà Codici G"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "Tutti i file di lavoro"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "files rs274ngc"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr "axis non può accettare comandi remoti durante il suo funzionamento"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 msgid "File not Writable:"
 msgstr "File non scrivibile:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7435,28 +7457,28 @@ msgstr ""
 "Salvarlo nella propria directory\n"
 "quindi aprire il file salvato, reso scrivibile"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr "Edit-sola lettura"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Custom Grid"
 msgstr "Griglia Personalizzata"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr "Imposta dimensione griglia"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr "Asse già azzerato, sei sicuro che vuoi ri-azzerarlo?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr "azzeramento asse <%s> Usa la modalità assi per eseguire azzeramento"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
@@ -7465,30 +7487,30 @@ msgstr ""
 "\n"
 "Homing ad asse singolo non consentito per la lettera duplicata:<%s> "
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr "Questo giunto è già azzerato, sei sicuro che vuoi ri-azzerarlo?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 msgid "Touch Off (system)"
 msgstr "Contatto (sistema)"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "Inserire %s coordinate relative al %%s:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, python-format
 msgid "Tool %s TouchOff"
 msgstr "Contatto Utensile %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "Errore nel salvataggio file"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7501,7 +7523,7 @@ msgstr ""
 "%s\n"
 "Vedere i documenti \"Configurazione INI\"\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7514,7 +7536,7 @@ msgstr ""
 "%s\n"
 "Vedere i documenti \"Configurazione INI\"\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7527,48 +7549,48 @@ msgstr ""
 "%s\n"
 "Vedere i documenti \"Configurazione INI\"\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr "Assi"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 msgid "Joints"
 msgstr "Giunti"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "Azzera tutto"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "Azzera tutti gli assi %s [Ctrl-Home]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, python-format
 msgid "Home All %s"
 msgstr "Azzera tutto %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, python-format
 msgid "Unhome All %s"
 msgstr "Dis-Azzera tutto %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 "Avviso: la cinematica in avanti deve gestire lettere di coordinate duplicate:"
 "%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr "Nota: numero di [TRAJ]COORDINATES%(t)s supera [KINS]JOINTS%(l)d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
@@ -7578,42 +7600,42 @@ msgstr ""
 "Nota:\n"
 "L'homing ad asse individuale non è attualmente supportato per"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr "KINEMATICS_IDENTITY con lettera dell'asse duplicata <%s>\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 msgid "Joint"
 msgstr "Giunto"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 msgid "Home Joint"
 msgstr "Azzera Assi"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr "Home %(name)s _%(id)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "Dis-azzera %(name)s _%(id)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "Avvia da qui"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr "alternare la visibilità del pannello PYVCP"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr "Mostra pan_el pyVCP"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "Errore in ~/.axisrc"
 
@@ -7927,11 +7949,13 @@ msgid "_Properties..."
 msgstr "_Proprietà..."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "Modifica _tabella utensili..."
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+#, fuzzy
+msgid "Reload tool _data"
 msgstr "Ricarica ta_bella utensile"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8258,11 +8282,11 @@ msgstr "Scambio Salto linee con '_/' [Alt-M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "Scambio pausa opzionale  [Alt-M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "Ingrandisci"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "Riduci"
 
@@ -8439,9 +8463,10 @@ msgstr "Superamento limite mandrino:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr "%"
 
@@ -8493,7 +8518,7 @@ msgid "Position:"
 msgstr "Posizione:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr "Macchina"
 
@@ -8598,21 +8623,20 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Permetti movimento temporaneo oltre i limiti macchina [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr "Segue Tema Sistema"
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "Mandrino orario"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "Mandrino antiorario"
@@ -8952,6 +8976,8 @@ msgid "."
 msgstr "."
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8961,43 +8987,88 @@ msgstr "."
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr "0"
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr "3"
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr "2"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr "1"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr "6"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr "5"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr "4"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr "9"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr "8"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr "7"
 
@@ -9052,7 +9123,6 @@ msgid "label26"
 msgstr "etichetta26"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr "<b>Mandrino</b>"
 
@@ -9222,7 +9292,6 @@ msgstr ""
 "3"
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr "Stato"
 
@@ -9281,8 +9350,8 @@ msgstr "<b>Opzioni Visualizzazione</b>"
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr "Pollici"
@@ -9417,10 +9486,10 @@ msgid "Stepconf"
 msgstr "Configurazione Passi"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9438,12 +9507,12 @@ msgid "Parallel Port 1"
 msgstr "Porta Parallela 1"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 msgid "Parallel Port 2"
 msgstr "Porta Parallela 2"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 msgid "Options"
 msgstr "Opzioni"
 
@@ -9452,225 +9521,276 @@ msgid "HALUI"
 msgstr "HALUI"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Tasto X Zero"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 msgid "Axis X"
 msgstr "Asse X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 msgid "Axis Y"
 msgstr "Asse Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 msgid "Axis Z"
 msgstr "Asse Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 msgid "Axis U"
 msgstr "Asse U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 msgid "Axis V"
 msgstr "Asse V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 msgid "Axis A"
 msgstr "Asse W"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "Spindle"
 msgstr "Mandrino"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr "Quasi Fatto"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr "Gecko 201"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr "Gecko 202"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr "Gecko 203v"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr "Gecko 210"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr "Gecko 212"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr "Gecko 320"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr "Gecko 540"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr "L297"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr "PMDX-150"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr "Sherline"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr "Xylotex 8S-3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr "Parker-Compumotor oem750"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr "JVL-SMD41 or 42"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr "Hobbycnc Pro Chopper"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr "Keling 4030"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr "Passo X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr "Direzione X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr "Passo Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr "Direzione Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr "Passo Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr "Direzione Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr "Passo A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr "Direzione A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "U Step"
 msgstr "Passo U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "U Direction"
 msgstr "Direzione U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "V Step"
 msgstr "Passo V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "V Direction"
 msgstr "Direzione V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "StepGen X2 Tandem"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "Direzione X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "StepGen X2 Tandem"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Direzione Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr "Mandrino ON"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr "Mandrino PWM"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr "Freno Mandrino"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr "Refrigerante Aria"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr "Refrigerante liquido"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr "ESTOP Out"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr "Abilita Amplificatore"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr "Carica Pompa"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr "Out digitale 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr "Out digitale 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr "Out digitale 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr "Out digitale 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+#, fuzzy
+msgid "Plasma Ohmic Enable"
+msgstr "Abilita POT"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9681,240 +9801,336 @@ msgstr "Out digitale 3"
 msgid "Unused"
 msgstr "Inutilizzato"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr "ESTOP In"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr "Probe In"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr "Indice Mandrino"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr "Fase A Mandrino"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr "Fase B Mandrino"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr "Origine X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr "Origine Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr "Origine Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr "Origine A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home U"
 msgstr "Origine U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home V"
 msgstr "Origine V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Origine X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Origine Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr "Limite Minimo + Home X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr "Limite Minimo + Home Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem X"
+msgstr "Limite Minimo + Home X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem Y"
+msgstr "Limite Minimo + Home Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr "Limite Minimo + Home Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr "Limite Minimo + Home A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr "Limite Minimo + Home U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr "Limite Minimo + Home V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr "Limite Massimo + Home X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr "Limite Massimo + Home Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem X"
+msgstr "Limite Massimo + Home X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem Y"
+msgstr "Limite Massimo + Home Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr "Limite Massimo + Home Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr "Limite Massimo + Home A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home U"
 msgstr "Limite Massimo + Home U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home V"
 msgstr "Limite Massimo + Home V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr "Entrambi i Limiti + Home X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr "Entrambi i Limiti + Home Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr "Entrambi i Limiti + Home Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr "Entrambi i Limiti + Home A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home U"
 msgstr "Entrambi i Limiti + Home U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home V"
 msgstr "Entrambi i Limiti + Home V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Entrambi i Limiti + Home X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Entrambi i Limiti + Home Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr "Limite Minimo X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr "Limite Minimo Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem X"
+msgstr "Limite Minimo X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem Y"
+msgstr "Limite Minimo Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr "Limite Minimo Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr "Limite Minimo A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit U"
 msgstr "Limite Minimo U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit V"
 msgstr "Limite Minimo V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr "Limite Massimo X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr "Limite Massimo Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem X"
+msgstr "Limite Massimo X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem Y"
+msgstr "Limite Massimo Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr "Limite Massimo Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr "Limite Massimo A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit U"
 msgstr "Limite Massimo U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit V"
 msgstr "Limite Massimo V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr "Entrambi i limiti X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr "Entrambi i limiti Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr "Entrambi i limiti Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr "Entrambi i limiti A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit U"
 msgstr "Entrambi i limiti U"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit V"
 msgstr "Entrambi i limiti V"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Entrambi i limiti X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Entrambi i limiti Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr "Tutti i limiti"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr "Azzeramento totale"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits + homes"
 msgstr "Tutti i limiti zero +"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr "Digital in 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr "Digital in 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr "Digital in 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr "Digital  n 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Up"
+msgstr "Muove Sopra"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "Muove Giù"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 msgid "Forward"
 msgstr "Avanti"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr "Fatto"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -9924,9 +10140,9 @@ msgstr ""
 "Custom.clp esistente sarà rinominato custom_backup.clp.\n"
 "Qualsiasi  file esistente di nome -custom_backup.clp- verrà perso. "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9940,8 +10156,8 @@ msgstr ""
 "\n"
 "Sei sicuro?  "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
@@ -9949,7 +10165,7 @@ msgstr ""
 "Bisogna indicare un input pin di E-stop nella pagina di Configurazione Porta "
 "Parallela di questo programma."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
@@ -9959,12 +10175,12 @@ msgstr ""
 "Custom.xlm esistente sarà rinominato custompanel_backup.xlm.\n"
 "Qualsiasi file esistente di nome custompanel_backup.xlm verrà perso. "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr "Esci da Stepconf e perdi modifiche?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
@@ -9972,8 +10188,8 @@ msgstr ""
 "La configurazione è stata compilata e salvata.\n"
 "Vuoi uscire?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
@@ -9981,8 +10197,8 @@ msgstr ""
 "Si sta usando una versione di LinuxCNC in realtime simulato, quindi non è "
 "possibile la prova/controllo di hardware esterno."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9999,16 +10215,16 @@ msgstr ""
 "Stai usando   %(actual)s  kernel.\n"
 "E' necessario usare il kernel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr "my-mill"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr "File %r e' stato modificato da quando è stato scritto da stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
@@ -10016,27 +10232,27 @@ msgstr ""
 "Salvare questo file di configurazione eliminera' i cambi alla configurazione "
 "fatti fuori da stepconf."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr "Continuo? "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr "yY"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr "avvio %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr "Avvio dalla Scrivania per configurazioni LinuxCNC fatte da Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -10044,34 +10260,34 @@ msgid ""
 "{}"
 msgstr "Selettore Configurazioni LinuxCNC"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr "Altro"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr "Test Asse %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr "gradi / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr "gradi / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr "gradi"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -10086,8 +10302,8 @@ msgstr "gradi"
 msgid "mm / s"
 msgstr "mm / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -10102,13 +10318,13 @@ msgstr "mm / s"
 msgid "mm / s²"
 msgstr "mm / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr "in / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr "in / s²"
 
@@ -10117,19 +10333,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "File configurazioni LinuxCNC 'stepconf"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr "Modifica Configurazione Esistente"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr "gradi / giro"
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr "Passi / grado"
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10141,7 +10357,7 @@ msgstr "Passi / grado"
 msgid "mm / rev"
 msgstr "mm / giro"
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10152,28 +10368,28 @@ msgstr "mm / giro"
 msgid "Steps / mm"
 msgstr "Passi / mm"
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr "giro / in"
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr "Passi / in"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr "# Generato da stepconf 1.1 a %s"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10181,67 +10397,67 @@ msgstr "# Se questo file viene modificato, questo sarà"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr "# sovrascritto quando si userà ancora stepconf"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr "# aggiungere qui i comandi halui MDI (max 64) "
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr "# **** Setup per programma ladder  estop esterno  -AVVIO ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr "# **** Setup per programma ladder  estop esterno  -FINE ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 "# Carica Classicladder con modbus master incluso (GUI deve girare per Modbus)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 "# Carica Classicladder senza GUI (puoi ricaricare LADDER GUI in AXIS GUI"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr "Includi qui il tuo Panello PyVCP.\n"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr "# Questi files sono caricati dopo Gui, nell'ordine con cui appaiono"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr "# **** Setup della velocità mandrino tramite pyvcp - START ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr "# **** Usa velocità mandrino EFFETTIVA dall'encoder mandrino"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr "# **** velocità mandrino intermittente, usa filtro passabasso"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
@@ -10249,16 +10465,16 @@ msgstr ""
 "# **** velocità mandrino con il segno, pertanto usa componente assoluta per "
 "rimuovere il segno"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 "# **** velocità EFFETTIVA è in giri/s e non giri/min spertanto viene scalata."
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr "# **** Imposta  velocità mandrino come indicatore ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
@@ -10266,23 +10482,29 @@ msgstr ""
 "# **** Usa velocità mandrino COMANDATA da LinuxCNC perchè non è stato "
 "specificato nessun encoder mandrino"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr "# Includi i tuoi comandi HAL personalizzati %s qui"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr "# Questo file non sara' sovrascritto quando si userà ancora stepconf"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 "# Questo file imposta i limiti simulati/Home/hardware encoder mandrino."
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
 msgstr "# Questo file è generato automaticamente, non modificabile."
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+#, fuzzy
+msgid "# Include your custom HAL commands here"
+msgstr "# Includi i tuoi comandi HAL personalizzati %s qui"
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
 msgid "Mach configuration files"
@@ -10351,11 +10573,16 @@ msgstr "Configurazione Guidata Stepconf-Stepper"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr "etichetta"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "Indietro"
 
@@ -10400,17 +10627,6 @@ msgstr "XY(speciale)"
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
 msgstr "MM"
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
-msgstr "ns"
 
 #: src/emc/usr_intf/stepconf/base.glade:209
 msgid "Step _Time:"
@@ -10771,53 +10987,154 @@ msgstr "Usa Velocità Mandrino:"
 msgid "Scale %"
 msgstr "Scala %"
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr "Axis"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
-msgstr "Usa Schermo AXIS"
+msgid "Gmoccapy"
+msgstr "Gmoccapy"
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
-msgstr "Usa Schermo Gmoccapy"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
+msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+#, fuzzy
+msgid "Screen:  "
+msgstr "Screen"
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr "0.000"
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Offset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Offset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+#, fuzzy
+msgid "Alignment Laser:"
+msgstr "allineamento corrente"
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+#, fuzzy
+msgid "Screen Aspect:"
+msgstr "Screen"
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Estop on"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+#, fuzzy
+msgid "4:3"
+msgstr "47:"
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+#, fuzzy
+msgid "Hidden"
+msgstr "HiddenColNbr!"
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Tasto sinistro"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "Modo"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr "Avviso sullo schermo per cambi_o utensile"
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr "Include componente interfaccia utente Halui"
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr "Includi Panello GUI PyVCP personalizzato"
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr "Azzera programma"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 msgid "Spindle speed display  "
 msgstr "Visualizza velocità mandrino "
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr "Programma custom esistente"
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr "Include collegamenti ad HAL"
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10829,68 +11146,68 @@ msgstr ""
 "semplice\n"
 "panello"
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr "Imposta opzione pyVCP"
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr "Includi _Classicladder PLC"
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr "Numero di pin digitali in input:"
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr "Numero di pin output digitali:"
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr " Numero di pin analogici (s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr " Numero di pin analogici (s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr " Numero di pin analogici (float):"
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr " Numero di pin output analogici (float):"
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr "imposta numero di pin esterni"
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr "Include supporto master modbus"
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr "Azzera programma ladder"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr "Estop programma ladder"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr "Programma modbus seriale"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
@@ -10899,9 +11216,13 @@ msgstr ""
 "Modifica programma\n"
 "ladder"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 msgid "Set Ladder Options"
 msgstr "Imposta Opzioni Ladder"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr "Include componente interfaccia utente Halui"
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10919,16 +11240,168 @@ msgstr "DELETE"
 msgid "Move UP"
 msgstr "Muovi SOPRA"
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+#, fuzzy
+msgid "NUM"
+msgstr "NML"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr "10"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+#, fuzzy
+msgid "11"
+msgstr "11:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+#, fuzzy
+msgid "12"
+msgstr "2"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+#, fuzzy
+msgid "13"
+msgstr "13:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+#, fuzzy
+msgid "14"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+#, fuzzy
+msgid "15"
+msgstr "15:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+#, fuzzy
+msgid "16"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr "17"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+#, fuzzy
+msgid "18"
+msgstr "1"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+#, fuzzy
+msgid "19"
+msgstr "19:"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+#, fuzzy
+msgid "20"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+#, fuzzy
+msgid "IDX"
+msgstr "PID"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+#, fuzzy
+msgid "32"
+msgstr "3"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+#, fuzzy
+msgid "64"
+msgstr "6"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+#, fuzzy
+msgid "300"
+msgstr "38400"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "Modo"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr "Uguale"
 
@@ -10938,10 +11411,10 @@ msgstr "Uguale"
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 msgid "Opposite"
 msgstr "Opposta"
 
@@ -10969,15 +11442,6 @@ msgstr "_:"
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
 msgstr "a"
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
-msgstr "s"
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
 #: src/emc/usr_intf/stepconf/axisy.glade:402
@@ -11194,24 +11658,24 @@ msgstr "Errore PNCCONF: errore di caricamento del firmware personalizzato"
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr "PNCCONF INFO: Trovato firmware aggiuntivo nel file"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr "Aggiornamento dei metadati di individuazione"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr "%s aggiornamento metadata"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr "Setup Pncconf"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr "Settaggio Pncconf"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
@@ -11219,15 +11683,15 @@ msgstr ""
 "\n"
 "Pausa di debug! ****"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr "Pagina Aiuto Specifica non disponibile.\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr "Pagine Aiuto"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11238,11 +11702,11 @@ msgstr ""
 "%s\n"
 "PNCconf usa dati firmware interni"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "File configurazioni 'PNCconf' LinuxCNC"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
@@ -11252,11 +11716,11 @@ msgstr ""
 "di PNCConf per potere continuare.\n"
 "."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr "Nessuna scheda trovata\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11271,32 +11735,32 @@ msgstr ""
 "\n"
 "%s"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr "Discovery non disponibile\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr "Ricerca Informazioni dispositivo USB"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr "Pagina dispositivo USB non disponibile.\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr "Nomi pin non disponibili.\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr "Nomi dispositivi non disponibili.\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr "Nessun Pncconf made device regola trovata\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11308,7 +11772,7 @@ msgstr ""
 "Verra rinominato e aggiunto alla cartella 'backups' .\n"
 "Cliccando 'existing custom program' si eviterà questo avviso"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
@@ -11319,41 +11783,41 @@ msgstr ""
 "'backups'.\n"
 "Cliccando  'existing custom program' si eviterà questo avviso. "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr "Canale Non utilizzato"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 "Non è possibile avere sia segnali stepper che pwm per il controllo mandrino\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 "Ti sei dimenticato di definire un segnale stepper o pwm per l'asse %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 "Ti sei dimenticato di definire un segnale encoder/resolver per l'asse %s "
 "servo \n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 "Ti sei dimenticato di definire un segnale stepper o pwm per l'asse %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr "Non è possibile avere sia segnali stepper che pwm per l'asse %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
@@ -11362,19 +11826,19 @@ msgstr ""
 "Se si utilizza un asse stepper tandem , è necessario selezionare un master "
 "stepgen per l'asse %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr "Touchy richiede un segnale inizio ciclo esterno\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr "Touchy richiede un segnale aborto esterno\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr "Touchy richiede un segnale passo singolo esterno\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
@@ -11382,7 +11846,7 @@ msgstr ""
 "Touchy richiede un segnale encoder per un encoder multi  handwheel MPG sulla "
 "pagina mesa\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
@@ -11390,7 +11854,7 @@ msgstr ""
 "Touchy richiede selezionato  'external mpg jogging' sulla pagina controlli "
 "esterni\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
@@ -11398,7 +11862,7 @@ msgstr ""
 "Touchy richiede gli mpg esterni in modo 'shared-mpg'  sulla pagina controlli "
 "esterni\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
@@ -11406,7 +11870,7 @@ msgstr ""
 "Touchy richiede gli incrementi selezionabili non selezionati sulla pagina "
 "controlli esterni\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
@@ -11414,7 +11878,7 @@ msgstr ""
 "La scheda madre 7i29 richiede generatori tipo PWM e una frequenza di base "
 "PWM di 20 Khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
@@ -11422,7 +11886,7 @@ msgstr ""
 "La scheda madre 7i30 richiede generatori tipo PWM e una frequenza di base "
 "PWM di 20 Khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
@@ -11430,7 +11894,7 @@ msgstr ""
 "La scheda madre 7i33 richiede generatori tipo PDM e una frequenza di base "
 "PDM di 6 Mhz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
@@ -11438,7 +11902,7 @@ msgstr ""
 "La scheda madre 7i40 richiede generatori tipo PWM e una frequenza di base "
 "PWM di 50 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
@@ -11446,65 +11910,65 @@ msgstr ""
 "La scheda madre 7i48 richiede generatori tipo UDM e una frequenza di base "
 "PWM di 24 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr "Rapporto Riduzione Cambio"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr "Rapporto Riduzione"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr "Passo della vite"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr "Passo della vite TPI"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr "("
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr " / min"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr " / s²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 msgid " / Step"
 msgstr " / Passo"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 msgid "Steps / "
 msgstr "Passi / "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr " / impulso encoder"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr "Impulsi encoder / "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 msgid "Resolver Scale:"
 msgstr "Scala Resolver:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 msgid "Spindle Scale Calculation"
 msgstr "Calcolo Scala Mandrino"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr "Calcolo Scala Axis"
 
@@ -11524,18 +11988,21 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr "Pagina Ricerca PCI non disponibile.\n"
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 msgid "in / min"
 msgstr "in / min"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr "mm / min"
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11545,7 +12012,7 @@ msgstr ""
 " Scegli il tipo di scheda, firmware, componenti e pressa il bottone 'Accetta "
 "cambio componenti'"
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
@@ -11553,7 +12020,7 @@ msgstr ""
 "La scheda Mesa0 è diversa da quella correntemente visualizzata.\n"
 "Prego pressare bottone 'Accetta cambi componenti'"
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11563,7 +12030,7 @@ msgstr ""
 " Scegli il tipo di scheda, firmware, componenti e pressa il bottone 'Accetta "
 "cambio componenti'"
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
@@ -11571,15 +12038,15 @@ msgstr ""
 "La scheda Mesa1 è diversa da quella correntemente visualizzata.\n"
 "Prego pressare bottone 'Accetta cambi componenti'"
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr "Bisogna designare un input pin di E-stop per questo programma ladder."
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr "Bisogna designare un input pin di sonda per questo programma ladder."
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11593,8 +12060,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr "# Generato da PNCconf a %s"
@@ -11610,87 +12077,92 @@ msgstr "# Versione LinuxCNC in uso:  %s"
 msgid "# overwritten when you run PNCconf again"
 msgstr "# sovrascritto quando si userà ancora PNCconf"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr "# collega diversi segnali"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr "#  ---segnali HALUI ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr "#  ---carica segnali pompa---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr "#  ---segnali refrigerante---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr "#  ---segnale sonda---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr "#  ---segnali bottone asse---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr "#  ---segnali bottone elemento jog USB--"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr "#  ---segnali mpg---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr "#  ---segnali controllo movimento ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr "#  ---segnali digitali in / out---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr "#  ---segnali estop---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr "#  ---segnali cambio utensile manuale---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+#, fuzzy
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr "#  ---segnali cambio utensile manuale---"
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr "#  ---segnali cambioutensile per cambio utensile personalizzato---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr "#  ---segnali Classicladder per il programma touch ff asse Z  ---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 "# Questi files sono caricati dopo gladeVCP, nell'ordine in cui appaiono"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr "# NON includere qui i tuoi comandi HAL ."
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr "# Inserire comandi custom HAl in custom_gvcp.hal"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 "# **** Imposta visualizzazione della velocità mandrino con gladevcp ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr "# **** Setup bottoni GLADE MDI ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
@@ -11698,89 +12170,90 @@ msgstr ""
 "# **** Bottone asse Z touch-off button - richiede il programma touch-off "
 "classicladder ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr "# Inserire comandi custom HAL in custom_postgui.hal"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr "# I comandi di questo file saranno eseguiti dopo l'avvio della GUI"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 "# **** Imposta visualizzazione della velocità mandrino con pyvcp -FINE ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr "# Questo file non sara' sovrascritto quando si userà ancora PNCconf"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
 msgstr "# Questi comandi sono necessari per Touchy GUI"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
+#: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
 msgid "Generated by PNCconf at %s"
 msgstr "Generato da PNCconf a %s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
 msgid "configures LinuxCNC as:\n"
 msgstr "configura LinuxCNC come: \n"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
 msgid "type CNC\n"
 msgstr "tipo CNC\n"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
 msgid "will be used as the frontend display"
 msgstr "sarà usato come display attivo"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
 msgid " connector"
 msgstr " connector"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
 msgid "invrt"
 msgstr "invert"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
 #, python-format
 msgid "%(name)s Parport"
 msgstr "%(name)s Parport"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
 msgid "-> inverted"
 msgstr "-> invertito"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1059
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
 #, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr "pin# %(pinnum)d è connesso al segnale di input:'%(data)s' %(mesag)s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr "pin# %(pinnum)d è connesso al segnale di output:'%(data)s' %(mesag)s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr "# **** Usa velocità mandrino EFFETTIVA dall'encoder mandrino"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 "#  spindle-velocity intermittente  pertanto viene filtrata con passabasso"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 "# **** velocità mandrino con il segno, pertanto usa componente assoluta per "
 "rimuovere il segno"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 "# **** velocità EFFETTIVA è in giri/s e non giri/min pertanto viene scalata."
@@ -11797,1386 +12270,1442 @@ msgstr "Screen"
 msgid "VCP"
 msgstr "VCP"
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 msgid "External Controls"
 msgstr "Controlli Esterni"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr "Mesa Card 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr "Mesa Card 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 msgid "Parallel Port"
 msgstr "Porta Parallela"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 msgid "X Motor"
 msgstr "Motore X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "X Axis"
 msgstr "Asse X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 msgid "Y Motor"
 msgstr "Motore Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Y Axis"
 msgstr "Asse Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 msgid "Z Motor"
 msgstr "Motore Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Z Axis"
 msgstr "Asse Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 msgid "A Motor"
 msgstr "Motore A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "A Axis"
 msgstr "Asse A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 msgid "Spindle Motor"
 msgstr "Motore Mandrino"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr "Realtime"
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr "Non Usato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr "Dummy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr "8i20 Servo Drive"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr "Output POT"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
 msgstr "Abilita POT"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Dir"
 msgstr "Dir POT"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Input"
 msgstr "Input GPIO"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Output"
 msgstr "Output GPIO"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO O Drain"
 msgstr "GPIO O Drain"
 
-#: src/emc/usr_intf/pncconf/private_data.py:113
+#: src/emc/usr_intf/pncconf/private_data.py:117
 msgid "SSR Output"
 msgstr "Output SSR"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr "Quad Enc-A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr "Quad Enc-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr "Quad Enc-I"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr "Quad Enc-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 0"
 msgstr "Muxed Enc 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 1"
 msgstr "Muxed Enc 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "muxed Enc I"
 msgstr "muxed Enc I"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc M"
 msgstr "Muxed Enc M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr "seleziona mux"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr "Encoder Resolver 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr "Encoder Resolver 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr "Encoder Resolver 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr "Encoder Resolver 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr "Encoder Resolver 4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr "Encoder Resolver 5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step Gen-A"
 msgstr "Step Gen-A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr "Dir Gen-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr "Step/Dir Gen-C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr "Step/Dir Gen-D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr "Step/Dir Gen-E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr "Step/Dir Gen-F"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr "PWM Gen-P"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr "PWM Gen-D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr "PWM Gen-E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr "PDM Gen-P"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr "PDM Gen-D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr "PDM Gen-E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr "UDM -Up"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-Down"
 msgstr "UDM-Down"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr "UDM-E"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr "Motore Fase A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr "Motore Fase B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr "Motore Fase C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr "Motore Fase A No"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr "Motore Fase B No"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr "Motore Fase C No"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr "Abilita Motore"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr "Guasto Motore"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr "SSERIAL-P0-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr "SSERIAL-P0-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr "SSERIAL-P0-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr "SSERIAL-P1-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr "SSERIAL-P1-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr "SSERIAL-P1-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr "SSERIAL-P2-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr "SSERIAL-P2-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr "SSERIAL-P2-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr "SSERIAL-P3-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr "SSERIAL-P3-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr "SSERIAL-P3-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr "SSERIAL-P4-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr "SSERIAL-P4-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr "SSERIAL-P4-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr "SSERIAL-P5-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr "SSERIAL-P5-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr "SSERIAL-P5-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr "SSERIAL-P6-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr "SSERIAL-P6-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr "SSERIAL-P6-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr "SSERIAL-P7-TX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr "SSERIAL-P7-RX"
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr "SSERIAL-P7-EN"
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr "7i76 I/O (SS0)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr "7i76 I/O (SS2)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr "7i76 I/O (SS3)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr "7i77 I/O-SS0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr "7i77 Analog-SS1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr "7i77 I/O-SS3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr "7i77 Analog-SS4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Analog Input"
 msgstr "Input Analogico"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "X Home"
 msgstr "Origine X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Y Home"
 msgstr "Origine Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Z Home"
 msgstr "Origine Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "A Home"
 msgstr "Origine A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "All Home"
 msgstr "Azzeramento Totale"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "X2 Tandem Home"
 msgstr "Origine Tandem X2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Y2 Tandem Home"
 msgstr "Origine Tandem Y2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Z2 Tandem Home"
 msgstr "Origine Tandem Z2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "A2 Tandem Home"
 msgstr "Origine Tandem A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr "Limite Minimo + Home X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr "Limite Minimo + Home Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr "Limite Minimo + Home Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr "Limite Minimo + Home A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr "Limite Massimo + Home X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr "Limite Massimo + Home Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr "Limite Massimo + Home Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr "Limite Massimo + Home A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr "Entrambi i Limiti + Home X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr "Entrambi i Limiti + Home Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr "Entrambi i Limiti + Home Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr "Entrambi i Limiti + Home A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "All Limits + Home"
 msgstr "Tutti i limiti + zero"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr "Limite Minimo X2 + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr "Limite Minimo Y2 + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr "Limite Minimo Z2 + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr "Limite Minimo A2 + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr "Limite Massimo X2 + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr "Limite Massimo Y2 + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr "Limite Massimo Z2 + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr "Limite Massimo A2 + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr "Entrambi i Limiti + Home X2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr "Entrambi i Limiti Y2 + Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr "Entrambi i Limiti Z2+ Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 msgid "A2 Both Limit + Home"
 msgstr "Entrambi i Limiti + Home A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr "Asse selezionato A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr "Asse selezionato B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr "Asse selezionato C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr "Asse selezionato D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr "Incr asse A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr "Incr asse B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr "Incr asse C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr "Incr asse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr A"
 msgstr "Incr. avanzamento A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr B"
 msgstr "Incr. avanzamento B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr C"
 msgstr "Incr. avanzamento C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr D"
 msgstr "Incr. avanzamentoD"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Spindle Override incr A"
 msgstr "Superamento limite mandrino A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr B"
 msgstr "Superamento limite mandrino B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr C"
 msgstr "Superamento limite mandrino C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr D"
 msgstr "Superamento limite mandrino D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr "Incr. Vel Max A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr "Incr. Vel Max B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr "Incr. Vel Max C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr "Incr. Vel Max D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Feed Override enable"
 msgstr "Incr. avanzamento abilitato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Spindle Override enable"
 msgstr "Superamento limite mandrino abilitato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 msgid "Max Vel Override enable"
 msgstr "Incr. Vel Max abilitato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CW"
 msgstr "Mandrino orario manuale"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CCW"
 msgstr "Mandrino antiorario manuale"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle Stop"
 msgstr "Stop Manuale Mandrino"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Spindle Up-To-Speed"
 msgstr "Aumento Velocità Mandrino"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Gear Select A"
 msgstr "Seleziona Ingranaggio A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr "Inizio Ciclo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr "Annulla"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Single Step"
 msgstr "Passo Singolo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr "Asse X +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr "Jog X -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr "Asse Y +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr "Asse Y -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr "Asse Z +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr "Asse Z -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr "Asse A +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr "Asse A -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr "Bottone asse selezionato +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr "Muove asse selezionato -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr "X HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr "X HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr "X HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr "X Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr "X Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr "X Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr "X Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr "Y HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr "Y HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr "Y HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr "Y Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr "Y Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr "Y Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr "Y Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr "Z HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr "Z HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr "Z HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr "Z Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr "Z Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr "Z Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr "Z Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr "A HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr "A HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr "A HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr "A Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr "A Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr "A Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr "A Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr "S HALL 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr "S HALL 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr "S HALL 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr "S Gray C1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr "S Gray C2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr "S Gray C4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr "S Gray C8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr "Limite Minimo X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr "Limite Minimo Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr "Limite Minimo Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr "Limite Minimo A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr "Limite Massimo X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr "Limite Massimo Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr "Limite Massimo Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr "Limite Massimo A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr "Entrambi i limiti X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr "Entrambi i limiti Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr "Entrambi i limiti Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr "Entrambi i limiti A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr "Tutti i Limiti"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr "Limite Minimo X2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr "Limite Minimo Y2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr "Limite Minimo Z2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr "Limite Minimo A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr "Limite Massimo X2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr "Limite Massimo Y2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr "Limite Massimo Z2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr "Limite Massimo A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr "Entrambi i limiti X2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr "Entrambi i limiti Y2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr "Entrambi i limiti Z2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "A2 Both Limit"
 msgstr "Entrambi i limiti A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 msgid "Main Axis"
 msgstr "Asse Principale"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 msgid "Tandem Axis"
 msgstr "Asse Tandem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Arc OK"
+msgstr "Arco orario"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Ohmic Probe"
+msgstr "Sonda"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "Switches"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr "Input Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Limits"
 msgstr "Limiti"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr "Limiti/Home Condiviso"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr "Digitale"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr "Selezione Asse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 msgid "Overrides"
 msgstr "Superamento"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "Operation"
 msgstr "Operazione"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "External Control"
 msgstr "Controllo Esterno"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 msgid "Axis rapid"
 msgstr "Asse rapido"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr "X BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr "Y BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr "Z BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr "A BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr "S BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr "Segnali personalizzati"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr "X2 Tandem PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr "Y2 Tandem PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr "Z2 Tandem PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr "A2 Tandem PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "X Axis PWM"
 msgstr "Asse X PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "Y Axis PWM"
 msgstr "Asse Y PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "Z Axis PWM"
 msgstr "Asse Z PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "A Axis PWM"
 msgstr "Asse A PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Unused PWM Gen"
 msgstr "Gen PWM Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Axis PWM"
 msgstr "Asse PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 msgid "X Axis StepGen"
 msgstr "StepGen Asse X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Y Axis StepGen"
 msgstr "StepGen asse Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Z Axis StepGen"
 msgstr "StepGen asse Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 msgid "A Axis StepGen"
 msgstr "StepGen asse A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "X2 Tandem StepGen"
 msgstr "StepGen X2 Tandem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "Y2 Tandem StepGen"
 msgstr "StepGen Y2 Tandem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 msgid "Z2 Tandem StepGen"
 msgstr "StepGen Z2 Tandem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 msgid "Unused StepGen"
 msgstr "StepGen inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr "Axis"
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr "Stepgen Carica Pompa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Spindle StepGen"
 msgstr "StepGen Mandrino"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr "Encoder X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr "Encoder Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr "Encoder Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr "Encoder A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 msgid "X2 Tandem Encoder"
 msgstr "Encoder Tandem X2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 msgid "Y2 Tandem Encoder"
 msgstr "Encoder Tandem Y2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 msgid "Z2 Tandem Encoder"
 msgstr "Encoder Tandem Z2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 msgid "A2 Tandem Encoder"
 msgstr "Encoder Tandem A2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr "Ruota manuale X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr "Ruota manuale Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr "Ruota manuale Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr "Ruota manuale A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr "Multi Ruota manuale"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Feed Override"
 msgstr "Incr. avanzamento"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "spindle Override"
 msgstr "superamento limite mandrino"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Max Vel Override"
 msgstr "Incr. Vel Max"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr "Encoder Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr "Encoder Asse"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Spindle Encoder"
 msgstr "Encoder Mandrino"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr "Controllo Jog  con MPG"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr "Controllo superamento MPG"
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Encoder X"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 msgid "Unused Unused"
 msgstr "Inutilizzato Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Enable"
 msgstr "Abilita  Mandrino"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "Machine Is Enabled"
 msgstr "La Macchina è Abilitata"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr "Abilita Amplificatore X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr "Abilita Amplificatore Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr "Abilita Amplificatore Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr "Abilita Amplificatore A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr "Forza Pin True"
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Abilita POT"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Macchina On"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "Contatto"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr "Output Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Coolant"
 msgstr "Refrigerante"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr "Controllo"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr " S BLDC Control"
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr "8I20 Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr "Resolver Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr "X Resolver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr "Y Resolver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr "Z Resolver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr "A Resolver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr "S Resolver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr "Output Analogico Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Spindle Output"
 msgstr "Uscita Mandrino"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr "Gen TPPWM Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr "X Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr "Y Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr "Z Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr "A Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr "S Axis BL Driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr "Scheda Amplificatore 8i20"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr "7i64 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr "7i69 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr "7i70 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr "7i71 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr "7i76 Modo 0 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr "7i76 Modo 2 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr "7i77 Modo 0 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr "7i73 Modo 3 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr "7i73 Modo 1 Scheda Pendant"
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr "7i84 Modo 1 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr "7i84 Modo 3 I/O Card"
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Unused Analog In"
 msgstr "Input Analogico Inutilizzato"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
@@ -13184,7 +13713,7 @@ msgstr ""
 "7i64-Input\n"
 "P3 and P4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
@@ -13192,11 +13721,11 @@ msgstr ""
 "7i64-Output\n"
 "P2 and P5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr "7i64-Analog In"
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
@@ -13204,7 +13733,7 @@ msgstr ""
 "7i69\n"
 "P2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
@@ -13212,7 +13741,7 @@ msgstr ""
 "7i69\n"
 "P3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
@@ -13220,7 +13749,7 @@ msgstr ""
 "7i70-Input\n"
 "TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
@@ -13228,7 +13757,7 @@ msgstr ""
 "7i70-Input\n"
 "TB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
@@ -13236,7 +13765,7 @@ msgstr ""
 "7i71-Output\n"
 "TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
@@ -13244,8 +13773,8 @@ msgstr ""
 "7i71-Output\n"
 "TB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
@@ -13253,8 +13782,8 @@ msgstr ""
 "7i76-I/O\n"
 "TB6"
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
@@ -13262,8 +13791,8 @@ msgstr ""
 "7i76-I/O\n"
 "TB5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
@@ -13271,8 +13800,8 @@ msgstr ""
 "7i76-Analog Output\n"
 "TB4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
@@ -13280,8 +13809,8 @@ msgstr ""
 "7i77-I/O\n"
 "TB8"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
@@ -13289,8 +13818,8 @@ msgstr ""
 "7i77-I/O\n"
 "TB7"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
@@ -13298,11 +13827,11 @@ msgstr ""
 "7i77-Analog Output\n"
 "TB5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr "7i73-I/O\n"
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
@@ -13310,8 +13839,8 @@ msgstr ""
 "7i84-I/O\n"
 "TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
@@ -13319,7 +13848,7 @@ msgstr ""
 "7i84-I/O\n"
 "TB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
@@ -13327,7 +13856,7 @@ msgstr ""
 "7i84-I/O-MPG\n"
 "TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13342,18 +13871,18 @@ msgstr ""
 "Qualsiasi file esistente di nome custompanel_backup.xml e custom_postgui.hal "
 "sarà perso. "
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr "Esci da PNCconf e perdi modifiche?"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 #, fuzzy
 msgid "Do you want to quit?"
 msgstr ""
 "Vuoi davvero chiudere?\n"
 "\n"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13374,68 +13903,77 @@ msgid ""
 msgstr ""
 "Bisogna specificare un gladefile  Ma non ce ne sono nella cartella macchina.."
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr "Taratura servo non verificata finora in PNCconf\n"
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr "gradi"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr "gradi / minuto"
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr "gradi / s²"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr "giri"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr "giri/min"
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr "giri  / second²"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr "mm / minuto"
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr "mm / s²"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr "pollici / minuto"
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr "pollici / s²"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr "Regolazione Asse %s"
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
@@ -13443,7 +13981,7 @@ msgstr ""
 " Bisogna indicare un segnale di ENCODER / RESOLVER e un ANALOG SPINDLE  per "
 "il test di quest'asse"
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
@@ -13451,7 +13989,7 @@ msgstr ""
 " Bisogna indicare un segnale di ENCODER / RESOLVER e un segnale PWM per il "
 "test di quest'asse"
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13469,7 +14007,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "la_mia_macchina_LinuxCNC"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13486,12 +14024,12 @@ msgstr ""
 "versione di PNConf - chiedi sul forum di LinuxCNC forum - può essere "
 "possibile..."
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr "File %r e' stato modificato da quando è stato scritto da PNCconf"
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
@@ -13499,7 +14037,7 @@ msgstr ""
 "Salvare questo file di configurazione eliminera' i cambi alla configurazione "
 "fatti fuori da PNCconf."
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr "Avvio dalla Scrivania per configurazioni LinuxCNC fatte da PNCconf"
 
@@ -15248,9 +15786,9 @@ msgid "Z"
 msgstr "Z"
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15405,6 +15943,13 @@ msgstr "usa debounce"
 #: src/emc/usr_intf/pncconf/external.glade:5401
 msgid "Mux options"
 msgstr "Opzioni Mux"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "Sec"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15584,176 +16129,194 @@ msgstr "Riprende posizione asse dopo chiusura"
 msgid "<b>Defaults and Options</b>"
 msgstr "<b>Standard e Opzioni</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr "<b>Lista Schermo Gui</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr "Posizione_distanza"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr "Posizione_lettura"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr "Superamento Mandrino Max "
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr "Superamento Mandrino min"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr "Incr. avanzamento Max"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr "xyzabc"
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr "Visualizza Geometria"
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr "<b>GUI Generale Standard </b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr "Velocita' lineare standard "
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr "Velocita' lineare min"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr "Velocita' lineare Max"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr "Velocità Angolare standard "
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr "gedit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr "Velocita' Angolare Min"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr "Incrementi "
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr "Velocita' Angolare Massima"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr "Gradi / min"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr "dimensione"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr "Posizione"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr "X"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr "W"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr "H"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr "Forza Axis a Massimizare"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr "AXIS Standard"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr "Forza Touchy alla Massimizzazione dopo il posizionamento"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr "Tema GTK"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr "Colore Testo Assoluto"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr "Textcolor Assoluto"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 msgid "Relative Textcolor"
 msgstr "Textcolor Relativa"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr "DTG Textcolor"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr "Errore Textcolor"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr "Touchy Defaults"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr "Forza Gmoccapy alla Massimizzazione dopo il posizionamento"
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr "Gmoccapy Defaults"
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Opzione Esempi"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15843,134 +16406,151 @@ msgstr "Dettagli Gladevcp"
 msgid "Include custom GladeVCP GUI panel"
 msgstr "Includi Panello GUI GladeVCP personalizzato"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
-msgstr "Tipo 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
+msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
-msgstr "Tipo 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
+msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr "Verso limite Negativo"
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Encoder X"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr "Verso limite Positivo"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr "Use Indice Encoder per Zero:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr "Velocita' finale Zero:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr "Direzione Ricerca Zero:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr "Direzione Ricerca Zero:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr "Velocita' ricerca Zero:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr "nomefile:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
 msgstr "Usa File Compensazione:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr "Usa Compensazione Giochi:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+#, fuzzy
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr "Locazione Posizione Zero   (distanza dall' Origine Zero Macchina):"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 "Distanza spostamento Negativa  (Origine Zero Macchina fino alla fine corsa): "
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+#, fuzzy
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr "Posizione Pulsante Zero  (Distanza dall'origine Zero Macchina):"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr "Velocita' Ricerca Zero:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 "Distanza corsa positiva  (dall'Origine Zero Macchina fino alla fine della "
 "corsa +): "
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 msgid "Home Search Sequence:"
 msgstr "Sequenza' Ricerca Zero:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+#, fuzzy
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr "Posizione Pulsante Zero  (Distanza dall'origine Zero Macchina):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr "Tipo 1"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr "Tipo 2"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr "Verso limite Negativo"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
+msgstr "Verso limite Positivo"
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -16901,10 +17481,6 @@ msgstr "hm2_7i90"
 msgid "24"
 msgstr "24"
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr "17"
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr "Numero di connettori:"
@@ -16995,10 +17571,6 @@ msgstr "Fattore Moltiplicativo Microstep:"
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr "Passi al giro del motore:"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
-msgstr "10"
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17494,7 +18066,6 @@ msgstr "Prego cambiare utensile # %s, quindi premere OK."
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr "INFO:"
 
@@ -17664,31 +18235,23 @@ msgid "Manual Toolchange"
 msgstr "Cambio utensile Manuale"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr "Messaggio Operatore"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 msgid "Restart Entry"
 msgstr "Immissione Riavvio"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr "Su"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr "Enter"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr "Giù"
 
@@ -17766,33 +18329,33 @@ msgstr "Messaggio"
 msgid "%d RPM"
 msgstr "%d Giri al minuto"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr "Utensile %(t)s     %(l)s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr "%4.2f mm/min"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr "%3.2f IPM"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr "%4.2f DPM"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr "%(n)s   Vista -%(v)s               %(t)s"
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr " mm "
 
@@ -17907,7 +18470,6 @@ msgid "<b>Status</b>"
 msgstr "<b>Stato</b>"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
@@ -17916,7 +18478,6 @@ msgstr ""
 "  Testo:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 msgid ""
 "Replace\n"
 "  Text:"
@@ -17925,7 +18486,6 @@ msgstr ""
 " Testo:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 msgid ""
 "Replace\n"
 "   All"
@@ -17934,7 +18494,6 @@ msgstr ""
 " Tutto"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17951,7 +18510,6 @@ msgid "Main Level"
 msgstr "Livello principale"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr "Temi"
 
@@ -17964,12 +18522,10 @@ msgid "DTG Text Color"
 msgstr "DTG Text Color"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr "Attenzione Audio"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr "Alert Audio"
 
@@ -17978,7 +18534,6 @@ msgid "Grid Size"
 msgstr "Dimensione Griglia"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 msgid "Starting RPM"
 msgstr "Avvio RPM"
 
@@ -18071,7 +18626,6 @@ msgstr ""
 "Halshow"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 msgid "Calibration"
 msgstr "Calibrazione"
 
@@ -18383,12 +18937,10 @@ msgstr ""
 " Avanti"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "Annulla"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "Riesegui"
 
@@ -18417,6 +18969,8 @@ msgstr ""
 "stato"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr "G54"
 
@@ -18486,1670 +19040,1545 @@ msgstr " REV"
 msgid "screen 2"
 msgstr "screen 2"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr "**** GMOCCAPY INI Entry **** \n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-msgid "user mode selected"
-msgstr "selezionato modo utente"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr "logo entry found = {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr "**** GMOCCAPY INI Errore Dati **** \n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-"Logfile è stato trovato, ma non è stato possibile convertirlo in percorso.\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr "Il percorso file non può avere spazi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr "Premere per azzerare tutti  {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr "Premere per visualizzare il pulsante homing precedente"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr "Premere per inizializzare  {0} {1}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr "Premere per visualizzare il pulsante homing successivo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr "Pressa per azzerare tutti  {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr "Pressa per ritorno alla lista bottoni principale"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr "**** ERRORE GMOCCAPY ****\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-"**** non è stato possibile risolvere il percorso dell'immagine ' {0} ' "
-"fornito per il pulsante macro ' {1} ' ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-"  modifica\n"
-"offsets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr "Pressa per modifica offsets"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr "Prego Inserire valore contatto per asse {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-"zero\n"
-" G92"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr "Pressa per azzerare tutti gli Offsets G92"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-" Altezza\n"
-"Blocco"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr "Inserire il nuovo valore altezza blocco"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-"    imposta\n"
-"selezionato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr "Pressa per attivare il sistema di coordinate scelto"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr "**** GMOCCAPY INFO ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr "**** nessuna configurazione sonda valida nel file INI ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr "**** misura utensile disabilitata ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr "**** trovata configurazione sonda valida nel file INI ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr "**** usa misurazione utensile automatica ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr "**** GMOCCAPY build_GUI INFO ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-"**** A molti incrementi indicati nel file INI per questa schermata ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-"**** Solo i primi 10 saranno raggiungibili attraverso questa schermata ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "comando jog  sconosciuto{0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr "Pressa per muovere asse {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr "Pressa per muovere joint {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr "**** GMOCCAPY INFO ****\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr "**** trovato più di 16 macro, utilizzerà solo i primi 16 ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr "Premere per visualizzare il pulsante macro precedente"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr "Premere per eseguire le {0} macro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr "Premere per visualizzare il pulsante macro successivo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr "Premi per mostrare la tastiera virtuale"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr "**** ERRORE GMOCCAPY ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr "questo non è un tornio, un tornio deve avere almeno\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr "un asse X e un asse Z\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr "Configurazione del lame sbagliato, lasceremo qui"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr "Situazione molto critica"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr "*****  GMOCCAPY INFO  *****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr "questa non è una configurazione usuale\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr "manca uno degli assi X, Y o Z\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr "Useremo da axisletter pulsante jog ordinato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr "mm/min"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr "pollici/min"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr "**** Configurazione della scheda integrata non valida ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr "**** Non verranno aggiunte schede! ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-"ERRORE, durante il tentativo di inizializzare le schede o i pannelli utente, "
-"verificare la presenza di errori di battitura"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr "**** Non è stato trovato un file toolfile in [EMCIO] TOOL_TABLE ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr "**** audio disponibile! ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr "**** nessun audio disponibile! ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr "**** libreria PYGST non installata? ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr "**** python-gstX.XX è installato? ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr "**** Inserimento di init gremlin ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-msgid ""
-" Joint\n"
-"mode"
-msgstr ""
-" Joint\n"
-"modo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr "**** programma per tastiera virtuale trovato: <onboard>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr "**** Programma di tastiera virtuale trovato: <matchbox-keyboard>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-"**** Nessuna tastiera virtuale installata, abbiamo verificato <onboard> e "
-"<matchbox-keyboard>."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr "**** ERRORE GMOCCAPY ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr "**** Errore con lancio tastiera virtuale,"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-"**** è installata la tastiera integrata o la scatola di fiammiferi? ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr "interrompe macro in esecuzione"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-"**** Impossibile trovare un file di parametri in [RS274NGC] PARAMETER_FILE "
-"****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr "Selezionare il file che si desidera caricare all'avvio del programma"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr "**** GMOCCAPY ERRORE **** /n Messaggio tipo {0} non supportato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr "Tipo di errore sconosciuto e nessun testo di errore dato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr "Avviso Importante"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr "ERRORE: ESTOP esterno impostato, impossibile modificare lo stato!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-"ERRORE: Impossibile accendere la macchina, è attivato l'interruttore di "
-"finecorsa?"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr "Non è possible cambiare in Mode MDI al momento"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr "Non è possible cambiare in Mode Auto al momento"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr "Inserire valore:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "Imposta parameter {0} a:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr "errore conversione"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr "Errore conversione!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr "Questo bottone mostra o nasconde la tastiera"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr "Cambio modo è possibile solo con l'interprete in stato di libero!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr "**** {0} ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr "**** Nessun widget chiamato: {0} per sensibilizzare ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr "Nessun descrizione utensile disponibile"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr "Halo, benvenuto al messaggio test {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr "Hal Pin è basso, Accesso negato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr "codice errato inserito, Accesso negato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr "Solo per avvertirti"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-"ERRORE: nessuna opzione di limite è attiva, i limiti di ignorare non "
-"verranno impostati."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-msgid "Classicladder real-time component not detected"
-msgstr "Componente Classicladder real-time non trovato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr "Qualcosa è andato storto, abbiamo un widget mandrino sconosciuto {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr "Vuoi davvero eliminare la cronologia MDI?\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr "questo non eliminerà il file di cronologia MDI, ma\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr "elimina le voci della casella di riepilogo per questa sessione"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr "Attenzione!!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-msgid "Enter value for diameter"
-msgstr "Inserire valore diametro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-msgid "Set diameter to:"
-msgstr "Imposta diametro a:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-msgid "Enter value for radius"
-msgstr "Inserire valore diametro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-msgid "Set radius to:"
-msgstr "Imposta raggio a:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr "Inserire valore per asse {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "Imposta valore asse {0} a:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr "Errore conversione in btn_set_value"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr "Errore di conversione in btn_set_value!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr "Immettere solo i valori numerici. I valori non sono stati applicati"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-"non è stato selezionato un sistema in cui cambiare, quindi nulla verrà "
-"modificato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr "Avviso Important!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr "Inserire altezza blocco"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr "Altezza blocco misurata dalla base tavola"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr "Errore di conversione in btn_block_height!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-"Immettere solo valori numerici\n"
-"I valori non sono stati utilizzati"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr "Si prega di rimuovere l'utensile montato e premere OK quando fatto"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-"Si prega di cambiare l'utensile\n"
-"\n"
-"# {0:d}    {1}\n"
-"\n"
-" quindi fare clic su OK."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-msgid "Manual Tool change"
-msgstr "Cambio utensile Manuale"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr "Il Cambio Utensile è stato cancellato!\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr "Il vecchio utensile rimarrà impostato!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr "Si sta tentando di eliminare l'utensile montato nel mandrino\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-"Questo non è permesso, si prega di cambiare utensile prima di eliminarlo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr "Avviso Utensile non può essere eliminato!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr "Nessun o più utensili selezionati nella tabella utensili"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr "Prego selezionare un solo utensile in tabella"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr "Avviso Contatto Utensile impossibile!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr "non si può toccare di uno strumento, strega non è montato nel mandrino"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr "la selezione è stata reimpostata sull'utensile nel mandrino"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-"Impossibile azzeramento utensile con compensazione raggio utensile attiva\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr "Si prega di usare un G40 prima del contatto utensile"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr "Vero grande errore!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-"Sei riuscito a venire in un posto che non è possibile in on_btn_tool_touchoff"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr "Immettere il valore per l'asse {0} da impostare:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr "Imposta parametro utensile {0:d} e asse {1} a:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-"Errore di conversione a causa di un'errata immissione per il tocco off asse "
-"{0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr "Inserire numero utensile come intero "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-msgid "Select the tool to change"
-msgstr "Selezione Utensile da Cambiare"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-"Errore di conversione a causa di una immissione errata del numero di "
-"utensile\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr "immettere solo numeri interi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr "L'utensile scelto è già nel mandrino, nessun cambio è necessario."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-"è stato selezionato nessuno o più di un utensile, la selezione dell'utensile "
-"deve essere unica"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr "Impossibile capire il numero di utensile inserito. Non cambierà nulla"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-msgid ""
-"World\n"
-"mode"
-msgstr ""
-"Modo\n"
-" globale"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-"Il jogging dell'asse è consentito solo in modalità mondo, ma sei in modalità "
-"congiunta!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr "Ricevuto un segnale non classificato dal pin {0}"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr "Impossibile trasformare {0} in numero"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-msgid "no button here"
-msgstr "nessun bottone presente"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr "il pulsante non è sensibile"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr "Il bottone {0} è stato attivato/disattivato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr "Il bottone {0} è stato pressato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr "Il bottone {0} è stato cliccato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr "sbagliato posizione per individuare i bambini"
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr "Inserire Codice Sblocco Sistema"
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr "Inserisci il valore"
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr "Immettere il valore da impostare"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr "**** GMOCCAPY GETINIINFO ****"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-"**** gmoccapy può gestire solo 9 assi, **** \n"
-"**** ma hai dato {0} tramite il tuo file INI **** \n"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-"**** gmoccapy non si avvia ****\n"
-"\n"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr "**** GMOCCAPY GETINIINFO ****\n"
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-"**** Nessuna cartella di subroutine o prefisso di programma è dato nel file "
-"ini **** \n"
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr "Errore provando a cancellare il messaggio col numero %s"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr "sinistro ruota,  centrale muove,  destro zoom"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr "sinistro zoom,  centrale muove,  destro ruota"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr "sinistro muove,  centrale ruota,  destro zoom"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr "sinistro zoom   centrale ruota,  destro muove"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr "sinistro muove,  centrale zoom ,  destro ruota"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr "sinistro muove,  centrale zoom ,  destro ruota"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-msgid "No Program loaded"
-msgstr "Nessun Programma caricato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr "altezza blocco = 0.0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-msgid "clear plot"
-msgstr "cancella plot"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-msgid "view perspective"
-msgstr "vista prospettica"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr "vista lungo l'asse X da positivo a negativo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr "vista lungo l'asse Y da positivo a negativo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr "vista lungo l'asse Z da positivo a negativo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr "Mostra o Nascondi percorso utensile"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr "Mostra o nasconda dimensioni"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-"vista lungo l'asse X da positivo a negativo come vista dalla parte "
-"posteriore del tornio"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-msgid "Offset Page"
-msgstr "Pagina Offset"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-msgid "Tooledit"
-msgstr "Settaggio Utensili"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-msgid "File Selection"
-msgstr "Seleziona file"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr "muovi assi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-msgid "jog joints"
-msgstr "muove giunto"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr "Logo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-msgid "Ignore limits"
-msgstr "Ignora limiti"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-msgid "<b>Jogging</b>"
-msgstr "<b>Rapido</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr "Informazioni sull''utensile nel mandrino"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-msgid "Tool no."
-msgstr "Utensile n."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-msgid "Diameter"
-msgstr "Diametro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-msgid "offset z"
-msgstr "offset z"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-msgid "offset x"
-msgstr "offset x"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr "Vc= 0.00"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-msgid "<b>Tool information</b>"
-msgstr "<b>Informazione Utensile</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-"Informazioni sul codice G e M, nonché sulla velocità e sull'avanzamento"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-msgid "active_mcodes_label"
-msgstr "label codici M attivi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-msgid "active_gcodes_label"
-msgstr "label codici G attivi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-msgid "<b>G-Code</b>"
-msgstr "<b>G-Code</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-msgid "<b>Cooling</b>"
-msgstr "<b>Refrigerante</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-msgid "<b>Spindle [rpm]</b>"
-msgstr "<b>Mandrino [giri/min]</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr "Vel."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr "Visualizza la velocità corrente"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-msgid "<b>Rapid Override</b>"
-msgstr ">b>Incr. Rapido>/b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr "Visualizza avanzamento programmato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-msgid "reset feed override to 100 %"
-msgstr "reimposta Incr. Avanzamento al 100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-msgid "<b>Feed Override</b>"
-msgstr "<b>Incr. Avanzamento</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-"Ricerca\n"
-" Indietro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-"Ricerca\n"
-" avanti"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr "Sostituisci"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr "Inizia come fullscreen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr "Avvio  Massimizzato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr "Avvia come finestra"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-msgid "X Pos."
-msgstr "X Pos."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-msgid "Y Pos."
-msgstr "Y Pos."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr "Larghezza"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr "Altezza"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr "nascondi cursore"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-msgid "<b>Main Window</b>"
-msgstr "<b>Finestra Principale</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-msgid "Show keyboard on offset"
-msgstr "Mostra tastiera on offset"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr "Mostra tastiera su tooledit"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr "Mostra tastiera su MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr "Mostra tastiera su EDIT"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr "Mostra tastiera su caricamento file"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-msgid "<b>Keyboard</b>"
-msgstr "<b>Tastiera</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-msgid "show preview"
-msgstr "mostra preview"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-msgid "show offsets"
-msgstr "mostra limiti"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr "<b>Contatto</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-msgid "Relative Color"
-msgstr "Colore Relativo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-msgid "Absolute Color"
-msgstr "Colore Assoluto"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr "DTG Color"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-msgid "Homed color"
-msgstr "Colore Azzeramento"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-msgid "Unhomed color"
-msgstr "Colore Dis-Azzeramento"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr "Cifre"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-"cambia modo DRO\n"
-"cliccando su DRO"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-msgid "<b>DRO</b>"
-msgstr "<b>DRO</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-msgid "Grid size"
-msgstr "Dimensione griglia"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-msgid "Show DRO"
-msgstr "Mostra DRO"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-msgid "Show offsets"
-msgstr "Mostra limiti"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-msgid "Show DTG"
-msgstr "Mostra DTG"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-msgid "<b>Mouse Button mode</b>"
-msgstr "<b>Modo Bottoni Mouse</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-msgid "<b>Preview</b>"
-msgstr "<b>Preview</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-msgid ""
-"current\n"
-"   file"
-msgstr ""
-"file\n"
-" corrente"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr "<b>File da caricare all'avvio</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-msgid "Select user dir"
-msgstr "Imposta dir utente"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-msgid "<b>Select jump to dir</b>"
-msgstr "<b>Select jump to dir</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr "<b>Temi e suoni</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr "Appearance"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-msgid "Scale rapid override"
-msgstr "Scala override rapido"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-msgid "Scale jog velocity"
-msgstr "Scala velocità jog"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-msgid "Scale feed override"
-msgstr "Scala incr. avanzamento"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-msgid "Scale spindle override"
-msgstr "Scala override mandrino"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "<b>Scala MPG Hardware</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr "Usa scorciatoie tastiera"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr "<b>Scorciatoie tastiera</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-msgid "Use unlock code"
-msgstr "Usa codice sblocco"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr "Non usare codice blocco"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr "Usa pin hal per sbloccare"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-msgid "<b>Unlock settings</b>"
-msgstr "<b>Impostazoni Sbloccaggio</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-msgid "Spindle bar min"
-msgstr "Bar mandrino min"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-msgid "Spindle bar max"
-msgstr "Bar mandrino max"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr "Nasconde Button turtle Jog"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr "Fattore Turtle jog"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-msgid "<b>Turtle Jog</b>"
-msgstr "<b>Turtle Jog</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr "Hardware"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr "Usa misurazione utensile automatica"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr "Altezza Probe"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr "0.000"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-msgid "Z Pos."
-msgstr "Z Pos."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr "Max. Sonda"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-msgid "<b>Probe Informations</b>"
-msgstr "<b>Informazioni Sonda</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-msgid "Search Vel."
-msgstr "Ricerca Vel."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr "Probe Vel."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr "<b>Velocità Sonda</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-"Nessuna configurazione valida\n"
-"trovati nel file INI,\n"
-"si prega di dare un'occhiata a \n"
-"WIKI per verificare come\n"
-"per configurare le impostazioni."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-msgid "<b>Tool Measurement</b>"
-msgstr "<b>Misurazione Utensile</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-msgid "Reload Tool on Start"
-msgstr "Ricarica Utensile all'avvio"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-"Se selezionata, l'utensile in\n"
-"verrà salvato ad ogni modifica\n"
-"e l'ultimo strumento verrà ricaricato\n"
-"all'inizio della GUI. Inoltre è \n"
-"l'offset di lunghezza verrà ricaricato.\n"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-"Tu usi NO_FORCE_HOMING,\n"
-"in modo che il ricaricamento di un utensile all'avvio\n"
-"non è possibile."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-msgid "<b>Reload Tool</b>"
-msgstr "<b>Ricarica Utensile</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr "Non usare avvio dalla linea"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-msgid "Use run from line"
-msgstr "Uso avvia dalla linea"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-msgid "<b>Run from line</b>"
-msgstr "<b>Avvia dalla linea</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr "Use frames"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr "Se selezionata, i messaggi saranno in una cornice."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr "max."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr "Imposta font"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr "Numero messaggi massimo da mostrare\t"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr "La larghezza dei messaggi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr "Posizione X in pixel dall'angolo in alto a sinistra dello schermo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr "Posizione Y in pixel dall'angolo in alto a sinistra dello schermo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr "Messaggio test lancio"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-"Premi qui per lanciare un messaggio di prova\n"
-"per testare le tue impostazioni."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr "<b> messaggio modo e aspetto gmoccapy \\ n </b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr ""
-"Opzioni\n"
-" Avanzate"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr "User tab 1"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr "User tabs"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-"Estop la macchina\n"
-"[F1]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr ""
-"Macchina on/off\n"
-"[F2]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-"accedere alla modalità manuale per spostare manualmente l'asse o toccare\n"
-"[F3]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-"passare alla modalità MDI per avviare i comandi g-code\n"
-"[F5]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-msgid "enter auto mode to run programs"
-msgstr "vai in modo auto per avviare programma"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-"Inserisci la pagina delle impostazioni, il codice predefinito è  \"123 \""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-msgid "show user tabs"
-msgstr "mostra stato utente"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr "apre lista bottoni azzeramento"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr "apri lista bottoni contatto utensile"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr "Apre pagina modifica Tabella Utensili"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-msgid ""
-"World\n"
-"Mode"
-msgstr ""
-"Modo\n"
-" globale"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-"Cambia la modalità di movimento tra modalità Joint e World\n"
-"F12 o il tasto $ fa lo stesso"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr "rende la preview più larga possibile"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr "Chiude gmoccapy / lascia il programma"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-msgid "Load a new program"
-msgstr "Carica un nuovo programma"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-msgid "Run the loaded program"
-msgstr "Avvia  programma caricato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-msgid "Stop the running program"
-msgstr "Ferma programma in esecuzione"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-msgid "Pause the running program"
-msgstr "Sospende programma in esecuzione"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-msgid "pause the running program"
-msgstr "pausa programma in esecuzione"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr "Esegue il programma caricato passo-passo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-"eseguire il programma da una certa riga, attenzione, che è pericoloso, "
-"perché le righe precedenti non verranno selezionate!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-"Macchina o meno i blocchi opzionali del programma. Se si preme il pulsante, "
-"i blocchi opzionali non verranno lavorati. Il pulsante lo indicherà con uno "
-"sfondo giallo."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-msgid "Edit the loaded program"
-msgstr "Modifica programma caricato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-msgid "delete MDI"
-msgstr "cancella MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-msgid "delete MDI history"
-msgstr "cancella storia MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr "Cl.-ladder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr "Apri classicladder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-msgid "Hal-Scope"
-msgstr "Hal-Scope"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr "avvio hal scope"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr "lancio stato linuxcnc"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr "lanciare Hal Meter"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-msgid "launch calibration"
-msgstr "avvio calibrazione"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr "Halshow"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr "apre lo strumento Mostra hal"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr "salvare il file utilizzando il nome originale"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr "salvare il file con un nuovo nome"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr "deselezionare il campo modifica e creare un nuovo file"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr "Mostrare o nascondere la tastiera virtuale"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr "Torna all'elenco dei pulsanti principali"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr "cancella utensile/i selezionato/i"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-msgid "add a new tool to tool table"
-msgstr "aggiungi un nuovo utensile alla tabella utensile"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-msgid "Reload"
-msgstr "Ricarica"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-msgid "reload tool table from file"
-msgstr "ricarica tabella utensile da file"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-"applicare le modifiche apportate, G43 sarà eseguito solo se è attivo g-code"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-msgid "Select a tool by number"
-msgstr "Scelta utensile da numero"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-"cambiare utensile con il comando M61 Q ?, non verrà eseguito alcun movimento "
-"della macchina"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr "cambio utensile a quello selezionato"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-"contatto\n"
-"  utensile x"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr "azzera utensile e imposta il valore nella tabella utensili"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-"contatto\n"
-"  utensile z"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr "Spostarsi nella home directory"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
-msgid "Move to parrent directory"
+#: lib/python/gladevcp/iconview.py:120
+#, fuzzy
+msgid "Move to parent directory"
 msgstr "Muovi al percorso superiore"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
-msgid "Select the previos file"
+#: lib/python/gladevcp/iconview.py:128
+#, fuzzy
+msgid "Select the previous file"
 msgstr "Selezione file precedente"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 msgid "Select the next file"
 msgstr "Selezione file successivo"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr "Salta alla cartella definita dall'utente"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr "seleziona il file evidenziato e ritorna il percorso"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr "Chiude senza restituire il percorso file"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-msgid "Load File"
-msgstr "File caricato"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
-msgid "home joints"
-msgstr "azzera tutti gli assi"
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+#, fuzzy
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr "Azzerramento completo sistema coordinate"
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "ricarica tabella utensile da file"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+#, fuzzy
+msgid "Tool file was modified since it was last read"
+msgstr "File %r e' stato modificato da quando è stato scritto da stepconf"
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Tasto Rotella mouse"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+#, fuzzy
+msgid "button"
+msgstr "nessun bottone presente"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "Autosend ON/OFF"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Utensile:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Nero"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+#, fuzzy
+msgid "G5x"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "Rotazione XY:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+#, fuzzy
+msgid "G92"
+msgstr "_G92"
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+#, fuzzy
+msgid "G55"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+#, fuzzy
+msgid "G56"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+#, fuzzy
+msgid "G57"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+#, fuzzy
+msgid "G58"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+#, fuzzy
+msgid "G59"
+msgstr "G54"
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+#, fuzzy
+msgid "G59.1"
+msgstr "P7  G59._1"
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+#, fuzzy
+msgid "G59.2"
+msgstr "P8  G59._2"
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+#, fuzzy
+msgid "G59.3"
+msgstr "P9  G59._3"
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Offset:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Pagina Offset"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+#, fuzzy
+msgid ""
+"Zero\n"
+"G92"
+msgstr ""
+"zero\n"
+" G92"
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr ""
+"  Rotazione\n"
+"Orizzontale"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "_Seleziona"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Utensile:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+#, fuzzy
+msgid "Pocket"
+msgstr "Tasche:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+msgid "Diameter"
+msgstr "Diametro"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "vista _frontale"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "Operazione"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "Commento"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+msgid "Reload"
+msgstr "Ricarica"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr ""
+"Offset\n"
+"%s"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "Diametro"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "Offset di lavoro:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Utensile:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Utensile:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Imposta Offset Utensili"
+
+#~ msgid "next search: %d\n"
+#~ msgstr "prossima ricerca: %d\n"
+
+#~ msgid "search: %d (wrapped=%d)\n"
+#~ msgstr "search: %d (wrapped=%d)\n"
+
+#~ msgid "Use AXIS Screen"
+#~ msgstr "Usa Schermo AXIS"
+
+#~ msgid "Use Gmoccapy Screen"
+#~ msgstr "Usa Schermo Gmoccapy"
+
+#~ msgid "filename:"
+#~ msgstr "nomefile:"
+
+#~ msgid "**** GMOCCAPY INI Entry **** \n"
+#~ msgstr "**** GMOCCAPY INI Entry **** \n"
+
+#~ msgid "user mode selected"
+#~ msgstr "selezionato modo utente"
+
+#~ msgid "logo entry found = {0}"
+#~ msgstr "logo entry found = {0}"
+
+#~ msgid "**** GMOCCAPY INI Entry Error **** \n"
+#~ msgstr "**** GMOCCAPY INI Errore Dati **** \n"
+
+#~ msgid "Logofile entry found, but could not be converted to path.\n"
+#~ msgstr ""
+#~ "Logfile è stato trovato, ma non è stato possibile convertirlo in "
+#~ "percorso.\n"
+
+#~ msgid "The file path should not contain any spaces"
+#~ msgstr "Il percorso file non può avere spazi"
+
+#~ msgid "Press to home all {0}"
+#~ msgstr "Premere per azzerare tutti  {0}"
+
+#~ msgid "Press to display previous homing button"
+#~ msgstr "Premere per visualizzare il pulsante homing precedente"
+
+#~ msgid "Press to home {0} {1}"
+#~ msgstr "Premere per inizializzare  {0} {1}"
+
+#~ msgid "Press to display next homing button"
+#~ msgstr "Premere per visualizzare il pulsante homing successivo"
+
+#~ msgid "Press to unhome all {0}"
+#~ msgstr "Pressa per azzerare tutti  {0}"
+
+#~ msgid "Press to return to main button list"
+#~ msgstr "Pressa per ritorno alla lista bottoni principale"
+
+#~ msgid "**** GMOCCAPY ERROR ****\n"
+#~ msgstr "**** ERRORE GMOCCAPY ****\n"
+
+#~ msgid ""
+#~ "**** could not resolv the image path '{0}' given for macro button '{1}' "
+#~ "****"
+#~ msgstr ""
+#~ "**** non è stato possibile risolvere il percorso dell'immagine ' {0} ' "
+#~ "fornito per il pulsante macro ' {1} ' ****"
+
+#~ msgid ""
+#~ "  edit\n"
+#~ "offsets"
+#~ msgstr ""
+#~ "  modifica\n"
+#~ "offsets"
+
+#~ msgid "Press to edit the offsets"
+#~ msgstr "Pressa per modifica offsets"
+
+#~ msgid "Press to set touch off value for axis {0}"
+#~ msgstr "Prego Inserire valore contatto per asse {0}"
+
+#~ msgid "Press to reset all G92 offsets"
+#~ msgstr "Pressa per azzerare tutti gli Offsets G92"
+
+#~ msgid ""
+#~ " Block\n"
+#~ "Height"
+#~ msgstr ""
+#~ " Altezza\n"
+#~ "Blocco"
+
+#~ msgid "Press to enter new value for block height"
+#~ msgstr "Inserire il nuovo valore altezza blocco"
+
+#~ msgid ""
+#~ "    set\n"
+#~ "selected"
+#~ msgstr ""
+#~ "    imposta\n"
+#~ "selezionato"
+
+#~ msgid "Press to set the selected coordinate system to be the active one"
+#~ msgstr "Pressa per attivare il sistema di coordinate scelto"
+
+#~ msgid "**** GMOCCAPY INFO ****"
+#~ msgstr "**** GMOCCAPY INFO ****"
+
+#~ msgid "**** no valid probe config in INI File ****"
+#~ msgstr "**** nessuna configurazione sonda valida nel file INI ****"
+
+#~ msgid "**** disabled tool measurement ****"
+#~ msgstr "**** misura utensile disabilitata ****"
+
+#~ msgid "**** found valid probe config in INI File ****"
+#~ msgstr "**** trovata configurazione sonda valida nel file INI ****"
+
+#~ msgid "**** will use auto tool measurement ****"
+#~ msgstr "**** usa misurazione utensile automatica ****"
+
+#~ msgid "**** GMOCCAPY build_GUI INFO ****"
+#~ msgstr "**** GMOCCAPY build_GUI INFO ****"
+
+#~ msgid "**** To many increments given in INI File for this screen ****"
+#~ msgstr ""
+#~ "**** A molti incrementi indicati nel file INI per questa schermata ****"
+
+#~ msgid "**** Only the first 10 will be reachable through this screen ****"
+#~ msgstr ""
+#~ "**** Solo i primi 10 saranno raggiungibili attraverso questa schermata "
+#~ "****"
+
+#~ msgid "unknown jog command {0}"
+#~ msgstr "comando jog  sconosciuto{0}"
+
+#~ msgid "Press to jog axis {0}"
+#~ msgstr "Pressa per muovere asse {0}"
+
+#~ msgid "Press to jog joint {0}"
+#~ msgstr "Pressa per muovere joint {0}"
+
+#~ msgid "**** GMOCCAPY INFO ****\n"
+#~ msgstr "**** GMOCCAPY INFO ****\n"
+
+#~ msgid "**** found more than 16 macros, will use only the first 16 ****"
+#~ msgstr "**** trovato più di 16 macro, utilizzerà solo i primi 16 ****"
+
+#~ msgid "Press to display previous macro button"
+#~ msgstr "Premere per visualizzare il pulsante macro precedente"
+
+#~ msgid "Press to run macro {0}"
+#~ msgstr "Premere per eseguire le {0} macro"
+
+#~ msgid "Press to display next macro button"
+#~ msgstr "Premere per visualizzare il pulsante macro successivo"
+
+#~ msgid "Press to display the virtual keyboard"
+#~ msgstr "Premi per mostrare la tastiera virtuale"
+
+#~ msgid "*****  GMOCCAPY ERROR  *****"
+#~ msgstr "**** ERRORE GMOCCAPY ****"
+
+#~ msgid "this is not a lathe, as a lathe must have at least\n"
+#~ msgstr "questo non è un tornio, un tornio deve avere almeno\n"
+
+#~ msgid "an X and an Z axis\n"
+#~ msgstr "un asse X e un asse Z\n"
+
+#~ msgid "Wrong lathe configuration, we will leave here"
+#~ msgstr "Configurazione del lame sbagliato, lasceremo qui"
+
+#~ msgid "Very critical situation"
+#~ msgstr "Situazione molto critica"
+
+#~ msgid "*****  GMOCCAPY INFO  *****"
+#~ msgstr "*****  GMOCCAPY INFO  *****"
+
+#~ msgid "this is not a usual config\n"
+#~ msgstr "questa non è una configurazione usuale\n"
+
+#~ msgid "we miss one of X , Y or Z axis\n"
+#~ msgstr "manca uno degli assi X, Y o Z\n"
+
+#~ msgid "We will use by axisletter ordered jog button"
+#~ msgstr "Useremo da axisletter pulsante jog ordinato"
+
+#~ msgid "mm/min"
+#~ msgstr "mm/min"
+
+#~ msgid "inch/min"
+#~ msgstr "pollici/min"
+
+#~ msgid "**** Invalid embedded tab configuration ****"
+#~ msgstr "**** Configurazione della scheda integrata non valida ****"
+
+#~ msgid "**** No tabs will be added! ****"
+#~ msgstr "**** Non verranno aggiunte schede! ****"
+
+#~ msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
+#~ msgstr ""
+#~ "ERRORE, durante il tentativo di inizializzare le schede o i pannelli "
+#~ "utente, verificare la presenza di errori di battitura"
+
+#~ msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
+#~ msgstr ""
+#~ "**** Non è stato trovato un file toolfile in [EMCIO] TOOL_TABLE ****"
+
+#~ msgid "**** audio available! ****"
+#~ msgstr "**** audio disponibile! ****"
+
+#~ msgid "**** no audio available! ****"
+#~ msgstr "**** nessun audio disponibile! ****"
+
+#~ msgid "**** PYGST libray not installed? ****"
+#~ msgstr "**** libreria PYGST non installata? ****"
+
+#~ msgid "**** is python-gstX.XX installed? ****"
+#~ msgstr "**** python-gstX.XX è installato? ****"
+
+#~ msgid "**** Entering init gremlin ****"
+#~ msgstr "**** Inserimento di init gremlin ****"
+
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr ""
+#~ " Joint\n"
+#~ "modo"
+
+#~ msgid "**** virtual keyboard program found : <onboard>"
+#~ msgstr "**** programma per tastiera virtuale trovato: <onboard>"
+
+#~ msgid "**** virtual keyboard program found : <matchbox-keyboard>"
+#~ msgstr "**** Programma di tastiera virtuale trovato: <matchbox-keyboard>"
+
+#~ msgid ""
+#~ "**** No virtual keyboard installed, we checked for <onboard> and "
+#~ "<matchbox-keyboard>."
+#~ msgstr ""
+#~ "**** Nessuna tastiera virtuale installata, abbiamo verificato <onboard> e "
+#~ "<matchbox-keyboard>."
+
+#~ msgid "**** GMOCCAPY ERROR ****"
+#~ msgstr "**** ERRORE GMOCCAPY ****"
+
+#~ msgid "**** Error with launching virtual keyboard,"
+#~ msgstr "**** Errore con lancio tastiera virtuale,"
+
+#~ msgid "**** is onboard or matchbox-keyboard installed? ****"
+#~ msgstr ""
+#~ "**** è installata la tastiera integrata o la scatola di fiammiferi? ****"
+
+#~ msgid "interrupt running macro"
+#~ msgstr "interrompe macro in esecuzione"
+
+#~ msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
+#~ msgstr ""
+#~ "**** Impossibile trovare un file di parametri in [RS274NGC] "
+#~ "PARAMETER_FILE ****"
+
+#~ msgid "Select the file you want to be loaded at program start"
+#~ msgstr ""
+#~ "Selezionare il file che si desidera caricare all'avvio del programma"
+
+#~ msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
+#~ msgstr "**** GMOCCAPY ERRORE **** /n Messaggio tipo {0} non supportato"
+
+#~ msgid "Unknown error type and no error text given"
+#~ msgstr "Tipo di errore sconosciuto e nessun testo di errore dato"
+
+#~ msgid "Important Warning"
+#~ msgstr "Avviso Importante"
+
+#~ msgid "ERROR : External ESTOP is set, could not change state!"
+#~ msgstr "ERRORE: ESTOP esterno impostato, impossibile modificare lo stato!"
+
+#~ msgid "ERROR : Could not switch the machine on, is limit switch activated?"
+#~ msgstr ""
+#~ "ERRORE: Impossibile accendere la macchina, è attivato l'interruttore di "
+#~ "finecorsa?"
+
+#~ msgid "It is not possible to change to MDI Mode at the moment"
+#~ msgstr "Non è possible cambiare in Mode MDI al momento"
+
+#~ msgid "It is not possible to change to Auto Mode at the moment"
+#~ msgstr "Non è possible cambiare in Mode Auto al momento"
+
+#~ msgid "Enter value:"
+#~ msgstr "Inserire valore:"
+
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "Imposta parameter {0} a:"
+
+#~ msgid "conversion error"
+#~ msgstr "errore conversione"
+
+#~ msgid "Conversion error !"
+#~ msgstr "Errore conversione!"
+
+#~ msgid "This button will show or hide the keyboard"
+#~ msgstr "Questo bottone mostra o nasconde la tastiera"
+
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr "Cambio modo è possibile solo con l'interprete in stato di libero!"
+
+#~ msgid "**** {0} ****"
+#~ msgstr "**** {0} ****"
+
+#~ msgid "**** No widget named: {0} to sensitize ****"
+#~ msgstr "**** Nessun widget chiamato: {0} per sensibilizzare ****"
+
+#~ msgid "No tool description available"
+#~ msgstr "Nessun descrizione utensile disponibile"
+
+#~ msgid "Halo, welcome to the test message {0}"
+#~ msgstr "Halo, benvenuto al messaggio test {0}"
+
+#~ msgid "Hal Pin is low, Access denied"
+#~ msgstr "Hal Pin è basso, Accesso negato"
+
+#~ msgid "wrong code entered, Access denied"
+#~ msgstr "codice errato inserito, Accesso negato"
+
+#~ msgid "Just to warn you"
+#~ msgstr "Solo per avvertirti"
+
+#~ msgid "ERROR : No limit switch is active, ignore limits will not be set."
+#~ msgstr ""
+#~ "ERRORE: nessuna opzione di limite è attiva, i limiti di ignorare non "
+#~ "verranno impostati."
+
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "Componente Classicladder real-time non trovato"
+
+#~ msgid "Something went wrong, we have an unknown spindle widget {0}"
+#~ msgstr ""
+#~ "Qualcosa è andato storto, abbiamo un widget mandrino sconosciuto {0}"
+
+#~ msgid "Do you really want to delete the MDI history?\n"
+#~ msgstr "Vuoi davvero eliminare la cronologia MDI?\n"
+
+#~ msgid "this will not delete the MDI History file, but will\n"
+#~ msgstr "questo non eliminerà il file di cronologia MDI, ma\n"
+
+#~ msgid "delete the listbox entries for this session"
+#~ msgstr "elimina le voci della casella di riepilogo per questa sessione"
+
+#~ msgid "Attention!!"
+#~ msgstr "Attenzione!!"
+
+#~ msgid "Enter value for diameter"
+#~ msgstr "Inserire valore diametro"
+
+#~ msgid "Set diameter to:"
+#~ msgstr "Imposta diametro a:"
+
+#~ msgid "Enter value for radius"
+#~ msgstr "Inserire valore diametro"
+
+#~ msgid "Set radius to:"
+#~ msgstr "Imposta raggio a:"
+
+#~ msgid "Enter value for axis {0}"
+#~ msgstr "Inserire valore per asse {0}"
+
+#~ msgid "Set axis {0} to:"
+#~ msgstr "Imposta valore asse {0} a:"
+
+#~ msgid "Conversion error in btn_set_value"
+#~ msgstr "Errore conversione in btn_set_value"
+
+#~ msgid "Conversion error in btn_set_value!"
+#~ msgstr "Errore di conversione in btn_set_value!"
+
+#~ msgid "Please enter only numerical values. Values have not been applied"
+#~ msgstr "Immettere solo i valori numerici. I valori non sono stati applicati"
+
+#~ msgid ""
+#~ "you did not selected a system to be changed to, so nothing will be changed"
+#~ msgstr ""
+#~ "non è stato selezionato un sistema in cui cambiare, quindi nulla verrà "
+#~ "modificato"
+
+#~ msgid "Important Warning!"
+#~ msgstr "Avviso Important!"
+
+#~ msgid "Enter the block height"
+#~ msgstr "Inserire altezza blocco"
+
+#~ msgid "Block height measured from base table"
+#~ msgstr "Altezza blocco misurata dalla base tavola"
+
+#~ msgid "Conversion error in btn_block_height!"
+#~ msgstr "Errore di conversione in btn_block_height!"
+
+#~ msgid ""
+#~ "Please enter only numerical values\n"
+#~ "Values have not been applied"
+#~ msgstr ""
+#~ "Immettere solo valori numerici\n"
+#~ "I valori non sono stati utilizzati"
+
+#~ msgid "Please remove the mounted tool and press OK when done"
+#~ msgstr "Si prega di rimuovere l'utensile montato e premere OK quando fatto"
+
+#~ msgid ""
+#~ "Please change to tool\n"
+#~ "\n"
+#~ "# {0:d}     {1}\n"
+#~ "\n"
+#~ " then click OK."
+#~ msgstr ""
+#~ "Si prega di cambiare l'utensile\n"
+#~ "\n"
+#~ "# {0:d}    {1}\n"
+#~ "\n"
+#~ " quindi fare clic su OK."
+
+#~ msgid "Manual Tool change"
+#~ msgstr "Cambio utensile Manuale"
+
+#~ msgid "Tool Change has been aborted!\n"
+#~ msgstr "Il Cambio Utensile è stato cancellato!\n"
+
+#~ msgid "The old tool will remain set!"
+#~ msgstr "Il vecchio utensile rimarrà impostato!"
+
+#~ msgid "You are trying to delete the tool mounted in the spindle\n"
+#~ msgstr "Si sta tentando di eliminare l'utensile montato nel mandrino\n"
+
+#~ msgid "This is not allowed, please change tool prior to delete it"
+#~ msgstr ""
+#~ "Questo non è permesso, si prega di cambiare utensile prima di eliminarlo"
+
+#~ msgid "Warning Tool can not be deleted!"
+#~ msgstr "Avviso Utensile non può essere eliminato!"
+
+#~ msgid "No or more than one tool selected in tool table"
+#~ msgstr "Nessun o più utensili selezionati nella tabella utensili"
+
+#~ msgid "Please select only one tool in the table"
+#~ msgstr "Prego selezionare un solo utensile in tabella"
+
+#~ msgid "Warning Tool Touch off not possible!"
+#~ msgstr "Avviso Contatto Utensile impossibile!"
+
+#~ msgid "you can not touch of a tool, witch is not mounted in the spindle"
+#~ msgstr ""
+#~ "non si può toccare di uno strumento, strega non è montato nel mandrino"
+
+#~ msgid "your selection has been reseted to the tool in spindle"
+#~ msgstr "la selezione è stata reimpostata sull'utensile nel mandrino"
+
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr ""
+#~ "Impossibile azzeramento utensile con compensazione raggio utensile "
+#~ "attiva\n"
+
+#~ msgid "Please emit an G40 before tool touch off"
+#~ msgstr "Si prega di usare un G40 prima del contatto utensile"
+
+#~ msgid "Real big error!"
+#~ msgstr "Vero grande errore!"
+
+#~ msgid ""
+#~ "You managed to come to a place that is not possible in "
+#~ "on_btn_tool_touchoff"
+#~ msgstr ""
+#~ "Sei riuscito a venire in un posto che non è possibile in "
+#~ "on_btn_tool_touchoff"
+
+#~ msgid "Enter value for axis {0} to set:"
+#~ msgstr "Immettere il valore per l'asse {0} da impostare:"
+
+#~ msgid "Set parameter of tool {0:d} and axis {1} to:"
+#~ msgstr "Imposta parametro utensile {0:d} e asse {1} a:"
+
+#~ msgid "Conversion error because of wrong entry for touch off axis {0}"
+#~ msgstr ""
+#~ "Errore di conversione a causa di un'errata immissione per il tocco off "
+#~ "asse {0}"
+
+#~ msgid "Enter the tool number as integer "
+#~ msgstr "Inserire numero utensile come intero "
+
+#~ msgid "Select the tool to change"
+#~ msgstr "Selezione Utensile da Cambiare"
+
+#~ msgid "Conversion error because of wrong entry for tool number\n"
+#~ msgstr ""
+#~ "Errore di conversione a causa di una immissione errata del numero di "
+#~ "utensile\n"
+
+#~ msgid "enter only integer numbers"
+#~ msgstr "immettere solo numeri interi"
+
+#~ msgid "Selected tool is already in spindle, no change needed."
+#~ msgstr "L'utensile scelto è già nel mandrino, nessun cambio è necessario."
+
+#~ msgid ""
+#~ "you selected no or more than one tool, the tool selection must be unique"
+#~ msgstr ""
+#~ "è stato selezionato nessuno o più di un utensile, la selezione "
+#~ "dell'utensile deve essere unica"
+
+#~ msgid ""
+#~ "Could not understand the entered tool number. Will not change anything"
+#~ msgstr ""
+#~ "Impossibile capire il numero di utensile inserito. Non cambierà nulla"
+
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr ""
+#~ "Modo\n"
+#~ " globale"
+
+#~ msgid ""
+#~ "Axis jogging is only allowed in world mode, but you are in joint mode!"
+#~ msgstr ""
+#~ "Il jogging dell'asse è consentito solo in modalità mondo, ma sei in "
+#~ "modalità congiunta!"
+
+#~ msgid "Recieved a not clasified signal from pin {0}"
+#~ msgstr "Ricevuto un segnale non classificato dal pin {0}"
+
+#~ msgid "Could not translate {0} to number"
+#~ msgstr "Impossibile trasformare {0} in numero"
+
+#~ msgid "the button is not sensitive"
+#~ msgstr "il pulsante non è sensibile"
+
+#~ msgid "Button {0} has been toggled"
+#~ msgstr "Il bottone {0} è stato attivato/disattivato"
+
+#~ msgid "Button {0} has been pressed"
+#~ msgstr "Il bottone {0} è stato pressato"
+
+#~ msgid "Button {0} has been clicked"
+#~ msgstr "Il bottone {0} è stato cliccato"
+
+#~ msgid "got wrong location to locate the childs"
+#~ msgstr "sbagliato posizione per individuare i bambini"
+
+#~ msgid "Enter System Unlock Code"
+#~ msgstr "Inserire Codice Sblocco Sistema"
+
+#~ msgid "Enter value"
+#~ msgstr "Inserisci il valore"
+
+#~ msgid "Enter the value to set"
+#~ msgstr "Immettere il valore da impostare"
+
+#~ msgid "**** GMOCCAPY GETINIINFO : ****"
+#~ msgstr "**** GMOCCAPY GETINIINFO ****"
+
+#~ msgid ""
+#~ "**** gmoccapy can only handle 9 axis, ****\n"
+#~ "**** but you have given {0} through your INI file ****\n"
+#~ msgstr ""
+#~ "**** gmoccapy può gestire solo 9 assi, **** \n"
+#~ "**** ma hai dato {0} tramite il tuo file INI **** \n"
+
+#~ msgid ""
+#~ "**** gmoccapy will not start ****\n"
+#~ "\n"
+#~ msgstr ""
+#~ "**** gmoccapy non si avvia ****\n"
+#~ "\n"
+
+#~ msgid "**** GMOCCAPY GETINIINFO ****\n"
+#~ msgstr "**** GMOCCAPY GETINIINFO ****\n"
+
+#~ msgid ""
+#~ "**** No subroutine folder or program prefix is given in the ini file "
+#~ "**** \n"
+#~ msgstr ""
+#~ "**** Nessuna cartella di subroutine o prefisso di programma è dato nel "
+#~ "file ini **** \n"
+
+#~ msgid "Error trying to delet the message with number %s"
+#~ msgstr "Errore provando a cancellare il messaggio col numero %s"
+
+#~ msgid "left rotate,  middle move,  right zoom"
+#~ msgstr "sinistro ruota,  centrale muove,  destro zoom"
+
+#~ msgid "left zoom,  middle move,  right rotate"
+#~ msgstr "sinistro zoom,  centrale muove,  destro ruota"
+
+#~ msgid "left move,  middle rotate,  right zoom"
+#~ msgstr "sinistro muove,  centrale ruota,  destro zoom"
+
+#~ msgid "left zoom,  middle rotate,  right move"
+#~ msgstr "sinistro zoom   centrale ruota,  destro muove"
+
+#~ msgid "left move,  middle zoom,  right rotate"
+#~ msgstr "sinistro muove,  centrale zoom ,  destro ruota"
+
+#~ msgid "left rotate,  middle zoom,  right move"
+#~ msgstr "sinistro muove,  centrale zoom ,  destro ruota"
+
+#~ msgid "No Program loaded"
+#~ msgstr "Nessun Programma caricato"
+
+#~ msgid "blockheight = 0.0"
+#~ msgstr "altezza blocco = 0.0"
+
+#~ msgid "clear plot"
+#~ msgstr "cancella plot"
+
+#~ msgid "view perspective"
+#~ msgstr "vista prospettica"
+
+#~ msgid "view along the X axis from positive to negative"
+#~ msgstr "vista lungo l'asse X da positivo a negativo"
+
+#~ msgid "view along the Y axis from positive to negative"
+#~ msgstr "vista lungo l'asse Y da positivo a negativo"
+
+#~ msgid "view along the Z axis from positive to negative"
+#~ msgstr "vista lungo l'asse Z da positivo a negativo"
+
+#~ msgid "Show or hide tool path"
+#~ msgstr "Mostra o Nascondi percorso utensile"
+
+#~ msgid "Show or hide dimensions"
+#~ msgstr "Mostra o nasconda dimensioni"
+
+#~ msgid ""
+#~ "view along the Y axis from positive to negative as viewn for a back tool "
+#~ "lathe"
+#~ msgstr ""
+#~ "vista lungo l'asse X da positivo a negativo come vista dalla parte "
+#~ "posteriore del tornio"
+
+#~ msgid "Tooledit"
+#~ msgstr "Settaggio Utensili"
+
+#~ msgid "File Selection"
+#~ msgstr "Seleziona file"
+
+#~ msgid "jog axes"
+#~ msgstr "muovi assi"
+
+#~ msgid "jog joints"
+#~ msgstr "muove giunto"
+
+#~ msgid "Logo"
+#~ msgstr "Logo"
+
+#~ msgid "Ignore limits"
+#~ msgstr "Ignora limiti"
+
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "<b>Rapido</b>"
+
+#~ msgid "Information over the tool in spindle"
+#~ msgstr "Informazioni sull''utensile nel mandrino"
+
+#~ msgid "Tool no."
+#~ msgstr "Utensile n."
+
+#~ msgid "offset z"
+#~ msgstr "offset z"
+
+#~ msgid "offset x"
+#~ msgstr "offset x"
+
+#~ msgid "Vc= 0.00"
+#~ msgstr "Vc= 0.00"
+
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "<b>Informazione Utensile</b>"
+
+#~ msgid "G and M code information as well as speed and feed"
+#~ msgstr ""
+#~ "Informazioni sul codice G e M, nonché sulla velocità e sull'avanzamento"
+
+#~ msgid "active_mcodes_label"
+#~ msgstr "label codici M attivi"
+
+#~ msgid "active_gcodes_label"
+#~ msgstr "label codici G attivi"
+
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "<b>G-Code</b>"
+
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "<b>Refrigerante</b>"
+
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "<b>Mandrino [giri/min]</b>"
+
+#~ msgid "Vel."
+#~ msgstr "Vel."
+
+#~ msgid "Displays the current velocity"
+#~ msgstr "Visualizza la velocità corrente"
+
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr ">b>Incr. Rapido>/b>"
+
+#~ msgid "Displayes the programmed feed rate"
+#~ msgstr "Visualizza avanzamento programmato"
+
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "reimposta Incr. Avanzamento al 100%"
+
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "<b>Incr. Avanzamento</b>"
+
+#~ msgid ""
+#~ "Search\n"
+#~ " back"
+#~ msgstr ""
+#~ "Ricerca\n"
+#~ " Indietro"
+
+#~ msgid ""
+#~ "Search\n"
+#~ "  fwd"
+#~ msgstr ""
+#~ "Ricerca\n"
+#~ " avanti"
+
+#~ msgid "Replace"
+#~ msgstr "Sostituisci"
+
+#~ msgid "Start as fullscreen"
+#~ msgstr "Inizia come fullscreen"
+
+#~ msgid "Start maximized"
+#~ msgstr "Avvio  Massimizzato"
+
+#~ msgid "Start as window"
+#~ msgstr "Avvia come finestra"
+
+#~ msgid "X Pos."
+#~ msgstr "X Pos."
+
+#~ msgid "Y Pos."
+#~ msgstr "Y Pos."
+
+#~ msgid "Width"
+#~ msgstr "Larghezza"
+
+#~ msgid "Height"
+#~ msgstr "Altezza"
+
+#~ msgid "hide cursor"
+#~ msgstr "nascondi cursore"
+
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "<b>Finestra Principale</b>"
+
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Mostra tastiera on offset"
+
+#~ msgid "Show keyboard on tooledit"
+#~ msgstr "Mostra tastiera su tooledit"
+
+#~ msgid "Show keyboard on MDI"
+#~ msgstr "Mostra tastiera su MDI"
+
+#~ msgid "Show keyboard on EDIT"
+#~ msgstr "Mostra tastiera su EDIT"
+
+#~ msgid "Show keyboard on load file"
+#~ msgstr "Mostra tastiera su caricamento file"
+
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "<b>Tastiera</b>"
+
+#~ msgid "show preview"
+#~ msgstr "mostra preview"
+
+#~ msgid "show offsets"
+#~ msgstr "mostra limiti"
+
+#~ msgid "<b>On Touch off</b>"
+#~ msgstr "<b>Contatto</b>"
+
+#~ msgid "Relative Color"
+#~ msgstr "Colore Relativo"
+
+#~ msgid "Absolute Color"
+#~ msgstr "Colore Assoluto"
+
+#~ msgid "DTG Color"
+#~ msgstr "DTG Color"
+
+#~ msgid "Homed color"
+#~ msgstr "Colore Azzeramento"
+
+#~ msgid "Unhomed color"
+#~ msgstr "Colore Dis-Azzeramento"
+
+#~ msgid "Digits"
+#~ msgstr "Cifre"
+
+#~ msgid ""
+#~ "toggle DRO mode \n"
+#~ "clicking on the DRO"
+#~ msgstr ""
+#~ "cambia modo DRO\n"
+#~ "cliccando su DRO"
+
+#~ msgid "<b>DRO</b>"
+#~ msgstr "<b>DRO</b>"
+
+#~ msgid "Grid size"
+#~ msgstr "Dimensione griglia"
+
+#~ msgid "Show DRO"
+#~ msgstr "Mostra DRO"
+
+#~ msgid "Show offsets"
+#~ msgstr "Mostra limiti"
+
+#~ msgid "Show DTG"
+#~ msgstr "Mostra DTG"
+
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "<b>Modo Bottoni Mouse</b>"
+
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Preview</b>"
+
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr ""
+#~ "file\n"
+#~ " corrente"
+
+#~ msgid "<b>File to load on start</b>"
+#~ msgstr "<b>File da caricare all'avvio</b>"
+
+#~ msgid "Select user dir"
+#~ msgstr "Imposta dir utente"
+
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "<b>Select jump to dir</b>"
+
+#~ msgid "<b>Themes and sound</b>"
+#~ msgstr "<b>Temi e suoni</b>"
+
+#~ msgid "Appearance"
+#~ msgstr "Appearance"
+
+#~ msgid "Scale rapid override"
+#~ msgstr "Scala override rapido"
+
+#~ msgid "Scale jog velocity"
+#~ msgstr "Scala velocità jog"
+
+#~ msgid "Scale feed override"
+#~ msgstr "Scala incr. avanzamento"
+
+#~ msgid "Scale spindle override"
+#~ msgstr "Scala override mandrino"
+
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "<b>Scala MPG Hardware</b>"
+
+#~ msgid "Use keyboard shortcuts"
+#~ msgstr "Usa scorciatoie tastiera"
+
+#~ msgid "<b>Keyboard shortcuts</b>"
+#~ msgstr "<b>Scorciatoie tastiera</b>"
+
+#~ msgid "Use unlock code"
+#~ msgstr "Usa codice sblocco"
+
+#~ msgid "Do not use unlock code"
+#~ msgstr "Non usare codice blocco"
+
+#~ msgid "Use hal pin to unlock"
+#~ msgstr "Usa pin hal per sbloccare"
+
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "<b>Impostazoni Sbloccaggio</b>"
+
+#~ msgid "Spindle bar min"
+#~ msgstr "Bar mandrino min"
+
+#~ msgid "Spindle bar max"
+#~ msgstr "Bar mandrino max"
+
+#~ msgid "Hide turtle Jog Button"
+#~ msgstr "Nasconde Button turtle Jog"
+
+#~ msgid "Turtle jog Factor"
+#~ msgstr "Fattore Turtle jog"
+
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "<b>Turtle Jog</b>"
+
+#~ msgid "Hardware"
+#~ msgstr "Hardware"
+
+#~ msgid "Use auto tool measurement"
+#~ msgstr "Usa misurazione utensile automatica"
+
+#~ msgid "Probe Height"
+#~ msgstr "Altezza Probe"
+
+#~ msgid "Z Pos."
+#~ msgstr "Z Pos."
+
+#~ msgid "Max. Probe"
+#~ msgstr "Max. Sonda"
+
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "<b>Informazioni Sonda</b>"
+
+#~ msgid "Search Vel."
+#~ msgstr "Ricerca Vel."
+
+#~ msgid "Probe Vel."
+#~ msgstr "Probe Vel."
+
+#~ msgid "<b>Probe velocitys</b>"
+#~ msgstr "<b>Velocità Sonda</b>"
+
+#~ msgid ""
+#~ "No valid configuration\n"
+#~ "found in your INI file,\n"
+#~ "please take a look at \n"
+#~ "the WIKI to check how\n"
+#~ "to configure the settings."
+#~ msgstr ""
+#~ "Nessuna configurazione valida\n"
+#~ "trovati nel file INI,\n"
+#~ "si prega di dare un'occhiata a \n"
+#~ "WIKI per verificare come\n"
+#~ "per configurare le impostazioni."
+
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "<b>Misurazione Utensile</b>"
+
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Ricarica Utensile all'avvio"
+
+#~ msgid ""
+#~ "If checked, the tool in spindle\n"
+#~ "will be saved on each change\n"
+#~ "and the last tool will be reloaded\n"
+#~ "at start of the GUI. Also it's \n"
+#~ "length offset will be reloaded.\n"
+#~ msgstr ""
+#~ "Se selezionata, l'utensile in\n"
+#~ "verrà salvato ad ogni modifica\n"
+#~ "e l'ultimo strumento verrà ricaricato\n"
+#~ "all'inizio della GUI. Inoltre è \n"
+#~ "l'offset di lunghezza verrà ricaricato.\n"
+
+#~ msgid ""
+#~ "You use NO_FORCE_HOMING,\n"
+#~ "so the reload of a tool at start\n"
+#~ "is not possible."
+#~ msgstr ""
+#~ "Tu usi NO_FORCE_HOMING,\n"
+#~ "in modo che il ricaricamento di un utensile all'avvio\n"
+#~ "non è possibile."
+
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "<b>Ricarica Utensile</b>"
+
+#~ msgid "Do not use run from line"
+#~ msgstr "Non usare avvio dalla linea"
+
+#~ msgid "Use run from line"
+#~ msgstr "Uso avvia dalla linea"
+
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "<b>Avvia dalla linea</b>"
+
+#~ msgid "Use frames"
+#~ msgstr "Use frames"
+
+#~ msgid ""
+#~ "If checked, the messages\n"
+#~ "will be in a frame."
+#~ msgstr "Se selezionata, i messaggi saranno in una cornice."
+
+#~ msgid "max."
+#~ msgstr "max."
+
+#~ msgid "The font to use"
+#~ msgstr "Imposta font"
+
+#~ msgid "The maximum messages you want to be shown\t"
+#~ msgstr "Numero messaggi massimo da mostrare\t"
+
+#~ msgid "The width of the messages"
+#~ msgstr "La larghezza dei messaggi"
+
+#~ msgid "X-position in pixel from top left corner of the screen"
+#~ msgstr "Posizione X in pixel dall'angolo in alto a sinistra dello schermo"
+
+#~ msgid "Y-position in pixel from top left corner of the screen"
+#~ msgstr "Posizione Y in pixel dall'angolo in alto a sinistra dello schermo"
+
+#~ msgid "Launch test message"
+#~ msgstr "Messaggio test lancio"
+
+#~ msgid ""
+#~ "Push here to launch a test message\n"
+#~ "to test your settings."
+#~ msgstr ""
+#~ "Premi qui per lanciare un messaggio di prova\n"
+#~ "per testare le tue impostazioni."
+
+#~ msgid ""
+#~ "<b>      gmoccapy message\n"
+#~ " behavior and appearance </b>"
+#~ msgstr "<b> messaggio modo e aspetto gmoccapy \\ n </b>"
+
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr ""
+#~ "Opzioni\n"
+#~ " Avanzate"
+
+#~ msgid "User tab 1"
+#~ msgstr "User tab 1"
+
+#~ msgid "User tabs"
+#~ msgstr "User tabs"
+
+#~ msgid ""
+#~ "Estop the machine\n"
+#~ "[F1]"
+#~ msgstr ""
+#~ "Estop la macchina\n"
+#~ "[F1]"
+
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr ""
+#~ "Macchina on/off\n"
+#~ "[F2]"
+
+#~ msgid ""
+#~ "enter manual mode to jog axis by hand or touch off\n"
+#~ "[F3]"
+#~ msgstr ""
+#~ "accedere alla modalità manuale per spostare manualmente l'asse o toccare\n"
+#~ "[F3]"
+
+#~ msgid ""
+#~ "enter MDI mode to launch g-code commands\n"
+#~ "[F5]"
+#~ msgstr ""
+#~ "passare alla modalità MDI per avviare i comandi g-code\n"
+#~ "[F5]"
+
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "vai in modo auto per avviare programma"
+
+#~ msgid "Enter the settings page, the default code is \"123\""
+#~ msgstr ""
+#~ "Inserisci la pagina delle impostazioni, il codice predefinito è  \"123 \""
+
+#~ msgid "show user tabs"
+#~ msgstr "mostra stato utente"
+
+#~ msgid "open homing button list"
+#~ msgstr "apre lista bottoni azzeramento"
+
+#~ msgid "open touch off button list"
+#~ msgstr "apri lista bottoni contatto utensile"
+
+#~ msgid "Open the tooleditor page"
+#~ msgstr "Apre pagina modifica Tabella Utensili"
+
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr ""
+#~ "Modo\n"
+#~ " globale"
+
+#~ msgid ""
+#~ "Switch motion mode between Joint and World mode\n"
+#~ "F12 or $ key does the same"
+#~ msgstr ""
+#~ "Cambia la modalità di movimento tra modalità Joint e World\n"
+#~ "F12 o il tasto $ fa lo stesso"
+
+#~ msgid "make the preview as large as possible"
+#~ msgstr "rende la preview più larga possibile"
+
+#~ msgid "Close gmoccapy / leave the program"
+#~ msgstr "Chiude gmoccapy / lascia il programma"
+
+#~ msgid "Load a new program"
+#~ msgstr "Carica un nuovo programma"
+
+#~ msgid "Run the loaded program"
+#~ msgstr "Avvia  programma caricato"
+
+#~ msgid "Stop the running program"
+#~ msgstr "Ferma programma in esecuzione"
+
+#~ msgid "Pause the running program"
+#~ msgstr "Sospende programma in esecuzione"
+
+#~ msgid "pause the running program"
+#~ msgstr "pausa programma in esecuzione"
+
+#~ msgid "Run the  loaded program step by step"
+#~ msgstr "Esegue il programma caricato passo-passo"
+
+#~ msgid ""
+#~ "run the program from a certain line, attention, that is dangerous, "
+#~ "because the previous lines will not checed!"
+#~ msgstr ""
+#~ "eseguire il programma da una certa riga, attenzione, che è pericoloso, "
+#~ "perché le righe precedenti non verranno selezionate!"
+
+#~ msgid ""
+#~ "Machine or not the optional blocks of the program. If the button is "
+#~ "pressed, the optional blocks will not be machined. The button will "
+#~ "indicate this by a yellow background."
+#~ msgstr ""
+#~ "Macchina o meno i blocchi opzionali del programma. Se si preme il "
+#~ "pulsante, i blocchi opzionali non verranno lavorati. Il pulsante lo "
+#~ "indicherà con uno sfondo giallo."
+
+#~ msgid "Edit the loaded program"
+#~ msgstr "Modifica programma caricato"
+
+#~ msgid "delete MDI"
+#~ msgstr "cancella MDI"
+
+#~ msgid "delete MDI history"
+#~ msgstr "cancella storia MDI"
+
+#~ msgid "Cl.-ladder"
+#~ msgstr "Cl.-ladder"
+
+#~ msgid "Open classicladder"
+#~ msgstr "Apri classicladder"
+
+#~ msgid "Hal-Scope"
+#~ msgstr "Hal-Scope"
+
+#~ msgid "launch hal scope"
+#~ msgstr "avvio hal scope"
+
+#~ msgid "launch linuxcnc status"
+#~ msgstr "lancio stato linuxcnc"
+
+#~ msgid "launch hal meter"
+#~ msgstr "lanciare Hal Meter"
+
+#~ msgid "launch calibration"
+#~ msgstr "avvio calibrazione"
+
+#~ msgid "Halshow"
+#~ msgstr "Halshow"
+
+#~ msgid "opens the show hal tool"
+#~ msgstr "apre lo strumento Mostra hal"
+
+#~ msgid "save the file using the original name"
+#~ msgstr "salvare il file utilizzando il nome originale"
+
+#~ msgid "save the file with a new name"
+#~ msgstr "salvare il file con un nuovo nome"
+
+#~ msgid "clear the edit field and make a new file"
+#~ msgstr "deselezionare il campo modifica e creare un nuovo file"
+
+#~ msgid "Show or hide the virtual keyboard"
+#~ msgstr "Mostrare o nascondere la tastiera virtuale"
+
+#~ msgid "Go back to main button list"
+#~ msgstr "Torna all'elenco dei pulsanti principali"
+
+#~ msgid "delete selected tool or tools"
+#~ msgstr "cancella utensile/i selezionato/i"
+
+#~ msgid "add a new tool to tool table"
+#~ msgstr "aggiungi un nuovo utensile alla tabella utensile"
+
+#~ msgid ""
+#~ "apply the changes you made, G43 will be excecuted only if it is active g-"
+#~ "code"
+#~ msgstr ""
+#~ "applicare le modifiche apportate, G43 sarà eseguito solo se è attivo g-"
+#~ "code"
+
+#~ msgid "Select a tool by number"
+#~ msgstr "Scelta utensile da numero"
+
+#~ msgid "change tool with the command M61 Q?, no machine move will be done"
+#~ msgstr ""
+#~ "cambiare utensile con il comando M61 Q ?, non verrà eseguito alcun "
+#~ "movimento della macchina"
+
+#~ msgid "change tool to the selected one"
+#~ msgstr "cambio utensile a quello selezionato"
+
+#~ msgid ""
+#~ "touchoff\n"
+#~ "  tool x"
+#~ msgstr ""
+#~ "contatto\n"
+#~ "  utensile x"
+
+#~ msgid "touch off the tool and set the value to the tool table"
+#~ msgstr "azzera utensile e imposta il valore nella tabella utensili"
+
+#~ msgid ""
+#~ "touchoff\n"
+#~ "  tool z"
+#~ msgstr ""
+#~ "contatto\n"
+#~ "  utensile z"
+
+#~ msgid "Load File"
+#~ msgstr "File caricato"
+
+#~ msgid "home joints"
+#~ msgstr "azzera tutti gli assi"
 
 #~ msgid "Substituting"
 #~ msgstr "Seostituzione"
@@ -20183,9 +20612,6 @@ msgstr "azzera tutti gli assi"
 
 #~ msgid "TKLinux"
 #~ msgstr "TKLinux"
-
-#~ msgid "Gmoccapy"
-#~ msgstr "Gmoccapy"
 
 #~ msgid "Touchy"
 #~ msgstr "Touchy"

--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -1,70 +1,70 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, fuzzy, c-format, tcl-format
 msgid "can't open %s"
 msgstr "開けません"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr ""
 
@@ -174,424 +174,424 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -704,30 +704,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -843,102 +843,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, fuzzy, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "パラムのファイルを読む"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, fuzzy, c-format
 msgid "cant open ini file '%s'"
 msgstr "開けません"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, fuzzy, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "パラムのファイルを読む"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 #, fuzzy
 msgid "Parameter file name is missing"
 msgstr "パラムのファイルを読む"
@@ -1359,7 +1359,7 @@ msgid "Negative spindle speed used"
 msgstr "フィード手直して:"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+msgid "Negative tool id (tool not found)"
 msgstr ""
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1743,24 +1743,23 @@ msgstr ""
 msgid "R less than V in cycle in UW plane"
 msgstr ""
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr ""
 
@@ -1772,99 +1771,121 @@ msgstr ""
 msgid "E_xit"
 msgstr ""
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr ""
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr ""
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr ""
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 #, fuzzy
 msgid " Para_meters "
 msgstr "パラムのファイルを読む"
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr ""
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 msgstr ""
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 #, fuzzy
 msgid "Open Configuration File:"
 msgstr "スピンドル消した"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "中止"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "開く..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "スピンドル消した"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "ファイル"
+
+#: src/hal/utils/scope.c:525
 #, fuzzy
 msgid "_Open Configuration..."
 msgstr "スピンドル消した"
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 #, fuzzy
 msgid "_Save Configuration..."
 msgstr "スピンドル消した"
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr ""
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 #, fuzzy
 msgid "_File"
 msgstr "ファイル"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 #, fuzzy
 msgid "_Help"
 msgstr "助け"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr ""
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr ""
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr ""
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr ""
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr ""
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1873,37 +1894,37 @@ msgstr ""
 msgid "Stop"
 msgstr "徐徐に"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr ""
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr ""
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1917,11 +1938,39 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr ""
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1934,106 +1983,82 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 #, fuzzy
 msgid "Record Length"
 msgstr "長さ:"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr ""
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2047,56 +2072,64 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
 "record length that supports more channels."
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
 "per div"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
 "at %s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2112,90 +2145,71 @@ msgstr ""
 msgid "Hz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, fuzzy, c-format
 msgid ""
 "Offset\n"
 "%s"
 msgstr "平行移動:"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
 "----"
 msgstr "平行移動:"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:715
-#, fuzzy
-msgid "Set Offset"
-msgstr "道具が平行移動"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
 "for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+#, fuzzy
+msgid "Set Offset"
+msgstr "道具が平行移動"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "中止"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2203,168 +2217,158 @@ msgid ""
 "the record length to allow for more channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
 "as the source for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr ""
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 #, fuzzy
 msgid "Parameters"
 msgstr "パラムのファイルを読む"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
 "Chan %2d"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "自動"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr ""
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr ""
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr ""
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr ""
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr ""
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+msgid "Probe tripped during non-probe move."
 msgstr ""
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr ""
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr ""
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr ""
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr ""
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr ""
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr ""
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
@@ -2433,177 +2437,177 @@ msgstr ""
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr ""
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr ""
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr ""
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr ""
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr ""
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr ""
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr ""
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr ""
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr ""
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2692,26 +2696,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2882,7 +2886,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -2971,19 +2975,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr ""
 
@@ -3034,7 +3038,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr ""
 
@@ -3052,7 +3056,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 #, fuzzy
 msgid "Editor"
 msgstr "エディット..."
@@ -3068,7 +3072,6 @@ msgid "Config"
 msgstr "ローグ..."
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 #, fuzzy
 msgid "Preview"
 msgstr "見方"
@@ -3499,7 +3502,7 @@ msgid "Edit mode..."
 msgstr "エディット..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr ""
 
@@ -3508,7 +3511,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr ""
 
@@ -3519,6 +3522,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr ""
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "中止"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3706,7 +3727,7 @@ msgid "Parameter"
 msgstr "パラムのファイルを読む"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3894,7 +3915,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 #, fuzzy
 msgid "Main"
 msgstr "手動"
@@ -3974,11 +3994,13 @@ msgid "Delete section"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Down"
 msgstr ""
 
@@ -4500,6 +4522,7 @@ msgid "Exit"
 msgstr "出る"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 #, fuzzy
 msgid "Edit"
 msgstr "出る"
@@ -4545,7 +4568,6 @@ msgid "Renumber File..."
 msgstr ""
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "撰"
 
@@ -4821,15 +4843,15 @@ msgstr "見方"
 msgid "Test HAL command :"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr ""
 
@@ -4946,23 +4968,23 @@ msgstr ""
 msgid "SIZE :"
 msgstr ""
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 #, fuzzy
 msgid "LinuxCNC Errors"
 msgstr "越度"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr ""
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 #, fuzzy
 msgid "Create Report File"
 msgstr "パラムのファイルを読む"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr ""
 
@@ -5047,7 +5069,7 @@ msgstr "道具が平行移動"
 msgid "Tool:"
 msgstr "道具:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "全部のファイル"
@@ -5115,18 +5137,18 @@ msgstr "ユーニット（刻）"
 msgid "auto"
 msgstr "自動"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "インチ"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5284,7 +5306,7 @@ msgstr "関節"
 msgid "world"
 msgstr "世界"
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "原点"
 
@@ -5370,17 +5392,16 @@ msgstr "質す"
 msgid "Optional Stop"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "フォントを撰ぶ"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 #, fuzzy
 msgid "Font"
 msgstr "フォント..."
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr ""
 
@@ -5491,7 +5512,7 @@ msgid "Coordinate System Control Window"
 msgstr ""
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 #, fuzzy
 msgid "Axis "
 msgstr "軸の平行移動"
@@ -6064,9 +6085,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 #, fuzzy
 msgid "Custom"
 msgstr "自動"
@@ -6087,8 +6108,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr ""
 
@@ -6162,148 +6183,148 @@ msgstr "NCファイル"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 #, fuzzy
 msgid "Switches"
 msgstr "インチ"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 msgid "no such file"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 #, fuzzy
 msgid "LinuxCNC"
 msgstr "越度"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "越度"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -6975,225 +6996,223 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 #, fuzzy
 msgid "Filtering..."
 msgstr "テスト..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
 "produced are shown below:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
 "%(error_str)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 #, fuzzy
 msgid "Continuous"
 msgstr "連綿"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 #, fuzzy
 msgid "T    Tool Table"
 msgstr "ツール表を読む"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 #, fuzzy
 msgid " diameter"
 msgstr "直径:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 #, fuzzy
 msgid "Tool order:"
 msgstr "道具:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
 "%(lines)s gcode lines"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 #, fuzzy
 msgid "All machinable files"
 msgstr "全部のファイル"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 msgid "File not Writable:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7204,59 +7223,59 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Custom Grid"
 msgstr "自動"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 msgid "Touch Off (system)"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, python-format
 msgid "Tool %s TouchOff"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7265,7 +7284,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7274,7 +7293,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7283,91 +7302,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "関節"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "原点"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "原点"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "関節"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "原点"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr ""
 
@@ -7679,12 +7698,13 @@ msgid "_Properties..."
 msgstr ""
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
-msgstr ""
+#, fuzzy
+msgid "Edit _tool data..."
+msgstr "エディット..."
 
 #: share/axis/tcl/axis.tcl:90
 #, fuzzy
-msgid "Reload tool ta_ble"
+msgid "Reload tool _data"
 msgstr "ツール表を読む"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8025,11 +8045,11 @@ msgstr ""
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr ""
 
@@ -8217,9 +8237,10 @@ msgstr "フィード手直して"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr ""
 
@@ -8264,7 +8285,7 @@ msgid "Position:"
 msgstr "動き"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 #, fuzzy
 msgid "Machine"
 msgstr "マッシン"
@@ -8375,22 +8396,21 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 #, fuzzy
 msgid "Spindle CW"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 #, fuzzy
 msgid "Spindle CCW"
@@ -8744,6 +8764,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8753,43 +8775,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8855,7 +8922,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 #, fuzzy
 msgid "<b>Spindle</b>"
 msgstr "スピンドル消した"
@@ -9024,7 +9090,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 #, fuzzy
 msgid "Status"
 msgstr "状態:"
@@ -9090,8 +9155,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9225,10 +9290,10 @@ msgid "Stepconf"
 msgstr "徐徐に"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9247,12 +9312,12 @@ msgid "Parallel Port 1"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 msgid "Parallel Port 2"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "動き"
@@ -9262,244 +9327,293 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+msgid "User Buttons"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "軸の平行移動"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "軸の平行移動"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "軸の平行移動"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "軸の平行移動"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "軸の平行移動"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "軸の平行移動"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "Spindle"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "X Step"
 msgstr "徐徐に"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "Y Step"
 msgstr "徐徐に"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "Z Step"
 msgstr "徐徐に"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "A Step"
 msgstr "徐徐に"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "徐徐に"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "徐徐に"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "スピンドル前進"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "スピンドル消した"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "スピンドル前進"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "スピンドル消した"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 #, fuzzy
 msgid "Spindle ON"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 #, fuzzy
 msgid "Spindle PWM"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Brake"
 msgstr "スピンドル前進"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "ESTOP Out"
 msgstr "終止符"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9510,263 +9624,349 @@ msgstr ""
 msgid "Unused"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 #, fuzzy
 msgid "ESTOP In"
 msgstr "終止符"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Index"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase A"
 msgstr "スピンドル逆"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase B"
 msgstr "スピンドル逆"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home X"
 msgstr "原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Y"
 msgstr "原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Z"
 msgstr "原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home A"
 msgstr "原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "原点"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "原点"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
-msgid "Maximum Limit + Home Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:236
-msgid "Maximum Limit + Home A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-msgid "Maximum Limit + Home U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-msgid "Maximum Limit + Home V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:238
-msgid "Both Limit + Home X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:238
-msgid "Both Limit + Home Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:239
-msgid "Both Limit + Home Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:239
-msgid "Both Limit + Home A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:240
-msgid "Both Limit + Home U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:240
-msgid "Both Limit + Home V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit A"
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem X"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit V"
+msgid "Maximum Limit + Home Tandem Y"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:250
+msgid "Maximum Limit + Home Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
+msgid "Maximum Limit + Home A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:251
+msgid "Maximum Limit + Home U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:251
+msgid "Maximum Limit + Home V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:252
+msgid "Both Limit + Home X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:252
+msgid "Both Limit + Home Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:253
+msgid "Both Limit + Home Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:253
+msgid "Both Limit + Home A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:254
+msgid "Both Limit + Home U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:254
+msgid "Both Limit + Home V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "全部のファイル"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "全部のファイル"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "全部のファイル"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "全部のファイル"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits"
 msgstr "全部のファイル"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All home"
 msgstr "原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits + homes"
 msgstr "全部のファイル"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Down"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "スピンドル前進"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9775,40 +9975,40 @@ msgid ""
 "Are you sure?  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
 "Any existing file named custompanel_backup.xml will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9819,43 +10019,43 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 #, fuzzy
 msgid "Continue? "
 msgstr "連綿"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9863,34 +10063,34 @@ msgid ""
 "{}"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, fuzzy, python-format
 msgid "%s Axis Test"
 msgstr "軸の平行移動"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -9905,8 +10105,8 @@ msgstr ""
 msgid "mm / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -9921,13 +10121,13 @@ msgstr ""
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr ""
 
@@ -9936,19 +10136,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -9960,7 +10160,7 @@ msgstr ""
 msgid "mm / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -9971,28 +10171,28 @@ msgstr ""
 msgid "Steps / mm"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10000,99 +10200,104 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+msgid "# Include your custom HAL commands here"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
@@ -10165,11 +10370,16 @@ msgstr "スピンドル消した"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr ""
 
@@ -10209,17 +10419,6 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:209
@@ -10569,54 +10768,150 @@ msgstr "フィード手直して:"
 msgid "Scale %"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+#, fuzzy
+msgid "Axis"
+msgstr "軸の平行移動"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "平行移動:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "平行移動:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "終止符点いた"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+msgid "Button"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "命令:"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 #, fuzzy
 msgid "Spindle speed display  "
 msgstr "フィード手直して"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10625,76 +10920,80 @@ msgid ""
 "panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
 "program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 msgid "Set Ladder Options"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
@@ -10713,16 +11012,154 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "命令:"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10732,10 +11169,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 msgid "Opposite"
 msgstr ""
 
@@ -10762,15 +11199,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisv.glade:249
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
@@ -10970,38 +11398,38 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11009,22 +11437,22 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11034,32 +11462,32 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11068,178 +11496,178 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 #, fuzzy
 msgid " / min"
 msgstr "インチ"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "徐徐に"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "徐徐に"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 msgid "Resolver Scale:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11257,53 +11685,56 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr "インチ"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11313,8 +11744,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr ""
@@ -11330,169 +11761,174 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
-#, python-format
-msgid "Generated by PNCconf at %s"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
-msgid "configures LinuxCNC as:\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
-msgid "type CNC\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
-msgid "will be used as the frontend display"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
-msgid " connector"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
-msgid "invrt"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
-#, python-format
-msgid "%(name)s Parport"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
-msgid "-> inverted"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
+msgid "Generated by PNCconf at %s"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
+msgid "configures LinuxCNC as:\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
+msgid "type CNC\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
+msgid "will be used as the frontend display"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
+msgid " connector"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
+msgid "invrt"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
+#, python-format
+msgid "%(name)s Parport"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
+msgid "-> inverted"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
+#, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11508,1569 +11944,1621 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 #, fuzzy
 msgid "External Controls"
 msgstr "手動"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 msgid "Parallel Port"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
-msgid "X Motor"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
-msgid "X Axis"
+msgid "Mesa THCAD"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:50
-msgid "Y Motor"
+msgid "X Motor"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
-msgid "Y Axis"
+#: src/emc/usr_intf/pncconf/private_data.py:534
+msgid "X Axis"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:52
-msgid "Z Motor"
+msgid "Y Motor"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
-msgid "Z Axis"
+#: src/emc/usr_intf/pncconf/private_data.py:534
+msgid "Y Axis"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:54
-msgid "A Motor"
+msgid "Z Motor"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
-msgid "A Axis"
+#: src/emc/usr_intf/pncconf/private_data.py:534
+msgid "Z Axis"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:56
+msgid "A Motor"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
+msgid "A Axis"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Dir"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO O Drain"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:113
+#: src/emc/usr_intf/pncconf/private_data.py:117
 #, fuzzy
 msgid "SSR Output"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "muxed Enc I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step Gen-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-Down"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "手動"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "X Home"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Y Home"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Z Home"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "A Home"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "All Home"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "A2 Tandem Home"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "全部のファイル"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 #, fuzzy
 msgid "A2 Both Limit + Home"
 msgstr "全部のファイル"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "フィード手直し:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "フィード手直し:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "フィード手直し:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "フィード手直し:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Spindle Override incr A"
 msgstr "フィード手直して"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr B"
 msgstr "フィード手直して"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr C"
 msgstr "フィード手直して"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr D"
 msgstr "フィード手直して"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "フィード手直し:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "フィード手直して"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "フィード手直し:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CW"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CCW"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle Stop"
 msgstr "スピンドル前進"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Spindle Up-To-Speed"
 msgstr "スピンドル前進"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Gear Select A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "インチ"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 #, fuzzy
 msgid "All Limits"
 msgstr "全部のファイル"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "A2 Both Limit"
 msgstr "全部のファイル"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "手動"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "インチ"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Limits"
 msgstr "全部のファイル"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "方図を聞き捨てる"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "Operation"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "External Control"
 msgstr "手動"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "軸の平行移動"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Custom Signals"
 msgstr "自動"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
-msgid "A2 Tandem PWM"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "X Axis PWM"
-msgstr "軸の平行移動"
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "Y Axis PWM"
-msgstr "軸の平行移動"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "Z Axis PWM"
-msgstr "軸の平行移動"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "A Axis PWM"
-msgstr "軸の平行移動"
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-msgid "Unused PWM Gen"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-#, fuzzy
-msgid "Axis PWM"
-msgstr "軸の平行移動"
-
-#: src/emc/usr_intf/pncconf/private_data.py:467
-#, fuzzy
-msgid "X Axis StepGen"
-msgstr "徐徐に"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Y Axis StepGen"
-msgstr "徐徐に"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Z Axis StepGen"
-msgstr "徐徐に"
-
-#: src/emc/usr_intf/pncconf/private_data.py:469
-#, fuzzy
-msgid "A Axis StepGen"
-msgstr "徐徐に"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "X2 Tandem StepGen"
-msgstr "スピンドル前進"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "Y2 Tandem StepGen"
-msgstr "スピンドル前進"
-
-#: src/emc/usr_intf/pncconf/private_data.py:471
-#, fuzzy
-msgid "Z2 Tandem StepGen"
-msgstr "スピンドル前進"
-
 #: src/emc/usr_intf/pncconf/private_data.py:473
-msgid "Unused StepGen"
+msgid "A2 Tandem PWM"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
-msgid "Axis"
+msgid "X Axis PWM"
+msgstr "軸の平行移動"
+
+#: src/emc/usr_intf/pncconf/private_data.py:474
+#, fuzzy
+msgid "Y Axis PWM"
 msgstr "軸の平行移動"
 
 #: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "Z Axis PWM"
+msgstr "軸の平行移動"
+
+#: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "A Axis PWM"
+msgstr "軸の平行移動"
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+msgid "Unused PWM Gen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+#, fuzzy
+msgid "Axis PWM"
+msgstr "軸の平行移動"
+
+#: src/emc/usr_intf/pncconf/private_data.py:481
+#, fuzzy
+msgid "X Axis StepGen"
+msgstr "徐徐に"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Y Axis StepGen"
+msgstr "徐徐に"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Z Axis StepGen"
+msgstr "徐徐に"
+
+#: src/emc/usr_intf/pncconf/private_data.py:483
+#, fuzzy
+msgid "A Axis StepGen"
+msgstr "徐徐に"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "X2 Tandem StepGen"
+msgstr "スピンドル前進"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "Y2 Tandem StepGen"
+msgstr "スピンドル前進"
+
+#: src/emc/usr_intf/pncconf/private_data.py:485
+#, fuzzy
+msgid "Z2 Tandem StepGen"
+msgstr "スピンドル前進"
+
+#: src/emc/usr_intf/pncconf/private_data.py:487
+msgid "Unused StepGen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Spindle StepGen"
 msgstr "スピンドル前進"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "スピンドル逆"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "スピンドル逆"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "スピンドル逆"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "スピンドル逆"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Feed Override"
 msgstr "フィード手直し:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "spindle Override"
 msgstr "フィード手直して"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "フィード手直し:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Spindle Encoder"
 msgstr "スピンドル逆"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "スピンドル逆"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 msgid "Unused Unused"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "スピンドル逆"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "出来るように"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "スピンドル逆"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "出来るように"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Coolant"
 msgstr "命令:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 #, fuzzy
 msgid "Spindle Output"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Unused Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13079,15 +13567,15 @@ msgid ""
 "be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 msgid "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13102,81 +13590,90 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 #, fuzzy
 msgid "inches / second²"
 msgstr "インチ"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13190,7 +13687,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "マッシン"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13200,18 +13697,18 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
 
@@ -14874,9 +15371,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15033,6 +15530,13 @@ msgstr ""
 #, fuzzy
 msgid "Mux options"
 msgstr "動き"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15218,183 +15722,200 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 #, fuzzy
 msgid "Position_offset"
 msgstr "動き"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 #, fuzzy
 msgid "Position_feedback"
 msgstr "動き"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 #, fuzzy
 msgid "Max Spindle Override "
 msgstr "フィード手直して"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 #, fuzzy
 msgid "Min Spindle Override"
 msgstr "フィード手直して"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 #, fuzzy
 msgid "Max Feed Override"
 msgstr "フィード手直し:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 #, fuzzy
 msgid "Deg / min"
 msgstr "インチ"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 #, fuzzy
 msgid "Position"
 msgstr "動き"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "相対"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+msgid "QtPlasmaC Options"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
@@ -15487,130 +16008,144 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr ""
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "スピンドル逆"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr ""
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 msgid "Home Search Sequence:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
@@ -16546,10 +17081,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr ""
@@ -16635,10 +17166,6 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:1409
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
@@ -17090,7 +17617,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17251,32 +17777,24 @@ msgid "Manual Toolchange"
 msgstr "手動"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 #, fuzzy
 msgid "Restart Entry"
 msgstr "リーセット"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr ""
 
@@ -17355,33 +17873,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17500,14 +18018,12 @@ msgid "<b>Status</b>"
 msgstr "命令:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17515,14 +18031,12 @@ msgid ""
 msgstr "相対"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 msgid ""
 "Replace\n"
 "   All"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17538,7 +18052,6 @@ msgid "Main Level"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17552,12 +18065,10 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17566,7 +18077,6 @@ msgid "Grid Size"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 #, fuzzy
 msgid "Starting RPM"
 msgstr "撰"
@@ -17647,7 +18157,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "較正..."
@@ -17910,12 +18419,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr ""
 
@@ -17940,6 +18447,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18004,1616 +18513,497 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
+#: lib/python/gladevcp/iconview.py:112
+msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-msgid "user mode selected"
+#: lib/python/gladevcp/iconview.py:120
+msgid "Move to parent directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
+#: lib/python/gladevcp/iconview.py:128
+msgid "Select the previous file"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
+#: lib/python/gladevcp/iconview.py:136
+msgid "Select the next file"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
+#: lib/python/gladevcp/iconview.py:160
+msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
+#: lib/python/gladevcp/iconview.py:168
+msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
+#: lib/python/gladevcp/iconview.py:176
+msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
+#: lib/python/gladevcp/offsetpage_widget.py:142
 msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
+#: lib/python/gladevcp/offsetpage_widget.py:486
+msgid "offsetpage_widget error: cannot select coordinate system"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, python-brace-format
-msgid "unknown jog command {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-msgid ""
-" Joint\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "パラムのファイルを読む"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-msgid "Classicladder real-time component not detected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-msgid "Enter value for diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
+#: lib/python/gladevcp/tooledit_widget.py:320
 #, fuzzy
-msgid "Set diameter to:"
-msgstr "直径:"
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "ツール表を読む"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-msgid "Enter value for radius"
+#: lib/python/gladevcp/tooledit_widget.py:480
+msgid "Tool file was modified since it was last read"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+msgid "checkbutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+msgid "button"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+msgid "togglebutton"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
 #, fuzzy
-msgid "Set radius to:"
-msgstr "軸の数値:"
+msgid "Tool"
+msgstr "道具:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, python-brace-format
-msgid "Enter value for axis {0}"
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+msgid "black"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, fuzzy, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "軸の数値:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
+#: lib/python/gladevcp/offsetpage.glade:88
+msgid "Rotation of Z"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
 #, fuzzy
-msgid "Manual Tool change"
-msgstr "手動"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-msgid "Select the tool to change"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-msgid ""
-"World\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-msgid "no button here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "プローグラム: "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-msgid "clear plot"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-msgid "view perspective"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
+msgid "Offset"
 msgstr "平行移動:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
+#: lib/python/gladevcp/offsetpage.glade:416
 #, fuzzy
-msgid "Tooledit"
-msgstr "道具:"
+msgid "Offset Name"
+msgstr "平行移動:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
+#: lib/python/gladevcp/offsetpage.glade:442
+msgid ""
+"Zero\n"
+"G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:456
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
 #, fuzzy
-msgid "File Selection"
+msgid "Select"
 msgstr "スピンドル消した"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
 #, fuzzy
-msgid "jog joints"
-msgstr "関節"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "方図を聞き捨てる"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "スピンドル消した"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
+msgid "Tool#"
 msgstr "道具:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
 #, fuzzy
 msgid "Diameter"
 msgstr "直径:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "平行移動:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "平行移動:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+msgid "Front"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "スピンドル消した"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+msgid "Orientation"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-msgid "active_mcodes_label"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-msgid "active_gcodes_label"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
 #, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "スピンドル消した"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
+msgid "Comments"
 msgstr "命令:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "スピンドル消した"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "フィード手直して"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "フィード手直して"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "フィード手直して"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-msgid "X Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-msgid "Y Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "スピンドル消した"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "工作物平行移動:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "命令:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "見方"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "工作物平行移動:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "相対"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-msgid "Absolute Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-msgid "Homed color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "原点"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-msgid "<b>DRO</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-msgid "Grid size"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-msgid "Show DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "工作物平行移動:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-msgid "Show DTG"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-msgid "<b>Mouse Button mode</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "見方"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-msgid ""
-"current\n"
-"   file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "ジョグ時速:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-msgid "<b>Select jump to dir</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "フィード手直して"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-msgid "Scale jog velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "フィード手直して:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "フィード手直して"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-msgid "<b>Hardware MPG Scale</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-msgid "Use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-msgid "<b>Unlock settings</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "スピンドル消した"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "スピンドル前進"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-msgid "<b>Turtle Jog</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-msgid "Z Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "スピンドル消した"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-msgid "Search Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "命令:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "ツール表を読む"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "ツール表を読む"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-msgid "Use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "スピンドル消した"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "撰"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "出来るように"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-msgid "enter auto mode to run programs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "状態:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-msgid ""
-"World\n"
-"Mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "プローグラム: "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "プローグラム: "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-msgid "Stop the running program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "プローグラム: "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "プローグラム: "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-msgid "Edit the loaded program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-msgid "delete MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-msgid "delete MDI history"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-msgid "Hal-Scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "較正..."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "ツール表を読む"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
+#: lib/python/gladevcp/tooledit_gtk.glade:325
 msgid "Reload"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
+#: lib/python/gladevcp/tooledit_gtk.glade:369
 #, fuzzy
-msgid "reload tool table from file"
-msgstr "ツール表を読む"
+msgid "All Offsets"
+msgstr "軸の平行移動"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-msgid "Select a tool by number"
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
-msgid "Move to your home directory"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
-msgid "Move to parrent directory"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
-msgid "Select the previos file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
-msgid "Select the next file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
-msgid "Jump to user defined directory"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
-msgid "select the highlighted file and return the path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
-msgid "Close without returning a file path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
 #, fuzzy
-msgid "Load File"
-msgstr "プローグラム: "
+msgid "DIameter"
+msgstr "直径:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/tooledit_gtk.glade:590
 #, fuzzy
-msgid "home joints"
-msgstr "関節"
+msgid "Lathe Wear Offsets"
+msgstr "工作物平行移動:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "道具:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "道具:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "道具が平行移動"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "パラムのファイルを読む"
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr "直径:"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "軸の数値:"
+
+#, fuzzy
+#~ msgid "Set axis {0} to:"
+#~ msgstr "軸の数値:"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "手動"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "プローグラム: "
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "道具:"
+
+#, fuzzy
+#~ msgid "jog joints"
+#~ msgstr "関節"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "方図を聞き捨てる"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "スピンドル消した"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "道具:"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "平行移動:"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "平行移動:"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "スピンドル消した"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "スピンドル消した"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "命令:"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "スピンドル消した"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "フィード手直して"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "フィード手直して"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "フィード手直して"
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "スピンドル消した"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "工作物平行移動:"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "命令:"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "見方"
+
+#, fuzzy
+#~ msgid "show offsets"
+#~ msgstr "工作物平行移動:"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "相対"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "原点"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "工作物平行移動:"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "見方"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "ジョグ時速:"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "フィード手直して"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "フィード手直して:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "フィード手直して"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "スピンドル消した"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "スピンドル前進"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "スピンドル消した"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "命令:"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "ツール表を読む"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "ツール表を読む"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "スピンドル消した"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "撰"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "出来るように"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "状態:"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "プローグラム: "
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "プローグラム: "
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "プローグラム: "
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "プローグラム: "
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "較正..."
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "ツール表を読む"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "プローグラム: "
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "関節"
 
 #, fuzzy
 #~ msgid "Substituting"
@@ -19654,9 +19044,6 @@ msgstr "関節"
 #, fuzzy
 #~ msgid "TEST"
 #~ msgstr "終止符"
-
-#~ msgid "Axis Offset"
-#~ msgstr "軸の平行移動"
 
 #, fuzzy
 #~ msgid "Spindle Motor/Encoder Configuration"

--- a/src/po/pl.po
+++ b/src/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LinuxCNC\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2014-11-04 22:24+0100\n"
 "Last-Translator: Michael Geszkiewicz <micges@wp.pl>\n"
 "Language-Team: Polish Translation <micges@wp.pl>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
@@ -25,60 +25,60 @@ msgid ""
 msgstr ""
 "polecenie (%s) nie może być wykonane gdy maszyna maszyna jest wyłączona"
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "nie można wykonać (%s) w trybie manualnym"
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr "nie można wykonać (%s) w trybie auto i wyłączonym interpreterem"
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr "nie można wykonać (%s) w trybie auto i interpreterem wczytującym"
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr "nie można wykonać (%s) w trybie auto i interpreterem zatrzymanym"
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr "nie można wykonać (%s) w trybie auto i interpreterem oczekującym"
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "nie można wykonać (%s) w trybie MDI"
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr "Nie można przełączyć trybu gdy tryb jest AUTO i interpreter pracuje"
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 #, fuzzy
 msgid "failed to close file"
 msgstr "Nie można otworzyć pliku <%s>"
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "nie można otworzyć %s"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr "Nie można wykonać polecenia MDI gdy nie zbazowano"
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "Musi być tryb MDI aby wykonać polecenie MDI"
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr "Nie można wykonać programu gdy nie zbazowano"
 
@@ -206,59 +206,59 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr "Nie można wykonać NURBS z prędkością zerową"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr "Musisz określić liczbę punktów kontrolnych co najmniej równą L = %d"
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr ""
 "Nie można skonwertować spline z włączoną kompensacją grubości narzędzia"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr "Splines muszą być w planie XY"
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
@@ -266,371 +266,371 @@ msgstr ""
 "Ruch zaraz po wyjściu z trybu kompensacji grubości narzędzia musi być linią, "
 "nie łukiem"
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 "Nie można ustawić punktu referencyjnego z włączoną kompensacją grubości "
 "narzędzia"
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr "Nie można wykonać sondowania w trybie posuwu na obrót"
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr "Słowa I J nie dozwolone razem z G10 L2"
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 "Nie można zmienić aktulanego układu współrzędznych z włączoną kompensacją "
 "grubości narzędzia"
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr "Słowo R nie dozwolone razem z G10 L20"
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr "Wrzeciono nie obraca się w G33"
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr "Wrzeciono nie obraca się w G33.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, fuzzy, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "Wrzeciono nie obraca się w G33"
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -745,30 +745,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "Nie można użyć współrzędnuch polarnych z G53"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -885,102 +885,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, fuzzy, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "Nie jest w definicji procedury"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "Nazwany parametr #<%s> nie zdefinowany"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, c-format
 msgid "cant open ini file '%s'"
 msgstr "nie można otworzyć %s"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "Kolejka nie jest pusta po zmianie narzędzia"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "Nie można otworzyć pliku pliku z parametrami <%s>"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 msgid "Parameter file name is missing"
 msgstr ""
 
@@ -1400,7 +1400,8 @@ msgid "Negative spindle speed used"
 msgstr "Użyta ujemna prędkość wrzeciona"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "Użyty ujemny numer narzędzia"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1789,24 +1790,23 @@ msgstr "R mniejsze niż U w cyklu na planie VW"
 msgid "R less than V in cycle in UW plane"
 msgstr "R mniejsze niż V w cyklu na planie UW"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "BŁĄD: '%s' nie jest prawidłowym typem\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "BŁĄD: brak nazwy pinu/sygnału/parametru\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr "BŁĄD: opcja -s wymaga typu skanowania i nazwy pinu/signału/parametru\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "Pomiar Hal"
 
@@ -1818,27 +1818,27 @@ msgstr "Wybierz"
 msgid "E_xit"
 msgstr "Wyjście"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "Zaznacz element do podglądu"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr " _Piny "
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr " _Sygnały "
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr " Para_metry "
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr "Zamknij"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
@@ -1846,67 +1846,89 @@ msgstr ""
 "Użycie:\n"
 "  halscope [-h] [-i plik_wejscia] [-o plik_wyjscia] [ilość_sampli]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "Otwórz plik konfiguracyjny:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Anuluj"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "Otwórz..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Otwórz plik konfiguracyjny:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "Zapisz"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "_Otwórz konfiguracje..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "Zapisz konfiguracje..."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "Otwórz _plik z danymi..."
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "Z_apisz plik danych..."
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "Wyjście"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "O Halscope"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "Plik"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "Pomoc"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "Oscyloskop HAL"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "Poziomo"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "Wybrany kanał"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "Tryb"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "Wyzwalacz"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "Pionowo"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1914,39 +1936,40 @@ msgstr "Pionowo"
 msgid "Stop"
 msgstr "Stop"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "Normalny"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "Pojedyńczy"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "Przewijaj"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "Powiększ"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr " Poz "
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "----- Próbek\n"
-"na ---- KHz"
+"na ---- kHz"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "Komponent RT nie załadowany"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1970,11 +1993,39 @@ msgstr ""
 "lub\n"
 "Kliknij 'Wyjście' aby zamknąć HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "Wyjście"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "Funkcja RT nie podłączona"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1996,11 +2047,11 @@ msgstr ""
 "lub\n"
 "Kliknij 'Wyjście' aby zamknąć HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "Wybierz częstotliwość próbkowania"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
@@ -2010,94 +2061,70 @@ msgstr ""
 "lub\n"
 "Kliknij 'Wyjście' aby zamknąć HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr "Wątek:"
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr "Okres próbki:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr "Częstotliwość próbek:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr "Wątek"
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "Okres"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "Mnożnik:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr "Długość pomiaru"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d próbek (1 kanał)"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d próbek (2 kanały)"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d próbek (4 kanały)"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d próbek (8 kanałów)"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d próbek (16 kanałów)"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "Wyjście"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr "Wątek(ki) czasu rzeczywistego nie są uruchomione"
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2120,15 +2147,15 @@ msgstr ""
 "lub\n"
 "Kliknij 'Wyjście' aby zamknąć HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr "Wybierz plik do zapisu logowania:"
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr "Niewystarczająca ilość kanałów"
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
@@ -2138,7 +2165,7 @@ msgstr ""
 "które są obecnie włączone.  Wybierz krótszą długość\n"
 "zapisu która obsługuje więcej kanałów."
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
@@ -2147,7 +2174,7 @@ msgstr ""
 "%s\n"
 "na podziałkę"
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
@@ -2156,27 +2183,35 @@ msgstr ""
 "%s próbek\n"
 "na %s"
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
-msgstr "nSek"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
-msgstr "uSek"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
-msgstr "mSek"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
-msgstr "Sek"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2190,17 +2225,17 @@ msgstr "Sek"
 #: src/emc/usr_intf/pncconf/mesa1.glade:460
 #: src/emc/usr_intf/pncconf/mesa1.glade:473
 msgid "Hz"
-msgstr "Hz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
-msgstr "kHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
-msgstr "MHz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
+msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
@@ -2209,24 +2244,25 @@ msgstr ""
 "Przesunięcie\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "Wzmoc"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr "Poz"
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr "Skala"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
@@ -2235,15 +2271,11 @@ msgstr ""
 "Przesunięcie\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr "KAN Wył"
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "Ustaw Przesunięcie"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
@@ -2252,35 +2284,19 @@ msgstr ""
 "Ustaw pionowe przesunięcie dla\n"
 "kanału %d."
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "Ustaw Przesunięcie"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr "Centruj wykres"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr "Zbyt wiele kanałów"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2292,21 +2308,7 @@ msgstr ""
 "Włącz większą ilość kanałów, lub krótszą\n"
 "długość zapisu aby zwiększyć ilość kanałów"
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr "Wybierz źródło kanału"
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
@@ -2315,29 +2317,33 @@ msgstr ""
 "Wybierz pin, sygnał, parametr\n"
 "jako źródło dla kanału %d."
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "Wybierz źródło kanału"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "Piny"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "Sygnały"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "Parametry"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr "Opadanie"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr "Wzrastanie"
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
@@ -2345,7 +2351,7 @@ msgstr ""
 "Źródło\n"
 "Brak"
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
@@ -2354,111 +2360,111 @@ msgstr ""
 "Źródło\n"
 "KAN %2d"
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "Auto"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr "Wymuś"
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr "Poziom"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr "Źródło wyzwalacza"
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr "Wybierz kanał używany do wyzwalania."
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "Źródło wyzwalacza"
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr "KAN"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr "Źródło"
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr "Ruch G38.4 zakończony bez utraty kontaktu z czujnikiem."
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr "Ruch G38.2 zakończony bez kontaktu z czujnikiem."
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+msgid "Probe tripped during non-probe move."
 msgstr ""
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr ""
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr ""
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr ""
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr ""
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, fuzzy, c-format
 msgid "spindle %d amplifier fault"
 msgstr "błąd sterownika w napędzie %d"
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "napęd %d na krańcówce awaryjnej"
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "błąd sterownika w napędzie %d"
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "błąd pozycji w napędzie %d"
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
@@ -2527,177 +2533,177 @@ msgstr ""
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr "Nie można poruszać żadnym napędem podczas bazowania"
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr ""
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr ""
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr "musi być w trybie napędów aby zbazować"
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr "sekwencja bazowania jest w toku"
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr "musi być tryb napędów lub wyłączony aby odbazować"
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr "Nie mogę odbazować w czasie bazowania napędu %d"
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr "Nie mogę odbazować w czasie poruszania napędu %d"
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, fuzzy, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr "Nie mogę odbazować nieprawidłowgo napędu %d (maks. %d)"
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr "Nie mogę odbazować nieaktywnego napędu %d"
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr "Nie mogę odbazować nieprawidłowgo napędu %d (maks. %d)"
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr ""
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr ""
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2786,26 +2792,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2976,7 +2982,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -3066,19 +3072,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "Tak"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 #, fuzzy
 msgid "No"
 msgstr "Brak"
@@ -3132,7 +3138,7 @@ msgstr "Plik"
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "Zapisz"
 
@@ -3151,7 +3157,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "Edytor"
 
@@ -3165,7 +3171,6 @@ msgid "Config"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 msgid "Preview"
 msgstr "Podgląd"
 
@@ -3597,7 +3602,7 @@ msgid "Edit mode..."
 msgstr "_Edytuj..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr ""
 
@@ -3606,7 +3611,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr ""
 
@@ -3617,6 +3622,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "Modyfikuj"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Anuluj"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3805,7 +3828,7 @@ msgid "Parameter"
 msgstr "Parametry"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3995,7 +4018,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "Główny"
 
@@ -4076,11 +4098,13 @@ msgid "Delete section"
 msgstr "Usuń / linie"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Down"
 msgstr ""
 
@@ -4602,6 +4626,7 @@ msgid "Exit"
 msgstr "Zakończ"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "Edytuj"
 
@@ -4644,7 +4669,6 @@ msgid "Renumber File..."
 msgstr "Przenumeruj plik..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "Ustawienia"
 
@@ -4933,15 +4957,15 @@ msgstr "Widok drzewa"
 msgid "Test HAL command :"
 msgstr "Testuj polecenie HAL :"
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr "Załaduj listę podglądu"
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr "Zapisz bieżącą listę podglądu"
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "Polecenia mogą być tu testowane ale NIE zostaną zapisane"
 
@@ -5069,22 +5093,22 @@ msgstr ""
 msgid "SIZE :"
 msgstr ""
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr ""
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr ""
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 #, fuzzy
 msgid "Create Report File"
 msgstr "Zapisz do pliku"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr ""
 
@@ -5158,7 +5182,7 @@ msgstr ""
 msgid "Tool:"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Wszystkie pliki"
@@ -5225,18 +5249,18 @@ msgstr "Jednostek"
 msgid "auto"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "cali"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5394,7 +5418,7 @@ msgstr ""
 msgid "world"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr ""
 
@@ -5475,16 +5499,15 @@ msgstr ""
 msgid "Optional Stop"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr ""
 
@@ -5593,7 +5616,7 @@ msgid "Coordinate System Control Window"
 msgstr ""
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr ""
 
@@ -6147,9 +6170,9 @@ msgstr "usuń"
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr ""
 
@@ -6169,8 +6192,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
@@ -6242,147 +6265,147 @@ msgstr ""
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr "Tekst"
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr "brak"
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr "tryb"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr "normalny"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 msgid "no such file"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 #, fuzzy
 msgid "LinuxCNC"
 msgstr "TKLinuxCNC"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "Status LinuxCNC"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7056,34 +7079,34 @@ msgid "Open a Menu"
 msgstr ""
 
 # python-format
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Nieznane narzędzie %d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Brak narzędzia"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Narzędzie %(tool)d, offs %(zo)g, śred %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "Narzędzie %(tool)d, zo %(zo)g, xo %(xo)g, śre %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "Filtrowanie..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "Filtrowanie nieukończone"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
@@ -7092,12 +7115,12 @@ msgstr ""
 "Program %(program)r zakończył sie z kodem %(code)d. Komunikaty błędów są "
 "wyświetlone poniżej:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "Błąd G-kodu w %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7106,130 +7129,128 @@ msgstr ""
 "W pobliżu linii %(seq)d w %(f)s:\n"
 "%(error_str)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "Ciągły"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr "T    Tabela Narzędzi"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "cale"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr " promień"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr " średnica"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "System współrzędnych:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr "punkt"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr "detal"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "Nazwa:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "Rozmiar:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "Kolejność narzędzi:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "Długość przestawcza:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "Długość robocza:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "Łączna długość:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "Czas wykonania:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "Zakres X:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Zakres Y:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Zakres Z:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "Zakres A:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "Zakres B:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "Zakres C:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "Program przekracza minimalny zakres maszyny w osi %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "Program przekracza maksymalny zakres maszyny w osi %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "Program przekracza zakresy maszyny"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Uruchom mimo to"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "Brak załadowanego pliku"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "wygenerowany z %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
@@ -7238,44 +7259,44 @@ msgstr ""
 "%(size)s bajtów\n"
 "%(lines)s linii gkodu"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr "%.1f minut"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr "%d sekund"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%(a)f do %(b)f = %(diff)f %(units)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "Właściwości G-kodu"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "Wszystkie pliku maszynowe"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "pliki rs274ngc"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr "Axis nie może przyjąć poleceń zdalnych w czasie wykonywania programu"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 #, fuzzy
 msgid "File not Writable:"
 msgstr "Plik nie jest otwarty"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7286,62 +7307,62 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Custom Grid"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Enter grid size"
 msgstr "Rozmiar"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 #, fuzzy
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr "Axis jest już zbazowany, czy na pewno chcesz bazować ponownie?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, fuzzy, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr "musi być w trybie napędów aby zbazować"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 #, fuzzy
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr "Ta oś jest już zbazowana, czy na pewno chcesz bazować ponownie?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 #, fuzzy
 msgid "Touch Off (system)"
 msgstr "Ustaw Offset"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "Wprowadź współrzędną %s względną do %%s:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, fuzzy, python-format
 msgid "Tool %s TouchOff"
 msgstr "Ustaw Offset"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "Błąd podczas zapisywania pliku"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7350,7 +7371,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7359,7 +7380,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7368,91 +7389,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "Napęd:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "Bazuj wszystkie"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, fuzzy, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "Bazuj wszystkie osie [Ctrl-Home]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "Bazuj wszystkie"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "Odbazuj wszystkie"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "Napęd:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "Pozycja bazowa:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, fuzzy, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr "Bazuj oś _%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, fuzzy, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "Odbazuj oś _%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "Uruchom od tego miejsca"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "Błąd w ~/.axisrc"
 
@@ -7765,11 +7786,13 @@ msgid "_Properties..."
 msgstr "Właściwości..."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "Edytuj _tabele narzędzi..."
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+#, fuzzy
+msgid "Reload tool _data"
 msgstr "Przeładuj ta_bele narzędzi"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8096,11 +8119,11 @@ msgstr "Przełącz pomijanie linii z '_/' [Alt-M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "Przełącz opcjonalną pauzę [Alt-M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "Powększ"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "Pomniejsz"
 
@@ -8279,9 +8302,10 @@ msgstr "Skala prędkości wrzeciona:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr "%"
 
@@ -8333,7 +8357,7 @@ msgid "Position:"
 msgstr "Pozycja:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr "Maszyny"
 
@@ -8438,21 +8462,20 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Czasowo pozwól na poruszanie maszyny poza zakresami [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "Wrzeciono CW"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "Wrzeciono CCW"
@@ -8795,6 +8818,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8804,43 +8829,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8895,7 +8965,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr "<b>Wrzeciono</b>"
 
@@ -9059,7 +9128,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr ""
 
@@ -9118,8 +9186,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr "cale"
@@ -9254,10 +9322,10 @@ msgid "Stepconf"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9278,13 +9346,13 @@ msgid "Parallel Port 1"
 msgstr "Ustawienia Portu Równoległego"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 #, fuzzy
 msgid "Parallel Port 2"
 msgstr "Ustawienia Portu Równoległego"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "opcja"
@@ -9294,235 +9362,285 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Przycisk zerowania X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Axis"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Axis"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Axis"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Axis"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Axis"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Axis"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "Spindle"
 msgstr "Wrzeciono"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr "JVL-SMD41 lub 42"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr "X Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr "X Kierunek"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr "Y Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr "Y Kierunek"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr "Z Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr "Z Kierunek"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr "A Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr "A Kieruek"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "X Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "X Kierunek"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "X Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "X Kierunek"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "X Krok"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "X Kierunek"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "Y Krok"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Y Kierunek"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr "Włączenie wrzeciona"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr "PWM Wrzeciona"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr "Hamulec wrzeciona"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr "Chłodziwo Mgła"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr "Chłodziwo Polewanie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr "ESTOP Wyjście"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr "Włączenie Wzmacnaczy"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr "Włączenie napięcia"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr "Cyfrowe wyjście 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr "Cyfrowe wyjście 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr "Cyfrowe wyjście 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr "Cyfrowe wyjście 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9533,255 +9651,349 @@ msgstr "Cyfrowe wyjście 3"
 msgid "Unused"
 msgstr "Nieużywane"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr "Wejście ESTOP"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr "Wejście Sondowania"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr "Indeks Wrzeciona"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr "Faza A Wrzeciona"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr "Faza B Wrzeciona"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr "Bazowanie X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr "Bazowanie Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr "Bazowanie Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr "Bazowanie A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "Bazowanie X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "Bazowanie X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Bazowanie X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Bazowanie Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr "Limit minimalny + Bazująca Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem X"
+msgstr "Limit minimalny + Bazująca X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem Y"
+msgstr "Limit minimalny + Bazująca Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr "Limit minimalny + Bazująca Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr "Limit minimalny + Bazująca A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home U"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home V"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr "Limit maksymalny + Bazująca Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem X"
+msgstr "Limit maksymalny + Bazująca X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem Y"
+msgstr "Limit maksymalny + Bazująca Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr "Limit maksymalny + Bazująca Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr "Limit maksymalny + Bazująca A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home U"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home V"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr "Obydwa limity + Bazująca Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr "Obydwa limity + Bazująca Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr "Obydwa limity + Bazująca A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home U"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home V"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Obydwa limity + Bazująca X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Obydwa limity + Bazująca Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr "Limit minimalny Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem X"
+msgstr "Limit minimalny X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem Y"
+msgstr "Limit minimalny Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr "Limit minimalny Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr "Limit minimalny A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit U"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit V"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr "Limit maksymalny Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem X"
+msgstr "Limit maksymalny X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem Y"
+msgstr "Limit maksymalny Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr "Limit maksymalny Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr "Limit maksymalny A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit U"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit V"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr "Obydwa limity Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr "Obydwa limity Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr "Obydwa limity A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit U"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit V"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Obydwa limity X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Obydwa limity Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr "Wszystkie limity"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr "Wszystkie bazujące"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits + homes"
 msgstr "Wszystkie limity i bazujące"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr "Wejście cyfrowe 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr "Wejście cyfrowe 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr "Wejście cyfrowe 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr "Wejście cyfrowe 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Down"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Wrzeciono Przód"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -9791,9 +10003,9 @@ msgstr ""
 "Isteniejący Custom.clp zostanie nazwany custom_backup.clp.\n"
 "Wszystkie pliki nazwane -custom_backup.clp- zostaną utracone."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9806,8 +10018,8 @@ msgstr ""
 "Edytowany program zostanie utracony.\n"
 "Czy jesteś pewien?  "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
@@ -9815,7 +10027,7 @@ msgstr ""
 "Musisz wskazać pin wejściowy E-stop w zakładce Konfiguracji Portu "
 "Równoległego dla tego programu."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
@@ -9826,26 +10038,26 @@ msgstr ""
 "Isteniejący Custom.clp zostanie nazwany custom_backup.clp.\n"
 "Wszystkie pliki nazwane -custom_backup.clp- zostaną utracone."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr "Wyjść z programu i odrzucić zmiany?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9856,16 +10068,16 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr "moja-frezarka"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr "Plik %r był zmodyfikowany od czasu zapisu przez Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
@@ -9873,27 +10085,27 @@ msgstr ""
 "Zapisanie tej konfiguracji spowoduje anulowanie zmian w konfiguracji "
 "dokonanych poza Stepconf."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr "Kontynuować?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr "uruchom %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr "Skrót do konfiguracji LinuxCNC utworzony przez Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9901,34 +10113,34 @@ msgid ""
 "{}"
 msgstr "Wybieranie konfiguracji LinuxCNC"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr "Inne"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr "Test osi %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr "st / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr "st / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr "stopnie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -9943,8 +10155,8 @@ msgstr "stopnie"
 msgid "mm / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -9959,13 +10171,13 @@ msgstr ""
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr "cal / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr "cal / s²"
 
@@ -9974,19 +10186,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "Pliki konfiguracyjne 'stepconf' LinuxCNC"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr "Zmodyfikuj instniejącą konfigurację"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr "stopnie / obrót"
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr "kroki / stopień"
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -9998,7 +10210,7 @@ msgstr "kroki / stopień"
 msgid "mm / rev"
 msgstr "mm / obrót"
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10009,28 +10221,28 @@ msgstr "mm / obrót"
 msgid "Steps / mm"
 msgstr "kroków / mm"
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr "obrotów / cal"
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr "kroki / cal"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, fuzzy, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr "# Wygenerowane przez Stepconf o %s"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10038,72 +10250,72 @@ msgstr "# Jeśli zmodyfikujesz ten plik zmainy zostaną"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr "# nadpisane gdy uruchomisz ponownie Stepconf"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr "# dodaj polecenia halui MDI (maks 64) "
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 "# **** Kofiguracja dla zewnętrznego programu PLC dla stopu awaryjnego -START "
 "****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 "# **** Kofiguracja dla zewnętrznego programu PLC dla stopu awaryjnego -END "
 "****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 "# Uruchom Classicladder z interfejsem modbus master (Modbus musi być "
 "uruchomione z GUI)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr "# Uruchom Classicladder bez GUI (można prezładować PLC GUI w AXIS GUI"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr "Dodaj twój panel PyVCP tutaj.\n"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 "# **** Konfiguracja wyświetlania prędkości wrzeciona w pyVCP - START ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr "# **** Używam AKTUALNEJ prędkości wrzeciona z enkodera"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 #, fuzzy
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
@@ -10112,16 +10324,16 @@ msgstr ""
 "#  prędkość wrzeciona jest ze znakiem wiec używamy komponent abs aby usunąć "
 "znak"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 "# **** prędkość AKTUALNA jest w RPS a nie w RPM więc musimy ją zeskalować."
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
@@ -10129,22 +10341,28 @@ msgstr ""
 "# **** Używaj ZADANEJ prędkości wrzeciona z LinuxCNC ponieważ nie jest "
 "zdefiniowany enkoder wrzeciona"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, fuzzy, python-format
 msgid "# Include your %s HAL commands here"
 msgstr "# Tutaj dodaj swoje polecenia HAL"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr "# Ten plik nie zostanie nadpisany gdy uruchomisz ponownie Stepconf"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
 msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+#, fuzzy
+msgid "# Include your custom HAL commands here"
+msgstr "# Tutaj dodaj swoje polecenia HAL"
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
 #, fuzzy
@@ -10215,11 +10433,16 @@ msgstr "Kalibracja Frezarki krokowej LinuxCNC"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr ""
 
@@ -10266,17 +10489,6 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:209
@@ -10629,56 +10841,152 @@ msgstr ""
 msgid "Scale %"
 msgstr "Skala %"
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr "Axis"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Ustaw Przesunięcie"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Ustaw Przesunięcie"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Lewy przycisk"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Lewy przycisk"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "tryb"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 #, fuzzy
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 "Komunikat o \n"
 " zmianie narzędzia"
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr "Dołącz Halui komponent interfejsu użytkownika"
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr "Dołącz panel PyVCP GUI"
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr "Pusty program"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 msgid "Spindle speed display  "
 msgstr "wyświetlanie prędkości wrzeciona"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr "Istniejący program"
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr "Dołącz połączenia HAL"
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10690,68 +10998,68 @@ msgstr ""
 "przykładowy\n"
 "panel"
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr "Dołącz Classicladder PLC"
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr "Liczba cyfrowych pinów wejścowych:"
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr "Liczba cyfrowych pinów wyjścowych:"
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr "Liczba analogowych (s32) pinów wejścowych:"
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr "Liczba analogowych (s32) pinów wyjścowych:"
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr "Liczba analogowych (float) pinów wejścowych:"
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr "Liczba analogowych (float) pinów wyjścowych:"
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr "ustaw liczbę zewnętrznych pinów"
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr "Dołącz obsługę modbus master"
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr "Pusty program PLC"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr "Program PLC stopu awaryjnego"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr "Szeregowy modbus program"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
@@ -10760,10 +11068,14 @@ msgstr ""
 "Edytuj program\n"
 "PLC"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "Przykładowe opcje"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr "Dołącz Halui komponent interfejsu użytkownika"
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10781,16 +11093,154 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "tryb"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10800,10 +11250,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr "Dodatnie"
@@ -10832,15 +11282,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
 msgstr "do"
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
-msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
 #: src/emc/usr_intf/stepconf/axisy.glade:402
@@ -11057,38 +11498,38 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr "Strony pomocy"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11096,22 +11537,22 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "Pliki konfiguracyjne 'stepconf' LinuxCNC"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11121,32 +11562,32 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11155,175 +11596,175 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr "Kanał nieużywany"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr "Skok śruby"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr "Skok śruby (TPI)"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr " / min"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr " / sek²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 msgid " / Step"
 msgstr " / krok"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 msgid "Steps / "
 msgstr "kroków / "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr " / impulsy enkodera"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr "Impulsy enkodera / "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 msgid "Resolver Scale:"
 msgstr "Skala resolvera"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Kierunek wrzeciona:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11341,59 +11782,62 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr " / min"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr "mm / min"
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 #, fuzzy
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 "Musisz wskazać pin wejściowy E-stop w zakładce Konfiguracji Portu "
 "Równoległego dla tego programu."
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 #, fuzzy
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 "Musisz wskazać pin wejściowy E-stop w zakładce Konfiguracji Portu "
 "Równoległego dla tego programu."
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 #, fuzzy
 msgid ""
 "OK to replace existing custom ladder program?\n"
@@ -11407,8 +11851,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, fuzzy, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr "# Wygenerowane przez Stepconf o %s"
@@ -11425,174 +11869,179 @@ msgstr "Status LinuxCNC"
 msgid "# overwritten when you run PNCconf again"
 msgstr "# nadpisane gdy uruchomisz ponownie Stepconf"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 #, fuzzy
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr "# Tutaj dodaj swoje polecenia HAL"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 #, fuzzy
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 "# **** Konfiguracja wyświetlania prędkości wrzeciona w pyVCP - START ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 #, fuzzy
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 "# Polecenia w tym pliku są wykonywane po uruchomieniu AXIS GUI (włączając "
 "panel PyVCP)"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 #, fuzzy
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 "# **** Konfiguracja wyświetlania prędkości wrzeciona w pyVCP - START ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 #, fuzzy
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr "# Ten plik nie zostanie nadpisany gdy uruchomisz ponownie Stepconf"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
+#: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, fuzzy, python-format
 msgid "Generated by PNCconf at %s"
 msgstr "# Wygenerowane przez Stepconf o %s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
 msgid "configures LinuxCNC as:\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
 msgid "type CNC\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
 msgid "will be used as the frontend display"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
 msgid " connector"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
 msgid "invrt"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
 #, fuzzy, python-format
 msgid "%(name)s Parport"
 msgstr "Adres trzeciego portu równoległego:"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
 msgid "-> inverted"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1059
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
 #, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 #, fuzzy
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr "# **** Używam AKTUALNEJ prędkości wrzeciona z enkodera"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 #, fuzzy
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
@@ -11600,7 +12049,7 @@ msgstr ""
 "#  prędkość wrzeciona jest ze znakiem wiec używamy komponent abs aby usunąć "
 "znak"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 #, fuzzy
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
@@ -11618,1661 +12067,1716 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 #, fuzzy
 msgid "External Controls"
 msgstr "Ręczna kontrola"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 #, fuzzy
 msgid "Parallel Port"
 msgstr "Ustawienia Portu Równoległego"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 msgid "X Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "X Axis"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 msgid "Y Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Y Axis"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 msgid "Z Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Z Axis"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 msgid "A Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "A Axis"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Wrzeciono Stop"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Output"
-msgstr "Wyjście"
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-msgid "POT Enable"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-msgid "POT Dir"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Input"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-#, fuzzy
-msgid "GPIO Output"
-msgstr "Wyjście"
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO O Drain"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
+msgid "POT Output"
+msgstr "Wyjście"
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+msgid "POT Enable"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+msgid "POT Dir"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Input"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+#, fuzzy
+msgid "GPIO Output"
+msgstr "Wyjście"
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO O Drain"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:117
+#, fuzzy
 msgid "SSR Output"
 msgstr "Wyjście"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "muxed Enc I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "mux select"
 msgstr "Zbazuj wybraną"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 0 Encoder"
 msgstr "Skala resolvera"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 1 Encoder"
 msgstr "Skala resolvera"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 2 Encoder"
 msgstr "Skala resolvera"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 3 Encoder"
 msgstr "Skala resolvera"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 4 Encoder"
 msgstr "Skala resolvera"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 5 Encoder"
 msgstr "Skala resolvera"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 #, fuzzy
 msgid "Step Gen-A"
 msgstr "Czas trwania kroku:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-Down"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "Analogowy limit min.:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "X Home"
 msgstr "Bazuj"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Y Home"
 msgstr "Bazuj"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Z Home"
 msgstr "Bazuj"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "A Home"
 msgstr "Bazuj"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "All Home"
 msgstr "Wszystkie bazujące"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "X2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Y2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Z2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "A2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 #, fuzzy
 msgid "X Minimum Limit + Home"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 #, fuzzy
 msgid "Y Minimum Limit + Home"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 #, fuzzy
 msgid "Z Minimum Limit + Home"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 #, fuzzy
 msgid "A Minimum Limit + Home"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 #, fuzzy
 msgid "X Maximum Limit + Home"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 #, fuzzy
 msgid "Y Maximum Limit + Home"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 #, fuzzy
 msgid "Z Maximum Limit + Home"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 #, fuzzy
 msgid "A Maximum Limit + Home"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 #, fuzzy
 msgid "X Both Limit + Home"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 #, fuzzy
 msgid "Y Both Limit + Home"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 #, fuzzy
 msgid "Z Both Limit + Home"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "A Both Limit + Home"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Wszystkie limity i bazujące"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 #, fuzzy
 msgid "X2 Minimum Limit + Home"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Y2 Minimum Limit + Home"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Z2 Minimum Limit + Home"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "A2 Minimum Limit + Home"
 msgstr "Limit minimalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "X2 Maximum Limit + Home"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Y2 Maximum Limit + Home"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Z2 Maximum Limit + Home"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "A2 Maximum Limit + Home"
 msgstr "Limit maksymalny + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "X2 Both Limit + Home"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Y2 Both Limit + Home"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Z2 Both Limit + Home"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 #, fuzzy
 msgid "A2 Both Limit + Home"
 msgstr "Obydwa limity + Bazująca X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select A"
 msgstr "Przesuwaj aktywną oś"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select B"
 msgstr "Przesuwaj aktywną oś"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select C"
 msgstr "Przesuwaj aktywną oś"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select D"
 msgstr "Przesuwaj aktywną oś"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "Skala prędkości:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "Skala prędkości:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "Skala prędkości:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "Skala prędkości:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Spindle Override incr A"
 msgstr "Skala prędkości wrzeciona:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr B"
 msgstr "Skala prędkości wrzeciona:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr C"
 msgstr "Skala prędkości wrzeciona:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr D"
 msgstr "Skala prędkości wrzeciona:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "Skala prędkości:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "Skala prędkości wrzeciona:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 msgid "Max Vel Override enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CW"
 msgstr "Ręczna kontrola"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CCW"
 msgstr "Ręczna kontrola"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle Stop"
 msgstr "Ręczna kontrola"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Spindle Up-To-Speed"
 msgstr "Prędkość wrzeciona:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "Zaznacz wszystko"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Cycle Start"
 msgstr "Uruchomienie"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "Pojedyńcza krok"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected +"
 msgstr "Przesuwaj aktywną oś"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected -"
 msgstr "Przesuwaj aktywną oś"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 1"
 msgstr "Zapisz INI HAL"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 2"
 msgstr "Zapisz INI HAL"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 3"
 msgstr "Zapisz INI HAL"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "X Minimum Limit"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "Y Minimum Limit"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "Z Minimum Limit"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "A Minimum Limit"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "X Maximum Limit"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "Y Maximum Limit"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "Z Maximum Limit"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "A Maximum Limit"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "X Both Limit"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "Y Both Limit"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "Z Both Limit"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "A Both Limit"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 #, fuzzy
 msgid "All Limits"
 msgstr "Wszystkie limity"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "X2 Minimum Limit"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Y2 Minimum Limit"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Z2 Minimum Limit"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "A2 Minimum Limit"
 msgstr "Limit minimalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "X2 Maximum Limit"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Y2 Maximum Limit"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Z2 Maximum Limit"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "A2 Maximum Limit"
 msgstr "Limit maksymalny X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "X2 Both Limit"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Y2 Both Limit"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Z2 Both Limit"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "A2 Both Limit"
 msgstr "Obydwa limity X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "Główny"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "Bazuj oś"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Arc OK"
+msgstr "Łuk CW"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Ohmic Probe"
+msgstr "Sondowanie"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Float Switch"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Unused Input"
 msgstr "Nieużywane"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Limits"
 msgstr "Limity"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 #, fuzzy
 msgid "Digital"
 msgstr "Wejście cyfrowe 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 #, fuzzy
 msgid "Axis Selection"
 msgstr "Wybór osi"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "Ignoruj zakresy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "Operation"
 msgstr "opcja"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "External Control"
 msgstr "Ręczna kontrola"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Custom Signals"
 msgstr " _Sygnały "
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
 msgid "X Axis PWM"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
 msgid "Y Axis PWM"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 #, fuzzy
 msgid "Z Axis PWM"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 #, fuzzy
 msgid "A Axis PWM"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Unused PWM Gen"
 msgstr "Nieużywane"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Axis PWM"
 msgstr "Axis"
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 #, fuzzy
 msgid "X Axis StepGen"
 msgstr "X Krok"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 #, fuzzy
 msgid "Y Axis StepGen"
 msgstr "Y Krok"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 #, fuzzy
 msgid "Z Axis StepGen"
 msgstr "Z Krok"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 #, fuzzy
 msgid "A Axis StepGen"
 msgstr "A Krok"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "X2 Tandem StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "Y2 Tandem StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 msgid "Z2 Tandem StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 #, fuzzy
 msgid "Unused StepGen"
 msgstr "Niezamknięte wyrażenie"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr "Axis"
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Charge Pump StepGen"
 msgstr "Włączenie napięcia"
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Spindle StepGen"
 msgstr "Pojedyńcza krok"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "X Encoder"
 msgstr "Enkoder X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "Y Encoder"
 msgstr "Enkoder X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "Z Encoder"
 msgstr "Enkoder X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "A Encoder"
 msgstr "Enkoder X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "Enkoder Przyrostowy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "Enkoder Przyrostowy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "Enkoder Przyrostowy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "Enkoder Przyrostowy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Feed Override"
 msgstr "Skala prędkości:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "spindle Override"
 msgstr "Skala prędkości wrzeciona:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "Skala prędkości:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 #, fuzzy
 msgid "Unused Encoder"
 msgstr "Użyj indeksu enkodera"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Spindle Encoder"
 msgstr "Indeks Wrzeciona"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Override MPG control"
 msgstr "Ignoruj zakresy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Enkoder X"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 #, fuzzy
 msgid "Unused Unused"
 msgstr "Kanał nieużywany"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Hamulec wrzeciona"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "Nazwa maszyny:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "X Amplifier Enable"
 msgstr "Włączenie Wzmacnaczy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Y Amplifier Enable"
 msgstr "Włączenie Wzmacnaczy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Z Amplifier Enable"
 msgstr "Włączenie Wzmacnaczy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "A Amplifier Enable"
 msgstr "Włączenie Wzmacnaczy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Włączenie Wzmacnaczy"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Maszyna włączona"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "Ustaw Offset"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 #, fuzzy
 msgid "Unused Output"
 msgstr "Nieużywane"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Coolant"
 msgstr "Chłodziwo:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Control"
 msgstr "Ciągły"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:518
-#, fuzzy
-msgid "Unused 8I20"
-msgstr "Nieużywane"
-
-#: src/emc/usr_intf/pncconf/private_data.py:521
-#, fuzzy
-msgid "Unused Resolver"
-msgstr "Kanał nieużywany"
-
-#: src/emc/usr_intf/pncconf/private_data.py:521
-#, fuzzy
-msgid "X Resolver"
-msgstr "Skala resolvera"
-
-#: src/emc/usr_intf/pncconf/private_data.py:522
-#, fuzzy
-msgid "Y Resolver"
-msgstr "Skala resolvera"
-
-#: src/emc/usr_intf/pncconf/private_data.py:522
-#, fuzzy
-msgid "Z Resolver"
-msgstr "Skala resolvera"
-
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#, fuzzy
-msgid "A Resolver"
-msgstr "Skala resolvera"
-
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#, fuzzy
-msgid "S Resolver"
-msgstr "Skala resolvera"
-
-#: src/emc/usr_intf/pncconf/private_data.py:525
-msgid "Unused Analog Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:525
-#, fuzzy
-msgid "Spindle Output"
-msgstr "Włączenie wrzeciona"
-
-#: src/emc/usr_intf/pncconf/private_data.py:529
-msgid "Unused TPPWM Gen"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:529
-msgid "X Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:530
-msgid "Y Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:530
-msgid "Z Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:531
-msgid "A Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:531
-msgid "S Axis BL Driver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
+msgid "Unused 8I20"
+msgstr "Nieużywane"
+
+#: src/emc/usr_intf/pncconf/private_data.py:537
+#, fuzzy
+msgid "Unused Resolver"
+msgstr "Kanał nieużywany"
+
+#: src/emc/usr_intf/pncconf/private_data.py:537
+#, fuzzy
+msgid "X Resolver"
+msgstr "Skala resolvera"
+
+#: src/emc/usr_intf/pncconf/private_data.py:538
+#, fuzzy
+msgid "Y Resolver"
+msgstr "Skala resolvera"
+
+#: src/emc/usr_intf/pncconf/private_data.py:538
+#, fuzzy
+msgid "Z Resolver"
+msgstr "Skala resolvera"
+
+#: src/emc/usr_intf/pncconf/private_data.py:539
+#, fuzzy
+msgid "A Resolver"
+msgstr "Skala resolvera"
+
+#: src/emc/usr_intf/pncconf/private_data.py:539
+#, fuzzy
+msgid "S Resolver"
+msgstr "Skala resolvera"
+
+#: src/emc/usr_intf/pncconf/private_data.py:541
+msgid "Unused Analog Output"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:541
+#, fuzzy
+msgid "Spindle Output"
+msgstr "Włączenie wrzeciona"
+
+#: src/emc/usr_intf/pncconf/private_data.py:545
+msgid "Unused TPPWM Gen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:545
+msgid "X Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:546
+msgid "Y Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:546
+msgid "Z Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:547
+msgid "A Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:547
+msgid "S Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:550
+#, fuzzy
 msgid "8i20 Amplifier Card"
 msgstr "Włączenie Wzmacnaczy"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Unused Analog In"
 msgstr "Kanał nieużywany"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13285,17 +13789,17 @@ msgstr ""
 "custompanel_backup.xml and postgui_backup.halJakiekolwiek istniejące "
 "custompanel_backup.xml and custom_postgui.hal zostaną utracone. "
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 #, fuzzy
 msgid "Quit PNCconf and discard changes?"
 msgstr "Wyjść z programu i odrzucić zmiany?"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 #, fuzzy
 msgid "Do you want to quit?"
 msgstr "Czy chcesz:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13310,86 +13814,95 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 #, fuzzy
 msgid "degrees"
 msgstr "stopnie / obrót"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 #, fuzzy
 msgid "degrees / minute"
 msgstr "stopnie / obrót"
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 #, fuzzy
 msgid "degrees / second²"
 msgstr "stopnie / obrót"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 #, fuzzy
 msgid "revs / second²"
 msgstr " / sek²"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 #, fuzzy
 msgid "mm / second²"
 msgstr " / sek²"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 #, fuzzy
 msgid "inches / second²"
 msgstr " / sek²"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, fuzzy, python-format
 msgid "%s Axis Tune"
 msgstr "Test osi %s"
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13402,7 +13915,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13412,12 +13925,12 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr "Plik %r był zmodyfikowany od czasu zapisu przez PNCconf"
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
@@ -13425,7 +13938,7 @@ msgstr ""
 "Zapisanie tej konfiguracji spowoduje anulowanie zmian w konfiguracji "
 "dokonanych poza PNCconf."
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr "Skrót do konfiguracji LinuxCNC utworzony przez PNCconf"
 
@@ -15086,9 +15599,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15243,6 +15756,13 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/external.glade:5401
 msgid "Mux options"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "Sek"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15430,176 +15950,194 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr "stopnie / min"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr "Rozmiar"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr "Pozycja"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 msgid "Relative Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Przykładowe opcje"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15689,132 +16227,146 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr "Dołącz panel GladeVCP GUI"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr ""
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Enkoder X"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr "Kierunek zjazdu z krańcówki:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr "Prędkość zjazdu z krańcówki:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr ""
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Kompensacja promienia po lewej"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr "Prędkość najazdu na krańcówkę:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 #, fuzzy
 msgid "Home Search Sequence:"
 msgstr "Prędkość najazdu na krańcówkę:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
+msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -16740,10 +17292,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 #, fuzzy
 msgid "Number of connectors:"
@@ -16833,10 +17381,6 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr "Kroki silnika na obrót:"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
-msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17302,7 +17846,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17464,31 +18007,23 @@ msgid "Manual Toolchange"
 msgstr "Ręczna zmieniarka narzędzi AXIS"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 msgid "Restart Entry"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr ""
 
@@ -17568,33 +18103,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17716,14 +18251,12 @@ msgid "<b>Status</b>"
 msgstr "<b>Chłodziwo</b>"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17731,7 +18264,6 @@ msgid ""
 msgstr "Zamień:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17739,7 +18271,6 @@ msgid ""
 msgstr "Zamień wszystko"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 #, fuzzy
 msgid ""
 "Ignore\n"
@@ -17757,7 +18288,6 @@ msgid "Main Level"
 msgstr "Poziom"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17770,13 +18300,11 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 #, fuzzy
 msgid "Warning Audio"
 msgstr "Ostrzeżenie"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17785,7 +18313,6 @@ msgid "Grid Size"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 #, fuzzy
 msgid "Starting RPM"
 msgstr "Ustawienia"
@@ -17866,7 +18393,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "Kalibra_cja"
@@ -18144,12 +18670,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr ""
 
@@ -18174,6 +18698,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18237,1673 +18763,729 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-#, fuzzy
-msgid "user mode selected"
-msgstr "Zbazuj wybraną"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-#, fuzzy
-msgid "Press to return to main button list"
-msgstr "Ustaw offset narzędzia względem punktu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-#, fuzzy
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-"Nie można zmienić aktulanego układu współrzędznych z włączoną kompensacją "
-"grubości narzędzia"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "Użyty nieznany kod G"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-#, fuzzy
-msgid "this is not a usual config\n"
-msgstr "Axis nie odpowiada"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-#, fuzzy
-msgid "**** Invalid embedded tab configuration ****"
-msgstr "Utwórz _nową konfiguracje"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "Tryb napędów"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "Brak parametrów"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-#, fuzzy
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr "nie można wykonać (%s) w trybie auto i wyłączonym interpreterem"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-#, fuzzy
-msgid "No tool description available"
-msgstr "Brak szczegółów."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-#, fuzzy
-msgid "Classicladder real-time component not detected"
-msgstr "Komponent RT nie załadowany"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-#, fuzzy
-msgid "Enter value for diameter"
-msgstr "Nie całkowita wartość dla całkowitego parametru"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-#, fuzzy
-msgid "Set diameter to:"
-msgstr "Brak parametrów"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-#, fuzzy
-msgid "Enter value for radius"
-msgstr "Nie całkowita wartość dla całkowitego parametru"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr " promień"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, fuzzy, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr "Nie całkowita wartość dla całkowitego parametru"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, python-brace-format
-msgid "Set axis {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "Ręczna zmieniarka narzędzi AXIS"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-#, fuzzy
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr "Nie można zmienić planu z włączoną kompensacją promienia narzędzia"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, fuzzy, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr "Nie całkowita wartość dla całkowitego parametru"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "Zaznacz element do podglądu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "Tryb rzeczywisty"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-msgid "no button here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "Brak załadowanego pliku"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "Czyści podgląd ruchu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "Widok perspektywy"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr ""
-"Przesunięcie\n"
-"%s"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "Długość narzędzia:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "Wybór osi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-msgid "jog joints"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "Ignoruj M1"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "<b>Bazowanie</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Kolejność narzędzi:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-#, fuzzy
-msgid "Diameter"
-msgstr " średnica"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-msgid "offset z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-msgid "offset x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "<b>Konfiguracja</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Aktywne kody:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Aktywne kody:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "<b>Moc</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "<b>Chłodziwo</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "<b>Wrzeciono</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "Skala prędkości wrzeciona:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Ustawia skalę prędkości od 0% do 100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "Skala prędkości:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-#, fuzzy
-msgid "X Pos."
-msgstr " Poz "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-#, fuzzy
-msgid "Y Pos."
-msgstr " Poz "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "<b>Wrzeciono</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "Pokaż offsety"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "<b>Moc</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Podgląd"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "Pokaż offsety"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "Względna"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-#, fuzzy
-msgid "Absolute Color"
-msgstr "Absolutne"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "Bazuj wszystkie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "Odbazuj wszystkie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr "<b>d)</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-#, fuzzy
-msgid "Grid size"
-msgstr "Rozmiar"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "Pokaż"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "Pokaż offsety"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-#, fuzzy
-msgid "Show DTG"
-msgstr "Pokaż"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "<b>Dane ruchu</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<b>Moc</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-msgid ""
-"current\n"
-"   file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "Wybiera prędkość posuwu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "Zaznacz element do podglądu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "Skala prędkości wrzeciona:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "Pokaż prędkość"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "Skala prędkości:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Skala prędkości wrzeciona:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "<b>Skala enkodera</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-#, fuzzy
-msgid "Use unlock code"
-msgstr "Nieużywany enkoder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "<b>Bazowanie</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Włącza hamulec wrzeciona"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Hamulec wrzeciona"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "<b>Bazowanie</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-#, fuzzy
-msgid "Probe Height"
-msgstr "Wejście Sondowania"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-#, fuzzy
-msgid "Z Pos."
-msgstr " Poz "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-#, fuzzy
-msgid "Max. Probe"
-msgstr "Sondowanie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "<b>Opcje programu</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-#, fuzzy
-msgid "Search Vel."
-msgstr "Prędkość najazdu na krańcówkę:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-#, fuzzy
-msgid "Probe Vel."
-msgstr "Wejście Sondowania"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "<b>Chłodziwo</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "Przeładuj ta_bele narzędzi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Przeładuj ta_bele narzędzi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "Uruchom od zaznaczo_nej linii"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "<b>Bazowanie</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "Zaawansowane Opcje"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Włącza maszyne"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-#, fuzzy
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr "Musi być tryb MDI aby wykonać polecenie MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "Szeregowy modbus program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "Pokaż status"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-#, fuzzy
-msgid "open touch off button list"
-msgstr "Ustaw offset narzędzia względem punktu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "Tryb rzeczywisty"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Przeładuj program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Przeładuj program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Zatrzymaj wykonywanie programu lub"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Zatrzymaj wykonywanie programu lub"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Zatrzymaj wykonywanie programu lub"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr ""
-"Edytuj program\n"
-"PLC"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-msgid "delete MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-#, fuzzy
-msgid "delete MDI history"
-msgstr "Wyczyść historię MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-#, fuzzy
-msgid "Open classicladder"
-msgstr "Dołącz Classicladder PLC"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "Oscy_loskop HAL"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-#, fuzzy
-msgid "launch hal scope"
-msgstr "uruchom %s"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "Kalibra_cja"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "Przeładuj ta_bele narzędzi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "P_rzeładuj"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "Przeładuj ta_bele narzędzi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "Zaznacz element do podglądu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-#, fuzzy
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr "Ustaw offset narzędzia względem punktu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
-msgid "Move to parrent directory"
+#: lib/python/gladevcp/iconview.py:120
+msgid "Move to parent directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "Zaznacz element do podglądu"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Zaznacz element do podglądu"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "Plik"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
 #, fuzzy
-msgid "home joints"
-msgstr "Bazuj oś"
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr "Przesuń wszystkie systemy współrzędnych"
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "Przeładuj ta_bele narzędzi"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+#, fuzzy
+msgid "Tool file was modified since it was last read"
+msgstr "Plik %r był zmodyfikowany od czasu zapisu przez Stepconf"
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Kółko myszki"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+msgid "button"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+msgid "togglebutton"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Załadowane narzędzie:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Czarny"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "Obrót XY:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr ""
+"Przesunięcie\n"
+"%s"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr ""
+"Przesunięcie\n"
+"%s"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+msgid ""
+"Zero\n"
+"G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "Poziomo"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "Wybierz"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Załadowane narzędzie:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+#, fuzzy
+msgid "Diameter"
+msgstr " średnica"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "Widok z przodu"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "opcja"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "Przyrost"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "P_rzeładuj"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr ""
+"Przesunięcie\n"
+"%s"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr " średnica"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+msgid "Lathe Wear Offsets"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Załadowane narzędzie:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Załadowane narzędzie:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Pokaż offsety"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "Zbazuj wybraną"
+
+#, fuzzy
+#~ msgid "Press to return to main button list"
+#~ msgstr "Ustaw offset narzędzia względem punktu"
+
+#, fuzzy
+#~ msgid "Press to set the selected coordinate system to be the active one"
+#~ msgstr ""
+#~ "Nie można zmienić aktulanego układu współrzędznych z włączoną kompensacją "
+#~ "grubości narzędzia"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "Użyty nieznany kod G"
+
+#, fuzzy
+#~ msgid "this is not a usual config\n"
+#~ msgstr "Axis nie odpowiada"
+
+#, fuzzy
+#~ msgid "**** Invalid embedded tab configuration ****"
+#~ msgstr "Utwórz _nową konfiguracje"
+
+#, fuzzy
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "Tryb napędów"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "Brak parametrów"
+
+#, fuzzy
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr "nie można wykonać (%s) w trybie auto i wyłączonym interpreterem"
+
+#, fuzzy
+#~ msgid "No tool description available"
+#~ msgstr "Brak szczegółów."
+
+#, fuzzy
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "Komponent RT nie załadowany"
+
+#, fuzzy
+#~ msgid "Enter value for diameter"
+#~ msgstr "Nie całkowita wartość dla całkowitego parametru"
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr "Brak parametrów"
+
+#, fuzzy
+#~ msgid "Enter value for radius"
+#~ msgstr "Nie całkowita wartość dla całkowitego parametru"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr " promień"
+
+#, fuzzy
+#~ msgid "Enter value for axis {0}"
+#~ msgstr "Nie całkowita wartość dla całkowitego parametru"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "Ręczna zmieniarka narzędzi AXIS"
+
+#, fuzzy
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr "Nie można zmienić planu z włączoną kompensacją promienia narzędzia"
+
+#, fuzzy
+#~ msgid "Enter value for axis {0} to set:"
+#~ msgstr "Nie całkowita wartość dla całkowitego parametru"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "Zaznacz element do podglądu"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "Tryb rzeczywisty"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "Brak załadowanego pliku"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "Czyści podgląd ruchu"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "Widok perspektywy"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Długość narzędzia:"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "Wybór osi"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "Ignoruj M1"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "<b>Bazowanie</b>"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Kolejność narzędzi:"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "<b>Konfiguracja</b>"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Aktywne kody:"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Aktywne kody:"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "<b>Moc</b>"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "<b>Chłodziwo</b>"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "<b>Wrzeciono</b>"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "Skala prędkości wrzeciona:"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Ustawia skalę prędkości od 0% do 100%"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "Skala prędkości:"
+
+#, fuzzy
+#~ msgid "X Pos."
+#~ msgstr " Poz "
+
+#, fuzzy
+#~ msgid "Y Pos."
+#~ msgstr " Poz "
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "<b>Wrzeciono</b>"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Pokaż offsety"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "<b>Moc</b>"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Podgląd"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Względna"
+
+#, fuzzy
+#~ msgid "Absolute Color"
+#~ msgstr "Absolutne"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "Bazuj wszystkie"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "Odbazuj wszystkie"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr "<b>d)</b>"
+
+#, fuzzy
+#~ msgid "Grid size"
+#~ msgstr "Rozmiar"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "Pokaż"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "Pokaż offsety"
+
+#, fuzzy
+#~ msgid "Show DTG"
+#~ msgstr "Pokaż"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "<b>Dane ruchu</b>"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Moc</b>"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "Wybiera prędkość posuwu"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "Zaznacz element do podglądu"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Skala prędkości wrzeciona:"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "Pokaż prędkość"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Skala prędkości:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Skala prędkości wrzeciona:"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "<b>Skala enkodera</b>"
+
+#, fuzzy
+#~ msgid "Use unlock code"
+#~ msgstr "Nieużywany enkoder"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "<b>Bazowanie</b>"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Włącza hamulec wrzeciona"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Hamulec wrzeciona"
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "<b>Bazowanie</b>"
+
+#, fuzzy
+#~ msgid "Probe Height"
+#~ msgstr "Wejście Sondowania"
+
+#, fuzzy
+#~ msgid "Z Pos."
+#~ msgstr " Poz "
+
+#, fuzzy
+#~ msgid "Max. Probe"
+#~ msgstr "Sondowanie"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "<b>Opcje programu</b>"
+
+#, fuzzy
+#~ msgid "Search Vel."
+#~ msgstr "Prędkość najazdu na krańcówkę:"
+
+#, fuzzy
+#~ msgid "Probe Vel."
+#~ msgstr "Wejście Sondowania"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "<b>Chłodziwo</b>"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Przeładuj ta_bele narzędzi"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Przeładuj ta_bele narzędzi"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "Uruchom od zaznaczo_nej linii"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "<b>Bazowanie</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "Zaawansowane Opcje"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Włącza maszyne"
+
+#, fuzzy
+#~ msgid ""
+#~ "enter MDI mode to launch g-code commands\n"
+#~ "[F5]"
+#~ msgstr "Musi być tryb MDI aby wykonać polecenie MDI"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "Szeregowy modbus program"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "Pokaż status"
+
+#, fuzzy
+#~ msgid "open touch off button list"
+#~ msgstr "Ustaw offset narzędzia względem punktu"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "Tryb rzeczywisty"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Przeładuj program"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Przeładuj program"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Zatrzymaj wykonywanie programu lub"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Zatrzymaj wykonywanie programu lub"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Zatrzymaj wykonywanie programu lub"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr ""
+#~ "Edytuj program\n"
+#~ "PLC"
+
+#, fuzzy
+#~ msgid "delete MDI history"
+#~ msgstr "Wyczyść historię MDI"
+
+#, fuzzy
+#~ msgid "Open classicladder"
+#~ msgstr "Dołącz Classicladder PLC"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "Oscy_loskop HAL"
+
+#, fuzzy
+#~ msgid "launch hal scope"
+#~ msgstr "uruchom %s"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "Kalibra_cja"
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "Przeładuj ta_bele narzędzi"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "Zaznacz element do podglądu"
+
+#, fuzzy
+#~ msgid ""
+#~ "touchoff\n"
+#~ "  tool x"
+#~ msgstr "Ustaw offset narzędzia względem punktu"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "Plik"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "Bazuj oś"
 
 #, fuzzy
 #~ msgid "Substituting"

--- a/src/po/pt_BR.po
+++ b/src/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Emc2-axis cvs-head to 2.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2010-05-15 16:56-0300\n"
 "Last-Translator: Matheus Degiovani <matheus@gigatron.com.br>\n"
 "Language-Team: Portuguese/Brazil <none>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
@@ -28,65 +28,65 @@ msgstr ""
 "o comando (%s) não pode ser executado até que a máquina esteja fora de E-"
 "STOP e ligada"
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "impossível realizar (%s) no modo manual"
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr "impossível realizar (%s) no modo automático com o interpretador ocioso"
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr "impossível realizar (%s) no modo automático com o interpretador lendo"
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 "impossível realizar (%s) no modo automático com o interpretador pausado"
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 "impossível realizar (%s) no modo automático com o interpretador esperando"
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "impossível realizar (%s) no modo MDI"
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 "impossível mudar o modo de operação enquanto o modo é AUTO e o interpretador "
 "não está em IDLE"
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 #, fuzzy
 msgid "failed to close file"
 msgstr "Impossível abrir arquivo"
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "impossível abrir %s"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr ""
 "Impossível executar comando MDI enquanto a máquina não foi referenciada"
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "Precisa estar no modo MDI para enviar um comando MDI"
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr "Impossível executar programa enquanto a máquina não for referenciada"
 
@@ -225,30 +225,30 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr "Parâmetro P fora dos limites com G10 L2"
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 #, fuzzy
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr "Impossível realizar arco com velocidade de movimentação zero"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 #, fuzzy
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr ""
 "Impossível usar G28 ou G30 com compensação de raio de ferramenta ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
@@ -257,76 +257,76 @@ msgstr ""
 "Você precisa especificar um número de pontos de controle pelo menos igual à "
 "ordem L=%d"
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr "Impossível converter spline com compensação de raio ligada"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr "Splines devem estar no plano XY"
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr ""
 "O movimento após sair da compensação de raio precisa ser reto, não um arco"
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, fuzzy, c-format
 msgid "%c word missing in absolute center arc"
 msgstr "Parâmetro F faltando com movimento em arco no modo de tempo inverso"
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 "Movimento em arco em uma quina côncava não pode ser alcançado pela "
 "ferramenta sem danificar o material"
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 "Arco para movimento em arco é inválido porque os arcos precisam ter o mesmo "
 "centro"
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
@@ -334,268 +334,268 @@ msgstr ""
 "Arco para movimento em arco gera uma quina onde a ferramenta compensada não "
 "pode alcançar sem danificar o material"
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr "Posição absoluta inválida (%5.2f) para eixo rotacional %c"
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 "Impossível mudar o modo de controle quando compensação de raio de corte está "
 "ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 "Impossível mudar sistema de coordenadas quando compensação de raio de corte "
 "está ativada"
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr "G%d.1 sem parâmetro D"
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr "G%d.1 com parâmetro L, mas plano ativo não é G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr "G%d requer que o parâmetro D seja um número inteiro"
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr "G%d com ferramenta de torno, mas plano não é G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 #, fuzzy
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 "Impossível setar saída do movimento quando compensação de raio de corte está "
 "ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 "Impossível setar saída do movimento quando compensação de raio de corte está "
 "ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr "Nenhum parâmetro P válido com M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 "Impossível ativar saída digital de movimento quando compensação de raio de "
 "corte está ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr "Nenhum parâmetro P válido com M63"
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 "Impossível alterar saída digital auxiliar com compensação de raio de corte "
 "ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr "Nenhum parâmetro P válido com M64"
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr "Nenhum parâmetro P válido com M65"
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 #, fuzzy
 msgid "invalid P-word with M66"
 msgstr "Nenhum parâmetro P válido com M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 "Impossível esperar por entrada digital quando compensação de raio de corte "
 "está ativada"
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 "Impossível esperar por entrada analógica quando compensação de raio de corte "
 "está ativada"
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 "Impossível alterar saída analógica com compensação de raio de corte ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr "Índice analógico inválido com M67"
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 "Impossível alterar saída analógica auxiliar quando compensação de raio de "
 "corte ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr "Índice analógico inválido com M68"
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 #, fuzzy
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 "Precisa de parâmetro Q positivo para especificar um número de ferramenta com "
 "M61"
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 "Impossível habilitar anulações quando compensação de raio de corte está "
 "ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 "Impossível desativar anulações quando compensação de raio de corte está "
 "ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 #, fuzzy
 msgid "Cannot probe with feed per rev mode"
 msgstr "Impossível realizar probing com velocidade de movimentação zero"
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 "Impossível modificar modo de retração quando compensação de raio de corte "
 "está ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr "Parâmetros I J não permitidos com G10 L2"
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 #, fuzzy
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
@@ -603,79 +603,79 @@ msgstr ""
 "Impossível mudar sistema de coordenadas quando compensação de raio de corte "
 "está ativada"
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 #, fuzzy
 msgid "R not allowed in G10 L20"
 msgstr "Parâmetros I J não permitidos com G10 L2"
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 #, fuzzy
 msgid "Spindle not turning in G33"
 msgstr "Spindle não está girando em G86"
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 #, fuzzy
 msgid "Spindle not turning in G33.1"
 msgstr "Spindle não está girando em G86"
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, fuzzy, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "Spindle não está girando em G86"
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 "Não pode usar G76 ciclo de rosca quando compensação de raio de corte está "
 "ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr "Em G76, I não pode ser 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr "Em G76, J precisa ser maior que 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr "Em G76, K precisa ser maior que J"
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr "Zero graus dentro de quina é inválido para compensação de corte"
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
@@ -683,23 +683,23 @@ msgstr ""
 "Movimento de arco para linha faz uma quina em que a compensação de "
 "ferramenta não pode ser encaixada"
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 "Impossível mudar de ferramenta enquanto a compensação de raio de corte está "
 "ativada"
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 "Impossível mudar offset de comprimento de ferramenta quando compensação de "
 "raio da ferramenta está ativado"
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -822,33 +822,33 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "Impossível usar coordenadas polares com G53"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr "Impossível especificar parâmetros X ou Y com coordenadas polares"
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 "Precisa especificar o ângulo em coordenadas polares caso esteja na origem"
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 "Movimento incremental com coordenadas polares é indeterminado quando na "
 "origem"
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr "Comando G91 com coordenadas polares é indeterminado quando na origem"
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr "Ferramenta requisitada %d não encontrada na tabela de ferramentas"
@@ -973,102 +973,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, fuzzy, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "Não existe na definição da subrotina"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "Parâmetro nomeado #<%s> não definido"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, fuzzy, c-format
 msgid "cant open ini file '%s'"
 msgstr "impossível abrir %s"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, fuzzy, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "Parâmetro nomeado #<%s> não definido"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr "Erro interno: impossível atribuir #<%s>"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "Fila não está vazia após troca de ferramenta"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, fuzzy, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "Impossível abrir arquivo"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 msgid "Parameter file name is missing"
 msgstr ""
 
@@ -1496,7 +1496,8 @@ msgid "Negative spindle speed used"
 msgstr "Velocidade negativa do spindle usada"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "ID de ferramenta negativo usado"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1886,17 +1887,17 @@ msgstr "R menos que U em ciclo no plano VW"
 msgid "R less than V in cycle in UW plane"
 msgstr "R menos que V em ciclo no plano UW"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "ERRO: '%s' não é um tipo válido de probe\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "ERRO: nenhum nome de pino/parâmetro/sinal\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
@@ -1904,8 +1905,7 @@ msgstr ""
 "ERRO: opção -s precisa de um tipo de probe e um nome de parâmetro/pino/"
 "sinal\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 #, fuzzy
 msgid "Hal Meter"
 msgstr "H_alMeter"
@@ -1919,27 +1919,27 @@ msgstr "S_elecionar"
 msgid "E_xit"
 msgstr "_Sair"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "Selecione item para examinar"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr "_Pinos"
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr "S_inais"
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr " Parâ_metros"
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr "_Fechar"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
@@ -1947,73 +1947,95 @@ msgstr ""
 "Utilização:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 #, fuzzy
 msgid "Open Configuration File:"
 msgstr "Mostrar _Configuração Hal"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Cancelar"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "_Abrir"
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Mostrar _Configuração Hal"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "_Arquivo"
+
+#: src/hal/utils/scope.c:525
 #, fuzzy
 msgid "_Open Configuration..."
 msgstr "Mostrar _Configuração Hal"
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 #, fuzzy
 msgid "_Save Configuration..."
 msgstr "Mostrar _Configuração Hal"
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "_Abrir arquivo de dados"
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "_Salvar arquivo de dados"
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 #, fuzzy
 msgid "_Quit"
 msgstr "_Sair"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "S_obre Halscope"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 #, fuzzy
 msgid "_File"
 msgstr "_Arquivo"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 #, fuzzy
 msgid "_Help"
 msgstr "_Ajuda"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "Osciloscópio HAL"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "Horizontal"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "Canal Selecionado"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "Modo execução"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "Gatilho"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "Vertical"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -2022,41 +2044,42 @@ msgstr "Vertical"
 msgid "Stop"
 msgstr "Parar"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "Normal"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 #, fuzzy
 msgid "Single"
 msgstr "Spindle:"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "Rolar"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 #, fuzzy
 msgid "Zoom"
 msgstr "Aproxima zoom [+]"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "----- Amostras\n"
-"a ---- KHz"
+"a ---- kHz"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "Componente de tempo real não carregado"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -2070,11 +2093,40 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+#, fuzzy
+msgid "Quit"
+msgstr "Sair"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "Função de tempo real não linkada"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -2087,11 +2139,11 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "Selecione a taxa de amostragem"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
@@ -2101,97 +2153,72 @@ msgstr ""
 "or\n"
 "Clique 'Sair' para fechar o HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 #, fuzzy
 msgid "Sample Period:"
 msgstr "Período de amostragem:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 #, fuzzy
 msgid "Sample Rate:"
 msgstr "Taxa de amostragem:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "Período"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "Multiplicador:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr "Comprimento do registro"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d amostras (1 canal)"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d amostras (2 canais)"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d amostras (4 canais)"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d amostras (8 canais)"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d amostras (16 canais)"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-#, fuzzy
-msgid "Quit"
-msgstr "Sair"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr "Thread(s) de tempo real não estão em execução"
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2205,22 +2232,22 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr "Escolha o arquivo de log de destino:"
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr "Número de canais insuficiente"
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
 "record length that supports more channels."
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
@@ -2229,7 +2256,7 @@ msgstr ""
 "%s\n"
 "por div"
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
@@ -2238,27 +2265,35 @@ msgstr ""
 "%s amostras\n"
 "a %s"
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2274,55 +2309,52 @@ msgstr ""
 msgid "Hz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
 "%s"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 #, fuzzy
 msgid "Gain"
 msgstr "Ganho"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 #, fuzzy
 msgid "Scale"
 msgstr "Escala"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 msgid ""
 "Offset\n"
 "----"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr "Canal Desl"
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "Alterar Offset"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
@@ -2331,36 +2363,20 @@ msgstr ""
 "Alterar o offset vertical\n"
 "para o canal %d."
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "Alterar Offset"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 #, fuzzy
 msgid "Too many channels"
 msgstr "Muitos canais"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2372,21 +2388,7 @@ msgstr ""
 "Desligue um ou mais canais ou diminua\n"
 "o comprimento do registro para permitir mais canais"
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr "Selecione a fonte do canal"
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
@@ -2395,29 +2397,33 @@ msgstr ""
 "Selecione um pino, sinal ou\n"
 "parâmetro como fonte para canal %d"
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "Selecione a fonte do canal"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "Pinos"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "Sinais"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "Parâmetros"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr "Descendo"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
@@ -2425,7 +2431,7 @@ msgstr ""
 "Fonte\n"
 "Nenhuma"
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
@@ -2434,118 +2440,119 @@ msgstr ""
 "Fonte\n"
 "Canal %2d"
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr "Forçar"
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr "Nível"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr "Fonte do gatilho"
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr "Selecione um canal para usar como gatilho"
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "Fonte do gatilho"
+
+#: src/hal/utils/scope_trig.c:336
 #, fuzzy
 msgid "Chan"
 msgstr "Canal"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr "Fonte"
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, fuzzy, c-format
 msgid "fault %d during orient in progress"
 msgstr "sequência de homing em execução"
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 #, fuzzy
 msgid "G38.4 move finished without breaking contact."
 msgstr "G38.2 movimento de probe terminado sem ativar o sensor"
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 #, fuzzy
 msgid "G38.2 move finished without making contact."
 msgstr "G38.2 movimento de probe terminado sem ativar o sensor"
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+#, fuzzy
+msgid "Probe tripped during non-probe move."
 msgstr "Probe ativado durante comando MDI que não utiliza probing"
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr "Probe ativado durante movimento de home"
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 #, fuzzy
 msgid "Probe tripped during a joint jog."
 msgstr "Probe ativado durante jog"
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 #, fuzzy
 msgid "Probe tripped during a coordinate jog."
 msgstr "Probe ativado durante jog"
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr "movimentação suspensa pela entrada 'enable'"
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, fuzzy, c-format
 msgid "spindle %d amplifier fault"
 msgstr "erro no amplificado do eixo %d"
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "erro no interruptor de limite do eixo %d"
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "erro no amplificado do eixo %d"
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "erro de cálculo de movimentação no eixo %d"
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, fuzzy, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr "Excedido limite positivo de software no eixo %d"
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 #, fuzzy
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 "todos os eixos precisam ser referenciados antes de entrar no modo teleop"
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, fuzzy, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr "Excedido limite positivo de software no eixo %d"
@@ -2615,182 +2622,182 @@ msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 "todos os eixos devem ser referenciados antes de entrar no modo coordenado"
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr "Impossível efetuar jog no eixo quando não habilitado"
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr ""
 "Impossível efetuar jog de eixos enquanto está efetuando o processo de homing"
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr ""
 "Impossível efetuar jog de qualquer eixo enquanto está efetuando o processo "
 "de homing"
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr "precisa estar habilitado, no modo coordenado, para movimento linear"
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr "impossível efetuar movimento linear com os limites excedidos"
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, fuzzy, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr "impossível efetuar movimento linear com os limites excedidos"
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 "precisa estar habilitado, em modo coordenado, para efetuar movimento circular"
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr "impossível efetuar movimento circular com os limites excedidos"
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, fuzzy, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr "impossível efetuar movimento circular com os limites excedidos"
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr "MOVIMENTAÇÃO: impossível efetuar PASSO enquanto já está executando"
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr "impossível habilitar movimentação: entrada 'enable' tem valor falso"
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr "precisa estar em modo JOINT para efetuar processo de homing"
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr "sequência de homing já está em execução"
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr "precisa estar em modo JOINT ou desabilitado para remover home"
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr "Impossível remover home enquanto está fazendo homing do eixo %d"
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr "Impossível remover home enquanto movendo eixo %d"
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, fuzzy, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr "Impossível efetuar jog no eixo quando não habilitado"
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr "Impossível remover home do eixo inativo %d"
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr "Impossível remover home do eixo inválido %d (máximo %d)"
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 "precisa estar habilitado, em modo coordenado para movimento de de probe"
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr "impossível efetuar movimento de probe com os limites excedidos"
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr "Probe já está limpo quanto iniciando comando G38.4 ou G38.5"
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr "Probe já está ativado quando iniciando comando G38.2 ou G38.3"
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr "impossível adicionar comando de probe"
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr "precisa estar habilitado, para movimento em tap"
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr "impossível realizar movimento de tap com os limites excedidos"
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, fuzzy, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr "impossível realizar movimento de tap com os limites excedidos"
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, fuzzy, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr "Tentativa de calcular potência não inteira de um número negativo"
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr "eixo %d: muitas compensações de entrada"
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr "eixo %d: valores de compensação precisam aumentar"
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr "comando não reconhecido: %d"
@@ -2880,27 +2887,27 @@ msgstr "MOTION: hal_exit() falhou, retornou %d\n"
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr "MOTION: emcmot_hal_data malloc falhou\n"
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, fuzzy, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr "MOTION: exportação dos parâmetros/pins do eixo %d falhou\n"
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr "MOTION: exportação dos parâmetros/pins do eixo %d falhou\n"
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 #, fuzzy
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr "MOTION: init_hal_io() falhou\n"
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, fuzzy, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr "MOTION: exportação dos parâmetros/pins do eixo %d falhou\n"
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, fuzzy, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr "MOTION: exportação dos parâmetros/pins do eixo %d falhou\n"
@@ -3077,7 +3084,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -3166,19 +3173,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 #, fuzzy
 msgid "No"
 msgstr "Nenhuma"
@@ -3232,7 +3239,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr ""
 
@@ -3251,7 +3258,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr ""
 
@@ -3265,7 +3272,6 @@ msgid "Config"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 #, fuzzy
 msgid "Preview"
 msgstr "Vista lateral"
@@ -3699,7 +3705,7 @@ msgid "Edit mode..."
 msgstr "Modo Joint"
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr ""
 
@@ -3708,7 +3714,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr ""
 
@@ -3719,6 +3725,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr ""
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Cancelar"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3908,7 +3932,7 @@ msgid "Parameter"
 msgstr "Parâmetros"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -4096,7 +4120,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 #, fuzzy
 msgid "Main"
 msgstr "Máquina"
@@ -4179,11 +4202,13 @@ msgid "Delete section"
 msgstr "Mostra posição relativa"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Down"
 msgstr ""
 
@@ -4705,6 +4730,7 @@ msgid "Exit"
 msgstr ""
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr ""
 
@@ -4749,7 +4775,6 @@ msgid "Renumber File..."
 msgstr ""
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr ""
 
@@ -5027,15 +5052,15 @@ msgstr ""
 msgid "Test HAL command :"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr ""
 
@@ -5157,21 +5182,21 @@ msgstr ""
 msgid "SIZE :"
 msgstr ""
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr ""
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr ""
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 msgid "Create Report File"
 msgstr ""
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr ""
 
@@ -5249,7 +5274,7 @@ msgstr ""
 msgid "Tool:"
 msgstr "Ordem das ferramentas:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Todos os arquivos"
@@ -5321,18 +5346,18 @@ msgstr "Unidades"
 msgid "auto"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5508,7 +5533,7 @@ msgstr ""
 msgid "world"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 #, fuzzy
 msgid "home"
 msgstr "Home"
@@ -5601,16 +5626,15 @@ msgstr ""
 msgid "Optional Stop"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 #, fuzzy
 msgid "Size"
 msgstr "Tamanho:"
@@ -5722,7 +5746,7 @@ msgid "Coordinate System Control Window"
 msgstr ""
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 #, fuzzy
 msgid "Axis "
 msgstr "Eixo:"
@@ -6297,9 +6321,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr ""
 
@@ -6319,8 +6343,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr ""
 
@@ -6397,153 +6421,153 @@ msgstr "AXIS (Sem arquivo)"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 #, fuzzy
 msgid "Linescale"
 msgstr "Eixo:"
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 #, fuzzy
 msgid "Mode"
 msgstr "Modo execução"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 #, fuzzy
 msgid "normal"
 msgstr "Normal"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 #, fuzzy
 msgid "Allow Rotation"
 msgstr "Posição:"
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 #, fuzzy
 msgid "no such file"
 msgstr "AXIS (Sem arquivo)"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 #, fuzzy
 msgid "file not readable"
 msgstr "Arquivo não aberto"
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 #, fuzzy
 msgid "not readable"
 msgstr "Arquivo não aberto"
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 msgid "LinuxCNC"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "Mostrar _Configuração Hal"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7227,48 +7251,48 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Ferramenta desconhecida %d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Hehe Sem ferramenta"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, fuzzy, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Ferramenta %d, offset %g, diâmetro %g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, fuzzy, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "Ferramenta %d, zo %g, xo%, dia %g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 #, fuzzy
 msgid "Filtering..."
 msgstr "Alternada"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 #, fuzzy
 msgid "Filter failed"
 msgstr "Filtro de programa %r falhado"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
 "produced are shown below:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "Erro no Código-G em %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, fuzzy, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7277,175 +7301,173 @@ msgstr ""
 "Próximo da linha %d de %s:\n"
 "%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "Contínuo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "Nome:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "Tamanho:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "Ordem das ferramentas:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "Distância em posicionamento:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "Distância em trabalho:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "Distância total"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "Tempo de execução:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "Limites em X:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Limites em Y:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Limites em Z:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "Limites em A:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "Limites em B"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "Limites em C"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "O programa excede o limite inferior no eixo %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "O programa excede o limite superior no eixo %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "O programa excede os limites da máquina"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Ignorar e rodar programa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
 "%(lines)s gcode lines"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, fuzzy, python-format
 msgid "%d seconds"
 msgstr "Jog no segundo eixo"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, fuzzy, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%f até %f = %f %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 #, fuzzy
 msgid "G-Code Properties"
 msgstr "Erro no Código-G em %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "Todos arquivos usináveis"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "Arquivos rs274ngc"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 #, fuzzy
 msgid "File not Writable:"
 msgstr "Arquivo não aberto"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7456,60 +7478,60 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Custom Grid"
 msgstr "S_inais"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, fuzzy, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr "precisa estar em modo JOINT para efetuar processo de homing"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 #, fuzzy
 msgid "Touch Off (system)"
 msgstr "Apalpador"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, fuzzy, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "Digite %s coordenada em relação a peça de trabalho"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, fuzzy, python-format
 msgid "Tool %s TouchOff"
 msgstr "Apalpador"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7518,7 +7540,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7527,7 +7549,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7536,92 +7558,92 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "Modo Joint"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 #, fuzzy
 msgid "Home All"
 msgstr "Home"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "Home"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "Home"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "Modo Joint"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "Home"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr ""
 
@@ -7944,12 +7966,13 @@ msgid "_Properties..."
 msgstr "_Propriedades."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
-msgstr ""
+#, fuzzy
+msgid "Edit _tool data..."
+msgstr "Modo Joint"
 
 #: share/axis/tcl/axis.tcl:90
 #, fuzzy
-msgid "Reload tool ta_ble"
+msgid "Reload tool _data"
 msgstr "Recarrega.lista de ferramentas"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8302,12 +8325,12 @@ msgstr ""
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 #, fuzzy
 msgid "Zoom in"
 msgstr "Aproxima zoom [+]"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 #, fuzzy
 msgid "Zoom out"
 msgstr "Afasta zoom [-]"
@@ -8500,9 +8523,10 @@ msgstr "Velocidade da máquina"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr "%"
 
@@ -8558,7 +8582,7 @@ msgid "Position:"
 msgstr "Posição:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 #, fuzzy
 msgid "Machine"
 msgstr "Máquina"
@@ -8670,22 +8694,21 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Permite temporariamente Jog além do limite da máquina [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 #, fuzzy
 msgid "Spindle CW"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 #, fuzzy
 msgid "Spindle CCW"
@@ -9043,6 +9066,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -9052,43 +9077,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr "0"
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -9154,7 +9224,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 #, fuzzy
 msgid "<b>Spindle</b>"
 msgstr "Spindle:"
@@ -9329,7 +9398,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr ""
 
@@ -9393,8 +9461,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9530,10 +9598,10 @@ msgid "Stepconf"
 msgstr "_Passo"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9552,12 +9620,12 @@ msgid "Parallel Port 1"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 msgid "Parallel Port 2"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "Posição:"
@@ -9567,246 +9635,297 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Botão esquerdo"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "Spindle"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "X Step"
 msgstr "_Passo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "Y Step"
 msgstr "_Passo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "Z Step"
 msgstr "_Passo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "A Step"
 msgstr "_Passo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "_Passo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "Freio do spindle ativado"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "_Passo"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "Freio do spindle ativado"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "Freio do spindle ativado"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "Freio do spindle ativado"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "Freio do spindle ativado"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Freio do spindle ativado"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 #, fuzzy
 msgid "Spindle ON"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 #, fuzzy
 msgid "Spindle PWM"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Brake"
 msgstr "Freio do spindle ativado"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 #, fuzzy
 msgid "Coolant Mist"
 msgstr "Refrigeração:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 #, fuzzy
 msgid "Coolant Flood"
 msgstr "Refrigeração:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "ESTOP Out"
 msgstr "PARADA DE EMERGÊNCIA"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+#, fuzzy
+msgid "Plasma Ohmic Enable"
+msgstr "Nome:"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9817,262 +9936,348 @@ msgstr ""
 msgid "Unused"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 #, fuzzy
 msgid "ESTOP In"
 msgstr "PARADA DE EMERGÊNCIA"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Index"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase A"
 msgstr "Freio do spindle ativado"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase B"
 msgstr "Freio do spindle ativado"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home X"
 msgstr "Home"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Y"
 msgstr "Home"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Z"
 msgstr "Home"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home A"
 msgstr "Home"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "Home"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "Home"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Home"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Home"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
-msgid "Maximum Limit + Home Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:236
-msgid "Maximum Limit + Home A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-msgid "Maximum Limit + Home U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-msgid "Maximum Limit + Home V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:238
-msgid "Both Limit + Home X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:238
-msgid "Both Limit + Home Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:239
-msgid "Both Limit + Home Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:239
-msgid "Both Limit + Home A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:240
-msgid "Both Limit + Home U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:240
-msgid "Both Limit + Home V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit A"
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem X"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit V"
+msgid "Maximum Limit + Home Tandem Y"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:250
+msgid "Maximum Limit + Home Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
+msgid "Maximum Limit + Home A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:251
+msgid "Maximum Limit + Home U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:251
+msgid "Maximum Limit + Home V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:252
+msgid "Both Limit + Home X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:252
+msgid "Both Limit + Home Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:253
+msgid "Both Limit + Home Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:253
+msgid "Both Limit + Home A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:254
+msgid "Both Limit + Home U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:254
+msgid "Both Limit + Home V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Todos os arquivos"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Todos os arquivos"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Todos os arquivos"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Todos os arquivos"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits"
 msgstr "Todos os arquivos"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits + homes"
 msgstr "Todos os arquivos"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Down"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Freio do spindle ativado"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -10081,40 +10286,40 @@ msgid ""
 "Are you sure?  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
 "Any existing file named custompanel_backup.xml will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -10125,43 +10330,43 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 #, fuzzy
 msgid "Continue? "
 msgstr "Continuar"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -10169,34 +10374,34 @@ msgid ""
 "{}"
 msgstr "Mostrar _Configuração Hal"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -10211,8 +10416,8 @@ msgstr ""
 msgid "mm / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -10227,13 +10432,13 @@ msgstr ""
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr ""
 
@@ -10243,20 +10448,20 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "Mostrar _Configuração Hal"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 #, fuzzy
 msgid "Modify Existing Configuration"
 msgstr "Mostrar _Configuração Hal"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10268,7 +10473,7 @@ msgstr ""
 msgid "mm / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10279,28 +10484,28 @@ msgstr ""
 msgid "Steps / mm"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10308,99 +10513,104 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+msgid "# Include your custom HAL commands here"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
@@ -10473,11 +10683,16 @@ msgstr "Mostrar _Configuração Hal"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 #, fuzzy
 msgid "Back"
 msgstr "Freio"
@@ -10518,17 +10733,6 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:209
@@ -10883,55 +11087,152 @@ msgstr "Velocidade da máquina"
 msgid "Scale %"
 msgstr "Escala"
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+#, fuzzy
+msgid "Axis"
+msgstr "Eixo:"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Alterar Offset"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Alterar Offset"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Botão esquerdo"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Botão esquerdo"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "Modo execução"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 #, fuzzy
 msgid "Blank program"
 msgstr "Roda o programa"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 #, fuzzy
 msgid "Spindle speed display  "
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10940,71 +11241,71 @@ msgid ""
 "panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 #, fuzzy
 msgid "Blank ladder program"
 msgstr "Recarrega o programa"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 #, fuzzy
 msgid "Estop ladder program"
 msgstr "Pára o carregamento da vista preliminar"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 #, fuzzy
 msgid "Serial modbus program"
 msgstr "Recarrega o programa"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 #, fuzzy
 msgid ""
@@ -11012,10 +11313,14 @@ msgid ""
 "program"
 msgstr "Recarrega o programa"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "Mostrar _Configuração Hal"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr ""
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -11033,16 +11338,156 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+#, fuzzy
+msgid "10"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+#, fuzzy
+msgid "20"
+msgstr "0"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "Modo execução"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -11052,10 +11497,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr "Positivo"
@@ -11083,15 +11528,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisv.glade:249
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
@@ -11292,39 +11728,39 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 #, fuzzy
 msgid "Help Pages"
 msgstr "Profundidade das imagens"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11332,23 +11768,23 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 #, fuzzy
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "Mostrar _Configuração Hal"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11358,32 +11794,32 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11392,180 +11828,180 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 #, fuzzy
 msgid "Unused Channel"
 msgstr "Canal Selecionado"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 #, fuzzy
 msgid " / sec²"
 msgstr "Jog no segundo eixo"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "_Passo"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "_Passo"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "Roda uma linha do programa"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Mostrar _Configuração Hal"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11583,52 +12019,55 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 msgid "in / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11638,8 +12077,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr ""
@@ -11655,169 +12094,174 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
-#, python-format
-msgid "Generated by PNCconf at %s"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
-msgid "configures LinuxCNC as:\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
-msgid "type CNC\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
-msgid "will be used as the frontend display"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
-msgid " connector"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
-msgid "invrt"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
-#, python-format
-msgid "%(name)s Parport"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
-msgid "-> inverted"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
+msgid "Generated by PNCconf at %s"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
+msgid "configures LinuxCNC as:\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
+msgid "type CNC\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
+msgid "will be used as the frontend display"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
+msgid " connector"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
+msgid "invrt"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
+#, python-format
+msgid "%(name)s Parport"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
+msgid "-> inverted"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
+#, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11833,1613 +12277,1665 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 #, fuzzy
 msgid "External Controls"
 msgstr "Controle manual"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 msgid "Parallel Port"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 msgid "X Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "X Axis"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 msgid "Y Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Y Axis"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 msgid "Z Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Z Axis"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 msgid "A Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "A Axis"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Freio do spindle desativado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Enable"
-msgstr "Nome:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Dir"
-msgstr "Freio do spindle ativado"
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Input"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO O Drain"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
+msgid "POT Enable"
+msgstr "Nome:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+#, fuzzy
+msgid "POT Dir"
+msgstr "Freio do spindle ativado"
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Input"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Output"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO O Drain"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:117
+#, fuzzy
 msgid "SSR Output"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 0"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 1"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "muxed Enc I"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc M"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "mux select"
 msgstr "Jog no eixo selecionado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 0 Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 1 Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 2 Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 3 Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 4 Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 5 Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 #, fuzzy
 msgid "Step Gen-A"
 msgstr "Roda uma linha do programa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-Down"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 #, fuzzy
 msgid "Motor Enable"
 msgstr "Nome:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "Controle manual"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "X Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Y Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Z Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "A Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "All Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "A2 Tandem Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Todos os arquivos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 #, fuzzy
 msgid "A2 Both Limit + Home"
 msgstr "Todos os arquivos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select A"
 msgstr "Jog no eixo selecionado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select B"
 msgstr "Jog no eixo selecionado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select C"
 msgstr "Jog no eixo selecionado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select D"
 msgstr "Jog no eixo selecionado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Spindle Override incr A"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr B"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr C"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr D"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr A"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr B"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr C"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Max Vel Override incr D"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CW"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CCW"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle Stop"
 msgstr "Reduz a rotação do spindle [F11]"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Spindle Up-To-Speed"
 msgstr "Reduz a rotação do spindle [F11]"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "Jog no eixo selecionado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected +"
 msgstr "Jog no eixo selecionado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected -"
 msgstr "Jog no eixo selecionado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 #, fuzzy
 msgid "All Limits"
 msgstr "Todos os arquivos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "A2 Both Limit"
 msgstr "Todos os arquivos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Float Switch"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Limits"
 msgstr "Todos os arquivos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 #, fuzzy
 msgid "Axis Selection"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "Ultrapassar limites"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "Operation"
 msgstr "Alternada"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "External Control"
 msgstr "Controle manual"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "Eixo:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 #, fuzzy
 msgid "X BLDC Control"
 msgstr "Ctrl-K"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 #, fuzzy
 msgid "Y BLDC Control"
 msgstr "Ctrl-K"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 #, fuzzy
 msgid "Z BLDC Control"
 msgstr "Ctrl-K"
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 #, fuzzy
 msgid "A BLDC Control"
 msgstr "Ctrl-K"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 #, fuzzy
 msgid "S BLDC Control"
 msgstr "Ctrl-K"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Custom Signals"
 msgstr "S_inais"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
-msgid "A2 Tandem PWM"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "X Axis PWM"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "Y Axis PWM"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "Z Axis PWM"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "A Axis PWM"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-msgid "Unused PWM Gen"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-#, fuzzy
-msgid "Axis PWM"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:467
-#, fuzzy
-msgid "X Axis StepGen"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Y Axis StepGen"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Z Axis StepGen"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:469
-#, fuzzy
-msgid "A Axis StepGen"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "X2 Tandem StepGen"
-msgstr "Freio do spindle ativado"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "Y2 Tandem StepGen"
-msgstr "Freio do spindle ativado"
-
-#: src/emc/usr_intf/pncconf/private_data.py:471
-#, fuzzy
-msgid "Z2 Tandem StepGen"
-msgstr "Freio do spindle ativado"
-
 #: src/emc/usr_intf/pncconf/private_data.py:473
-msgid "Unused StepGen"
+msgid "A2 Tandem PWM"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
-msgid "Axis"
+msgid "X Axis PWM"
+msgstr "Eixo:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:474
+#, fuzzy
+msgid "Y Axis PWM"
 msgstr "Eixo:"
 
 #: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "Z Axis PWM"
+msgstr "Eixo:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "A Axis PWM"
+msgstr "Eixo:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+msgid "Unused PWM Gen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+#, fuzzy
+msgid "Axis PWM"
+msgstr "Eixo:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:481
+#, fuzzy
+msgid "X Axis StepGen"
+msgstr "Eixo:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Y Axis StepGen"
+msgstr "Eixo:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Z Axis StepGen"
+msgstr "Eixo:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:483
+#, fuzzy
+msgid "A Axis StepGen"
+msgstr "Eixo:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "X2 Tandem StepGen"
+msgstr "Freio do spindle ativado"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "Y2 Tandem StepGen"
+msgstr "Freio do spindle ativado"
+
+#: src/emc/usr_intf/pncconf/private_data.py:485
+#, fuzzy
+msgid "Z2 Tandem StepGen"
+msgstr "Freio do spindle ativado"
+
+#: src/emc/usr_intf/pncconf/private_data.py:487
+msgid "Unused StepGen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Spindle StepGen"
 msgstr "Freio do spindle ativado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "X Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "Y Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "Z Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "A Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Feed Override"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "spindle Override"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 #, fuzzy
 msgid "Axis Encoder"
 msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Spindle Encoder"
 msgstr "Freio do spindle ativado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Inverter imagem"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 msgid "Unused Unused"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Freio do spindle ativado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "Máquina"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Nome:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Máquina"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "Apalpador"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Coolant"
 msgstr "Refrigeração:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Control"
 msgstr "Ctrl-K"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 #, fuzzy
 msgid "Spindle Output"
 msgstr "Spindle:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Unused Analog In"
 msgstr "Canal Selecionado"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13448,15 +13944,15 @@ msgid ""
 "be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 msgid "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13471,84 +13967,93 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 #, fuzzy
 msgid "degrees"
 msgstr "45 graus"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 #, fuzzy
 msgid "revolutions"
 msgstr "Posição:"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 #, fuzzy
 msgid "revs / second²"
 msgstr "Jog no segundo eixo"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 #, fuzzy
 msgid "mm / second²"
 msgstr "Jog no segundo eixo"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13562,7 +14067,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "_Máquina"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13572,18 +14077,18 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
 
@@ -15252,9 +15757,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15415,6 +15920,13 @@ msgstr ""
 #, fuzzy
 msgid "Mux options"
 msgstr "Posição:"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 #, fuzzy
@@ -15603,186 +16115,204 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 #, fuzzy
 msgid "Position_offset"
 msgstr "Posição:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 #, fuzzy
 msgid "Position_feedback"
 msgstr "Posição:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 #, fuzzy
 msgid "Max Spindle Override "
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 #, fuzzy
 msgid "Min Spindle Override"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 #, fuzzy
 msgid "Max Feed Override"
 msgstr "Velocidade da máquina"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 #, fuzzy
 msgid "Increments "
 msgstr "Seleciona incremento de Jog"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 #, fuzzy
 msgid "size"
 msgstr "Tamanho:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 #, fuzzy
 msgid "Position"
 msgstr "Posição:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 #, fuzzy
 msgid "Absolute Textcolor"
 msgstr "Sobre o AXIS"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "Mostra posição relativa"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Mostrar _Configuração Hal"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15880,130 +16410,144 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr ""
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Inverter imagem"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr ""
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Mostrar _Configuração Hal"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 msgid "Home Search Sequence:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
@@ -16950,10 +17494,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 #, fuzzy
 msgid "Number of connectors:"
@@ -17042,11 +17582,6 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr ""
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-#, fuzzy
-msgid "10"
-msgstr "0"
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17504,7 +18039,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17666,31 +18200,23 @@ msgid "Manual Toolchange"
 msgstr "Troca de ferramenta"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 msgid "Restart Entry"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr ""
 
@@ -17769,33 +18295,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17917,14 +18443,12 @@ msgid "<b>Status</b>"
 msgstr "Refrigeração:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17932,7 +18456,6 @@ msgid ""
 msgstr "Relativa"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17940,7 +18463,6 @@ msgid ""
 msgstr "Relativa"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17957,7 +18479,6 @@ msgid "Main Level"
 msgstr "Nível"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17971,12 +18492,10 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17986,7 +18505,6 @@ msgid "Grid Size"
 msgstr "Tamanho:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 msgid "Starting RPM"
 msgstr ""
 
@@ -18065,7 +18583,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "_Calibrar"
@@ -18336,12 +18853,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr ""
 
@@ -18366,6 +18881,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18430,1654 +18947,650 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-#, fuzzy
-msgid "user mode selected"
-msgstr "Jog no eixo selecionado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "Código G desconhecido usado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "Modo Joint"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr " Parâ_metros"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-#, fuzzy
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr "impossível realizar (%s) no modo automático com o interpretador ocioso"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-#, fuzzy
-msgid "Classicladder real-time component not detected"
-msgstr "Componente de tempo real não carregado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-#, fuzzy
-msgid "Enter value for diameter"
-msgstr "Valor não-inteiro onde deveria haver um inteiro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-msgid "Set diameter to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-#, fuzzy
-msgid "Enter value for radius"
-msgstr "Valor não-inteiro onde deveria haver um inteiro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr "Arco de raio zero"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, fuzzy, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr "Valor não-inteiro onde deveria haver um inteiro"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, python-brace-format
-msgid "Set axis {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "Troca de ferramenta"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-#, fuzzy
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-"Impossível mudar offset de comprimento de ferramenta quando compensação de "
-"raio da ferramenta está ativado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "Selecione item para examinar"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "Modo Joint"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-#, fuzzy
-msgid "no button here"
-msgstr "Jog no eixo selecionado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "Filtro de programa %r falhado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "Apaga traçado da ferramenta"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "Vista em perspectiva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "Profundidade das imagens"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "Ordem das ferramentas:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "Eixo:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-msgid "jog joints"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "Ultrapassar limites"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "Refrigeração:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Troca de ferramenta"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-#, fuzzy
-msgid "Diameter"
-msgstr "Parâmetros"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-msgid "offset z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-msgid "offset x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "Mostrar _Configuração Hal"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Códigos G ativos:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Códigos G ativos:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "Spindle:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "Refrigeração:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "Spindle:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "Velocidade da máquina"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Seleciona velocidade da máquina de 0% a 100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "Velocidade da máquina"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-#, fuzzy
-msgid "Replace"
-msgstr "Relativa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-msgid "X Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-msgid "Y Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "Spindle:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "Mostra _limites"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "Spindle:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Vista lateral"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "Mostra _limites"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "Mostra posição relativa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-#, fuzzy
-msgid "Absolute Color"
-msgstr "Sobre o AXIS"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "Home"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "Home"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr "Spindle:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-#, fuzzy
-msgid "Grid size"
-msgstr "Tamanho:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "Mostra _limites"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "Mostra _limites"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-msgid "Show DTG"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "Refrigeração:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "Vista lateral"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "Recarrega Código G [Control-R]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "Seleciona incremento de Jog"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "Selecione item para examinar"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "Velocidade da máquina"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "_Mostra o traçado em tempo real"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "Velocidade da máquina"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Velocidade da máquina"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "Spindle:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-msgid "Use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-#, fuzzy
-msgid "Do not use unlock code"
-msgstr "Impossível usar palavra c"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "Refrigeração:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Freio do spindle ativado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Freio do spindle ativado"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "Refrigeração:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-msgid "Z Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "Mostrar _Configuração Hal"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-msgid "Search Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-#, fuzzy
-msgid "<b>Probe velocitys</b>"
-msgstr "Velocidade da máquina"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "Refrigeração:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "Recarrega.lista de ferramentas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Recarrega.lista de ferramentas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "Vista da bandeja ou seleciona linha"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "Vista da bandeja ou seleciona linha"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Liga a máquina"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "Recarrega o programa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "Mostra _limites"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "Modo Joint"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Recarrega o programa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Recarrega o programa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Pára o programa, ou"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Pára o programa, ou"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Pára o programa, ou"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr "Recarrega o programa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-msgid "delete MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-msgid "delete MDI history"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "Ha_lScope"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "_Calibrar"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-#, fuzzy
-msgid "delete selected tool or tools"
-msgstr "Número do slot de ferramenta selecionado é muito alto"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "Recarrega.lista de ferramentas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "_Reload"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "Recarrega.lista de ferramentas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "Número do slot de ferramenta selecionado é muito alto"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-#, fuzzy
-msgid "touch off the tool and set the value to the tool table"
-msgstr "Ferramenta requisitada %d não encontrada na tabela de ferramentas"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
-msgid "Move to parrent directory"
+#: lib/python/gladevcp/iconview.py:120
+msgid "Move to parent directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "Selecione o item para exibir"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Selecione o item para exibir"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "Filtro de programa %r falhado"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
 #, fuzzy
-msgid "home joints"
-msgstr "M_ostra o programa"
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "Recarrega.lista de ferramentas"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+msgid "Tool file was modified since it was last read"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Botão scroll do mouse"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+#, fuzzy
+msgid "button"
+msgstr "Jog no eixo selecionado"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "Refrigeração líquida"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Ordem das ferramentas:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Freio"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "Posição:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Alterar Offset"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Profundidade das imagens"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+msgid ""
+"Zero\n"
+"G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "Horizontal"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "S_elecionar"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Ordem das ferramentas:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+#, fuzzy
+msgid "Diameter"
+msgstr "Parâmetros"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "_Vista frontal"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "Alternada"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "Comandada"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "_Reload"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "Todos os arquivos"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "Parâmetros"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+msgid "Lathe Wear Offsets"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Ordem das ferramentas:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Ordem das ferramentas:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Mostra _limites"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "Jog no eixo selecionado"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "Código G desconhecido usado"
+
+#, fuzzy
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "Modo Joint"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr " Parâ_metros"
+
+#, fuzzy
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr ""
+#~ "impossível realizar (%s) no modo automático com o interpretador ocioso"
+
+#, fuzzy
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "Componente de tempo real não carregado"
+
+#, fuzzy
+#~ msgid "Enter value for diameter"
+#~ msgstr "Valor não-inteiro onde deveria haver um inteiro"
+
+#, fuzzy
+#~ msgid "Enter value for radius"
+#~ msgstr "Valor não-inteiro onde deveria haver um inteiro"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "Arco de raio zero"
+
+#, fuzzy
+#~ msgid "Enter value for axis {0}"
+#~ msgstr "Valor não-inteiro onde deveria haver um inteiro"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "Troca de ferramenta"
+
+#, fuzzy
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr ""
+#~ "Impossível mudar offset de comprimento de ferramenta quando compensação "
+#~ "de raio da ferramenta está ativado"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "Selecione item para examinar"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "Modo Joint"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "Filtro de programa %r falhado"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "Apaga traçado da ferramenta"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "Vista em perspectiva"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Ordem das ferramentas:"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "Eixo:"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "Ultrapassar limites"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "Refrigeração:"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Troca de ferramenta"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "Mostrar _Configuração Hal"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Códigos G ativos:"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Códigos G ativos:"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "Spindle:"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "Refrigeração:"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "Spindle:"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "Velocidade da máquina"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Seleciona velocidade da máquina de 0% a 100%"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "Velocidade da máquina"
+
+#, fuzzy
+#~ msgid "Replace"
+#~ msgstr "Relativa"
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "Spindle:"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Mostra _limites"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "Spindle:"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Vista lateral"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Mostra posição relativa"
+
+#, fuzzy
+#~ msgid "Absolute Color"
+#~ msgstr "Sobre o AXIS"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "Home"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "Home"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr "Spindle:"
+
+#, fuzzy
+#~ msgid "Grid size"
+#~ msgstr "Tamanho:"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "Mostra _limites"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "Mostra _limites"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "Refrigeração:"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "Vista lateral"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "Recarrega Código G [Control-R]"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "Seleciona incremento de Jog"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "Selecione item para examinar"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Velocidade da máquina"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "_Mostra o traçado em tempo real"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Velocidade da máquina"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Velocidade da máquina"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "Spindle:"
+
+#, fuzzy
+#~ msgid "Do not use unlock code"
+#~ msgstr "Impossível usar palavra c"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "Refrigeração:"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Freio do spindle ativado"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Freio do spindle ativado"
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "Refrigeração:"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "Mostrar _Configuração Hal"
+
+#, fuzzy
+#~ msgid "<b>Probe velocitys</b>"
+#~ msgstr "Velocidade da máquina"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "Refrigeração:"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Recarrega.lista de ferramentas"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Recarrega.lista de ferramentas"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "Vista da bandeja ou seleciona linha"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "Vista da bandeja ou seleciona linha"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Liga a máquina"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "Recarrega o programa"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "Mostra _limites"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "Modo Joint"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Recarrega o programa"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Recarrega o programa"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Pára o programa, ou"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Pára o programa, ou"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Pára o programa, ou"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr "Recarrega o programa"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "Ha_lScope"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "_Calibrar"
+
+#, fuzzy
+#~ msgid "delete selected tool or tools"
+#~ msgstr "Número do slot de ferramenta selecionado é muito alto"
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "Recarrega.lista de ferramentas"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "Número do slot de ferramenta selecionado é muito alto"
+
+#, fuzzy
+#~ msgid "touch off the tool and set the value to the tool table"
+#~ msgstr "Ferramenta requisitada %d não encontrada na tabela de ferramentas"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "Filtro de programa %r falhado"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "M_ostra o programa"
 
 #~ msgid "Unexpected realtime delay: check dmesg for details."
 #~ msgstr ""
@@ -20156,10 +19669,6 @@ msgstr "M_ostra o programa"
 #, fuzzy
 #~ msgid "Active G Codes"
 #~ msgstr "Códigos G ativos:"
-
-#, fuzzy
-#~ msgid "Tool #:"
-#~ msgstr "Ordem das ferramentas:"
 
 #, fuzzy
 #~ msgid "Speed:"

--- a/src/po/ro.po
+++ b/src/po/ro.po
@@ -1,70 +1,70 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "nu pot deschide %s"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr ""
 
@@ -174,424 +174,424 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -705,30 +705,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -844,105 +844,105 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, fuzzy, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "Incarca fisier parametri"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, fuzzy, c-format
 msgid "cant open ini file '%s'"
 msgstr "nu pot deschide %s"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, fuzzy, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "Incarca fisier parametri"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 #, fuzzy
 msgid "Queue is not empty after tool change"
 msgstr ""
 "Confirmare pe ecran pentru\n"
 "schimbare scula"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 #, fuzzy
 msgid "Parameter file name is missing"
 msgstr "Fisier parametri este %s"
@@ -1365,7 +1365,7 @@ msgid "Negative spindle speed used"
 msgstr "Seteaza depasire viteza freza:"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+msgid "Negative tool id (tool not found)"
 msgstr ""
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1756,24 +1756,23 @@ msgstr ""
 msgid "R less than V in cycle in UW plane"
 msgstr ""
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "Hal Meter"
 
@@ -1786,106 +1785,128 @@ msgstr "Selectare totala"
 msgid "E_xit"
 msgstr ""
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 #, fuzzy
 msgid "Select Item to Probe"
 msgstr "Selecteaza un nod pentru afisare"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 #, fuzzy
 msgid " _Pins "
 msgstr "_Pin 14:"
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 #, fuzzy
 msgid " _Signals "
 msgstr "Extinde semnale"
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 #, fuzzy
 msgid " Para_meters "
 msgstr "Fisier parametri"
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 #, fuzzy
 msgid "_Close"
 msgstr "Inchide"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 msgstr ""
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 #, fuzzy
 msgid "Open Configuration File:"
 msgstr "Configuratie copiata"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Anulare"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "Deschide..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Configuratie copiata"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "Salveaza"
+
+#: src/hal/utils/scope.c:525
 #, fuzzy
 msgid "_Open Configuration..."
 msgstr "Configuratii model"
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 #, fuzzy
 msgid "_Save Configuration..."
 msgstr "Configuratii model"
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 #, fuzzy
 msgid "S_ave Data File..."
 msgstr "Salveaza in fisier"
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 #, fuzzy
 msgid "_Quit"
 msgstr "Terminare"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 #, fuzzy
 msgid "_File"
 msgstr "Fisier"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 #, fuzzy
 msgid "_Help"
 msgstr "Ajutor"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr ""
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 #, fuzzy
 msgid "Selected Channel"
 msgstr "Selectare totala"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr ""
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr ""
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr ""
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1894,39 +1915,39 @@ msgstr ""
 msgid "Stop"
 msgstr "Pas"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr ""
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 #, fuzzy
 msgid "Single"
 msgstr "Spatiu simplu"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 #, fuzzy
 msgid "Zoom"
 msgstr "Mareste vedere"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1940,11 +1961,39 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "Terminare"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1957,107 +2006,83 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 #, fuzzy
 msgid "Sample Period:"
 msgstr "Perioada Base minima:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 #, fuzzy
 msgid "Record Length"
 msgstr "Lungime:"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "Terminare"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2071,57 +2096,64 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
 "record length that supports more channels."
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
 "per div"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
 "at %s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-#, fuzzy
-msgid "Sec"
-msgstr "Secundar"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2135,94 +2167,74 @@ msgstr "Secundar"
 #: src/emc/usr_intf/pncconf/mesa1.glade:460
 #: src/emc/usr_intf/pncconf/mesa1.glade:473
 msgid "Hz"
-msgstr "Hz"
-
-#: src/hal/utils/scope_horiz.c:1202
-#, fuzzy
-msgid "KHz"
-msgstr "Hz"
-
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
+msgstr ""
+
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
+msgstr ""
+
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, fuzzy, c-format
 msgid ""
 "Offset\n"
 "%s"
 msgstr "Ofseturi"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
 "----"
 msgstr "Ofseturi"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:715
-#, fuzzy
-msgid "Set Offset"
-msgstr "Seteaza offset scula"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
 "for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+#, fuzzy
+msgid "Set Offset"
+msgstr "Seteaza offset scula"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Anulare"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 #, fuzzy
 msgid "Too many channels"
 msgstr "Fisier scule"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2230,169 +2242,159 @@ msgid ""
 "the record length to allow for more channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
 "as the source for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr ""
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 #, fuzzy
 msgid "Signals"
 msgstr "Extinde semnale"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 #, fuzzy
 msgid "Parameters"
 msgstr "Fisier parametri"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
 "Chan %2d"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "Auto"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr ""
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr ""
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr ""
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr ""
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr ""
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+msgid "Probe tripped during non-probe move."
 msgstr ""
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr ""
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr ""
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr ""
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr ""
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr ""
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr ""
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
@@ -2461,177 +2463,177 @@ msgstr ""
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr ""
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr ""
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr ""
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr ""
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr ""
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr ""
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr ""
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr ""
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr ""
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2720,26 +2722,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2910,7 +2912,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -2999,19 +3001,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "Da"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr "Nu"
 
@@ -3064,7 +3066,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "Salveaza"
 
@@ -3083,7 +3085,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "Editor"
 
@@ -3098,7 +3100,6 @@ msgid "Config"
 msgstr "HAL Config"
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 #, fuzzy
 msgid "Preview"
 msgstr "Vedere arbore"
@@ -3532,7 +3533,7 @@ msgid "Edit mode..."
 msgstr "Editeaza"
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "Sterge"
 
@@ -3541,7 +3542,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "Aduna"
 
@@ -3552,6 +3553,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "Modifica"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Anulare"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3740,7 +3759,7 @@ msgid "Parameter"
 msgstr "Fisier parametri"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3930,7 +3949,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "Principal"
 
@@ -4013,11 +4031,13 @@ msgid "Delete section"
 msgstr "Pozitie relativa"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 #, fuzzy
 msgid "Move Down"
 msgstr "Jos"
@@ -4541,6 +4561,7 @@ msgid "Exit"
 msgstr "Iesire"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "Editare"
 
@@ -4583,7 +4604,6 @@ msgid "Renumber File..."
 msgstr "Renumeroteaza fisier..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "Setari"
 
@@ -4872,15 +4892,15 @@ msgstr "Vedere arbore"
 msgid "Test HAL command :"
 msgstr "Testeaza comanda HAL :"
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "Comenzi pot fi testate aici, dar nu vor fi salvate"
 
@@ -5012,12 +5032,12 @@ msgstr "DIRECTIE"
 msgid "SIZE :"
 msgstr "DIMENSIUNE :"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 #, fuzzy
 msgid "LinuxCNC Errors"
 msgstr "Erori EMC2"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 #, fuzzy
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
@@ -5026,12 +5046,12 @@ msgstr ""
 "EMC2 s-a terminat cu eroare. Cand raportati va rugam includeti toata "
 "informatiade mai jos in mesajul Dvs."
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 #, fuzzy
 msgid "Create Report File"
 msgstr "Fisier parametri"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "Inchide"
 
@@ -5113,7 +5133,7 @@ msgstr "Seteaza offset scula"
 msgid "Tool:"
 msgstr "Scula:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Toate fisierele"
@@ -5182,18 +5202,18 @@ msgstr "Unitati"
 msgid "auto"
 msgstr "auto"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "inch"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5351,7 +5371,7 @@ msgstr "articulatie"
 msgid "world"
 msgstr "global"
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "poz.0"
 
@@ -5433,16 +5453,15 @@ msgstr "Verifica"
 msgid "Optional Stop"
 msgstr "Stop optional"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "Seteaza font"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "Font"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "Dimensiune"
 
@@ -5552,7 +5571,7 @@ msgid "Coordinate System Control Window"
 msgstr "Fereastra sistem control coordinate"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "Axa"
 
@@ -6133,9 +6152,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 #, fuzzy
 msgid "Custom"
 msgstr "Decupare"
@@ -6156,8 +6175,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr ""
 
@@ -6234,153 +6253,153 @@ msgstr "(fara fisier)"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 #, fuzzy
 msgid "problem with"
 msgstr "Inlocuieste cu:"
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 #, fuzzy
 msgid "default"
 msgstr "Foloseste implicit"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 #, fuzzy
 msgid "fontname"
 msgstr "Nume:"
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 #, fuzzy
 msgid "Switches"
 msgstr "inch"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 #, fuzzy
 msgid "Unicode"
 msgstr "End"
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 #, fuzzy
 msgid "no such file"
 msgstr "(fara fisier)"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 #, fuzzy
 msgid "LinuxCNC"
 msgstr "EMC Diagnostic"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "Erori EMC2"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7077,35 +7096,35 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Scula %d necunoscuta"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Fara scula"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Scula %(tool)d, ofset %(zo)g, diametru %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "Scula %(tool)d, ofset-z %(zo)g, ofset-x %(xo)g, diametru %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 #, fuzzy
 msgid "Filtering..."
 msgstr "Testare..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "Filtru esuat"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
@@ -7114,12 +7133,12 @@ msgstr ""
 "Programul %(program)r s-a terminat cu codul de eroare %(code)d. Mesajele de "
 "eroare produse sunt vizibile in cele ce urmeaza:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "Eroare G-cod in %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, fuzzy, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7128,139 +7147,137 @@ msgstr ""
 "In apropierea liniei %(seq)d din %(f)s:\n"
 "$(error_str)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 #, fuzzy
 msgid "Continuous"
 msgstr "continuu"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 #, fuzzy
 msgid "T    Tool Table"
 msgstr "Incarca tabela scule"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 #, fuzzy
 msgid "in"
 msgstr "Principal"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 #, fuzzy
 msgid " diameter"
 msgstr "Diametru:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 #, fuzzy
 msgid "Coordinate System:"
 msgstr "Fereastra sistem control coordinate"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 #, fuzzy
 msgid "Name:"
 msgstr "Nume INI"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 #, fuzzy
 msgid "Size:"
 msgstr "Dimensiune"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 #, fuzzy
 msgid "Tool order:"
 msgstr "Scula #:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "Distanta viteza mare:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "Distanta viteza prelucrare:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "Distanta totala:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 #, fuzzy
 msgid "Run time:"
 msgstr "Timp miscare"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "Limite X:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Limite Y:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Limite Z:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "Limite A:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "Limite B:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "Limite C:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "Program depaseste limita inferioara pe axa %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "Program depaseste limita superioara pe axa %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "Program depaseste limite masina"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Totusi executa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "Niciun fisier incarcat"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "generat din %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
@@ -7269,44 +7286,44 @@ msgstr ""
 "%(size)s bytes\n"
 "%(lines)s linii g-cod"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr "%.1f minute"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr "%d secunde"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%(a)f la %(b)f = %(diff)f %(units)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "Proprietati G-cod"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 #, fuzzy
 msgid "All machinable files"
 msgstr "Toate fisierele"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "fisiere rs274ngc"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 msgid "File not Writable:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7317,60 +7334,60 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Custom Grid"
 msgstr "Decupare"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 #, fuzzy
 msgid "Touch Off (system)"
 msgstr "Atingere"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, fuzzy, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "Introdu coordinata %s relativa la piesa:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, fuzzy, python-format
 msgid "Tool %s TouchOff"
 msgstr "Atingere"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "Eroare salvare fisier"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7379,7 +7396,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7388,7 +7405,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7397,92 +7414,92 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "articulatie"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 #, fuzzy
 msgid "Home All"
 msgstr "Salveaza tot"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, fuzzy, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "Pozitie 0 toate axele [Ctrl-Home]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "Salveaza tot"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "Anuleaza pozitie 0 toate axele"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "articulatie"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "Pozitie 0:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, fuzzy, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "Anuleaza pozitie 0 axa _%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "Ruleaza de aici"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "Eroare in ~/.axisrc"
 
@@ -7816,12 +7833,13 @@ msgid "_Properties..."
 msgstr "_Proprietati..."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "Editeaza _tabela scule"
 
 #: share/axis/tcl/axis.tcl:90
 #, fuzzy
-msgid "Reload tool ta_ble"
+msgid "Reload tool _data"
 msgstr "Incarca tabela scule"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8175,11 +8193,11 @@ msgstr "Sari peste linii cu '/' [Alt-M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "Basculeaza pauza optionala [Alt-M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "Mareste vedere"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "Micsoreaza vedere"
 
@@ -8369,9 +8387,10 @@ msgstr "Seteaza depasire freza"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr "%"
 
@@ -8426,7 +8445,7 @@ msgid "Position:"
 msgstr "Tip pozitie"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 #, fuzzy
 msgid "Machine"
 msgstr "masina"
@@ -8539,22 +8558,21 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Permite temporar miscarea in afara limitelor [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 #, fuzzy
 msgid "Spindle CW"
 msgstr "Freza oprita"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 #, fuzzy
 msgid "Spindle CCW"
@@ -8917,6 +8935,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8926,43 +8946,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -9025,7 +9090,6 @@ msgid "label26"
 msgstr "label42"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 #, fuzzy
 msgid "<b>Spindle</b>"
 msgstr "Freza oprita"
@@ -9210,7 +9274,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 #, fuzzy
 msgid "Status"
 msgstr "Stare:"
@@ -9279,8 +9342,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9421,10 +9484,10 @@ msgid "Stepconf"
 msgstr "Pas"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9445,13 +9508,13 @@ msgid "Parallel Port 1"
 msgstr "Initializare imprimare"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 #, fuzzy
 msgid "Parallel Port 2"
 msgstr "Initializare imprimare"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "Optiuni PLC"
@@ -9461,244 +9524,294 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Buton stanga"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Axa"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Axa"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Axa"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Axa"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Axa"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Axa"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "Spindle"
 msgstr "Freza oprita"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr "Gecko 201"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr "Gecko 202"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr "Gecko 203v"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr "Gecko 210"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr "Gecko 212"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr "Gecko 320"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr "Gecko 540"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr "L297"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr "PMDX-150"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr "Sherline"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr "Xylotex 8S-3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr "Parker-Compumotor oem750"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr "JVL-SMD41 sau 42"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr "Hobbycnc Pro Chopper"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr "Keling 4030"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "X Step"
 msgstr "Pas"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr "X Directie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "Y Step"
 msgstr "Pas"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr "Y Directie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "Z Step"
 msgstr "Pas"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr "Z Directie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "A Step"
 msgstr "Pas"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr "A Directie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "Pas"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "X Directie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "Pas"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "X Directie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "Freza mai incet"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "X Directie"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "Freza mai incet"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Y Directie"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 #, fuzzy
 msgid "Spindle ON"
 msgstr "Freza oprita"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 #, fuzzy
 msgid "Spindle PWM"
 msgstr "Freza oprita"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Brake"
 msgstr "Freza mai repede"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr "Racire vapori"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr "Racire lichid"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "ESTOP Out"
 msgstr "ESTOP"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr "Activare driver"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr "Charge pump"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr "Iesire digitala 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr "Iesire digitala 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr "Iesire digitala 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr "Iesire digitala 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9710,266 +9823,361 @@ msgstr "Iesire digitala 3"
 msgid "Unused"
 msgstr "Anulare"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 #, fuzzy
 msgid "ESTOP In"
 msgstr "ESTOP"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr "Digitizor intrare"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Index"
 msgstr "Freza mai repede"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase A"
 msgstr "Freza mai repede"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase B"
 msgstr "Freza mai repede"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home X"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Y"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Z"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home A"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "poz.0"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "poz.0"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr "Limita minima + poz 0 Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem X"
+msgstr "Limita minima + poz 0 X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem Y"
+msgstr "Limita minima + poz 0 Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr "Limita minima + poz 0 Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr "Limita minima + poz 0 A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home U"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home V"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr "Limita maxima + poz 0 Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem X"
+msgstr "Limita maxima + poz 0 X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem Y"
+msgstr "Limita maxima + poz 0 Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr "Limita maxima + poz 0 Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr "Limita maxima + poz 0 A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home U"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home V"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr "Ambele limite + poz 0 Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr "Ambele limite + poz 0 Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr "Ambele limite + poz 0 A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home U"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home V"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Ambele limite + poz 0 X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Ambele limite + poz 0 Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr "Limita min Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem X"
+msgstr "Limita min X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem Y"
+msgstr "Limita min Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr "Limita min Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr "Limita min A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit U"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit V"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr "Limita max Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem X"
+msgstr "Limita max X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem Y"
+msgstr "Limita max Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr "Limita max Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr "Limita max A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit U"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit V"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr "Ambele limite Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr "Ambele limite Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr "Ambele limite A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit U"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit V"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Ambele limite X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Ambele limite Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits"
 msgstr "Toate fisierele"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits + homes"
 msgstr "Toate fisierele"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr "Intrare digitala 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr "Intrare digitala 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr "Intrare digitala 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr "Intrare digitala 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "Jos"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Freza inainte"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -9979,9 +10187,9 @@ msgstr ""
 "Fisierul existent Custom.clp va fi redenumit custom_backup.clp.\n"
 "Daca exista deja un fisier -custom_backup.clp- acesta va fi pierdut. "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9995,8 +10203,8 @@ msgstr ""
 "\n"
 "Sunteti sigur? "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
@@ -10004,7 +10212,7 @@ msgstr ""
 "Trebuie sa asignezi un pin de intrare pentru E-stop la pagina de setare a "
 "portului paralel, pentru acest program."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
@@ -10015,26 +10223,26 @@ msgstr ""
 "Fisierul existent Custom.clp va fi redenumit custom_backup.clp.\n"
 "Daca exista deja un fisier -custom_backup.clp- acesta va fi pierdut. "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr "Paraseste Stepconf si sterge modificari?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -10045,16 +10253,16 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr "freza-mea"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr "Fisierul %r a fost modificat decand a fost generat de stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
@@ -10062,29 +10270,29 @@ msgstr ""
 "Salvarea aceste configuratii va supascrie orice modificari facute in afara "
 "de stepconf."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 #, fuzzy
 msgid "Continue? "
 msgstr "continuu"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr "yY"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr "lanseaza %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr "Dekstop Launcher pentru EMC creat de Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -10092,35 +10300,35 @@ msgid ""
 "{}"
 msgstr "Selector configuratii EMC2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr "Altele"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, fuzzy, python-format
 msgid "%s Axis Test"
 msgstr "Ofset axa"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr "grade / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 #, fuzzy
 msgid "deg / s²"
 msgstr "grade / sÂ²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr "grade"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -10135,8 +10343,8 @@ msgstr "grade"
 msgid "mm / s"
 msgstr "mm / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -10151,13 +10359,13 @@ msgstr "mm / s"
 msgid "mm / s²"
 msgstr "mm / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr "inch / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 #, fuzzy
 msgid "in / s²"
 msgstr "inch / sÂ²"
@@ -10168,20 +10376,20 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "Selector configuratii EMC2"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 #, fuzzy
 msgid "Modify Existing Configuration"
 msgstr "Configuratiile mele"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr "grade / tura"
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr "Pasi / grad"
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10193,7 +10401,7 @@ msgstr "Pasi / grad"
 msgid "mm / rev"
 msgstr "mm / tura"
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10204,28 +10412,28 @@ msgstr "mm / tura"
 msgid "Steps / mm"
 msgstr "Pasi / mm"
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr "ture / inch"
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr "Pasi / inch"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, fuzzy, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr "# Generat de stepconf la %s"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10233,101 +10441,107 @@ msgstr "# Daca faceti modificari pe acest fisier, ele vor fi"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr "# suprascrise cand rulati stepconf din nou"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 #, fuzzy
 msgid "# add halui MDI commands here (max 64) "
 msgstr "# adauga comenzi MDI aici (max 10)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr "Include panou PyVCP aici.\n"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, fuzzy, python-format
 msgid "# Include your %s HAL commands here"
 msgstr "# Indlude comenzi HAL customizate aici"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr "# Acest fisier nu va fi suprascris cand rulati stepconf din nou"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
 msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+#, fuzzy
+msgid "# Include your custom HAL commands here"
+msgstr "# Indlude comenzi HAL customizate aici"
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
 #, fuzzy
@@ -10399,12 +10613,17 @@ msgstr "Configuratii model"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 #, fuzzy
 msgid "label"
 msgstr "label42"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "Inapoi"
 
@@ -10452,17 +10671,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
 msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
-msgstr "ns"
 
 #: src/emc/usr_intf/stepconf/base.glade:209
 msgid "Step _Time:"
@@ -10835,58 +11043,155 @@ msgstr "Seteaza depasire viteza freza:"
 msgid "Scale %"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+#, fuzzy
+msgid "Axis"
+msgstr "Axa"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Ofset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Ofset:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Estop pornit"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Buton stanga"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "Comanda:"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 #, fuzzy
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 "Confirmare pe ecran pentru\n"
 "schimbare scula"
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr "Include interfata Halui"
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr "Include panou PyVCP customizat"
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 #, fuzzy
 msgid "Blank program"
 msgstr "Program"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 #, fuzzy
 msgid "Spindle speed display  "
 msgstr "Afisaj viteza/pozitie scula"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr "Program existent"
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr "Include conexiuni HAL"
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10898,69 +11203,69 @@ msgstr ""
 "panou\n"
 "implicit"
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr "Include PLC _Classicladder"
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr "Numar de intrari digitale:"
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr "Numar de iesiri digitale:"
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr "Numare de intrari analogice (s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr "Numar de iesiri analogice (s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr "Numar de intrari analogice (float):"
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr "Numar de iesiri analogice (float):"
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 #, fuzzy
 msgid "setup number of external pins"
 msgstr "Numar de intrari digitale:"
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr "Include suport pt. modbus master"
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr "Program ladder gol"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr "Program ladder Estop"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr "Program serial modbus"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
@@ -10969,10 +11274,14 @@ msgstr ""
 "Editeaza program\n"
 "ladder"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "Optiuni exemple PyVCP"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr "Include interfata Halui"
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10990,16 +11299,156 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+#, fuzzy
+msgid "NUM"
+msgstr "NML"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+#, fuzzy
+msgid "IDX"
+msgstr "RAPID"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "Comanda:"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -11009,10 +11458,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr ""
@@ -11043,15 +11492,6 @@ msgstr "_"
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
 msgstr "la"
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
-msgstr "s"
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
 #: src/emc/usr_intf/stepconf/axisy.glade:402
@@ -11269,40 +11709,40 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 #, fuzzy
 msgid "Specific Help page is unavailable\n"
 msgstr "Nu exista detalii."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 #, fuzzy
 msgid "Help Pages"
 msgstr "Imagine de adancime"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11310,23 +11750,23 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 #, fuzzy
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "Selector configuratii EMC2"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11336,34 +11776,34 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 #, fuzzy
 msgid "Discovery is  unavailable\n"
 msgstr "Nu exista detalii."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 #, fuzzy
 msgid "USB device  page is unavailable\n"
 msgstr "Nu exista detalii."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 #, fuzzy
 msgid ""
 "OK to replace existing glade panel ?\n"
@@ -11376,7 +11816,7 @@ msgstr ""
 "Fisierul existent Custom.clp va fi redenumit custom_backup.clp.\n"
 "Daca exista deja un fisier -custom_backup.clp- acesta va fi pierdut. "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
@@ -11387,178 +11827,178 @@ msgstr ""
 "Fisierul existent Custom.clp va fi redenumit custom_backup.clp.\n"
 "Daca exista deja un fisier -custom_backup.clp- acesta va fi pierdut. "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 #, fuzzy
 msgid "Unused Channel"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 #, fuzzy
 msgid "Leadscrew Pitch"
 msgstr "Pas surub:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 #, fuzzy
 msgid "Leadscrew TPI"
 msgstr "Pas surub:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 #, fuzzy
 msgid " / min"
 msgstr "mm / s"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 #, fuzzy
 msgid " / sec²"
 msgstr "mm / sÂ²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "Pas"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "Pasi / mm"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 #, fuzzy
 msgid " / encoder pulse"
 msgstr "grade / tura"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 #, fuzzy
 msgid "Encoder pulses / "
 msgstr "mm / tura"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "Spatiu simplu"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Configuratii model"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11576,60 +12016,63 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr "mm / s"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 #, fuzzy
 msgid "mm / min"
 msgstr "mm / s"
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 #, fuzzy
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 "Trebuie sa asignezi un pin de intrare pentru E-stop la pagina de setare a "
 "portului paralel, pentru acest program."
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 #, fuzzy
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 "Trebuie sa asignezi un pin de intrare pentru E-stop la pagina de setare a "
 "portului paralel, pentru acest program."
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 #, fuzzy
 msgid ""
 "OK to replace existing custom ladder program?\n"
@@ -11643,8 +12086,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, fuzzy, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr "# Generat de stepconf la %s"
@@ -11661,174 +12104,179 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr "# suprascrise cand rulati stepconf din nou"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 #, fuzzy
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr "# Indlude comenzi HAL customizate aici"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 #, fuzzy
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 "# Comenzile din acest fisier sunt executate dupa ce AXIS (inclusiv PyVCP)\n"
 "# a pornit"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 #, fuzzy
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr "# Acest fisier nu va fi suprascris cand rulati stepconf din nou"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
+#: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, fuzzy, python-format
 msgid "Generated by PNCconf at %s"
 msgstr "Generat de stepconf la %s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
 msgid "configures LinuxCNC as:\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
 msgid "type CNC\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
 msgid "will be used as the frontend display"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
 msgid " connector"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
 msgid "invrt"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
 #, python-format
 msgid "%(name)s Parport"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
 msgid "-> inverted"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1059
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
 #, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11844,1691 +12292,1745 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 #, fuzzy
 msgid "External Controls"
 msgstr "Manual"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 #, fuzzy
 msgid "Parallel Port"
 msgstr "Initializare imprimare"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 #, fuzzy
 msgid "X Motor"
 msgstr "Inverseaza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "X Axis"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 #, fuzzy
 msgid "Y Motor"
 msgstr "Inverseaza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Y Axis"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 #, fuzzy
 msgid "Z Motor"
 msgstr "Inverseaza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Z Axis"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 #, fuzzy
 msgid "A Motor"
 msgstr "Inverseaza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "A Axis"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Freza oprita"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Output"
-msgstr "Nefolosit"
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-msgid "POT Enable"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Dir"
-msgstr "X Directie"
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Input"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO O Drain"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
+msgid "POT Output"
+msgstr "Nefolosit"
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+msgid "POT Enable"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+#, fuzzy
+msgid "POT Dir"
+msgstr "X Directie"
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Input"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Output"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO O Drain"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:117
+#, fuzzy
 msgid "SSR Output"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-A"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-B"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-I"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-M"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 0"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 1"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "muxed Enc I"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc M"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 0 Encoder"
 msgstr "Inverseaza imagine"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 1 Encoder"
 msgstr "Inverseaza imagine"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 2 Encoder"
 msgstr "Inverseaza imagine"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 3 Encoder"
 msgstr "Inverseaza imagine"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 4 Encoder"
 msgstr "Inverseaza imagine"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 5 Encoder"
 msgstr "Inverseaza imagine"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 #, fuzzy
 msgid "Step Gen-A"
 msgstr "X Pas"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-P"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-D"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-E"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 #, fuzzy
 msgid "UDM-Down"
 msgstr "Jos"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "Manual"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "X Home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Y Home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Z Home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "A Home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "All Home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "A2 Tandem Home"
 msgstr "poz.0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 #, fuzzy
 msgid "X Minimum Limit + Home"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 #, fuzzy
 msgid "Y Minimum Limit + Home"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 #, fuzzy
 msgid "Z Minimum Limit + Home"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 #, fuzzy
 msgid "A Minimum Limit + Home"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 #, fuzzy
 msgid "X Maximum Limit + Home"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 #, fuzzy
 msgid "Y Maximum Limit + Home"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 #, fuzzy
 msgid "Z Maximum Limit + Home"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 #, fuzzy
 msgid "A Maximum Limit + Home"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 #, fuzzy
 msgid "X Both Limit + Home"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 #, fuzzy
 msgid "Y Both Limit + Home"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 #, fuzzy
 msgid "Z Both Limit + Home"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "A Both Limit + Home"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Toate fisierele"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 #, fuzzy
 msgid "X2 Minimum Limit + Home"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Y2 Minimum Limit + Home"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Z2 Minimum Limit + Home"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "A2 Minimum Limit + Home"
 msgstr "Limita minima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "X2 Maximum Limit + Home"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Y2 Maximum Limit + Home"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Z2 Maximum Limit + Home"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "A2 Maximum Limit + Home"
 msgstr "Limita maxima + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "X2 Both Limit + Home"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Y2 Both Limit + Home"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Z2 Both Limit + Home"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 #, fuzzy
 msgid "A2 Both Limit + Home"
 msgstr "Ambele limite + poz 0 X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select A"
 msgstr "Misca axa selectata"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select B"
 msgstr "Misca axa selectata"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select C"
 msgstr "Misca axa selectata"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select D"
 msgstr "Misca axa selectata"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "Depasire viteza:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "Depasire viteza:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "Depasire viteza:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "Depasire viteza:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Spindle Override incr A"
 msgstr "Seteaza depasire freza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr B"
 msgstr "Seteaza depasire freza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr C"
 msgstr "Seteaza depasire freza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr D"
 msgstr "Seteaza depasire freza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "Depasire viteza:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "Seteaza depasire freza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "Depasire viteza:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CW"
 msgstr "Freza oprita"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CCW"
 msgstr "Freza oprita"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle Stop"
 msgstr "Freza mai incet"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Spindle Up-To-Speed"
 msgstr "Seteaza depasire viteza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "Selectare totala"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "Spatiu simplu"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 #, fuzzy
 msgid "Jog X +"
 msgstr "JOG X +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 #, fuzzy
 msgid "Jog X -"
 msgstr "JOG X -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected +"
 msgstr "Misca axa selectata"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected -"
 msgstr "Misca axa selectata"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 1"
 msgstr "Salveaza HAL ini"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 2"
 msgstr "Salveaza HAL ini"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 3"
 msgstr "Salveaza HAL ini"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "X Minimum Limit"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "Y Minimum Limit"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "Z Minimum Limit"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "A Minimum Limit"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "X Maximum Limit"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "Y Maximum Limit"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "Z Maximum Limit"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "A Maximum Limit"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "X Both Limit"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "Y Both Limit"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "Z Both Limit"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "A Both Limit"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 #, fuzzy
 msgid "All Limits"
 msgstr "Toate fisierele"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "X2 Minimum Limit"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Y2 Minimum Limit"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Z2 Minimum Limit"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "A2 Minimum Limit"
 msgstr "Limita min X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "X2 Maximum Limit"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Y2 Maximum Limit"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Z2 Maximum Limit"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "A2 Maximum Limit"
 msgstr "Limita max X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "X2 Both Limit"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Y2 Both Limit"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Z2 Both Limit"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "A2 Both Limit"
 msgstr "Ambele limite X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "Pozitie 0 Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Ohmic Probe"
+msgstr "Digitizor intrare"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "inch"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Unused Input"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Limits"
 msgstr "Toate fisierele"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 #, fuzzy
 msgid "Digital"
 msgstr "Intrare digitala 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 #, fuzzy
 msgid "Axis Selection"
 msgstr "A Directie"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "depaseste limite"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "Operation"
 msgstr "Accelerare"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "External Control"
 msgstr "Manual"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 #, fuzzy
 msgid "X BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 #, fuzzy
 msgid "Y BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 #, fuzzy
 msgid "Z BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 #, fuzzy
 msgid "A BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 #, fuzzy
 msgid "S BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Custom Signals"
 msgstr "Decupare"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
 msgid "X Axis PWM"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
 msgid "Y Axis PWM"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 #, fuzzy
 msgid "Z Axis PWM"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 #, fuzzy
 msgid "A Axis PWM"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Unused PWM Gen"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Axis PWM"
 msgstr "Axa"
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 #, fuzzy
 msgid "X Axis StepGen"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 #, fuzzy
 msgid "Y Axis StepGen"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 #, fuzzy
 msgid "Z Axis StepGen"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 #, fuzzy
 msgid "A Axis StepGen"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "X2 Tandem StepGen"
 msgstr "Freza mai incet"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "Y2 Tandem StepGen"
 msgstr "Freza mai incet"
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 #, fuzzy
 msgid "Z2 Tandem StepGen"
 msgstr "Freza mai incet"
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 #, fuzzy
 msgid "Unused StepGen"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-#, fuzzy
-msgid "Axis"
-msgstr "Axa"
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Charge Pump StepGen"
 msgstr "Charge pump"
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Spindle StepGen"
 msgstr "Freza mai incet"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "X Encoder"
 msgstr "End"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "Y Encoder"
 msgstr "End"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "Z Encoder"
 msgstr "End"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "A Encoder"
 msgstr "End"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "End"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "End"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "End"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "End"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Feed Override"
 msgstr "Depasire viteza:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "spindle Override"
 msgstr "Seteaza depasire freza"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "Depasire viteza:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 #, fuzzy
 msgid "Unused Encoder"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 #, fuzzy
 msgid "Axis Encoder"
 msgstr "End"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Spindle Encoder"
 msgstr "Freza sens invers"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "End"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 #, fuzzy
 msgid "Unused Unused"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Freza mai incet"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "Masina pornita"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "X Amplifier Enable"
 msgstr "Activare driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Y Amplifier Enable"
 msgstr "Activare driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Z Amplifier Enable"
 msgstr "Activare driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "A Amplifier Enable"
 msgstr "Activare driver"
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Activare driver"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Masina pornita"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "Atingere"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 #, fuzzy
 msgid "Unused Output"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Coolant"
 msgstr "Comanda:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:518
-#, fuzzy
-msgid "Unused 8I20"
-msgstr "Anulare"
-
-#: src/emc/usr_intf/pncconf/private_data.py:521
-#, fuzzy
-msgid "Unused Resolver"
-msgstr "Nefolosit"
-
-#: src/emc/usr_intf/pncconf/private_data.py:521
-msgid "X Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:522
-msgid "Y Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:522
-msgid "Z Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:523
-msgid "A Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:523
-msgid "S Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:525
-#, fuzzy
-msgid "Unused Analog Output"
-msgstr "Nefolosit"
-
-#: src/emc/usr_intf/pncconf/private_data.py:525
-#, fuzzy
-msgid "Spindle Output"
-msgstr "Freza oprita"
-
-#: src/emc/usr_intf/pncconf/private_data.py:529
-#, fuzzy
-msgid "Unused TPPWM Gen"
-msgstr "Nefolosit"
-
-#: src/emc/usr_intf/pncconf/private_data.py:529
-msgid "X Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:530
-msgid "Y Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:530
-msgid "Z Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:531
-msgid "A Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:531
-msgid "S Axis BL Driver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
-msgid "8i20 Amplifier Card"
-msgstr "Activare driver"
-
-#: src/emc/usr_intf/pncconf/private_data.py:535
-msgid "7i64 I/O Card"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:535
-msgid "7i69 I/O Card"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:536
-msgid "7i70 I/O Card"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:536
-msgid "7i71 I/O Card"
-msgstr ""
+msgid "Unused 8I20"
+msgstr "Anulare"
 
 #: src/emc/usr_intf/pncconf/private_data.py:537
-msgid "7i76 Mode 0 I/O Card"
-msgstr ""
+#, fuzzy
+msgid "Unused Resolver"
+msgstr "Nefolosit"
 
 #: src/emc/usr_intf/pncconf/private_data.py:537
-msgid "7i76 Mode 2 I/O Card"
+msgid "X Resolver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:538
-msgid "7i77 Mode 0 I/O Card"
+msgid "Y Resolver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:538
-msgid "7i77 Mode 3 I/O Card"
+msgid "Z Resolver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:539
+msgid "A Resolver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:539
+msgid "S Resolver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:541
+#, fuzzy
+msgid "Unused Analog Output"
+msgstr "Nefolosit"
+
+#: src/emc/usr_intf/pncconf/private_data.py:541
+#, fuzzy
+msgid "Spindle Output"
+msgstr "Freza oprita"
+
+#: src/emc/usr_intf/pncconf/private_data.py:545
+#, fuzzy
+msgid "Unused TPPWM Gen"
+msgstr "Nefolosit"
+
+#: src/emc/usr_intf/pncconf/private_data.py:545
+msgid "X Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:546
+msgid "Y Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:546
+msgid "Z Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:547
+msgid "A Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:547
+msgid "S Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:550
+#, fuzzy
+msgid "8i20 Amplifier Card"
+msgstr "Activare driver"
+
+#: src/emc/usr_intf/pncconf/private_data.py:551
+msgid "7i64 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:551
+msgid "7i69 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:552
+msgid "7i70 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:552
+msgid "7i71 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:553
+msgid "7i76 Mode 0 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:553
+msgid "7i76 Mode 2 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:554
+msgid "7i77 Mode 0 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:554
+msgid "7i77 Mode 3 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Unused Analog In"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 #, fuzzy
 msgid "7i64-Analog In"
 msgstr "dialog1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 #, fuzzy
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 #, fuzzy
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr "Nefolosit"
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13542,17 +14044,17 @@ msgstr ""
 "Fisiere existente numite custompanel_backup.xml si custom_postgui.hal vor fi "
 "suprascrise. "
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 #, fuzzy
 msgid "Quit PNCconf and discard changes?"
 msgstr "Paraseste Stepconf si sterge modificari?"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 #, fuzzy
 msgid "Do you want to quit?"
 msgstr "Doriti sa:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13567,88 +14069,97 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 #, fuzzy
 msgid "degrees"
 msgstr "grade / tura"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 #, fuzzy
 msgid "degrees / minute"
 msgstr "grade / tura"
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 #, fuzzy
 msgid "degrees / second²"
 msgstr "grade / sÂ²"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 #, fuzzy
 msgid "revolutions"
 msgstr "Pozitie:"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 #, fuzzy
 msgid "revs / second²"
 msgstr "grade / sÂ²"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 #, fuzzy
 msgid "mm / minute"
 msgstr "mm / tura"
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 #, fuzzy
 msgid "mm / second²"
 msgstr "mm / sÂ²"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 #, fuzzy
 msgid "inches / second²"
 msgstr "inch / sÂ²"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, fuzzy, python-format
 msgid "%s Axis Tune"
 msgstr "Testeaza axa %s"
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13662,7 +14173,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "masina"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13672,12 +14183,12 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, fuzzy, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr "Fisierul %r a fost modificat decand a fost generat de stepconf"
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 #, fuzzy
 msgid ""
 "Saving this configuration file will discard configuration changes made "
@@ -13686,7 +14197,7 @@ msgstr ""
 "Salvarea aceste configuratii va supascrie orice modificari facute in afara "
 "de stepconf."
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr "Dekstop Launcher pentru EMC creat de Stepconf"
@@ -15370,9 +15881,9 @@ msgid "Z"
 msgstr "_Z"
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15535,6 +16046,14 @@ msgstr ""
 #, fuzzy
 msgid "Mux options"
 msgstr "Miscare"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+#, fuzzy
+msgid "Sec"
+msgstr "Secundar"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 #, fuzzy
@@ -15731,116 +16250,125 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 #, fuzzy
 msgid "Position_offset"
 msgstr "Tip pozitie"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 #, fuzzy
 msgid "Position_feedback"
 msgstr "Tip pozitie"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 #, fuzzy
 msgid "Max Spindle Override "
 msgstr "Seteaza depasire freza"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 #, fuzzy
 msgid "Min Spindle Override"
 msgstr "Seteaza depasire freza"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 #, fuzzy
 msgid "Max Feed Override"
 msgstr "Depasire viteza:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 #, fuzzy
 msgid "Default linear velocity "
 msgstr "Viteza cautare poz 0"
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 #, fuzzy
 msgid "Min linear velocity"
 msgstr "Viteza cautare poz 0"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 #, fuzzy
 msgid "Max linear velocity"
 msgstr "Viteza maxima:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 #, fuzzy
 msgid "Min Angular velocity"
 msgstr "Viteza maxima:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 #, fuzzy
 msgid "Increments "
 msgstr "Increment"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 #, fuzzy
 msgid "Max Angular velocity"
 msgstr "Viteza maxima:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 #, fuzzy
 msgid "Deg / min"
 msgstr "grade / tura"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 #, fuzzy
 msgid "Position"
 msgstr "Tip pozitie"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
@@ -15848,77 +16376,86 @@ msgstr "Tip pozitie"
 msgid "X"
 msgstr "_X"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 #, fuzzy
 msgid "H"
 msgstr "Hz"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 #, fuzzy
 msgid "AXIS Defaults"
 msgstr "Foloseste implicit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "Pozitie relativa"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 #, fuzzy
 msgid "Touchy Defaults"
 msgstr "Foloseste implicit"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Optiuni exemple PyVCP"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -16017,137 +16554,151 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr "Include panou PyVCP customizat"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr ""
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "End"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 #, fuzzy
 msgid "Home Final Velocity:"
 msgstr "Viteza cautare poz 0"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 #, fuzzy
 msgid "Home Latch Direction:"
 msgstr "Directie latch"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 #, fuzzy
 msgid "Home Search Direction:"
 msgstr "Directie latch"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 #, fuzzy
 msgid "Home latch Velocity:"
 msgstr "Viteza cautare poz 0"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr ""
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Configuratie copiata"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 #, fuzzy
 msgid "Home Search Velocity:"
 msgstr "Viteza cautare poz 0"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 #, fuzzy
 msgid "Home Search Sequence:"
 msgstr "Viteza cautare poz 0"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
+msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -17122,10 +17673,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr ""
@@ -17219,10 +17766,6 @@ msgstr ""
 #, fuzzy
 msgid "Motor steps per revolution:"
 msgstr "Nr. pasi _motor per tura:"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
-msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17705,7 +18248,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17868,32 +18410,24 @@ msgid "Manual Toolchange"
 msgstr "AXIS schimbare manuala a sculei"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 #, fuzzy
 msgid "Restart Entry"
 msgstr "Restart"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr "Sus"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr "Jos"
 
@@ -17974,33 +18508,33 @@ msgstr "Mesaj AXIS"
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -18124,14 +18658,12 @@ msgid "<b>Status</b>"
 msgstr "Pozitie 0"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -18139,7 +18671,6 @@ msgid ""
 msgstr "Inlocuieste cu:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -18147,7 +18678,6 @@ msgid ""
 msgstr "Inlocuieste toate"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -18163,7 +18693,6 @@ msgid "Main Level"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -18177,12 +18706,10 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -18192,7 +18719,6 @@ msgid "Grid Size"
 msgstr "Dimensiune"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 #, fuzzy
 msgid "Starting RPM"
 msgstr "Setari"
@@ -18275,7 +18801,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "Calibrare..."
@@ -18549,12 +19074,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "Anulare"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "Repetare"
 
@@ -18579,6 +19102,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18643,1662 +19168,698 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-#, fuzzy
-msgid "user mode selected"
-msgstr "Misca axa selectata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "Scula %d necunoscuta"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-#, fuzzy
-msgid "inch/min"
-msgstr "inch"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "Mod articulatii"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "Incarca fisier parametri"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-#, fuzzy
-msgid "No tool description available"
-msgstr "Nu exista detalii."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-msgid "Classicladder real-time component not detected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-msgid "Enter value for diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-#, fuzzy
-msgid "Set diameter to:"
-msgstr "Diametru:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-msgid "Enter value for radius"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr "Seteaza valoara axa:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, fuzzy, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "Seteaza valoara axa:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "AXIS schimbare manuala a sculei"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "Selecteaza un nod pentru afisare"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "Mod articulatii"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-#, fuzzy
-msgid "no button here"
-msgstr "Misca axa selectata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "Fisier Program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "Sterge vedere curenta"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "Vedere din perspectiva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "Valoare Ofset"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "Scule"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "A Directie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-#, fuzzy
-msgid "jog joints"
-msgstr "articulatie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "depaseste limite"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Informatii scula"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-#, fuzzy
-msgid "Diameter"
-msgstr "Diametru:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "Ofseturi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "Ofseturi"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "Configurare HAL"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Coduri G active"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Coduri G active"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "Freza oprita"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "Seteaza depasire freza"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Seteaza depasire viteza"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "Seteaza depasire viteza"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr "Inlocuieste"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-msgid "X Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-msgid "Y Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "Arata restart"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Vedere arbore"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "Arata restart"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "Pozitie relativa"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-msgid "Absolute Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "Salveaza tot"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "Anuleaza pozitie 0 toate axele"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-#, fuzzy
-msgid "Digits"
-msgstr "Intrare digitala 3"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-msgid "Grid size"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "Arata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "Arata restart"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-#, fuzzy
-msgid "Show DTG"
-msgstr "Arata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "Redeschide fisier curent [Control-R]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "Viteza jog:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "Selecteaza un nod pentru afisare"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "Seteaza depasire freza"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "Ara_ta vit_eza"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "Seteaza depasire viteza:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Seteaza depasire freza"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-#, fuzzy
-msgid "Use unlock code"
-msgstr "Nefolosit"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Freza mai repede"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Freza mai repede"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-#, fuzzy
-msgid "Probe Height"
-msgstr "Digitizor intrare"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-msgid "Z Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-#, fuzzy
-msgid "Max. Probe"
-msgstr "Digitizor intrare"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-#, fuzzy
-msgid "Search Vel."
-msgstr "Viteza cautare poz 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-#, fuzzy
-msgid "Probe Vel."
-msgstr "Digitizor intrare"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "Incarca tabela scule"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Incarca tabela scule"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "Por_neste de la linia selectata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "Pozitie 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-#, fuzzy
-msgid "Launch test message"
-msgstr "Rezultat test _latenta:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "Configuratii model"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Masina pornita"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "Program serial modbus"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "Arata restart"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "Mod articulatii"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Executa program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Executa program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Opreste executie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Opreste executie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Opreste executie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr ""
-"Editeaza program\n"
-"ladder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-#, fuzzy
-msgid "delete MDI"
-msgstr "Sterge"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-#, fuzzy
-msgid "delete MDI history"
-msgstr "Sterge istoric MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-#, fuzzy
-msgid "Open classicladder"
-msgstr "Include PLC _Classicladder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "Hal Scope"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-#, fuzzy
-msgid "launch hal scope"
-msgstr "lanseaza %s"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "Calibrare..."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "Incarca tabela scule"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "_Reincarca"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "Incarca tabela scule"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "Selecteaza un nod pentru afisare"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
+#: lib/python/gladevcp/iconview.py:120
 #, fuzzy
-msgid "Move to parrent directory"
+msgid "Move to parent directory"
 msgstr "Selector configuratii EMC2"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "Selecteaza un nod pentru afisare"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Selecteaza un nod pentru afisare"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "Fisier Program"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
 #, fuzzy
-msgid "home joints"
-msgstr "articulatie"
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr "Sterge ofset sistem coordinate"
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+#, fuzzy
+msgid "Toolfile does not exist"
+msgstr "Fisier scula este %s"
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "Incarca tabela scule"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+#, fuzzy
+msgid "Tool file was modified since it was last read"
+msgstr "Fisierul %r a fost modificat decand a fost generat de stepconf"
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Rotita mouse"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+#, fuzzy
+msgid "button"
+msgstr "Misca axa selectata"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "Lichid On/Off"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Scula:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Inapoi"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "Pozitie 0:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+#, fuzzy
+msgid "G92"
+msgstr "_G92"
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+#, fuzzy
+msgid "G59.1"
+msgstr "P7  G59._1"
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+#, fuzzy
+msgid "G59.2"
+msgstr "P8  G59._2"
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+#, fuzzy
+msgid "G59.3"
+msgstr "P9  G59._3"
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Ofset:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Valoare Ofset"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+#, fuzzy
+msgid ""
+"Zero\n"
+"G92"
+msgstr "Zero toate G59.2"
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "Pozitie 0:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "Selectare totala"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Scula #:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+#, fuzzy
+msgid "Diameter"
+msgstr "Diametru:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "Vedere din _fata"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "Accelerare"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "Comanda:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "_Reincarca"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "Ofset axa"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "Diametru:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "Ofseturi de lucru:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Scula:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Scula:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Seteaza offset scula"
+
+#, fuzzy
+#~ msgid "KHz"
+#~ msgstr "Hz"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "Misca axa selectata"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "Scula %d necunoscuta"
+
+#, fuzzy
+#~ msgid "inch/min"
+#~ msgstr "inch"
+
+#, fuzzy
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "Mod articulatii"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "Incarca fisier parametri"
+
+#, fuzzy
+#~ msgid "No tool description available"
+#~ msgstr "Nu exista detalii."
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr "Diametru:"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "Seteaza valoara axa:"
+
+#, fuzzy
+#~ msgid "Set axis {0} to:"
+#~ msgstr "Seteaza valoara axa:"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "AXIS schimbare manuala a sculei"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "Selecteaza un nod pentru afisare"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "Mod articulatii"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "Fisier Program"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "Sterge vedere curenta"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "Vedere din perspectiva"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Scule"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "A Directie"
+
+#, fuzzy
+#~ msgid "jog joints"
+#~ msgstr "articulatie"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "depaseste limite"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Informatii scula"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "Ofseturi"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "Ofseturi"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "Configurare HAL"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Coduri G active"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Coduri G active"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "Freza oprita"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "Seteaza depasire freza"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Seteaza depasire viteza"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "Seteaza depasire viteza"
+
+#~ msgid "Replace"
+#~ msgstr "Inlocuieste"
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Arata restart"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Vedere arbore"
+
+#, fuzzy
+#~ msgid "show offsets"
+#~ msgstr "Arata restart"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Pozitie relativa"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "Salveaza tot"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "Anuleaza pozitie 0 toate axele"
+
+#, fuzzy
+#~ msgid "Digits"
+#~ msgstr "Intrare digitala 3"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "Arata"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "Arata restart"
+
+#, fuzzy
+#~ msgid "Show DTG"
+#~ msgstr "Arata"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "Redeschide fisier curent [Control-R]"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "Viteza jog:"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "Selecteaza un nod pentru afisare"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Seteaza depasire freza"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "Ara_ta vit_eza"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Seteaza depasire viteza:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Seteaza depasire freza"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "Use unlock code"
+#~ msgstr "Nefolosit"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Freza mai repede"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Freza mai repede"
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "Probe Height"
+#~ msgstr "Digitizor intrare"
+
+#, fuzzy
+#~ msgid "Max. Probe"
+#~ msgstr "Digitizor intrare"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "Search Vel."
+#~ msgstr "Viteza cautare poz 0"
+
+#, fuzzy
+#~ msgid "Probe Vel."
+#~ msgstr "Digitizor intrare"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Incarca tabela scule"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Incarca tabela scule"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "Por_neste de la linia selectata"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "Pozitie 0"
+
+#, fuzzy
+#~ msgid "Launch test message"
+#~ msgstr "Rezultat test _latenta:"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "Configuratii model"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Masina pornita"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "Program serial modbus"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "Arata restart"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "Mod articulatii"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Executa program"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Executa program"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Opreste executie"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Opreste executie"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Opreste executie"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr ""
+#~ "Editeaza program\n"
+#~ "ladder"
+
+#, fuzzy
+#~ msgid "delete MDI"
+#~ msgstr "Sterge"
+
+#, fuzzy
+#~ msgid "delete MDI history"
+#~ msgstr "Sterge istoric MDI"
+
+#, fuzzy
+#~ msgid "Open classicladder"
+#~ msgstr "Include PLC _Classicladder"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "Hal Scope"
+
+#, fuzzy
+#~ msgid "launch hal scope"
+#~ msgstr "lanseaza %s"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "Calibrare..."
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "Incarca tabela scule"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "Selecteaza un nod pentru afisare"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "Fisier Program"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "articulatie"
 
 #, fuzzy
 #~ msgid "Substituting"
@@ -20390,9 +19951,6 @@ msgstr "articulatie"
 #~ msgid "Tool File"
 #~ msgstr "Fisier scule"
 
-#~ msgid "Tool file is %s"
-#~ msgstr "Fisier scula este %s"
-
 #~ msgid "Active G Codes"
 #~ msgstr "Coduri G active"
 
@@ -20405,9 +19963,6 @@ msgstr "articulatie"
 
 #~ msgid "CONTINUE"
 #~ msgstr "CONTINUA"
-
-#~ msgid "Tool #:"
-#~ msgstr "Scula #:"
 
 #~ msgid "Length :"
 #~ msgstr "Lungime :"
@@ -20578,9 +20133,6 @@ msgstr "articulatie"
 #~ msgid "Zero All G59.1"
 #~ msgstr "Zero toate G59.1"
 
-#~ msgid "Zero All G59.2"
-#~ msgstr "Zero toate G59.2"
-
 #~ msgid "Zero All G59.3"
 #~ msgstr "Zero toate G59.3"
 
@@ -20677,9 +20229,6 @@ msgstr "articulatie"
 
 #~ msgid "Show Setup"
 #~ msgstr "Arata setari"
-
-#~ msgid "Axis Offset"
-#~ msgstr "Ofset axa"
 
 #~ msgid "Home All Axes"
 #~ msgstr "Pozitie 0 toate axele"

--- a/src/po/ru.po
+++ b/src/po/ru.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: emc 2.2.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2010-01-26 10:20+0300\n"
 "Last-Translator: Alexey Starikovskiy <aystarik@gmail.com>\n"
 "Language-Team: Russian <en@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
@@ -27,61 +27,61 @@ msgid ""
 msgstr ""
 "команда (%s) не может быть исполнена пока станок на АВОСТе или выключен."
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "не могу делать это (%s) в ручном режиме"
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr "не могу делать это (%s) в авто режиме с остановленным интерпретатором"
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr "не могу делать это (%s) в авто режиме с читающим интерпретатором"
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 "не могу делать это (%s) в авто режиме с приостановленным интерпретатором"
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr "не могу делать это (%s) в авто режиме с ждущим интерпретатором"
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "не могу делать это (%s) в MDI режиме"
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr "Не могу переключить режим из авто при не остановленном интерпретаторе"
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 #, fuzzy
 msgid "failed to close file"
 msgstr "Не могу открыть файл"
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "не могу открыть %s"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr "Не могу исполнить команду MDI если не найдены начала"
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "Должен быть в MDI режиме для исполнения команд MDI"
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr "Не могу исполнить программу если не найдены начала"
 
@@ -208,100 +208,100 @@ msgstr "K слово без G2, G3, G33, G33.1, G76, G87 или G43.1 перед
 msgid "R value must be within 0..360 with M19"
 msgstr "Значение P вне диапазона для g10 l2"
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 #, fuzzy
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr "Не могу делать арку с нулевой подачей"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 #, fuzzy
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr "Не могу использовать G53 с компенсацией радиуса"
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr "Вы должны задать по крайней мере %d контрольных точек"
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr "Не могу конвертировать сплайн с компенсацией радиуса инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr "Сплайны должны быть в плоскости XY"
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr "Движение после отмены компенсации инструмента должно быть линейным"
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, fuzzy, c-format
 msgid "%c word missing in absolute center arc"
 msgstr "F слово не задано в движении с инверсным временем"
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr "Арка в вогнутом угле не может быть достигнута инструментом без зареза"
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr "Переход из арки в арку неверен, так как арки имеют общий центр"
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
@@ -309,264 +309,264 @@ msgstr ""
 "Переход от арки к арке делает угол в который скомпенсированный инструмент не "
 "может проникнуть без зареза"
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 "Не могу сменить режим управления с включенной компенсацией радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 "Не могу изменить координатную систему с включенной компенсацией радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr "G%d.1 без D слова"
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr "G%d.1 с L словом, но плоскость не G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr "G%d требует D слово как целое число"
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr "G%d с токарным инструментом, но плоскость не G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 #, fuzzy
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 "Не могу установить выход движения при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 "Не могу установить выход движения при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 "Не могу установить выход движения при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 "Не могу установить дополнительный выход при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 "Не могу ждать цифровой вход при включенной компенсации радиуса инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 "Не могу ждать аналоговый вход при включенной компенсации радиуса инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 "Не могу установить аналоговый выход при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 "Не могу установить дополнительный аналоговый выход при включенной "
 "компенсации радиуса инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 #, fuzzy
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr "Нужно положительное Q-слово для обозначения номера инструмента с M61"
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 "Не могу установить переопределения при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 "Не могу сбросить переопределения при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 #, fuzzy
 msgid "Cannot probe with feed per rev mode"
 msgstr "Не могу мерить с нулевой подачей"
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 "Не могу изменить режим возврата при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr "I J не разрешены вместе с G10 L2"
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 #, fuzzy
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
@@ -574,79 +574,79 @@ msgstr ""
 "Не могу изменить координатную систему с включенной компенсацией радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 #, fuzzy
 msgid "R not allowed in G10 L20"
 msgstr "I J не разрешены вместе с G10 L2"
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 #, fuzzy
 msgid "Spindle not turning in G33"
 msgstr "Шпиндель не крутится при g86"
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 #, fuzzy
 msgid "Spindle not turning in G33.1"
 msgstr "Шпиндель не крутится при g86"
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, fuzzy, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "Шпиндель не крутится при g86"
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 "Не могу использовать цикл резьбы G76 при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr "В G76, J дожно быть больше 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr "В G76, K дожно быть больше J"
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr "Нулевой внутренний угол неверен для компенсации радиуса инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
@@ -654,22 +654,22 @@ msgstr ""
 "Переход от арки к линейному ходу делает угол, который не может быть исполнен "
 "без зареза при включенной компенсации радиуса инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 "Не могу менять инструмент при включенной компенсации радиуса инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 "Не могу изменять отступ инструмента при включенной компенсации радиуса "
 "инструмента"
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -789,30 +789,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "Нельзя использовать полярные координаты с G53"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -935,102 +935,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, fuzzy, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "Вне определения подпрогаммы"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "Поименованный параметр #<%s> не определен"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, fuzzy, c-format
 msgid "cant open ini file '%s'"
 msgstr "не могу открыть %s"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, fuzzy, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "Поименованный параметр #<%s> не определен"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "Очередь не пуста после смены инструмента"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, fuzzy, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "Не могу открыть файл"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 #, fuzzy
 msgid "Parameter file name is missing"
 msgstr "Файл параметров %s"
@@ -1455,7 +1455,8 @@ msgid "Negative spindle speed used"
 msgstr "Отрицательное значение скорости шпинделя"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "Отрицательный индекс инструмента "
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1838,24 +1839,23 @@ msgstr "R меньше U в цикле на VW плоскости"
 msgid "R less than V in cycle in UW plane"
 msgstr "R меньше V в цикле на UW плоскости"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "ОШИБКА: '%s' неверный тип пробника\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "ОШИБКА: не имя ноги, сигнала или параметра\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr "ОШИБКА: -s опция требует тип пробника и имя сигнала или входа\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "HAL-метр"
 
@@ -1867,27 +1867,27 @@ msgstr "Выбрать"
 msgid "E_xit"
 msgstr "Выход"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "Выберите узел для показа"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr "Ножки"
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr "Сигналы"
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr "Параметры"
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr "Закрыть"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
@@ -1895,67 +1895,89 @@ msgstr ""
 "Использование:\n"
 "  halscope [-h] [-i входной файл] [-o выходной файл] [количество точек]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "Открыть файл конфигурации"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Отмена"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "Oткрыть..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Открыть файл конфигурации"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "Сохранить"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "Открыть конфигурацию..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "Сохранить конфигурацию..."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "Открыть файл данных"
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "Сохранить файл данных"
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "Выход"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "О Halscope"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "Файл"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "Помощь"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "HAL Осциллограф"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "Горизонтальный"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "Выбранный канал"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "Режим работы"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "Запуск"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "Вертикальный"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1963,39 +1985,40 @@ msgstr "Вертикальный"
 msgid "Stop"
 msgstr "Стоп"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "Нормальный"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "Одиночный"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "Прокрутить"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "zoom"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr "Поз"
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "----- Точки\n"
-"на ---- КГц"
+"на ---- кГц"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "Компонента реального времени не загружена"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -2019,11 +2042,39 @@ msgstr ""
 "or\n"
 "Click 'Quit' to exit HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "Да"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "Выход"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "Функция не слинкована"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -2045,11 +2096,11 @@ msgstr ""
 "or\n"
 "Click 'Quit' to exit HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "Выберите скорость отсчетов"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
@@ -2059,94 +2110,70 @@ msgstr ""
 "или\n"
 "Нажмите 'Quit' для выхода из HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "Да"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr "Поток:"
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr "Период опроса:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr "Скорость опроса"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr "Поток"
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "Период"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "Множитель:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr "Длина записи"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d замеров (1 канал)"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d замеров (2 канала)"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d замеров (4 канала)"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d замеров (8 каналов)"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d замеров (16 каналов)"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "Да"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "Выход"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2160,56 +2187,64 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
 "record length that supports more channels."
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
 "per div"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
 "at %s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
+msgstr "нс"
+
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
-msgstr ""
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
+msgstr "с"
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
-msgstr "секунды"
-
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2225,15 +2260,17 @@ msgstr "секунды"
 msgid "Hz"
 msgstr "Гц"
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
-msgstr "КГц"
+#: src/hal/utils/scope_horiz.c:1189
+#, fuzzy
+msgid "kHz"
+msgstr "кГц"
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
-msgstr ""
+#: src/hal/utils/scope_horiz.c:1193
+#, fuzzy
+msgid "MHz"
+msgstr "МГц"
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
@@ -2242,24 +2279,25 @@ msgstr ""
 "Отступ\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "Усиление"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr "Масштаб"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
@@ -2268,50 +2306,30 @@ msgstr ""
 "Отступ\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "Установить отступ"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
 "for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "Установить отступ"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Отмена"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr "Слишком много каналов"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2319,167 +2337,157 @@ msgid ""
 "the record length to allow for more channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
 "as the source for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr ""
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "Ножки"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "Сигналы"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "Параметры"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
 "Chan %2d"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "Авто"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr ""
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr ""
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr "Канал"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr ""
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr ""
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr ""
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+msgid "Probe tripped during non-probe move."
 msgstr ""
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr ""
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr ""
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr ""
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr ""
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr ""
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr ""
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
@@ -2548,179 +2556,179 @@ msgstr ""
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr ""
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr ""
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 #, fuzzy
 msgid "must be in joint mode to home"
 msgstr "Должен быть в MDI режиме для исполнения команд MDI"
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr ""
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 #, fuzzy
 msgid "must be in joint mode or disabled to unhome"
 msgstr "Должен быть в MDI режиме для исполнения команд MDI"
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr ""
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr ""
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, fuzzy, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr "Попытка возвести отрицательное число в нецелую степень"
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr ""
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr ""
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2809,26 +2817,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2999,7 +3007,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -3088,19 +3096,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "Да"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr "Нет"
 
@@ -3154,7 +3162,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "Сохранить"
 
@@ -3173,7 +3181,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "Редактор"
 
@@ -3188,7 +3196,6 @@ msgid "Config"
 msgstr "Настроить HAL"
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 msgid "Preview"
 msgstr "Вид"
 
@@ -3621,7 +3628,7 @@ msgid "Edit mode..."
 msgstr "Изменить..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "Удалить"
 
@@ -3630,7 +3637,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "Добавить"
 
@@ -3641,6 +3648,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "Изменить"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Отмена"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3830,7 +3855,7 @@ msgid "Parameter"
 msgstr "Параметры"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -4019,7 +4044,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "Главная"
 
@@ -4102,11 +4126,13 @@ msgid "Delete section"
 msgstr "Относительная позиция"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 #, fuzzy
 msgid "Move Down"
 msgstr "Вниз"
@@ -4629,6 +4655,7 @@ msgid "Exit"
 msgstr "Выход"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "Изменить"
 
@@ -4671,7 +4698,6 @@ msgid "Renumber File..."
 msgstr "Перенумеровать..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "Настройки"
 
@@ -4957,15 +4983,15 @@ msgstr "Вид дерева"
 msgid "Test HAL command :"
 msgstr "Проверить команду HAL:"
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "Команды можно проверить здесь без сохранения"
 
@@ -5093,12 +5119,12 @@ msgstr "Направление"
 msgid "SIZE :"
 msgstr "Размер:"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 #, fuzzy
 msgid "LinuxCNC Errors"
 msgstr "Ошибки EMC2"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 #, fuzzy
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
@@ -5107,12 +5133,12 @@ msgstr ""
 "EMC2 завершился с ошибкой. При сообщении о проблеме, пожалуйста вложите все "
 "следующие сведения."
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 #, fuzzy
 msgid "Create Report File"
 msgstr "Файл параметров"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "Закрыть"
 
@@ -5194,7 +5220,7 @@ msgstr "Установить отступ инструмента"
 msgid "Tool:"
 msgstr "Инструмент:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Все файлы"
@@ -5261,18 +5287,18 @@ msgstr "Единицы"
 msgid "auto"
 msgstr "авто"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "дюймы"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5430,7 +5456,7 @@ msgstr "Сочленение:"
 msgid "world"
 msgstr "Координаты"
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "начало"
 
@@ -5511,16 +5537,15 @@ msgstr "Проверить"
 msgid "Optional Stop"
 msgstr "Останов по запросу"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "Установить шрифт"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "Шрифт"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "Размер"
 
@@ -5630,7 +5655,7 @@ msgid "Coordinate System Control Window"
 msgstr "Окно управления координатной системой:"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "Ось "
 
@@ -6214,9 +6239,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr ""
 
@@ -6236,8 +6261,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr ""
 
@@ -6315,157 +6340,157 @@ msgstr "(нет файла)"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 #, fuzzy
 msgid "problem with"
 msgstr "Заменить на:"
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr "текст"
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 #, fuzzy
 msgid "Linescale"
 msgstr "Масштаб оси:"
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 #, fuzzy
 msgid "default"
 msgstr "умолчания AXIS"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 #, fuzzy
 msgid "Mode"
 msgstr "Режим работы"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 #, fuzzy
 msgid "normal"
 msgstr "Нормальный"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 #, fuzzy
 msgid "Switches"
 msgstr "дюймы"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 #, fuzzy
 msgid "Allow Rotation"
 msgstr "XY вращение:"
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 #, fuzzy
 msgid "no such file"
 msgstr "(нет файла)"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 #, fuzzy
 msgid "file not readable"
 msgstr "Файл не найден"
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 #, fuzzy
 msgid "not readable"
 msgstr "Файл не найден"
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 #, fuzzy
 msgid "LinuxCNC"
 msgstr "Отладка EMC"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "Ошибки EMC2"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7141,34 +7166,34 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Неизвестный инструмент %d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Без инструмента"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Инструмент %(tool)d, отступ %(zo)g, диаметр %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "Инструмент %(tool)d, zo %(zo)g, xo %(xo)g, диаметр %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "Фильтрую..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "Ошибка фильтра"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
@@ -7177,12 +7202,12 @@ msgstr ""
 "Программа %(program)r завершилась с кодом %(code)d.  Все сообщения об "
 "ошибках показаны ниже:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "Ошибка G-кода на %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7191,130 +7216,128 @@ msgstr ""
 "Около строки %(seq)d в %(f)s:\n"
 "%(error_str)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "Постоянный"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr "T Таблица инструментов"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "дюйм"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr "радиус"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr "диаметр"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr "°"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "Координатная система:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "Имя:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "Размер:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "Номер инструмента:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "Расстояние быстрого хода:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "Расстояние рабочего хода:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "Общее расстояние:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "Время работы:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "границы по X:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "границы по Y:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "границы по Z:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "границы по A:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "границы по B:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "границы по C:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "Программа выходит за минимум оси %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "Программа выходит за максимум оси %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "Программа выходит за пределы станка"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Исполнить все равно"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "Файл не загружен"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "получено из %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
@@ -7323,44 +7346,44 @@ msgstr ""
 "%(size)s байт\n"
 "%(lines)s строк gcode"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr "%.1f минут"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr "%d секунд"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%(a)f к %(b)f = %(diff)f %(units)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "Свойства G-кода"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "Все исполняемые файлы"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "rs274ngc файлы"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 #, fuzzy
 msgid "File not Writable:"
 msgstr "Файл не найден"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7371,60 +7394,60 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Custom Grid"
 msgstr "Сигналы"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, fuzzy, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr "Должен быть в MDI режиме для исполнения команд MDI"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 #, fuzzy
 msgid "Touch Off (system)"
 msgstr "Задать отступ"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, fuzzy, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "Введите %s координату относительно заготовки:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, fuzzy, python-format
 msgid "Tool %s TouchOff"
 msgstr "Задать отступ"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "Ошибка при сохранении файла"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7433,7 +7456,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7442,7 +7465,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7451,91 +7474,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "Ось:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "Все в начало"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, fuzzy, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "Все оси в начало [Ctrl-Home]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "Все в начало"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "Забыть начало всех осей"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "Ось:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "Положение начала:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, fuzzy, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "Забыть начало оси _%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "Исполнить отсюда"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "Ошибка в ~/.axisrc"
 
@@ -7848,11 +7871,13 @@ msgid "_Properties..."
 msgstr "Свойства..."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "Изменить таблицу инструментов..."
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+#, fuzzy
+msgid "Reload tool _data"
 msgstr "Перегрузить таблицу инструментов"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8183,11 +8208,11 @@ msgstr "Пропускать строки с '/' [Alt-M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "Включить остановку по требованию [Alt-M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "Приблизить"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "Удалить"
 
@@ -8366,9 +8391,10 @@ msgstr "Скорость шпинделя:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr "%"
 
@@ -8420,7 +8446,7 @@ msgid "Position:"
 msgstr "Позиция:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr "Абсолютная"
 
@@ -8526,21 +8552,20 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Временно разрешить ход за пределами станка [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "Шпиндель вперед"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "Шпиндель назад"
@@ -8884,6 +8909,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8893,43 +8920,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8984,7 +9056,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr "<b>Шпиндель</b>"
 
@@ -9152,7 +9223,6 @@ msgid ""
 msgstr "<b>b)</b>"
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr "Статус"
 
@@ -9212,8 +9282,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr "дюйм"
@@ -9349,10 +9419,10 @@ msgid "Stepconf"
 msgstr "Шаг"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9373,13 +9443,13 @@ msgid "Parallel Port 1"
 msgstr "Настройка параллельного порта"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 #, fuzzy
 msgid "Parallel Port 2"
 msgstr "Настройка параллельного порта"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "Опции PLC"
@@ -9389,236 +9459,287 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Левая кнопка"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Ось "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Ось "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Ось "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Ось "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Ось "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Ось "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "Spindle"
 msgstr "Шпиндель:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr "Gecko 201"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr "Gecko 202"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr "Gecko 203v"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr "Gecko 210"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr "Gecko 212"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr "Gecko 320"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr "Gecko 540"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr "L297"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr "PMDX-150"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr "Sherline"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr "Xylotex 8S-3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr "Parker-Compumotor OEM750"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr "JVL-SMD41 or 42"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr "Hobbycnc Pro Chopper"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr "Keling 4030"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr "X·Шаг"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr "X Направление"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr "Y·Шаг"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr "Y·Направление"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr "Z·Шаг"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr "Z·Направление"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr "A Шаг"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr "A Направление"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "X·Шаг"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "X Направление"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "X·Шаг"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "X Направление"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "Шпиндель медленнее"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "X Направление"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "Шпиндель медленнее"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Y·Направление"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr "Шпиндель ON"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr "Шпиндель ШИМ"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr "Шпиндель тормоз"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr "Туман"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr "Струя"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr "ESTOP выход"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr "Включить усилитель"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr "Пульс"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr "Цифровой выход 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr "Цифровой выход 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr "Цифровой выход 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr "Цифровой выход 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+#, fuzzy
+msgid "Plasma Ohmic Enable"
+msgstr "Разрешение"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9629,256 +9750,351 @@ msgstr "Цифровой выход 3"
 msgid "Unused"
 msgstr "Не подключен"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr "ESTOP вход"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr "Щуп вход"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr "Шпиндель индекс"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr "Шпиндель Фаза А"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr "Шпиндель фаза B"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr "Начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr "Начало Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr "Начало Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr "Начало A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "Начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "Начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Начало X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Начало Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr "Меньший предел + начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr "Меньший предел + начало Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem X"
+msgstr "Меньший предел + начало X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem Y"
+msgstr "Меньший предел + начало Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr "Меньший предел + начало Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr "Меньший предел + начало A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home U"
 msgstr "Меньший предел + начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home V"
 msgstr "Меньший предел + начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr "Больший предел + начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr "Больший предел + начало Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem X"
+msgstr "Больший предел + начало X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem Y"
+msgstr "Больший предел + начало Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr "Больший предел + начало Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr "Больший предел + начало A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home U"
 msgstr "Больший предел + начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home V"
 msgstr "Больший предел + начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr "Оба предела + начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr "Оба предела + начало Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr "Оба предела + начало Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr "Оба предела + начало A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home U"
 msgstr "Оба предела + начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home V"
 msgstr "Оба предела + начало X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Оба предела + начало X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Оба предела + начало Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr "Меньший предел X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr "Меньший предел Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem X"
+msgstr "Меньший предел X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem Y"
+msgstr "Меньший предел Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr "Меньший предел Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr "Меньший предел A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit U"
 msgstr "Меньший предел X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit V"
 msgstr "Меньший предел X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr "Больший предел X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr "Больший предел Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem X"
+msgstr "Больший предел X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem Y"
+msgstr "Больший предел Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr "Больший предел Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr "Больший предел A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit U"
 msgstr "Больший предел X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit V"
 msgstr "Больший предел X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr "Оба предела X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr "Оба предела Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr "Оба предела Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr "Оба предела A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit U"
 msgstr "Оба предела X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit V"
 msgstr "Оба предела X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Оба предела X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Оба предела Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr "Все пределы"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr "Все начала"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits + homes"
 msgstr "Все пределы"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr "Цифровой вход 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr "Цифровой вход 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr "Цифровой вход 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr "Цифровой вход 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "Вниз"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Шпиндель вперед"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -9888,9 +10104,9 @@ msgstr ""
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9904,8 +10120,8 @@ msgstr ""
 "\n"
 "Are you sure?  "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
@@ -9913,7 +10129,7 @@ msgstr ""
 "Вам нужно определить вход для ABOCT на странице настройки параллельного "
 "порта для работы этой программы"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
@@ -9924,26 +10140,26 @@ msgstr ""
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr "Выйти из Stepconf и сбросить все изменения?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9954,44 +10170,44 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr "мой-станок"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr "Файл %r был изменен после записи stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr ""
 "Сохранение этого файла конфигурации отменит все изменения, сделанные вручную."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr "Продолжить?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr "дД"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr "Запустить %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr "Desktop Launcher for EMC config made by Stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9999,34 +10215,34 @@ msgid ""
 "{}"
 msgstr "Выбор конфигураций EMC"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr "Другое"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr "%s Axis Test"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr "градус/с"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr "градус/с²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr "градус"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -10041,8 +10257,8 @@ msgstr "градус"
 msgid "mm / s"
 msgstr "мм/с"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -10057,13 +10273,13 @@ msgstr "мм/с"
 msgid "mm / s²"
 msgstr "мм/с²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr "дюйм/с"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr "дюйм/с²"
 
@@ -10073,19 +10289,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "EMC2 'stepconf' configuration files"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr "Изменить существующую конфигурацию"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr "градусы/об."
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr "шаг/градус"
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10097,7 +10313,7 @@ msgstr "шаг/градус"
 msgid "mm / rev"
 msgstr "мм/об"
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10108,28 +10324,28 @@ msgstr "мм/об"
 msgid "Steps / mm"
 msgstr "шаг/мм"
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr "об/дюйм"
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr "шаг/дюйм"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, fuzzy, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr "# Создан stepconf в %s"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10137,62 +10353,62 @@ msgstr "# Все изменения в этом файле будут перез
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr "# при следующем запуске stepconf"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr "# добавьте halui MDI команды сюда (max 64)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr "# ****Установки для программы внешнего АВОСТ -START ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr "# ****Установки для программы внешнего АВОСТ -END ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr "Include your PyVCP panel here.\n"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 #, fuzzy
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 "# **** Setup of spindle speed and tool number display using pyvcp -START ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr "# **** Use ACTUAL spindle velocity from spindle encoder"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 #, fuzzy
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
@@ -10200,7 +10416,7 @@ msgid ""
 msgstr ""
 "# **** spindle-velocity is signed so we use absolute compoent to remove sign"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 #, fuzzy
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
@@ -10208,15 +10424,15 @@ msgid ""
 msgstr ""
 "# **** spindle-velocity is signed so we use absolute compoent to remove sign"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 #, fuzzy
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
@@ -10225,22 +10441,28 @@ msgstr ""
 "# **** Use COMMANDED spindle velocity from EMC because no spindle encoder "
 "was specified"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, fuzzy, python-format
 msgid "# Include your %s HAL commands here"
 msgstr "# Include your customized HAL commands here"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr "# This file will not be overwritten when you run stepconf again"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
 msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+#, fuzzy
+msgid "# Include your custom HAL commands here"
+msgstr "# Include your customized HAL commands here"
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
 #, fuzzy
@@ -10311,11 +10533,16 @@ msgstr "Конфигурация LinuxCNC для фрезера на шагов�
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "Назад"
 
@@ -10364,17 +10591,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
 msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
-msgstr "нс"
 
 #: src/emc/usr_intf/stepconf/base.glade:209
 msgid "Step _Time:"
@@ -10737,55 +10953,151 @@ msgstr "Обороты шпинделя:"
 msgid "Scale %"
 msgstr "Масштаб"
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr "Ось "
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Отступ:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Отступ:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "АВОСТ вкл"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Левая кнопка"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "Режим работы"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 #, fuzzy
 msgid "_Onscreen prompt for manual tool change"
 msgstr "Экранный запрос смены инструмента"
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr "Добавить компоненту HALUI интерфейсa"
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr "Добавить PyVCP GUI панель"
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr "Пустая программа"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 #, fuzzy
 msgid "Spindle speed display  "
 msgstr "Скорость шпинделя/номер инструмента"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr "Существующая программа"
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr "Добавить привязку к HAL"
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10797,78 +11109,82 @@ msgstr ""
 "пример\n"
 "панели"
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr "Добавить Classicladder PLC"
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr "Количество цифровых входов:"
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr "Количество цифровых выходов:"
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr "Количество аналоговых (s32) входов:"
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr "Количество аналоговых (s32) выходов:"
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr "Количество аналоговых (float) входов:"
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr "Количество аналоговых (float) выходов:"
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr "Количество цифровых входов:"
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr "Добавить поддержку мастера MODBUS"
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr "Пустая программа PLC"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr "Лестница АвОст"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr "Программа последовательной modbus"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
 "program"
 msgstr "Редактировать лестницу"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "Пример устнавок Pyvcp"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr "Добавить компоненту HALUI интерфейсa"
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10886,16 +11202,155 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+#, fuzzy
+msgid "NUM"
+msgstr "NML"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "Режим работы"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10905,10 +11360,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr ""
@@ -10939,15 +11394,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
 msgstr "до"
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
-msgstr "с"
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
 #: src/emc/usr_intf/stepconf/axisy.glade:402
@@ -11161,39 +11607,39 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 #, fuzzy
 msgid "Specific Help page is unavailable\n"
 msgstr "Помощь не доступна\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr "Страницы помощи"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11201,23 +11647,23 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 #, fuzzy
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "EMC2 'stepconf' configuration files"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11227,36 +11673,36 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 #, fuzzy
 msgid "Discovery is  unavailable\n"
 msgstr "Помощь не доступна\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 #, fuzzy
 msgid "USB device  page is unavailable\n"
 msgstr "Помощь не доступна\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 #, fuzzy
 msgid "Pin names are unavailable\n"
 msgstr "Помощь не доступна\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 #, fuzzy
 msgid "Device names are unavailable\n"
 msgstr "Помощь не доступна\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 #, fuzzy
 msgid ""
 "OK to replace existing glade panel ?\n"
@@ -11269,7 +11715,7 @@ msgstr ""
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
@@ -11280,176 +11726,176 @@ msgstr ""
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 #, fuzzy
 msgid "Unused Channel"
 msgstr "Выбранный канал"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 #, fuzzy
 msgid " / min"
 msgstr "градусы/мин"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 #, fuzzy
 msgid " / sec²"
 msgstr "мм/сек²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "мм/шаг"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "шаг/мм"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 #, fuzzy
 msgid " / encoder pulse"
 msgstr "Множитель энкодера:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 #, fuzzy
 msgid "Encoder pulses / "
 msgstr "Шаги енкодера за оборот"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "Множитель энкодера:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Конфигурация шпинделя"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11467,56 +11913,59 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr "градусы/мин"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 #, fuzzy
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 "Вам нужно определить вход для ABOCT на странице настройки параллельного "
 "порта для работы этой программы"
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 #, fuzzy
 msgid ""
 "OK to replace existing custom ladder program?\n"
@@ -11530,8 +11979,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr ""
@@ -11547,180 +11996,185 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 #, fuzzy
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr "# Include your customized HAL commands here"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 #, fuzzy
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 "# **** Setup of spindle speed and tool number display using pyvcp -START ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 #, fuzzy
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 "# The commands in this file are run after the AXIS GUI (including PyVCP "
 "panel) starts"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 #, fuzzy
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 "# **** Setup of spindle speed and tool number display using pyvcp -START ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
-#, python-format
-msgid "Generated by PNCconf at %s"
-msgstr "Сделано PNCconf в %s"
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
-msgid "configures LinuxCNC as:\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
-msgid "type CNC\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
-msgid "will be used as the frontend display"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
-msgid " connector"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
-msgid "invrt"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
-#, python-format
-msgid "%(name)s Parport"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
-msgid "-> inverted"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
+msgid "Generated by PNCconf at %s"
+msgstr "Сделано PNCconf в %s"
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
+msgid "configures LinuxCNC as:\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
+msgid "type CNC\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
+msgid "will be used as the frontend display"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
+msgid " connector"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
+msgid "invrt"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
+#, python-format
+msgid "%(name)s Parport"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
+msgid "-> inverted"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
+#, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 #, fuzzy
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr "# **** Use ACTUAL spindle velocity from spindle encoder"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 #, fuzzy
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 "# **** spindle-velocity is signed so we use absolute compoent to remove sign"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 #, fuzzy
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr "# **** ACTUAL velocity is in RPS not RPM so we scale it."
@@ -11737,1644 +12191,1699 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 msgid "External Controls"
 msgstr "внешнее управление"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 #, fuzzy
 msgid "Parallel Port"
 msgstr "Настройка параллельного порта"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 #, fuzzy
 msgid "X Motor"
 msgstr "Инвертировать мотор"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "X Axis"
 msgstr "Ось X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 #, fuzzy
 msgid "Y Motor"
 msgstr "Инвертировать мотор"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Y Axis"
 msgstr "Ось Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 #, fuzzy
 msgid "Z Motor"
 msgstr "Инвертировать мотор"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Z Axis"
 msgstr "Ось Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 #, fuzzy
 msgid "A Motor"
 msgstr "Инвертировать мотор"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "A Axis"
 msgstr "Ось A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Выключить шпиндель"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
 msgid "POT Output"
 msgstr "GPIO выход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
 msgid "POT Enable"
 msgstr "Разрешение"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
 msgid "POT Dir"
 msgstr "X Направление"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Input"
 msgstr "GPIO вход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Output"
 msgstr "GPIO выход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO O Drain"
 msgstr "GPIO открытый исток"
 
-#: src/emc/usr_intf/pncconf/private_data.py:113
+#: src/emc/usr_intf/pncconf/private_data.py:117
 #, fuzzy
 msgid "SSR Output"
 msgstr "GPIO выход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-A"
 msgstr "Неиспользованный енкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-B"
 msgstr "Неиспользованный енкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-I"
 msgstr "Неиспользованный енкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-M"
 msgstr "Неиспользованный енкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 0"
 msgstr "Неиспользованный енкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 1"
 msgstr "Неиспользованный енкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "muxed Enc I"
 msgstr "Неиспользованный енкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc M"
 msgstr "Неиспользованный енкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "mux select"
 msgstr "Найти начало активной оси"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 0 Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 1 Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 2 Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 3 Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 4 Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 5 Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 #, fuzzy
 msgid "Step Gen-A"
 msgstr "X·Шаг"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-P"
 msgstr "Неиспользованный ШИМ генератор"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-D"
 msgstr "Неиспользованный ШИМ генератор"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-E"
 msgstr "Неиспользованный ШИМ генератор"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 #, fuzzy
 msgid "UDM-Down"
 msgstr "Вниз"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 #, fuzzy
 msgid "Motor Enable"
 msgstr "X Разрешение"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "Ручное управление"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "X Home"
 msgstr "Начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Y Home"
 msgstr "Начало Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Z Home"
 msgstr "Начало Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "A Home"
 msgstr "Начало A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "All Home"
 msgstr "Все начала"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "Начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "Начало Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "Начало Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "A2 Tandem Home"
 msgstr "Начало A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr "Меньший предел + начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr "Меньший предел + начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr "Меньший предел + начало Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr "Меньший предел + начало A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr "Больший предел + начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr "Больший предел + начало Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr "Больший предел + начало Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr "Больший предел + начало A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr "Оба предела + начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr "Оба предела + начало Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr "Оба предела + начало Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr "Оба предела + начало A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Все пределы"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 #, fuzzy
 msgid "X2 Minimum Limit + Home"
 msgstr "Меньший предел + начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Y2 Minimum Limit + Home"
 msgstr "Меньший предел + начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Z2 Minimum Limit + Home"
 msgstr "Меньший предел + начало Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "A2 Minimum Limit + Home"
 msgstr "Меньший предел + начало A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "X2 Maximum Limit + Home"
 msgstr "Больший предел + начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Y2 Maximum Limit + Home"
 msgstr "Больший предел + начало Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Z2 Maximum Limit + Home"
 msgstr "Больший предел + начало Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "A2 Maximum Limit + Home"
 msgstr "Больший предел + начало A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "X2 Both Limit + Home"
 msgstr "Оба предела + начало X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Y2 Both Limit + Home"
 msgstr "Оба предела + начало Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Z2 Both Limit + Home"
 msgstr "Оба предела + начало Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 #, fuzzy
 msgid "A2 Both Limit + Home"
 msgstr "Оба предела + начало A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "Изменить подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "Изменить подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "Изменить подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "Изменить подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Spindle Override incr A"
 msgstr "Скорость шпинделя:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr B"
 msgstr "Скорость шпинделя:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr C"
 msgstr "Скорость шпинделя:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr D"
 msgstr "Скорость шпинделя:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr A"
 msgstr "Изменить максимальную подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr B"
 msgstr "Изменить максимальную подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr C"
 msgstr "Изменить максимальную подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Max Vel Override incr D"
 msgstr "Изменить максимальную подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "Изменить подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "Скорость шпинделя:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "Изменить максимальную подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CW"
 msgstr "Шпиндель вперед"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CCW"
 msgstr "Шпиндель назад"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle Stop"
 msgstr "Остановить шпиндель"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Spindle Up-To-Speed"
 msgstr "Шпинделя раскручен"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "Выбрать всё"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "Один пробел"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr "Двигать X +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr "Двигать X -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr "Двигать активную ось"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr "Двигать активную ось"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 1"
 msgstr "Сохранить HAL INI"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 2"
 msgstr "Сохранить HAL INI"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 3"
 msgstr "Сохранить HAL INI"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr "Меньший предел X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr "Меньший предел Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr "Меньший предел Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr "Меньший предел A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr "Больший предел Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr "Больший предел Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr "Больший предел Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr "Больший предел A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr "Оба предела X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr "Оба предела Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr "Оба предела Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr "Оба предела A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr "Все пределы"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "X2 Minimum Limit"
 msgstr "Меньший предел X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Y2 Minimum Limit"
 msgstr "Меньший предел Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Z2 Minimum Limit"
 msgstr "Меньший предел Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "A2 Minimum Limit"
 msgstr "Меньший предел A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "X2 Maximum Limit"
 msgstr "Больший предел Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Y2 Maximum Limit"
 msgstr "Больший предел Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Z2 Maximum Limit"
 msgstr "Больший предел Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "A2 Maximum Limit"
 msgstr "Больший предел A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "X2 Both Limit"
 msgstr "Оба предела X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Y2 Both Limit"
 msgstr "Оба предела Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Z2 Both Limit"
 msgstr "Оба предела Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "A2 Both Limit"
 msgstr "Оба предела A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "Ось X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "Найти начало оси"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Ohmic Probe"
+msgstr "Щуп"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "дюймы"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr "Неиспользованный вход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Limits"
 msgstr "Все пределы"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 #, fuzzy
 msgid "Digital"
 msgstr "Цифровой вход 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 #, fuzzy
 msgid "Axis Selection"
 msgstr "A Направление"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "Игнорировать пределы"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "Operation"
 msgstr "Ускорение:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "External Control"
 msgstr "внешнее управление"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "Ось "
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 #, fuzzy
 msgid "X BLDC Control"
 msgstr "Control-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 #, fuzzy
 msgid "Y BLDC Control"
 msgstr "Control-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 #, fuzzy
 msgid "Z BLDC Control"
 msgstr "Control-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 #, fuzzy
 msgid "A BLDC Control"
 msgstr "Control-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 #, fuzzy
 msgid "S BLDC Control"
 msgstr "Control-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Custom Signals"
 msgstr "Сигналы"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
 msgid "X Axis PWM"
 msgstr "Ось X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
 msgid "Y Axis PWM"
 msgstr "Ось Y"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 #, fuzzy
 msgid "Z Axis PWM"
 msgstr "Ось Z"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 #, fuzzy
 msgid "A Axis PWM"
 msgstr "Ось A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Unused PWM Gen"
 msgstr "Неиспользованный ШИМ генератор"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Axis PWM"
 msgstr "Ось X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 #, fuzzy
 msgid "X Axis StepGen"
 msgstr "Неиспользованный генератор шагов"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 #, fuzzy
 msgid "Y Axis StepGen"
 msgstr "Неиспользованный генератор шагов"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 #, fuzzy
 msgid "Z Axis StepGen"
 msgstr "Неиспользованный генератор шагов"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 #, fuzzy
 msgid "A Axis StepGen"
 msgstr "Неиспользованный генератор шагов"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "X2 Tandem StepGen"
 msgstr "Шпиндель медленнее"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "Y2 Tandem StepGen"
 msgstr "Шпиндель медленнее"
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 #, fuzzy
 msgid "Z2 Tandem StepGen"
 msgstr "Шпиндель медленнее"
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 msgid "Unused StepGen"
 msgstr "Неиспользованный генератор шагов"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr "Ось "
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Charge Pump StepGen"
 msgstr "Пульс"
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Spindle StepGen"
 msgstr "Шпиндель медленнее"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "X Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "Y Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "Z Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "A Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Feed Override"
 msgstr "Изменить подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "spindle Override"
 msgstr "Скорость шпинделя:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "Изменить максимальную подачу:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr "Неиспользованный енкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 #, fuzzy
 msgid "Axis Encoder"
 msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Spindle Encoder"
 msgstr "Шпиндель тормоз"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Сбросить энкодер"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 #, fuzzy
 msgid "Unused Unused"
 msgstr "Неиспользованный вход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Шпиндель разрешение"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "Название станка:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "X Amplifier Enable"
 msgstr "Включить усилитель"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Y Amplifier Enable"
 msgstr "Включить усилитель"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Z Amplifier Enable"
 msgstr "Включить усилитель"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "A Amplifier Enable"
 msgstr "Включить усилитель"
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Разрешение"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Станок вкл"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "Задать отступ"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr "Неиспользованный выход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Coolant"
 msgstr "Охлаждение:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Control"
 msgstr "Control-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:518
-#, fuzzy
-msgid "Unused 8I20"
-msgstr "Не подключен"
-
-#: src/emc/usr_intf/pncconf/private_data.py:521
-#, fuzzy
-msgid "Unused Resolver"
-msgstr "Неиспользованный енкодер"
-
-#: src/emc/usr_intf/pncconf/private_data.py:521
-msgid "X Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:522
-msgid "Y Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:522
-msgid "Z Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:523
-msgid "A Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:523
-msgid "S Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:525
-#, fuzzy
-msgid "Unused Analog Output"
-msgstr "Неиспользованный выход"
-
-#: src/emc/usr_intf/pncconf/private_data.py:525
-#, fuzzy
-msgid "Spindle Output"
-msgstr "Шпиндель ON"
-
-#: src/emc/usr_intf/pncconf/private_data.py:529
-#, fuzzy
-msgid "Unused TPPWM Gen"
-msgstr "Неиспользованный ШИМ генератор"
-
-#: src/emc/usr_intf/pncconf/private_data.py:529
-msgid "X Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:530
-msgid "Y Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:530
-msgid "Z Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:531
-msgid "A Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:531
-msgid "S Axis BL Driver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
-msgid "8i20 Amplifier Card"
-msgstr "Включить усилитель"
-
-#: src/emc/usr_intf/pncconf/private_data.py:535
-msgid "7i64 I/O Card"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:535
-msgid "7i69 I/O Card"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:536
-msgid "7i70 I/O Card"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:536
-msgid "7i71 I/O Card"
-msgstr ""
+msgid "Unused 8I20"
+msgstr "Не подключен"
 
 #: src/emc/usr_intf/pncconf/private_data.py:537
-msgid "7i76 Mode 0 I/O Card"
-msgstr ""
+#, fuzzy
+msgid "Unused Resolver"
+msgstr "Неиспользованный енкодер"
 
 #: src/emc/usr_intf/pncconf/private_data.py:537
-msgid "7i76 Mode 2 I/O Card"
+msgid "X Resolver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:538
-msgid "7i77 Mode 0 I/O Card"
+msgid "Y Resolver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:538
-msgid "7i77 Mode 3 I/O Card"
+msgid "Z Resolver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:539
+msgid "A Resolver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:539
+msgid "S Resolver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:541
+#, fuzzy
+msgid "Unused Analog Output"
+msgstr "Неиспользованный выход"
+
+#: src/emc/usr_intf/pncconf/private_data.py:541
+#, fuzzy
+msgid "Spindle Output"
+msgstr "Шпиндель ON"
+
+#: src/emc/usr_intf/pncconf/private_data.py:545
+#, fuzzy
+msgid "Unused TPPWM Gen"
+msgstr "Неиспользованный ШИМ генератор"
+
+#: src/emc/usr_intf/pncconf/private_data.py:545
+msgid "X Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:546
+msgid "Y Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:546
+msgid "Z Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:547
+msgid "A Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:547
+msgid "S Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:550
+#, fuzzy
+msgid "8i20 Amplifier Card"
+msgstr "Включить усилитель"
+
+#: src/emc/usr_intf/pncconf/private_data.py:551
+msgid "7i64 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:551
+msgid "7i69 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:552
+msgid "7i70 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:552
+msgid "7i71 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:553
+msgid "7i76 Mode 0 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:553
+msgid "7i76 Mode 2 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:554
+msgid "7i77 Mode 0 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:554
+msgid "7i77 Mode 3 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Unused Analog In"
 msgstr "Неиспользованный выход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 #, fuzzy
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr "Неиспользованный выход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 #, fuzzy
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr "Неиспользованный выход"
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13388,17 +13897,17 @@ msgstr ""
 "Any existing file named custompanel_backup.xml and custom_postgui.hal will "
 "be lost. "
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 #, fuzzy
 msgid "Quit PNCconf and discard changes?"
 msgstr "Выйти из Stepconf и сбросить все изменения?"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 #, fuzzy
 msgid "Do you want to quit?"
 msgstr "Вы хотите:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13413,82 +13922,91 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr "градусы"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr "градусы/сек²"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 #, fuzzy
 msgid "revolutions"
 msgstr "Разрешение:"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 #, fuzzy
 msgid "revs / second²"
 msgstr "градусы/сек²"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr "мм/мин"
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr "мм/сек²"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13502,7 +14020,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "Моя_машина"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13512,18 +14030,18 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr "Desktop Launcher for EMC config made by Stepconf"
@@ -15199,9 +15717,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15359,6 +15877,13 @@ msgstr ""
 #, fuzzy
 msgid "Mux options"
 msgstr "Motion"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "секунды"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 #, fuzzy
@@ -15548,180 +16073,198 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr "Отступ позиции"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr "Обратная связь по позиции"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr "Максимальное изменение шпинделя"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr "Минимальное изменение шпинделя"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr "Изменить максимальную подачу:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr "Скорость по умолчанию"
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr "Минимальная скорость"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr "Максимальная скорость"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr "Максимальная скорость вращения:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr "Увеличить"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr "Максимальная скорость вращения:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr "градусы/мин"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr "Размер"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr "Позиция"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 #, fuzzy
 msgid "AXIS Defaults"
 msgstr "умолчания AXIS"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 #, fuzzy
 msgid "Absolute Textcolor"
 msgstr "Абсолютный"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "Относительная позиция"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 #, fuzzy
 msgid "Touchy Defaults"
 msgstr "Использовать умолчания"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Пример устнавок Pyvcp"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15820,132 +16363,146 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr "Добавить PyVCP GUI панель"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr ""
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Сбросить энкодер"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr "Максимальная скорость поиска начала"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr "Направление датчика начала"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr "Направление поиска начала:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr "Максимальная скорость на датчике начала"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr ""
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Открыть файл конфигурации"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr "Максимальная скорость поиска начала:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 #, fuzzy
 msgid "Home Search Sequence:"
 msgstr "Максимальная скорость поиска начала:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
+msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -16911,10 +17468,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr ""
@@ -17003,10 +17556,6 @@ msgstr "Множитель микрошага:"
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr "Шаги мотора на оборот:"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
-msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17478,7 +18027,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17643,32 +18191,24 @@ msgid "Manual Toolchange"
 msgstr "Ручная смена инструмента AXIS"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 #, fuzzy
 msgid "Restart Entry"
 msgstr "Рестарт"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr "Вверх"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr "Вниз"
 
@@ -17748,33 +18288,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, fuzzy, python-format
 msgid "%4.2f mm/min"
 msgstr "мм/мин"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17897,14 +18437,12 @@ msgid "<b>Status</b>"
 msgstr " <b>a)</b>"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17912,7 +18450,6 @@ msgid ""
 msgstr "Заменить на:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17920,7 +18457,6 @@ msgid ""
 msgstr "Заменить все"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17936,7 +18472,6 @@ msgid "Main Level"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17950,12 +18485,10 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17965,7 +18498,6 @@ msgid "Grid Size"
 msgstr "Размер"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 #, fuzzy
 msgid "Starting RPM"
 msgstr "Настройки"
@@ -18048,7 +18580,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "Калибровка"
@@ -18327,12 +18858,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "Откатить"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "Накатить"
 
@@ -18357,6 +18886,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18421,1674 +18952,752 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-#, fuzzy
-msgid "user mode selected"
-msgstr "Найти начало активной оси"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "Использован неизвестный G-код"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-#, fuzzy
-msgid "mm/min"
-msgstr "мм/мин"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "Режим сочленений"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "Параметры"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-#, fuzzy
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr "не могу делать это (%s) в авто режиме с остановленным интерпретатором"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-#, fuzzy
-msgid "No tool description available"
-msgstr "Детали не доступны."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-#, fuzzy
-msgid "Classicladder real-time component not detected"
-msgstr "Компонента реального времени не загружена"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-#, fuzzy
-msgid "Enter value for diameter"
-msgstr "Не целое число для целого аргумента"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-#, fuzzy
-msgid "Set diameter to:"
-msgstr "диаметр"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-#, fuzzy
-msgid "Enter value for radius"
-msgstr "Не целое число для целого аргумента"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr "радиус"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, fuzzy, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr "Не целое число для целого аргумента"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, fuzzy, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "Установить значение оси:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "Ручная смена инструмента AXIS"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-#, fuzzy
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-"Не могу изменять отступ инструмента при включенной компенсации радиуса "
-"инструмента"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "Выберите узел для показа"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "Режим координат"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-#, fuzzy
-msgid "no button here"
-msgstr "Двигать активную ось"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "Файл программы"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "Очистить плоттер"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "Вид в перспективе"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "Значение отступа"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "Инструменты"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "A Направление"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-#, fuzzy
-msgid "jog joints"
-msgstr "Сочленение:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "Игнорировать пределы"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "<b>Поиск начала</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Инфо инструмента"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-#, fuzzy
-msgid "Diameter"
-msgstr "Диаметр:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "Отступы"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "Отступы"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "Установки *"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Активные коды:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Активные коды:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "<b>Питание</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "<b>Охлаждение</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "<b>Шпиндель</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "Изменить обороты шпинделя:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Установить скорость подачи от 0% до 100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "Изменить подачу:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr "Заменить"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-#, fuzzy
-msgid "X Pos."
-msgstr "Поз"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-#, fuzzy
-msgid "Y Pos."
-msgstr "Поз"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "<b>Штурвал</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "Показать размеры"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "<b>Питание</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Вид"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "Показать размеры"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "Относительная позиция"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-#, fuzzy
-msgid "Absolute Color"
-msgstr "Абсолютный"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "Все в начало"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "Забыть начало всех осей"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-#, fuzzy
-msgid "Digits"
-msgstr "Цифровой вход 0"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr " <b>a)</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-#, fuzzy
-msgid "Grid size"
-msgstr "Размер"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "Показать"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "Показать размеры"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-#, fuzzy
-msgid "Show DTG"
-msgstr "Показать"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "<b>Охлаждение</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<b>Страница</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "Перечитать текущий файл·[Control-R]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "Выбрать скорость быстрого хода"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "Выберите узел для показа"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "Изменить обороты шпинделя:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "Показать скорость"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "Изменить подачу:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Изменить обороты шпинделя:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "Множитель энкодера:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-#, fuzzy
-msgid "Use unlock code"
-msgstr "Неиспользованный енкодер"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-#, fuzzy
-msgid "Do not use unlock code"
-msgstr "Не могу использовать С слово"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "<b>Поиск начала</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Включить тормоз шпинделя"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Шпиндель тормоз"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "<b>Поиск начала</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-#, fuzzy
-msgid "Probe Height"
-msgstr "Щуп вход"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-#, fuzzy
-msgid "Z Pos."
-msgstr "Поз"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-#, fuzzy
-msgid "Max. Probe"
-msgstr "Щуп"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "<b>Опции программы</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-#, fuzzy
-msgid "Search Vel."
-msgstr "Максимальная скорость поиска начала:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-#, fuzzy
-msgid "Probe Vel."
-msgstr "Щуп вход"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-#, fuzzy
-msgid "<b>Probe velocitys</b>"
-msgstr "Изменить максимальную подачу:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "<b>Охлаждение</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "Загрузить таблицу инструментов"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Загрузить таблицу инструментов"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "Исполнить с выделенной строки"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "<b>Поиск начала</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "Продвинутые настройки"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Включить станок"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "Программа последовательной modbus"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "Показать перезапуск"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "Режим координат"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Перезагрузить программу"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Перезагрузить программу"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Остановить запущенную программу или"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Остановить запущенную программу или"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Остановить запущенную программу или"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr "Редактировать лестницу"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-#, fuzzy
-msgid "delete MDI"
-msgstr "Удалить"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-#, fuzzy
-msgid "delete MDI history"
-msgstr "Очистить журнал MDI"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-#, fuzzy
-msgid "Open classicladder"
-msgstr "Добавить Classicladder PLC"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "HAL-скоп"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-#, fuzzy
-msgid "launch hal scope"
-msgstr "Запустить %s"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "Калибровка"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-#, fuzzy
-msgid "delete selected tool or tools"
-msgstr "Выбранный номер слота инструмента слишком большой"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "Перегрузить таблицу инструментов"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "Перегрузить"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "Перегрузить таблицу инструментов"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "Выбранный номер слота инструмента слишком большой"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
+#: lib/python/gladevcp/iconview.py:120
 #, fuzzy
-msgid "Move to parrent directory"
+msgid "Move to parent directory"
 msgstr "Каталог конфигураций:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "Выберите объект для показа"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Выберите объект для показа"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "Файл программы"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
 #, fuzzy
-msgid "home joints"
-msgstr "Сочленение:"
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr "Отступ всех координат"
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+#, fuzzy
+msgid "Toolfile does not exist"
+msgstr "Файл инструмента %s"
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "Перегрузить таблицу инструментов"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+#, fuzzy
+msgid "Tool file was modified since it was last read"
+msgstr "Файл %r был изменен после записи stepconf"
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Колёсико"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+#, fuzzy
+msgid "button"
+msgstr "Двигать активную ось"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "Включить охлаждение"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Инструмент:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Черный"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "XY вращение:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+#, fuzzy
+msgid "G92"
+msgstr "_G92"
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+#, fuzzy
+msgid "G59.1"
+msgstr "P7  G59._1"
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+#, fuzzy
+msgid "G59.2"
+msgstr "P8  G59._2"
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+#, fuzzy
+msgid "G59.3"
+msgstr "P9  G59._3"
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Отступ:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Значение отступа"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+#, fuzzy
+msgid ""
+"Zero\n"
+"G92"
+msgstr "Обнулить все G59.2"
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "Горизонтальный"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "Выбрать"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Номер инструмента:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+#, fuzzy
+msgid "Diameter"
+msgstr "Диаметр:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "Вид спереди"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "Ускорение:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "Команда:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "Перегрузить"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "Отступ оси"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "Диаметр:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "Рабочий отступ:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Инструмент:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Инструмент:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Установить отступ инструмента"
+
+#~ msgid "KHz"
+#~ msgstr "КГц"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "Найти начало активной оси"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "Использован неизвестный G-код"
+
+#, fuzzy
+#~ msgid "mm/min"
+#~ msgstr "мм/мин"
+
+#, fuzzy
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "Режим сочленений"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "Параметры"
+
+#, fuzzy
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr ""
+#~ "не могу делать это (%s) в авто режиме с остановленным интерпретатором"
+
+#, fuzzy
+#~ msgid "No tool description available"
+#~ msgstr "Детали не доступны."
+
+#, fuzzy
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "Компонента реального времени не загружена"
+
+#, fuzzy
+#~ msgid "Enter value for diameter"
+#~ msgstr "Не целое число для целого аргумента"
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr "диаметр"
+
+#, fuzzy
+#~ msgid "Enter value for radius"
+#~ msgstr "Не целое число для целого аргумента"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "радиус"
+
+#, fuzzy
+#~ msgid "Enter value for axis {0}"
+#~ msgstr "Не целое число для целого аргумента"
+
+#, fuzzy
+#~ msgid "Set axis {0} to:"
+#~ msgstr "Установить значение оси:"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "Ручная смена инструмента AXIS"
+
+#, fuzzy
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr ""
+#~ "Не могу изменять отступ инструмента при включенной компенсации радиуса "
+#~ "инструмента"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "Выберите узел для показа"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "Режим координат"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "Файл программы"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "Очистить плоттер"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "Вид в перспективе"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Инструменты"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "A Направление"
+
+#, fuzzy
+#~ msgid "jog joints"
+#~ msgstr "Сочленение:"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "Игнорировать пределы"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "<b>Поиск начала</b>"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Инфо инструмента"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "Отступы"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "Отступы"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "Установки *"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Активные коды:"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Активные коды:"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "<b>Питание</b>"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "<b>Охлаждение</b>"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "<b>Шпиндель</b>"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "Изменить обороты шпинделя:"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Установить скорость подачи от 0% до 100%"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "Изменить подачу:"
+
+#~ msgid "Replace"
+#~ msgstr "Заменить"
+
+#, fuzzy
+#~ msgid "X Pos."
+#~ msgstr "Поз"
+
+#, fuzzy
+#~ msgid "Y Pos."
+#~ msgstr "Поз"
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "<b>Штурвал</b>"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Показать размеры"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "<b>Питание</b>"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Вид"
+
+#, fuzzy
+#~ msgid "show offsets"
+#~ msgstr "Показать размеры"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Относительная позиция"
+
+#, fuzzy
+#~ msgid "Absolute Color"
+#~ msgstr "Абсолютный"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "Все в начало"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "Забыть начало всех осей"
+
+#, fuzzy
+#~ msgid "Digits"
+#~ msgstr "Цифровой вход 0"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr " <b>a)</b>"
+
+#, fuzzy
+#~ msgid "Grid size"
+#~ msgstr "Размер"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "Показать"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "Показать размеры"
+
+#, fuzzy
+#~ msgid "Show DTG"
+#~ msgstr "Показать"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "<b>Охлаждение</b>"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>Страница</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "Перечитать текущий файл·[Control-R]"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "Выбрать скорость быстрого хода"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "Выберите узел для показа"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Изменить обороты шпинделя:"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "Показать скорость"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Изменить подачу:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Изменить обороты шпинделя:"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "Множитель энкодера:"
+
+#, fuzzy
+#~ msgid "Use unlock code"
+#~ msgstr "Неиспользованный енкодер"
+
+#, fuzzy
+#~ msgid "Do not use unlock code"
+#~ msgstr "Не могу использовать С слово"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "<b>Поиск начала</b>"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Включить тормоз шпинделя"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Шпиндель тормоз"
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "<b>Поиск начала</b>"
+
+#, fuzzy
+#~ msgid "Probe Height"
+#~ msgstr "Щуп вход"
+
+#, fuzzy
+#~ msgid "Z Pos."
+#~ msgstr "Поз"
+
+#, fuzzy
+#~ msgid "Max. Probe"
+#~ msgstr "Щуп"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "<b>Опции программы</b>"
+
+#, fuzzy
+#~ msgid "Search Vel."
+#~ msgstr "Максимальная скорость поиска начала:"
+
+#, fuzzy
+#~ msgid "Probe Vel."
+#~ msgstr "Щуп вход"
+
+#, fuzzy
+#~ msgid "<b>Probe velocitys</b>"
+#~ msgstr "Изменить максимальную подачу:"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "<b>Охлаждение</b>"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Загрузить таблицу инструментов"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Загрузить таблицу инструментов"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "Исполнить с выделенной строки"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "<b>Поиск начала</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "Продвинутые настройки"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Включить станок"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "Программа последовательной modbus"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "Показать перезапуск"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "Режим координат"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Перезагрузить программу"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Перезагрузить программу"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Остановить запущенную программу или"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Остановить запущенную программу или"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Остановить запущенную программу или"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr "Редактировать лестницу"
+
+#, fuzzy
+#~ msgid "delete MDI"
+#~ msgstr "Удалить"
+
+#, fuzzy
+#~ msgid "delete MDI history"
+#~ msgstr "Очистить журнал MDI"
+
+#, fuzzy
+#~ msgid "Open classicladder"
+#~ msgstr "Добавить Classicladder PLC"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "HAL-скоп"
+
+#, fuzzy
+#~ msgid "launch hal scope"
+#~ msgstr "Запустить %s"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "Калибровка"
+
+#, fuzzy
+#~ msgid "delete selected tool or tools"
+#~ msgstr "Выбранный номер слота инструмента слишком большой"
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "Перегрузить таблицу инструментов"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "Выбранный номер слота инструмента слишком большой"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "Файл программы"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "Сочленение:"
 
 #, fuzzy
 #~ msgid "Substituting"
@@ -20183,9 +19792,6 @@ msgstr "Сочленение:"
 #~ msgid "Tool File"
 #~ msgstr "Файл инструмента"
 
-#~ msgid "Tool file is %s"
-#~ msgstr "Файл инструмента %s"
-
 #~ msgid "Active G Codes"
 #~ msgstr "Активные G-коды:"
 
@@ -20198,9 +19804,6 @@ msgstr "Сочленение:"
 
 #~ msgid "CONTINUE"
 #~ msgstr "Продолжить"
-
-#~ msgid "Tool #:"
-#~ msgstr "Номер инструмента:"
 
 #~ msgid "Length :"
 #~ msgstr "Длина:"
@@ -20365,9 +19968,6 @@ msgstr "Сочленение:"
 #~ msgid "Zero All G59.1"
 #~ msgstr "Обнулить все G59.1"
 
-#~ msgid "Zero All G59.2"
-#~ msgstr "Обнулить все G59.2"
-
 #~ msgid "Zero All G59.3"
 #~ msgstr "Обнулить все G59.3"
 
@@ -20454,9 +20054,6 @@ msgstr "Сочленение:"
 
 #~ msgid "Show Setup"
 #~ msgstr "Показать настройки"
-
-#~ msgid "Axis Offset"
-#~ msgstr "Отступ оси"
 
 #~ msgid "Home All Axes"
 #~ msgstr "Все оси в начало"

--- a/src/po/sk.po
+++ b/src/po/sk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sk\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2009-01-25 14:12+0100\n"
 "Last-Translator: Ševc Dominik <sevc2post.sk>\n"
 "Language-Team: Slovak <emc-developers@lists.sourceforge.net>\n"
@@ -14,66 +14,66 @@ msgstr ""
 "X-Poedit-Language: Slovak\n"
 "X-Poedit-Country: SLOVAKIA\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "Nie je možné otvoriť %s."
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr ""
 
@@ -183,424 +183,424 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -714,30 +714,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -853,102 +853,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, fuzzy, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "Načítať súbor parametra"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, fuzzy, c-format
 msgid "cant open ini file '%s'"
 msgstr "Nie je možné otvoriť %s."
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, fuzzy, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "Načítať súbor parametra"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 #, fuzzy
 msgid "Parameter file name is missing"
 msgstr "Súbor parametrov je %s"
@@ -1369,7 +1369,7 @@ msgid "Negative spindle speed used"
 msgstr "Nastaviť zmenu rýchlosti vretena:"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+msgid "Negative tool id (tool not found)"
 msgstr ""
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1753,24 +1753,23 @@ msgstr ""
 msgid "R less than V in cycle in UW plane"
 msgstr ""
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "HAL-Meter"
 
@@ -1783,105 +1782,127 @@ msgstr "Vybrať všetky"
 msgid "E_xit"
 msgstr ""
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 #, fuzzy
 msgid "Select Item to Probe"
 msgstr "Vyberte premennú pre zobrazenie."
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr ""
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 #, fuzzy
 msgid " _Signals "
 msgstr "Rozšíriť signály"
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 #, fuzzy
 msgid " Para_meters "
 msgstr "Súbor parametrov"
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 #, fuzzy
 msgid "_Close"
 msgstr "Ukončiť"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 msgstr ""
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 #, fuzzy
 msgid "Open Configuration File:"
 msgstr "Konfigurácia skopírovaná"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "ZrušiťAbbrechen"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "Otvoriť..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Konfigurácia skopírovaná"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "Uložiť"
+
+#: src/hal/utils/scope.c:525
 #, fuzzy
 msgid "_Open Configuration..."
 msgstr "Príklady konfigurácií"
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 #, fuzzy
 msgid "_Save Configuration..."
 msgstr "Príklady konfigurácií"
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 #, fuzzy
 msgid "S_ave Data File..."
 msgstr "Uložiť"
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 #, fuzzy
 msgid "_Quit"
 msgstr "Ukončiť"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 #, fuzzy
 msgid "_File"
 msgstr "Súbor"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 #, fuzzy
 msgid "_Help"
 msgstr "Pomoc"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr ""
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 #, fuzzy
 msgid "Selected Channel"
 msgstr "Vybrať všetky"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr ""
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr ""
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr ""
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1890,38 +1911,38 @@ msgstr ""
 msgid "Stop"
 msgstr "Krok"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr ""
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 #, fuzzy
 msgid "Single"
 msgstr "Jedna medzera"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1935,11 +1956,39 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "Ukončiť"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1952,106 +2001,82 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 #, fuzzy
 msgid "Record Length"
 msgstr "Dĺžka:"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "Ukončiť"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2065,56 +2090,64 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
 "record length that supports more channels."
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
 "per div"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
 "at %s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2130,91 +2163,72 @@ msgstr ""
 msgid "Hz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, fuzzy, c-format
 msgid ""
 "Offset\n"
 "%s"
 msgstr "Doplnky"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
 "----"
 msgstr "Doplnky"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:715
-#, fuzzy
-msgid "Set Offset"
-msgstr "Určiť doplnok nástroja"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
 "for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+#, fuzzy
+msgid "Set Offset"
+msgstr "Určiť doplnok nástroja"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "ZrušiťAbbrechen"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 #, fuzzy
 msgid "Too many channels"
 msgstr "Súbor nástrojov"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2222,169 +2236,159 @@ msgid ""
 "the record length to allow for more channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
 "as the source for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr ""
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 #, fuzzy
 msgid "Signals"
 msgstr "Rozšíriť signály"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 #, fuzzy
 msgid "Parameters"
 msgstr "Súbor parametrov"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
 "Chan %2d"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "Automatika"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr ""
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr ""
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr ""
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr ""
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr ""
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+msgid "Probe tripped during non-probe move."
 msgstr ""
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr ""
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr ""
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr ""
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr ""
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr ""
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr ""
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
@@ -2453,177 +2457,177 @@ msgstr ""
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr ""
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr ""
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr ""
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr ""
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr ""
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr ""
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr ""
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr ""
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr ""
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2712,26 +2716,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2902,7 +2906,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -2991,19 +2995,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "Áno"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr "Nie"
 
@@ -3055,7 +3059,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "Uložiť"
 
@@ -3074,7 +3078,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "Editor"
 
@@ -3089,7 +3093,6 @@ msgid "Config"
 msgstr "HAL nastavenie..."
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 #, fuzzy
 msgid "Preview"
 msgstr "Vetvený Pohľad"
@@ -3520,7 +3523,7 @@ msgid "Edit mode..."
 msgstr "Upraviť..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "Vymazať"
 
@@ -3529,7 +3532,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "Pridať"
 
@@ -3540,6 +3543,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "Zmeniť "
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "ZrušiťAbbrechen"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3727,7 +3748,7 @@ msgid "Parameter"
 msgstr "Súbor parametrov"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3916,7 +3937,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "Hlavné"
 
@@ -3999,11 +4019,13 @@ msgid "Delete section"
 msgstr "Relatívna pozícia"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 #, fuzzy
 msgid "Move Down"
 msgstr "Dole"
@@ -4526,6 +4548,7 @@ msgid "Exit"
 msgstr "Ukončiť"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "Upraviť"
 
@@ -4568,7 +4591,6 @@ msgid "Renumber File..."
 msgstr "Zmeniť číslo súboru..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "Nastavenia"
 
@@ -4860,15 +4882,15 @@ msgstr "Vetvený Pohľad"
 msgid "Test HAL command :"
 msgstr "Vyskúšať príkaz HAL :"
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "Tu môžete vyskúšať príkazy, ale NEBUDÚ uložené."
 
@@ -4999,12 +5021,12 @@ msgstr "SMER"
 msgid "SIZE :"
 msgstr "VEĽKOSŤ"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 #, fuzzy
 msgid "LinuxCNC Errors"
 msgstr "Chyby EMC2"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 #, fuzzy
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
@@ -5013,12 +5035,12 @@ msgstr ""
 "EMC2 ukončené kvôli chybe.  Pri nahlasovaní problému prosím zahrňte všetky "
 "informácie vo vašej správe."
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 #, fuzzy
 msgid "Create Report File"
 msgstr "Súbor parametrov"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "Ukončiť"
 
@@ -5102,7 +5124,7 @@ msgstr "Určiť doplnok nástroja"
 msgid "Tool:"
 msgstr "Nástroj:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Všetky súbory"
@@ -5170,18 +5192,18 @@ msgstr "Jednotky"
 msgid "auto"
 msgstr "auto"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "inch"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5339,7 +5361,7 @@ msgstr "spoj"
 msgid "world"
 msgstr "Global"
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "Domov"
 
@@ -5421,16 +5443,15 @@ msgstr "Overiť"
 msgid "Optional Stop"
 msgstr "Možnosť prerušenia"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "Vybrať font"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "Font"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "Veľkosť"
 
@@ -5540,7 +5561,7 @@ msgid "Coordinate System Control Window"
 msgstr "Okno Kontroly Systému Súradníc"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "Os"
 
@@ -6117,9 +6138,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 #, fuzzy
 msgid "Custom"
 msgstr "Vystrihnúť"
@@ -6140,8 +6161,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr ""
 
@@ -6217,150 +6238,150 @@ msgstr "Súbory"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 #, fuzzy
 msgid "problem with"
 msgstr "Nahradiť týmto:"
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 #, fuzzy
 msgid "default"
 msgstr "Použiť pôvodné"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 #, fuzzy
 msgid "Switches"
 msgstr "inch"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 msgid "no such file"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 #, fuzzy
 msgid "LinuxCNC"
 msgstr "EMC2 Debug"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "Chyby EMC2"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7045,230 +7066,228 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 #, fuzzy
 msgid "Filtering..."
 msgstr "Testujem..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
 "produced are shown below:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
 "%(error_str)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 #, fuzzy
 msgid "Continuous"
 msgstr "Priebežný"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 #, fuzzy
 msgid "T    Tool Table"
 msgstr "Načítať tabuľku nástrojov"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 #, fuzzy
 msgid "in"
 msgstr "Hlavné"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 #, fuzzy
 msgid " diameter"
 msgstr "Priemer:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 #, fuzzy
 msgid "Coordinate System:"
 msgstr "Okno Kontroly Systému Súradníc"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 #, fuzzy
 msgid "Name:"
 msgstr "INI-Názov"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 #, fuzzy
 msgid "Size:"
 msgstr "Veľkosť"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 #, fuzzy
 msgid "Tool order:"
 msgstr "Nástroj :"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 #, fuzzy
 msgid "Run time:"
 msgstr "Čas pohybu"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
 "%(lines)s gcode lines"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 #, fuzzy
 msgid "All machinable files"
 msgstr "Všetky súbory"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 msgid "File not Writable:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7279,59 +7298,59 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Custom Grid"
 msgstr "Vystrihnúť"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 msgid "Touch Off (system)"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, python-format
 msgid "Tool %s TouchOff"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7340,7 +7359,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7349,7 +7368,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7358,92 +7377,92 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "spoj"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 #, fuzzy
 msgid "Home All"
 msgstr "Uložiť všetky"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "Uložiť všetky"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "Uložiť všetky"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "spoj"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "Domov"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr ""
 
@@ -7771,12 +7790,13 @@ msgid "_Properties..."
 msgstr ""
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
-msgstr ""
+#, fuzzy
+msgid "Edit _tool data..."
+msgstr "Upraviť..."
 
 #: share/axis/tcl/axis.tcl:90
 #, fuzzy
-msgid "Reload tool ta_ble"
+msgid "Reload tool _data"
 msgstr "Načítať tabuľku nástrojov"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8132,11 +8152,11 @@ msgstr ""
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr ""
 
@@ -8327,9 +8347,10 @@ msgstr "Nastaviť zmenu vretena"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr ""
 
@@ -8374,7 +8395,7 @@ msgid "Position:"
 msgstr "Typ polohy"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 #, fuzzy
 msgid "Machine"
 msgstr "Stroj"
@@ -8488,22 +8509,21 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 #, fuzzy
 msgid "Spindle CW"
 msgstr "Vreteno vypni"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 #, fuzzy
 msgid "Spindle CCW"
@@ -8859,6 +8879,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8868,43 +8890,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8966,7 +9033,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 #, fuzzy
 msgid "<b>Spindle</b>"
 msgstr "Vreteno vypni"
@@ -9137,7 +9203,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 #, fuzzy
 msgid "Status"
 msgstr "Stav:"
@@ -9204,8 +9269,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9340,10 +9405,10 @@ msgid "Stepconf"
 msgstr "Krok"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9364,13 +9429,13 @@ msgid "Parallel Port 1"
 msgstr "Vytlačiť nastavenia"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 #, fuzzy
 msgid "Parallel Port 2"
 msgstr "Vytlačiť nastavenia"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "Pohyb"
@@ -9380,244 +9445,293 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+msgid "User Buttons"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Os"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Os"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Os"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Os"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Os"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Os"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "Spindle"
 msgstr "Vreteno vypni"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "X Step"
 msgstr "Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "Y Step"
 msgstr "Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "Z Step"
 msgstr "Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "A Step"
 msgstr "Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "Vytlačiť nastavenia"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "Krok"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "Vytlačiť nastavenia"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "Vreteno Pomalšie"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "Vytlačiť nastavenia"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "Vreteno Pomalšie"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Vytlačiť nastavenia"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 #, fuzzy
 msgid "Spindle ON"
 msgstr "Vreteno vypni"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 #, fuzzy
 msgid "Spindle PWM"
 msgstr "Vreteno vypni"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Brake"
 msgstr "Vreteno rýchlejšie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "ESTOP Out"
 msgstr "NÚDZOVÉ PRERUŠENIE"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9629,263 +9743,350 @@ msgstr ""
 msgid "Unused"
 msgstr "Späť"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 #, fuzzy
 msgid "ESTOP In"
 msgstr "NÚDZOVÉ PRERUŠENIE"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Index"
 msgstr "Vreteno rýchlejšie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase A"
 msgstr "Vreteno rýchlejšie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase B"
 msgstr "Vreteno rýchlejšie"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home X"
 msgstr "Domov"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Y"
 msgstr "Domov"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Z"
 msgstr "Domov"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home A"
 msgstr "Domov"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "Domov"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "Domov"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Domov"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Domov"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
-msgid "Maximum Limit + Home Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:236
-msgid "Maximum Limit + Home A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-msgid "Maximum Limit + Home U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:237
-msgid "Maximum Limit + Home V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:238
-msgid "Both Limit + Home X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:238
-msgid "Both Limit + Home Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:239
-msgid "Both Limit + Home Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:239
-msgid "Both Limit + Home A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:240
-msgid "Both Limit + Home U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:240
-msgid "Both Limit + Home V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit A"
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem X"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit V"
+msgid "Maximum Limit + Home Tandem Y"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:250
+msgid "Maximum Limit + Home Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
+msgid "Maximum Limit + Home A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:251
+msgid "Maximum Limit + Home U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:251
+msgid "Maximum Limit + Home V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:252
+msgid "Both Limit + Home X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:252
+msgid "Both Limit + Home Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:253
+msgid "Both Limit + Home Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:253
+msgid "Both Limit + Home A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:254
+msgid "Both Limit + Home U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:254
+msgid "Both Limit + Home V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Všetky súbory"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Všetky súbory"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Všetky súbory"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Všetky súbory"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits"
 msgstr "Všetky súbory"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits + homes"
 msgstr "Všetky súbory"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "Dole"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Vreteno Dopredu"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9894,40 +10095,40 @@ msgid ""
 "Are you sure?  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
 "Any existing file named custompanel_backup.xml will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9938,43 +10139,43 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 #, fuzzy
 msgid "Continue? "
 msgstr "Priebežný"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9982,34 +10183,34 @@ msgid ""
 "{}"
 msgstr "EMC2 Pomocník nastavenia"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, fuzzy, python-format
 msgid "%s Axis Test"
 msgstr "Doplnok osi"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -10024,8 +10225,8 @@ msgstr ""
 msgid "mm / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -10040,13 +10241,13 @@ msgstr ""
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr ""
 
@@ -10056,20 +10257,20 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "EMC2 Pomocník nastavenia"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 #, fuzzy
 msgid "Modify Existing Configuration"
 msgstr "Moje konfigurácie"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10081,7 +10282,7 @@ msgstr ""
 msgid "mm / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10092,28 +10293,28 @@ msgstr ""
 msgid "Steps / mm"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10121,99 +10322,104 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+msgid "# Include your custom HAL commands here"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
@@ -10286,11 +10492,16 @@ msgstr "Príklady konfigurácií"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "Späť"
 
@@ -10330,17 +10541,6 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:209
@@ -10698,55 +10898,151 @@ msgstr "Nastaviť zmenu rýchlosti vretena:"
 msgid "Scale %"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+#, fuzzy
+msgid "Axis"
+msgstr "Os"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Nástrojový doplnok:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Nástrojový doplnok:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Núdzové prerušenie zapnuté"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+msgid "Button"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "Príkaz:"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 #, fuzzy
 msgid "Blank program"
 msgstr "Program"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 #, fuzzy
 msgid "Spindle speed display  "
 msgstr "Zmena rýchlosti vretena:"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10755,78 +11051,82 @@ msgid ""
 "panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
 "program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "Príklady konfigurácií"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr ""
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10844,16 +11144,156 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+#, fuzzy
+msgid "NUM"
+msgstr "NML"
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+#, fuzzy
+msgid "IDX"
+msgstr "RÝCHLY"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "Príkaz:"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10863,10 +11303,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr "Typ polohy"
@@ -10894,15 +11334,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisv.glade:249
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
@@ -11103,40 +11534,40 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 #, fuzzy
 msgid "Specific Help page is unavailable\n"
 msgstr "Nie sú dostupné žiadne detaily."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 #, fuzzy
 msgid "Help Pages"
 msgstr "Testovať"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11144,23 +11575,23 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 #, fuzzy
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "EMC2 Pomocník nastavenia"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11170,34 +11601,34 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 #, fuzzy
 msgid "Discovery is  unavailable\n"
 msgstr "Nie sú dostupné žiadne detaily."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 #, fuzzy
 msgid "USB device  page is unavailable\n"
 msgstr "Nie sú dostupné žiadne detaily."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11206,180 +11637,180 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 #, fuzzy
 msgid "Unused Channel"
 msgstr "Späť"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 #, fuzzy
 msgid " / min"
 msgstr "inch"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "Krok"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "Krok"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "Jedna medzera"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Príklady konfigurácií"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11397,53 +11828,56 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr "inch"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11453,8 +11887,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr ""
@@ -11470,169 +11904,174 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
-#, python-format
-msgid "Generated by PNCconf at %s"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
-msgid "configures LinuxCNC as:\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
-msgid "type CNC\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
-msgid "will be used as the frontend display"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
-msgid " connector"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
-msgid "invrt"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
-#, python-format
-msgid "%(name)s Parport"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
-msgid "-> inverted"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
+msgid "Generated by PNCconf at %s"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
+msgid "configures LinuxCNC as:\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
+msgid "type CNC\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
+msgid "will be used as the frontend display"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
+msgid " connector"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
+msgid "invrt"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
+#, python-format
+msgid "%(name)s Parport"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
+msgid "-> inverted"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
+#, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11648,1587 +12087,1639 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 #, fuzzy
 msgid "External Controls"
 msgstr "Manuál"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 #, fuzzy
 msgid "Parallel Port"
 msgstr "Vytlačiť nastavenia"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 msgid "X Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "X Axis"
 msgstr "Os"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 msgid "Y Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Y Axis"
 msgstr "Os"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 msgid "Z Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Z Axis"
 msgstr "Os"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 msgid "A Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "A Axis"
 msgstr "Os"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Vreteno vypni"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Dir"
-msgstr "Vytlačiť nastavenia"
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Input"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO O Drain"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
+msgid "POT Dir"
+msgstr "Vytlačiť nastavenia"
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Input"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Output"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO O Drain"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:117
+#, fuzzy
 msgid "SSR Output"
 msgstr "Vreteno vypni"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "muxed Enc I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 #, fuzzy
 msgid "Step Gen-A"
 msgstr "Jedna medzera"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 #, fuzzy
 msgid "UDM-Down"
 msgstr "Dole"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "Manuál"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "X Home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Y Home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Z Home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "A Home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "All Home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "A2 Tandem Home"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Všetky súbory"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 #, fuzzy
 msgid "A2 Both Limit + Home"
 msgstr "Všetky súbory"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "Začať posun:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "Začať posun:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "Začať posun:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "Začať posun:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Spindle Override incr A"
 msgstr "Nastaviť zmenu vretena"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr B"
 msgstr "Nastaviť zmenu vretena"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr C"
 msgstr "Nastaviť zmenu vretena"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr D"
 msgstr "Nastaviť zmenu vretena"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "Začať posun:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "Nastaviť zmenu vretena"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "Začať posun:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CW"
 msgstr "Vreteno vypni"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CCW"
 msgstr "Vreteno vypni"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle Stop"
 msgstr "Vreteno Pomalšie"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Spindle Up-To-Speed"
 msgstr "Zmena rýchlosti vretena:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "Vybrať všetky"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "Jedna medzera"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 #, fuzzy
 msgid "Jog X +"
 msgstr "X +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 #, fuzzy
 msgid "Jog X -"
 msgstr "X -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 1"
 msgstr "Uložiť HAL Ini"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 2"
 msgstr "Uložiť HAL Ini"
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 #, fuzzy
 msgid "S HALL 3"
 msgstr "Uložiť HAL Ini"
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 #, fuzzy
 msgid "All Limits"
 msgstr "Všetky súbory"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "A2 Both Limit"
 msgstr "Všetky súbory"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "Os"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "Domov"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "inch"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Limits"
 msgstr "Všetky súbory"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 #, fuzzy
 msgid "Axis Selection"
 msgstr "Nastavenie HAL"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "Zmeniť limity"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "Operation"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "External Control"
 msgstr "Manuál"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "Os"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Custom Signals"
 msgstr "Vystrihnúť"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
-msgid "A2 Tandem PWM"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "X Axis PWM"
-msgstr "Os"
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "Y Axis PWM"
-msgstr "Os"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "Z Axis PWM"
-msgstr "Os"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "A Axis PWM"
-msgstr "Os"
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-msgid "Unused PWM Gen"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-#, fuzzy
-msgid "Axis PWM"
-msgstr "Os"
-
-#: src/emc/usr_intf/pncconf/private_data.py:467
-#, fuzzy
-msgid "X Axis StepGen"
-msgstr "Os"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Y Axis StepGen"
-msgstr "Os"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Z Axis StepGen"
-msgstr "Os"
-
-#: src/emc/usr_intf/pncconf/private_data.py:469
-#, fuzzy
-msgid "A Axis StepGen"
-msgstr "Os"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "X2 Tandem StepGen"
-msgstr "Vreteno Pomalšie"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "Y2 Tandem StepGen"
-msgstr "Vreteno Pomalšie"
-
-#: src/emc/usr_intf/pncconf/private_data.py:471
-#, fuzzy
-msgid "Z2 Tandem StepGen"
-msgstr "Vreteno Pomalšie"
-
 #: src/emc/usr_intf/pncconf/private_data.py:473
-msgid "Unused StepGen"
+msgid "A2 Tandem PWM"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
-msgid "Axis"
+msgid "X Axis PWM"
+msgstr "Os"
+
+#: src/emc/usr_intf/pncconf/private_data.py:474
+#, fuzzy
+msgid "Y Axis PWM"
 msgstr "Os"
 
 #: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "Z Axis PWM"
+msgstr "Os"
+
+#: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "A Axis PWM"
+msgstr "Os"
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+msgid "Unused PWM Gen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+#, fuzzy
+msgid "Axis PWM"
+msgstr "Os"
+
+#: src/emc/usr_intf/pncconf/private_data.py:481
+#, fuzzy
+msgid "X Axis StepGen"
+msgstr "Os"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Y Axis StepGen"
+msgstr "Os"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Z Axis StepGen"
+msgstr "Os"
+
+#: src/emc/usr_intf/pncconf/private_data.py:483
+#, fuzzy
+msgid "A Axis StepGen"
+msgstr "Os"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "X2 Tandem StepGen"
+msgstr "Vreteno Pomalšie"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "Y2 Tandem StepGen"
+msgstr "Vreteno Pomalšie"
+
+#: src/emc/usr_intf/pncconf/private_data.py:485
+#, fuzzy
+msgid "Z2 Tandem StepGen"
+msgstr "Vreteno Pomalšie"
+
+#: src/emc/usr_intf/pncconf/private_data.py:487
+msgid "Unused StepGen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Spindle StepGen"
 msgstr "Vreteno Pomalšie"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "Vreteno dozadu"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "Vreteno dozadu"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "Vreteno dozadu"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "Vreteno dozadu"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Feed Override"
 msgstr "Začať posun:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "spindle Override"
 msgstr "Nastaviť zmenu vretena"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "Začať posun:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Spindle Encoder"
 msgstr "Vreteno dozadu"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Vreteno dozadu"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 #, fuzzy
 msgid "Unused Unused"
 msgstr "Späť"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Vreteno Pomalšie"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "Stroj zapnutý"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Vreteno Pomalšie"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Stroj zapnutý"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Coolant"
 msgstr "Príkaz:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Unused 8I20"
 msgstr "Späť"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 #, fuzzy
 msgid "Spindle Output"
 msgstr "Vreteno vypni"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Unused Analog In"
 msgstr "Späť"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13237,15 +13728,15 @@ msgid ""
 "be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 msgid "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13260,81 +13751,90 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 #, fuzzy
 msgid "inches / second²"
 msgstr "inch"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13348,7 +13848,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "Stroj"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13358,18 +13858,18 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
 
@@ -15040,9 +15540,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15200,6 +15700,13 @@ msgstr ""
 #, fuzzy
 msgid "Mux options"
 msgstr "Pohyb"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 #, fuzzy
@@ -15388,187 +15895,205 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 #, fuzzy
 msgid "Position_offset"
 msgstr "Typ polohy"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 #, fuzzy
 msgid "Position_feedback"
 msgstr "Typ polohy"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 #, fuzzy
 msgid "Max Spindle Override "
 msgstr "Nastaviť zmenu vretena"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 #, fuzzy
 msgid "Min Spindle Override"
 msgstr "Nastaviť zmenu vretena"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 #, fuzzy
 msgid "Max Feed Override"
 msgstr "Začať posun:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 #, fuzzy
 msgid "Increments "
 msgstr "Pričítať"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 #, fuzzy
 msgid "Deg / min"
 msgstr "inch"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 #, fuzzy
 msgid "Position"
 msgstr "Typ polohy"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 #, fuzzy
 msgid "AXIS Defaults"
 msgstr "Použiť pôvodné"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "Relatívna pozícia"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 #, fuzzy
 msgid "Touchy Defaults"
 msgstr "Použiť pôvodné"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Príklady konfigurácií"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15661,130 +16186,144 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr ""
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Vreteno dozadu"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr ""
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Konfigurácia skopírovaná"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 msgid "Home Search Sequence:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
@@ -16733,10 +17272,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr ""
@@ -16823,10 +17358,6 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:1409
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
@@ -17286,7 +17817,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17447,32 +17977,24 @@ msgid "Manual Toolchange"
 msgstr "Súbor nástrojov"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 #, fuzzy
 msgid "Restart Entry"
 msgstr "Reštartovať"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr "Hore"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr "Dole"
 
@@ -17552,33 +18074,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17698,14 +18220,12 @@ msgid "<b>Status</b>"
 msgstr "Príkaz:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17713,7 +18233,6 @@ msgid ""
 msgstr "Nahradiť týmto:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17721,7 +18240,6 @@ msgid ""
 msgstr "Nahradiť všetky"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17737,7 +18255,6 @@ msgid "Main Level"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17751,12 +18268,10 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17766,7 +18281,6 @@ msgid "Grid Size"
 msgstr "Veľkosť"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 #, fuzzy
 msgid "Starting RPM"
 msgstr "Nastavenia"
@@ -17848,7 +18362,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "Kalibrácia..."
@@ -18117,12 +18630,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "Späť"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "Obnoviť"
 
@@ -18147,6 +18658,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18211,1631 +18724,560 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-msgid "user mode selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, python-brace-format
-msgid "unknown jog command {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-msgid ""
-" Joint\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "Načítať súbor parametra"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-#, fuzzy
-msgid "No tool description available"
-msgstr "Nie sú dostupné žiadne detaily."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-msgid "Classicladder real-time component not detected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-msgid "Enter value for diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-#, fuzzy
-msgid "Set diameter to:"
-msgstr "Priemer:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-msgid "Enter value for radius"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr "Hodnota osi:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, fuzzy, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "Hodnota osi:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "Súbor nástrojov"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "Vyberte premennú pre zobrazenie."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-msgid ""
-"World\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-msgid "no button here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "Súbor programu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-msgid "clear plot"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-msgid "view perspective"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "Offset hodnota"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "Nástroje"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "Nastavenie HAL"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-#, fuzzy
-msgid "jog joints"
-msgstr "spoj"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "Zmeniť limity"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "Nastavenie HAL"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Informácie o nástroji"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-#, fuzzy
-msgid "Diameter"
-msgstr "Priemer:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "Doplnky"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "Doplnky"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "Nastavenie HAL"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Aktívne G Kódy"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Aktívne G Kódy"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "Vreteno vypni"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "Príkaz:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "Vreteno vypni"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "Nastaviť zmenu vretena"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Nastav prechod posunu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "Nastav prechod posunu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr "Nahradiť"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-msgid "X Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-msgid "Y Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "Vreteno vypni"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "Ukázať Reštart"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "Príkaz:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Vetvený Pohľad"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "Ukázať Reštart"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "Relatívna pozícia"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-msgid "Absolute Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "Uložiť všetky"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "Uložiť všetky"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-msgid "<b>DRO</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-msgid "Grid size"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "Ukázať"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "Ukázať Reštart"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-#, fuzzy
-msgid "Show DTG"
-msgstr "Ukázať"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-msgid "<b>Mouse Button mode</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "Vetvený Pohľad"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-msgid ""
-"current\n"
-"   file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "Nastaviť rýchlosť krokov:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "Vyberte premennú pre zobrazenie."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "Nastaviť zmenu vretena"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-msgid "Scale jog velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "Nastav prechod posunu:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Nastaviť zmenu vretena"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-msgid "<b>Hardware MPG Scale</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-msgid "Use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-msgid "<b>Unlock settings</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Vreteno rýchlejšie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Vreteno rýchlejšie"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-msgid "<b>Turtle Jog</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-msgid "Z Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "Nastavenie HAL"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-msgid "Search Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "Príkaz:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "Načítať tabuľku nástrojov"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Načítať tabuľku nástrojov"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-msgid "Use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "Nastavenie HAL"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "Príklady konfigurácií"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Stroj zapnutý"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-msgid "enter auto mode to run programs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "Ukázať Reštart"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-msgid ""
-"World\n"
-"Mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-msgid "Edit the loaded program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-#, fuzzy
-msgid "delete MDI"
-msgstr "Vymazať"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-msgid "delete MDI history"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "HAL-Dosah"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "Kalibrácia..."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "Načítať tabuľku nástrojov"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-msgid "Reload"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "Načítať tabuľku nástrojov"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "Vyberte premennú pre zobrazenie."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
+#: lib/python/gladevcp/iconview.py:120
 #, fuzzy
-msgid "Move to parrent directory"
+msgid "Move to parent directory"
 msgstr "EMC2 Pomocník nastavenia"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "Vyberte premennú pre zobrazenie."
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Vyberte premennú pre zobrazenie."
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "Súbor programu"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
 #, fuzzy
-msgid "home joints"
-msgstr "spoj"
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr "Okno Kontroly Systému Súradníc"
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+#, fuzzy
+msgid "Toolfile does not exist"
+msgstr "Súbor nástrojov je %s"
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "Načítať tabuľku nástrojov"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+msgid "Tool file was modified since it was last read"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+msgid "checkbutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+msgid "button"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+msgid "togglebutton"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Nástroj:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Späť"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+msgid "Rotation of Z"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Nástrojový doplnok:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Offset hodnota"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+#, fuzzy
+msgid ""
+"Zero\n"
+"G92"
+msgstr "Nula pre všetky G59.2"
+
+#: lib/python/gladevcp/offsetpage.glade:456
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "Vybrať všetky"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Nástroj :"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+#, fuzzy
+msgid "Diameter"
+msgstr "Priemer:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "Neuložiť"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+msgid "Orientation"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "Príkaz:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+msgid "Reload"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "Doplnok osi"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "Priemer:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "Pracovný doplnok:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Nástroj:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Nástroj:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Určiť doplnok nástroja"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "Načítať súbor parametra"
+
+#, fuzzy
+#~ msgid "No tool description available"
+#~ msgstr "Nie sú dostupné žiadne detaily."
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr "Priemer:"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "Hodnota osi:"
+
+#, fuzzy
+#~ msgid "Set axis {0} to:"
+#~ msgstr "Hodnota osi:"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "Súbor nástrojov"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "Vyberte premennú pre zobrazenie."
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "Súbor programu"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Nástroje"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "Nastavenie HAL"
+
+#, fuzzy
+#~ msgid "jog joints"
+#~ msgstr "spoj"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "Zmeniť limity"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "Nastavenie HAL"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Informácie o nástroji"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "Doplnky"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "Doplnky"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "Nastavenie HAL"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Aktívne G Kódy"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Aktívne G Kódy"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "Vreteno vypni"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "Príkaz:"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "Vreteno vypni"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "Nastaviť zmenu vretena"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Nastav prechod posunu"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "Nastav prechod posunu"
+
+#~ msgid "Replace"
+#~ msgstr "Nahradiť"
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "Vreteno vypni"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Ukázať Reštart"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "Príkaz:"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Vetvený Pohľad"
+
+#, fuzzy
+#~ msgid "show offsets"
+#~ msgstr "Ukázať Reštart"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Relatívna pozícia"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "Uložiť všetky"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "Uložiť všetky"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "Ukázať"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "Ukázať Reštart"
+
+#, fuzzy
+#~ msgid "Show DTG"
+#~ msgstr "Ukázať"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "Vetvený Pohľad"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "Nastaviť rýchlosť krokov:"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "Vyberte premennú pre zobrazenie."
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Nastaviť zmenu vretena"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Nastav prechod posunu:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Nastaviť zmenu vretena"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Vreteno rýchlejšie"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Vreteno rýchlejšie"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "Nastavenie HAL"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "Príkaz:"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Načítať tabuľku nástrojov"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Načítať tabuľku nástrojov"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "Nastavenie HAL"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "Príklady konfigurácií"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Stroj zapnutý"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "Ukázať Reštart"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Program"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Program"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Program"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Program"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Program"
+
+#, fuzzy
+#~ msgid "delete MDI"
+#~ msgstr "Vymazať"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "HAL-Dosah"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "Kalibrácia..."
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "Načítať tabuľku nástrojov"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "Vyberte premennú pre zobrazenie."
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "Súbor programu"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "spoj"
 
 #, fuzzy
 #~ msgid "Substituting"
@@ -19920,9 +19362,6 @@ msgstr "spoj"
 #~ msgid "Tool File"
 #~ msgstr "Súbor nástrojov"
 
-#~ msgid "Tool file is %s"
-#~ msgstr "Súbor nástrojov je %s"
-
 #~ msgid "Active G Codes"
 #~ msgstr "Aktívne G Kódy"
 
@@ -19935,9 +19374,6 @@ msgstr "spoj"
 
 #~ msgid "CONTINUE"
 #~ msgstr "POKRAČOVAŤ"
-
-#~ msgid "Tool #:"
-#~ msgstr "Nástroj :"
 
 #~ msgid "Length :"
 #~ msgstr "Dĺžka:"
@@ -20109,9 +19545,6 @@ msgstr "spoj"
 #~ msgid "Zero All G59.1"
 #~ msgstr "Nula pre všetky G59.1"
 
-#~ msgid "Zero All G59.2"
-#~ msgstr "Nula pre všetky G59.2"
-
 #~ msgid "Zero All G59.3"
 #~ msgstr "Nula pre všetky G59.3"
 
@@ -20207,9 +19640,6 @@ msgstr "spoj"
 
 #~ msgid "Show Setup"
 #~ msgstr "Ukázať nastavenia."
-
-#~ msgid "Axis Offset"
-#~ msgstr "Doplnok osi"
 
 #, fuzzy
 #~ msgid "%s Axis Configuration"

--- a/src/po/sr.po
+++ b/src/po/sr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AXIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2008-04-27 13:20+0200\n"
 "Last-Translator: Bojin Marinkovic <ir.micro.business@gmail.com>\n"
 "Language-Team: Serbian Translation <emc-developers@lists.sourceforge.net>\n"
@@ -17,66 +17,66 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr ""
 
@@ -186,424 +186,424 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -717,30 +717,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -855,103 +855,103 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, c-format
 msgid "cant open ini file '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 #, fuzzy
 msgid "Queue is not empty after tool change"
 msgstr "_Prikazi upit za promenu alata"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 msgid "Parameter file name is missing"
 msgstr ""
 
@@ -1373,7 +1373,7 @@ msgid "Negative spindle speed used"
 msgstr "Prekoracenje brzine obr.motora:"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+msgid "Negative tool id (tool not found)"
 msgstr ""
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1760,24 +1760,23 @@ msgstr ""
 msgid "R less than V in cycle in UW plane"
 msgstr ""
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 #, fuzzy
 msgid "Hal Meter"
 msgstr "H_AL-Metar..."
@@ -1790,99 +1789,121 @@ msgstr ""
 msgid "E_xit"
 msgstr ""
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr ""
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr ""
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr ""
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr ""
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr ""
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 msgstr ""
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 #, fuzzy
 msgid "Open Configuration File:"
 msgstr "Verzeichnis:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "Odustani"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "_Otvori..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "Verzeichnis:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "_Snimi G-kod kao..."
+
+#: src/hal/utils/scope.c:525
 #, fuzzy
 msgid "_Open Configuration..."
 msgstr "Konfiguration der Spindel"
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 #, fuzzy
 msgid "_Save Configuration..."
 msgstr "Konfiguration der Spindel"
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 #, fuzzy
 msgid "_Quit"
 msgstr "_Odustani"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 #, fuzzy
 msgid "_File"
 msgstr "_Datoteka"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 #, fuzzy
 msgid "_Help"
 msgstr "_Pomoc"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr ""
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr ""
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr ""
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr ""
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr ""
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1891,39 +1912,39 @@ msgstr ""
 msgid "Stop"
 msgstr "_Korak po korak"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr ""
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 #, fuzzy
 msgid "Single"
 msgstr "Duzina _koraka:"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 #, fuzzy
 msgid "Zoom"
 msgstr "Uvecaj"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1937,11 +1958,40 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+#, fuzzy
+msgid "Quit"
+msgstr "_Odustani"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1954,107 +2004,82 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "OK"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 #, fuzzy
 msgid "Sample Period:"
 msgstr "Min Base Period:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "OK"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-#, fuzzy
-msgid "Quit"
-msgstr "_Odustani"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2068,57 +2093,64 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
 "record length that supports more channels."
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
 "per div"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
 "at %s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-#, fuzzy
-msgid "Sec"
-msgstr "Skundarni"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
+msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2134,91 +2166,72 @@ msgstr "Skundarni"
 msgid "Hz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, fuzzy, c-format
 msgid ""
 "Offset\n"
 "%s"
 msgstr "Test %s-ose"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
 "----"
 msgstr "Test %s-ose"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:715
-#, fuzzy
-msgid "Set Offset"
-msgstr "Test %s-ose"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
 "for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+#, fuzzy
+msgid "Set Offset"
+msgstr "Test %s-ose"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Odustani"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 #, fuzzy
 msgid "Too many channels"
 msgstr "Promena alata"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2226,167 +2239,157 @@ msgid ""
 "the record length to allow for more channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
 "as the source for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr ""
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
 "Chan %2d"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr ""
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr ""
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr ""
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr ""
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr ""
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+msgid "Probe tripped during non-probe move."
 msgstr ""
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr ""
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr ""
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr ""
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr ""
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr ""
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr ""
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
@@ -2455,177 +2458,177 @@ msgstr ""
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr ""
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr ""
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr ""
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr ""
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr ""
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr ""
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr ""
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr ""
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr ""
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2714,26 +2717,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2903,7 +2906,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -2992,19 +2995,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "Da"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 #, fuzzy
 msgid "No"
 msgstr "bez"
@@ -3057,7 +3060,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr ""
 
@@ -3077,7 +3080,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr ""
 
@@ -3091,7 +3094,6 @@ msgid "Config"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 #, fuzzy
 msgid "Preview"
 msgstr "Bocni pogled"
@@ -3525,7 +3527,7 @@ msgid "Edit mode..."
 msgstr "_Uredi..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr ""
 
@@ -3534,7 +3536,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr ""
 
@@ -3545,6 +3547,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr ""
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Odustani"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3732,7 +3752,7 @@ msgid "Parameter"
 msgstr ""
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3921,7 +3941,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 #, fuzzy
 msgid "Main"
 msgstr "apsolutna"
@@ -4004,11 +4023,13 @@ msgid "Delete section"
 msgstr "Rela_tivna pozicija"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 #, fuzzy
 msgid "Move Down"
 msgstr "Gore, Dole"
@@ -4534,6 +4555,7 @@ msgid "Exit"
 msgstr ""
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 #, fuzzy
 msgid "Edit"
 msgstr "_Uredi..."
@@ -4580,7 +4602,6 @@ msgid "Renumber File..."
 msgstr ""
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr ""
 
@@ -4862,15 +4883,15 @@ msgstr ""
 msgid "Test HAL command :"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr ""
 
@@ -4992,21 +5013,21 @@ msgstr ""
 msgid "SIZE :"
 msgstr ""
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr ""
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr ""
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 msgid "Create Report File"
 msgstr ""
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr ""
 
@@ -5084,7 +5105,7 @@ msgstr ""
 msgid "Tool:"
 msgstr "Redosled alata:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "Sve datoteke"
@@ -5159,18 +5180,18 @@ msgstr "Jedinice"
 msgid "auto"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5347,7 +5368,7 @@ msgstr ""
 msgid "world"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 #, fuzzy
 msgid "home"
 msgstr "Home"
@@ -5441,16 +5462,15 @@ msgstr ""
 msgid "Optional Stop"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 #, fuzzy
 msgid "Size"
 msgstr "Velicina:"
@@ -5563,7 +5583,7 @@ msgid "Coordinate System Control Window"
 msgstr "Koordinatni sistem:"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 #, fuzzy
 msgid "Axis "
 msgstr "Ose:"
@@ -6132,9 +6152,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr ""
 
@@ -6154,8 +6174,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr ""
 
@@ -6232,150 +6252,150 @@ msgstr "AXIS (nema datoteke)"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 #, fuzzy
 msgid "problem with"
 msgstr "_korak navojnog vretena:"
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 #, fuzzy
 msgid "fontname"
 msgstr "Naziv:"
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 #, fuzzy
 msgid "Unicode"
 msgstr "END"
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 #, fuzzy
 msgid "no such file"
 msgstr "AXIS (nema datoteke)"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 msgid "LinuxCNC"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "EMC2 konfiguracija masine"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7048,34 +7068,34 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Nepoznat alat%d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Nema alata"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, fuzzy, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Alat%d, ofser %g, precnik %g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, fuzzy, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "Alat %d, Zo %g, Xo %g, precnik %g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "Filtriranje..."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "Filtriranje neuspesno"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, fuzzy, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
@@ -7083,12 +7103,12 @@ msgid ""
 msgstr ""
 "Program %r obustavljen sa kodom %d. Poruke o gresci prikazane su ispod:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "G-kode greska in %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, fuzzy, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7097,130 +7117,128 @@ msgstr ""
 "Najbliza linija %d u %s:\n"
 "%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "Neprekidan"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "in"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "Koordinatni sistem:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "Naziv:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "Velicina:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "Redosled alata:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "Duzina praznog hoda:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "Radna duzina:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "Ukupna duzina:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "Vreme:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "X-granice:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Y-granice:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Z-granice:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "A-granice:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "B-granice:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "C-granice:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "Program prevazilazi minimum masine po osi %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "Program prevazilazi maksimum masine po osi %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "Program prevazilazi granicne vrednosti masine"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Izvrsi bezuslovno"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "Datoteka nije ucitana"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "generisao %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, fuzzy, python-format
 msgid ""
 "%(size)s bytes\n"
@@ -7229,43 +7247,43 @@ msgstr ""
 "%s bajta\n"
 "%s linija G-koda"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr "%.1f min"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr "%d s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, fuzzy, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%f do %f = %f %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "G-kod osobine"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "Sve izvrsne datoteke"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "NC datoteke"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 msgid "File not Writable:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7276,59 +7294,59 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Custom Grid"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 #, fuzzy
 msgid "Touch Off (system)"
 msgstr "Iskljuceno"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, fuzzy, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "Unesite %s-koordinate u odnosu na pripremak"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, fuzzy, python-format
 msgid "Tool %s TouchOff"
 msgstr "Iskljuceno"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "Greska pri snimanju datoteke"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7337,7 +7355,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7346,7 +7364,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7355,91 +7373,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "Joint rezim"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "HOME sve ose"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, fuzzy, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "HOME sve ose [Ctrl-Home]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "HOME sve ose"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "HOME sve ose"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "Joint rezim"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "_Referentna pozicija:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, fuzzy, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "HOME _%s-osa"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "Greska~/.axisrc"
 
@@ -7760,12 +7778,13 @@ msgid "_Properties..."
 msgstr "Oso_bine..."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "_Uredi tabelu alata"
 
 #: share/axis/tcl/axis.tcl:90
 #, fuzzy
-msgid "Reload tool ta_ble"
+msgid "Reload tool _data"
 msgstr "Po_novo ucitaj tabelu alata"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8124,11 +8143,11 @@ msgstr "Preskoci linije sa '_/'"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "Uvecaj"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "Umanji"
 
@@ -8318,9 +8337,10 @@ msgstr "Prekoracenje brzine obr.motora:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr "%"
 
@@ -8376,7 +8396,7 @@ msgid "Position:"
 msgstr "Pozicija:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 #, fuzzy
 msgid "Machine"
 msgstr "apsolutna"
@@ -8486,21 +8506,20 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "Privremeno omoguci JOG van granica masine [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "Obradni motor +"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "Obradni motor -"
@@ -8860,6 +8879,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8869,43 +8890,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8971,7 +9037,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 #, fuzzy
 msgid "<b>Spindle</b>"
 msgstr "Index. sig. enkodera obr.mot."
@@ -9145,7 +9210,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr ""
 
@@ -9207,8 +9271,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9345,10 +9409,10 @@ msgid "Stepconf"
 msgstr "_Korak po korak"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9368,13 +9432,13 @@ msgid "Parallel Port 1"
 msgstr "Podesavanje paralelnog porta"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 #, fuzzy
 msgid "Parallel Port 2"
 msgstr "Podesavanje paralelnog porta"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "Pozicija:"
@@ -9384,239 +9448,289 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Levi taster"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "Spindle"
 msgstr "Obradni motor +"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 #, fuzzy
 msgid "Sherline"
 msgstr "_Sherline"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr "X korak"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr "X smer"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr "Y korak"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr "Y smer"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr "Z korak"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr "Z smer"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr "A korak"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr "A smer"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "X korak"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "X smer"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "X korak"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "X smer"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "Index. sig. enkodera obr.mot."
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "X smer"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "Index. sig. enkodera obr.mot."
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Y smer"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 #, fuzzy
 msgid "Spindle ON"
 msgstr "Obradni motor +"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr "Obradni motor PWM"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Brake"
 msgstr "Kocnica obr.mot.uklj."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr "Hladjenje Komp.vazduh"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr "Hladjenje Emulzija"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr "E-STOP Out"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr "Pojacavac ukljucen"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr "Charge Pump"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9627,265 +9741,360 @@ msgstr ""
 msgid "Unused"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr "E-STOP in"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr "Sonda"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr "Index. sig. enkodera obr.mot."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr "Obradni motor faza A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr "Obradni motor faza B"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr "HOME X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr "HOME Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr "HOME Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr "HOME A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "HOME X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "HOME X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "HOME X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "HOME Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr "Min. granic. + Home. Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem X"
+msgstr "Min. granic. + Home. X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem Y"
+msgstr "Min. granic. + Home. Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr "Min. granic. + Home. Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr "Min. granic. + Ref. A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home U"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 #, fuzzy
 msgid "Minimum Limit + Home V"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr "Max. granic. + Ref. Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem X"
+msgstr "Max. granic. + Ref. X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem Y"
+msgstr "Max. granic. + Ref. Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr "Max. granic. + Ref. Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr "Max. granic. + Ref. A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home U"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 #, fuzzy
 msgid "Maximum Limit + Home V"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr "Oba granic. + Ref. Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr "Oba granic. + Ref. Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr "Oba granic. + Ref. A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home U"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 #, fuzzy
 msgid "Both Limit + Home V"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Oba. granic. + Ref. X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Oba granic. + Ref. Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr "Minimum granic. Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem X"
+msgstr "Minimum granic. X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem Y"
+msgstr "Minimum granic. Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr "Minimum granic. Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr "Minimum granic. A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit U"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 #, fuzzy
 msgid "Minimum Limit V"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr "Maximum granic. Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem X"
+msgstr "Maximum granic. X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem Y"
+msgstr "Maximum granic. Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr "Maximum granic. Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr "Maximum granic. A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit U"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 #, fuzzy
 msgid "Maximum Limit V"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr "Oba granic. Y"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr "Oba granic. Z"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr "Oba granic. A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit U"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 #, fuzzy
 msgid "Both Limit V"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "Oba granic. X"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Oba granic. Y"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr "Svi granicni prek."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr "Sve Home"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 #, fuzzy
 msgid "All limits + homes"
 msgstr "Svi granicni prek."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "Gore, Dole"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9894,40 +10103,40 @@ msgid ""
 "Are you sure?  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
 "Any existing file named custompanel_backup.xml will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr "Maschinenkonfiguration beenden und Änderungen verwerfen?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9938,16 +10147,16 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr "Moja-masina"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr "Datoteka %r je izmenjena i izmene sacuvane u stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
@@ -9955,27 +10164,27 @@ msgstr ""
 "Cuvanjem ove konfiguracione datoteke bice izgubljeni parametri konfiguracije "
 "koji se ne cuvaju u datoteci stepconf"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr "Nastavi?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9983,35 +10192,35 @@ msgid ""
 "{}"
 msgstr "Verzeichnis:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr "Test %s-ose"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr "Grad / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 #, fuzzy
 msgid "deg / s²"
 msgstr "stepen / s²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr "stepen"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -10026,8 +10235,8 @@ msgstr "stepen"
 msgid "mm / s"
 msgstr "mm/s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -10042,13 +10251,13 @@ msgstr "mm/s"
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr "in / s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 #, fuzzy
 msgid "in / s²"
 msgstr "in / s"
@@ -10059,19 +10268,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr ".stepconf Dateien"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr "Bestehende Konfiguration bearbeiten"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr "Grad / Umdrehung"
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10083,7 +10292,7 @@ msgstr ""
 msgid "mm / rev"
 msgstr "mm / obr."
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10094,29 +10303,29 @@ msgstr "mm / obr."
 msgid "Steps / mm"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr "obr./in"
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 #, fuzzy
 msgid "Steps / in"
 msgstr "obr./in"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, fuzzy, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr "# Generisao stepconf %s"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10124,103 +10333,110 @@ msgstr "# Oko izmenite ovu datoteku, izmene ce biti"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr "# prepisane pri sledecem pokretanju stepconf"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 #, fuzzy
 msgid "Include your PyVCP panel here.\n"
 msgstr "Ukljucu korisnicki P_yVCP-panel"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, fuzzy, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 "# Benutzerdefinierte HAL-Anweisungen können nachfolgend angegeben werden"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 "# Diese Datei wird überschrieben, wenn stepconf erneut ausgeführt wird."
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
 msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+#, fuzzy
+msgid "# Include your custom HAL commands here"
+msgstr ""
+"# Benutzerdefinierte HAL-Anweisungen können nachfolgend angegeben werden"
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
 #, fuzzy
@@ -10291,11 +10507,16 @@ msgstr "LinuxCNC konfiguracija masine"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 #, fuzzy
 msgid "Back"
 msgstr "Crna"
@@ -10345,17 +10566,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
 msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
-msgstr "ns"
 
 #: src/emc/usr_intf/stepconf/base.glade:209
 msgid "Step _Time:"
@@ -10717,57 +10927,154 @@ msgstr "Prekoracenje brzine obr.motora:"
 msgid "Scale %"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+#, fuzzy
+msgid "Axis"
+msgstr "Ose:"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Test %s-ose"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Test %s-ose"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Levi taster"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Levi taster"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "zadata"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 #, fuzzy
 msgid "_Onscreen prompt for manual tool change"
 msgstr "_Prikazi upit za promenu alata"
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 #, fuzzy
 msgid "Include custom PyVCP GUI panel"
 msgstr "Ukljucu korisnicki P_yVCP-panel"
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 #, fuzzy
 msgid "Blank program"
 msgstr "Pokreni program"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 #, fuzzy
 msgid "Spindle speed display  "
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10776,71 +11083,71 @@ msgid ""
 "panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 #, fuzzy
 msgid "Blank ladder program"
 msgstr "Ponovo ucitaj program"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 #, fuzzy
 msgid "Estop ladder program"
 msgstr "zaustavu ucitavanje pregleda programa"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 #, fuzzy
 msgid "Serial modbus program"
 msgstr "Ponovo ucitaj program"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 #, fuzzy
 msgid ""
@@ -10848,10 +11155,14 @@ msgid ""
 "program"
 msgstr "Ponovo ucitaj program"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "Konfiguration der Spindel"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr ""
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10869,16 +11180,154 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "zadata"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10888,10 +11337,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr ""
@@ -10922,15 +11371,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
 msgstr "_do"
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
-msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
 #: src/emc/usr_intf/stepconf/axisy.glade:402
@@ -11149,39 +11589,39 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 #, fuzzy
 msgid "Help Pages"
 msgstr "Dubina slike"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11189,23 +11629,23 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 #, fuzzy
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr ".stepconf Dateien"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11215,32 +11655,32 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11249,185 +11689,185 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 #, fuzzy
 msgid "Unused Channel"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 #, fuzzy
 msgid "Leadscrew Pitch"
 msgstr "_korak navojnog vretena:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 #, fuzzy
 msgid "Leadscrew TPI"
 msgstr "_korak navojnog vretena:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 #, fuzzy
 msgid " / min"
 msgstr "mm/s"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 #, fuzzy
 msgid " / sec²"
 msgstr "mm/s"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "mm / obr."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "obr./in"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 #, fuzzy
 msgid " / encoder pulse"
 msgstr "Grad / Umdrehung"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 #, fuzzy
 msgid "Encoder pulses / "
 msgstr "mm / obr."
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "Duzina _koraka:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Konfiguration der Spindel"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11445,54 +11885,57 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr "mm/s"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 #, fuzzy
 msgid "mm / min"
 msgstr "mm/s"
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11502,8 +11945,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, fuzzy, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr "# Generisao stepconf %s"
@@ -11520,97 +11963,101 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr "# prepisane pri sledecem pokretanju stepconf"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 #, fuzzy
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 "# Benutzerdefinierte HAL-Anweisungen können nachfolgend angegeben werden"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 #, fuzzy
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
@@ -11618,79 +12065,80 @@ msgstr ""
 "ausgeführt.\n"
 "# Diese Datei wird nicht überschrieben, wenn stepconf erneut ausgeführt wird."
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 #, fuzzy
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 "# Diese Datei wird überschrieben, wenn stepconf erneut ausgeführt wird."
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
+#: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, fuzzy, python-format
 msgid "Generated by PNCconf at %s"
 msgstr "Erstell durch stepconf am %s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
 msgid "configures LinuxCNC as:\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
 msgid "type CNC\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
 msgid "will be used as the frontend display"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
 msgid " connector"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
 msgid "invrt"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
 #, python-format
 msgid "%(name)s Parport"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
 msgid "-> inverted"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1059
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
 #, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11706,1683 +12154,1736 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 #, fuzzy
 msgid "External Controls"
 msgstr "Manualna kontrola"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 #, fuzzy
 msgid "Parallel Port"
 msgstr "Podesavanje paralelnog porta"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 #, fuzzy
 msgid "X Motor"
 msgstr "Invertovan"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "X Axis"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 #, fuzzy
 msgid "Y Motor"
 msgstr "Invertovan"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Y Axis"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 #, fuzzy
 msgid "Z Motor"
 msgstr "Invertovan"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Z Axis"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 #, fuzzy
 msgid "A Motor"
 msgstr "Invertovan"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "A Axis"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Kocnica obr.mot.isklj."
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Output"
-msgstr "Neupotrebljen"
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-msgid "POT Enable"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Dir"
-msgstr "X smer"
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Input"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO O Drain"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
+msgid "POT Output"
+msgstr "Neupotrebljen"
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+msgid "POT Enable"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+#, fuzzy
+msgid "POT Dir"
+msgstr "X smer"
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Input"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Output"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO O Drain"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:117
+#, fuzzy
 msgid "SSR Output"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-A"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-B"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-I"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 #, fuzzy
 msgid "Quad Enc-M"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 0"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 1"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "muxed Enc I"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc M"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 0 Encoder"
 msgstr "Invertovana slika"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 1 Encoder"
 msgstr "Invertovana slika"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 2 Encoder"
 msgstr "Invertovana slika"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 3 Encoder"
 msgstr "Invertovana slika"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 4 Encoder"
 msgstr "Invertovana slika"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 5 Encoder"
 msgstr "Invertovana slika"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 #, fuzzy
 msgid "Step Gen-A"
 msgstr "X korak"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-P"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-D"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 #, fuzzy
 msgid "PWM Gen-E"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 #, fuzzy
 msgid "UDM-Down"
 msgstr "Gore, Dole"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "Manualna kontrola"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "X Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Y Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Z Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "A Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "All Home"
 msgstr "Sve Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "A2 Tandem Home"
 msgstr "Home"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 #, fuzzy
 msgid "X Minimum Limit + Home"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 #, fuzzy
 msgid "Y Minimum Limit + Home"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 #, fuzzy
 msgid "Z Minimum Limit + Home"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 #, fuzzy
 msgid "A Minimum Limit + Home"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 #, fuzzy
 msgid "X Maximum Limit + Home"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 #, fuzzy
 msgid "Y Maximum Limit + Home"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 #, fuzzy
 msgid "Z Maximum Limit + Home"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 #, fuzzy
 msgid "A Maximum Limit + Home"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 #, fuzzy
 msgid "X Both Limit + Home"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 #, fuzzy
 msgid "Y Both Limit + Home"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 #, fuzzy
 msgid "Z Both Limit + Home"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "A Both Limit + Home"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Svi granicni prek."
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 #, fuzzy
 msgid "X2 Minimum Limit + Home"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Y2 Minimum Limit + Home"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 #, fuzzy
 msgid "Z2 Minimum Limit + Home"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "A2 Minimum Limit + Home"
 msgstr "Min. granic. + Home. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 #, fuzzy
 msgid "X2 Maximum Limit + Home"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Y2 Maximum Limit + Home"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 #, fuzzy
 msgid "Z2 Maximum Limit + Home"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "A2 Maximum Limit + Home"
 msgstr "Max. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 #, fuzzy
 msgid "X2 Both Limit + Home"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Y2 Both Limit + Home"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 #, fuzzy
 msgid "Z2 Both Limit + Home"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 #, fuzzy
 msgid "A2 Both Limit + Home"
 msgstr "Oba. granic. + Ref. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select A"
 msgstr "JOG izabrane ose"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select B"
 msgstr "JOG izabrane ose"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select C"
 msgstr "JOG izabrane ose"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select D"
 msgstr "JOG izabrane ose"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "Prekoracenje posmaka:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "Prekoracenje posmaka:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "Prekoracenje posmaka:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "Prekoracenje posmaka:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Spindle Override incr A"
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr B"
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr C"
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr D"
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "Prekoracenje posmaka:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "Prekoracenje posmaka:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CW"
 msgstr "Obradni motor +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CCW"
 msgstr "Obradni motor -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle Stop"
 msgstr "Index. sig. enkodera obr.mot."
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Spindle Up-To-Speed"
 msgstr "Brzina obradnog motora (1/min)"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "JOG izabrane ose"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "Duzina _koraka:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected +"
 msgstr "JOG izabrane ose"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected -"
 msgstr "JOG izabrane ose"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "X Minimum Limit"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "Y Minimum Limit"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "Z Minimum Limit"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 #, fuzzy
 msgid "A Minimum Limit"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "X Maximum Limit"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "Y Maximum Limit"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "Z Maximum Limit"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 #, fuzzy
 msgid "A Maximum Limit"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "X Both Limit"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "Y Both Limit"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "Z Both Limit"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 #, fuzzy
 msgid "A Both Limit"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 #, fuzzy
 msgid "All Limits"
 msgstr "Svi granicni prek."
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "X2 Minimum Limit"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Y2 Minimum Limit"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "Z2 Minimum Limit"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 #, fuzzy
 msgid "A2 Minimum Limit"
 msgstr "Minimum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "X2 Maximum Limit"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Y2 Maximum Limit"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "Z2 Maximum Limit"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 #, fuzzy
 msgid "A2 Maximum Limit"
 msgstr "Maximum granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "X2 Both Limit"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Y2 Both Limit"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "Z2 Both Limit"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 #, fuzzy
 msgid "A2 Both Limit"
 msgstr "Oba granic. X"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "HOME"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Ohmic Probe"
+msgstr "Sonda"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Float Switch"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Unused Input"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 #, fuzzy
 msgid "Limits"
 msgstr "Svi granicni prek."
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 #, fuzzy
 msgid "Axis Selection"
 msgstr "A smer"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "Prekoraci ogranicenja"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "Operation"
 msgstr "Ubrzanje:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "External Control"
 msgstr "Manualna kontrola"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 #, fuzzy
 msgid "X BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 #, fuzzy
 msgid "Y BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 #, fuzzy
 msgid "Z BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 #, fuzzy
 msgid "A BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 #, fuzzy
 msgid "S BLDC Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
 msgid "X Axis PWM"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
 msgid "Y Axis PWM"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 #, fuzzy
 msgid "Z Axis PWM"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 #, fuzzy
 msgid "A Axis PWM"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Unused PWM Gen"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Axis PWM"
 msgstr "Ose:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 #, fuzzy
 msgid "X Axis StepGen"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 #, fuzzy
 msgid "Y Axis StepGen"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 #, fuzzy
 msgid "Z Axis StepGen"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 #, fuzzy
 msgid "A Axis StepGen"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "X2 Tandem StepGen"
 msgstr "Index. sig. enkodera obr.mot."
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "Y2 Tandem StepGen"
 msgstr "Index. sig. enkodera obr.mot."
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 #, fuzzy
 msgid "Z2 Tandem StepGen"
 msgstr "Index. sig. enkodera obr.mot."
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 #, fuzzy
 msgid "Unused StepGen"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-#, fuzzy
-msgid "Axis"
-msgstr "Ose:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Charge Pump StepGen"
 msgstr "Charge Pump"
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Spindle StepGen"
 msgstr "Index. sig. enkodera obr.mot."
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "X Encoder"
 msgstr "END"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 #, fuzzy
 msgid "Y Encoder"
 msgstr "END"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "Z Encoder"
 msgstr "END"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 #, fuzzy
 msgid "A Encoder"
 msgstr "END"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "END"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "END"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "END"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "END"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Feed Override"
 msgstr "Prekoracenje posmaka:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "spindle Override"
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "Prekoracenje posmaka:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 #, fuzzy
 msgid "Unused Encoder"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 #, fuzzy
 msgid "Axis Encoder"
 msgstr "END"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Spindle Encoder"
 msgstr "Obradni motor faza A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "END"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 #, fuzzy
 msgid "Unused Unused"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Obradni motor PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "_Ime masine:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "X Amplifier Enable"
 msgstr "Pojacavac ukljucen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Y Amplifier Enable"
 msgstr "Pojacavac ukljucen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "Z Amplifier Enable"
 msgstr "Pojacavac ukljucen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 #, fuzzy
 msgid "A Amplifier Enable"
 msgstr "Pojacavac ukljucen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Pojacavac ukljucen"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "apsolutna"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "Iskljuceno"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 #, fuzzy
 msgid "Unused Output"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Coolant"
 msgstr "Hladjenje:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Control"
 msgstr "Ctrl-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:518
-#, fuzzy
-msgid "Unused 8I20"
-msgstr "Neupotrebljen"
-
-#: src/emc/usr_intf/pncconf/private_data.py:521
-#, fuzzy
-msgid "Unused Resolver"
-msgstr "Neupotrebljen"
-
-#: src/emc/usr_intf/pncconf/private_data.py:521
-msgid "X Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:522
-msgid "Y Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:522
-msgid "Z Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:523
-msgid "A Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:523
-msgid "S Resolver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:525
-#, fuzzy
-msgid "Unused Analog Output"
-msgstr "Neupotrebljen"
-
-#: src/emc/usr_intf/pncconf/private_data.py:525
-#, fuzzy
-msgid "Spindle Output"
-msgstr "Obradni motor +"
-
-#: src/emc/usr_intf/pncconf/private_data.py:529
-#, fuzzy
-msgid "Unused TPPWM Gen"
-msgstr "Neupotrebljen"
-
-#: src/emc/usr_intf/pncconf/private_data.py:529
-msgid "X Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:530
-msgid "Y Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:530
-msgid "Z Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:531
-msgid "A Axis BL Driver"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:531
-msgid "S Axis BL Driver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
-msgid "8i20 Amplifier Card"
-msgstr "Pojacavac ukljucen"
-
-#: src/emc/usr_intf/pncconf/private_data.py:535
-msgid "7i64 I/O Card"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:535
-msgid "7i69 I/O Card"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:536
-msgid "7i70 I/O Card"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:536
-msgid "7i71 I/O Card"
-msgstr ""
+msgid "Unused 8I20"
+msgstr "Neupotrebljen"
 
 #: src/emc/usr_intf/pncconf/private_data.py:537
-msgid "7i76 Mode 0 I/O Card"
-msgstr ""
+#, fuzzy
+msgid "Unused Resolver"
+msgstr "Neupotrebljen"
 
 #: src/emc/usr_intf/pncconf/private_data.py:537
-msgid "7i76 Mode 2 I/O Card"
+msgid "X Resolver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:538
-msgid "7i77 Mode 0 I/O Card"
+msgid "Y Resolver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:538
-msgid "7i77 Mode 3 I/O Card"
+msgid "Z Resolver"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:539
+msgid "A Resolver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:539
+msgid "S Resolver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:541
+#, fuzzy
+msgid "Unused Analog Output"
+msgstr "Neupotrebljen"
+
+#: src/emc/usr_intf/pncconf/private_data.py:541
+#, fuzzy
+msgid "Spindle Output"
+msgstr "Obradni motor +"
+
+#: src/emc/usr_intf/pncconf/private_data.py:545
+#, fuzzy
+msgid "Unused TPPWM Gen"
+msgstr "Neupotrebljen"
+
+#: src/emc/usr_intf/pncconf/private_data.py:545
+msgid "X Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:546
+msgid "Y Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:546
+msgid "Z Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:547
+msgid "A Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:547
+msgid "S Axis BL Driver"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:550
+#, fuzzy
+msgid "8i20 Amplifier Card"
+msgstr "Pojacavac ukljucen"
+
+#: src/emc/usr_intf/pncconf/private_data.py:551
+msgid "7i64 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:551
+msgid "7i69 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:552
+msgid "7i70 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:552
+msgid "7i71 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:553
+msgid "7i76 Mode 0 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:553
+msgid "7i76 Mode 2 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:554
+msgid "7i77 Mode 0 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:554
+msgid "7i77 Mode 3 I/O Card"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Unused Analog In"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 #, fuzzy
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 #, fuzzy
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr "Neupotrebljen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13391,17 +13892,17 @@ msgid ""
 "be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 #, fuzzy
 msgid "Quit PNCconf and discard changes?"
 msgstr "Maschinenkonfiguration beenden und Änderungen verwerfen?"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 #, fuzzy
 msgid "Do you want to quit?"
 msgstr "Da li zelite da:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13416,88 +13917,97 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 #, fuzzy
 msgid "degrees"
 msgstr "Grad / Umdrehung"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 #, fuzzy
 msgid "degrees / minute"
 msgstr "Grad / Umdrehung"
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 #, fuzzy
 msgid "degrees / second²"
 msgstr "Grad / Umdrehung"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 #, fuzzy
 msgid "revolutions"
 msgstr "Zyklen pro Umdrehung:"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 #, fuzzy
 msgid "revs / second²"
 msgstr "Grad / Umdrehung"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 #, fuzzy
 msgid "mm / minute"
 msgstr "mm / obr."
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 #, fuzzy
 msgid "mm / second²"
 msgstr "mm/s"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 #, fuzzy
 msgid "inches / second²"
 msgstr "Grad / Umdrehung"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, fuzzy, python-format
 msgid "%s Axis Tune"
 msgstr "Test %s-ose"
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13511,7 +14021,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "_Masina"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13521,12 +14031,12 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, fuzzy, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr "Datoteka %r je izmenjena i izmene sacuvane u stepconf"
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 #, fuzzy
 msgid ""
 "Saving this configuration file will discard configuration changes made "
@@ -13535,7 +14045,7 @@ msgstr ""
 "Cuvanjem ove konfiguracione datoteke bice izgubljeni parametri konfiguracije "
 "koji se ne cuvaju u datoteci stepconf"
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
 
@@ -15209,9 +15719,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15373,6 +15883,14 @@ msgstr ""
 #, fuzzy
 msgid "Mux options"
 msgstr "Pozicija:"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+#, fuzzy
+msgid "Sec"
+msgstr "Skundarni"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 #, fuzzy
@@ -15564,190 +16082,208 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 #, fuzzy
 msgid "Position_offset"
 msgstr "Pozicija:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 #, fuzzy
 msgid "Position_feedback"
 msgstr "Pozicija:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 #, fuzzy
 msgid "Max Spindle Override "
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 #, fuzzy
 msgid "Min Spindle Override"
 msgstr "Prekoracenje brzine obr.motora:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 #, fuzzy
 msgid "Max Feed Override"
 msgstr "Prekoracenje posmaka:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 #, fuzzy
 msgid "Default linear velocity "
 msgstr "Brzina pri _trazenju referentne pozicije:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 #, fuzzy
 msgid "Min linear velocity"
 msgstr "Brzina pri _trazenju referentne pozicije:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 #, fuzzy
 msgid "Max linear velocity"
 msgstr "Maksinalna _Brzina:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 #, fuzzy
 msgid "Min Angular velocity"
 msgstr "Maksinalna _Brzina:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 #, fuzzy
 msgid "Increments "
 msgstr "Izaberi JOG inkrement"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 #, fuzzy
 msgid "Max Angular velocity"
 msgstr "Maksinalna _Brzina:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 #, fuzzy
 msgid "Deg / min"
 msgstr "Grad / Umdrehung"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 #, fuzzy
 msgid "Position"
 msgstr "Pozicija:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "Rela_tivna pozicija"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Konfiguration der Spindel"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15846,137 +16382,151 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr "Ukljucu korisnicki P_yVCP-panel"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr ""
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "END"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 #, fuzzy
 msgid "Home Final Velocity:"
 msgstr "Brzina pri _trazenju referentne pozicije:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 #, fuzzy
 msgid "Home Latch Direction:"
 msgstr "Pozija referentnog _Latch-a:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 #, fuzzy
 msgid "Home Search Direction:"
 msgstr "Pozija referentnog _Latch-a:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 #, fuzzy
 msgid "Home latch Velocity:"
 msgstr "Brzina pri _trazenju referentne pozicije:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr ""
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Verzeichnis:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 #, fuzzy
 msgid "Home Search Velocity:"
 msgstr "Brzina pri _trazenju referentne pozicije:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 #, fuzzy
 msgid "Home Search Sequence:"
 msgstr "Brzina pri _trazenju referentne pozicije:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
+msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -16928,10 +17478,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr ""
@@ -17023,10 +17569,6 @@ msgstr ""
 #, fuzzy
 msgid "Motor steps per revolution:"
 msgstr "_Broj koraka po okretaju motora"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
-msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17506,7 +18048,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17666,31 +18207,23 @@ msgid "Manual Toolchange"
 msgstr "AXIS manuelna promena alata"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 msgid "Restart Entry"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 #, fuzzy
 msgid "Down"
 msgstr "Gore, Dole"
@@ -17772,33 +18305,33 @@ msgstr "AXIS poruka"
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17919,14 +18452,12 @@ msgid "<b>Status</b>"
 msgstr "Homin_g"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17934,7 +18465,6 @@ msgid ""
 msgstr "_korak navojnog vretena:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17942,7 +18472,6 @@ msgid ""
 msgstr "relativna"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17958,7 +18487,6 @@ msgid "Main Level"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17972,12 +18500,10 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17987,7 +18513,6 @@ msgid "Grid Size"
 msgstr "Velicina:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 msgid "Starting RPM"
 msgstr ""
 
@@ -18066,7 +18591,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "_Kalibracija"
@@ -18337,13 +18861,11 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 #, fuzzy
 msgid "Undo"
 msgstr "Neupotrebljen"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr ""
 
@@ -18368,6 +18890,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18432,1645 +18956,620 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-#, fuzzy
-msgid "user mode selected"
-msgstr "JOG izabrane ose"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "Nepoznat alat%d"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-#, fuzzy
-msgid "inch/min"
-msgstr "obr./in"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "Joint rezim"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-msgid "Classicladder real-time component not detected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-msgid "Enter value for diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-msgid "Set diameter to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-msgid "Enter value for radius"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-msgid "Set radius to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, python-brace-format
-msgid "Set axis {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "AXIS manuelna promena alata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-msgid "Select the tool to change"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "Joint rezim"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-#, fuzzy
-msgid "no button here"
-msgstr "JOG izabrane ose"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "Datoteka nije ucitana"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "Obrisi prikaz"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "Perspektiva"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "Test %s-ose"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "Redosled alata:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "A smer"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-msgid "jog joints"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "Prekoraci ogranicenja"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Promena alata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-msgid "Diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-msgid "offset z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-msgid "offset x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "Konfiguracija X ose"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Aktivni G-kod:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Aktivni G-kod:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "Index. sig. enkodera obr.mot."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "Prekoracenje brzine obr.motora:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Prekoracenje posmaka 0-100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "Prekoracenje posmaka:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-#, fuzzy
-msgid "Replace"
-msgstr "relativna"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-msgid "X Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-msgid "Y Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "_Prikazi rastojanja"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Bocni pogled"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "_Prikazi rastojanja"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "Rela_tivna pozicija"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-msgid "Absolute Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "HOME sve ose"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "HOME sve ose"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-msgid "Grid size"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "_Prikazi rastojanja"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "_Prikazi rastojanja"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-msgid "Show DTG"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "Ponovo otvori tekucu datoteku [Ctrl-R]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "Izaberi JOG brzinu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-msgid "<b>Select jump to dir</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "Prekoracenje brzine obr.motora:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "B_rzina"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "Prekoracenje posmaka:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Prekoracenje brzine obr.motora:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-#, fuzzy
-msgid "Use unlock code"
-msgstr "Neupotrebljen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Kocnica obr.mot.uklj."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Kocnica obr.mot.uklj."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-#, fuzzy
-msgid "Probe Height"
-msgstr "Sonda"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-msgid "Z Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-#, fuzzy
-msgid "Max. Probe"
-msgstr "Sonda"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-#, fuzzy
-msgid "Search Vel."
-msgstr "Brzina pri _trazenju referentne pozicije:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-#, fuzzy
-msgid "Probe Vel."
-msgstr "Sonda"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "Po_novo ucitaj tabelu alata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Po_novo ucitaj tabelu alata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "PAN, rotacija ili izbor linije"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "Homin_g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-#, fuzzy
-msgid "Launch test message"
-msgstr "Rezultat _Latency testa:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "Maschinenkonfiguration komplett"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Ukljuci masinu"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "Ponovo ucitaj program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "_Prikazi rastojanja"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "Joint rezim"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Ponovo ucitaj program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Ponovo ucitaj program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Zaustavi izvrsenje programa ili"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Zaustavi izvrsenje programa ili"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Zaustavi izvrsenje programa ili"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr "Ponovo ucitaj program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-msgid "delete MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-#, fuzzy
-msgid "delete MDI history"
-msgstr "Obrisi MDI istoriju"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "HA_L-Scope..."
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "_Kalibracija"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "Po_novo ucitaj tabelu alata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "_Ucitaj ponovo"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "Po_novo ucitaj tabelu alata"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-msgid "Select a tool by number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
+#: lib/python/gladevcp/iconview.py:120
 #, fuzzy
-msgid "Move to parrent directory"
+msgid "Move to parent directory"
 msgstr "Verzeichnis:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
-msgid "Select the previos file"
-msgstr ""
+#: lib/python/gladevcp/iconview.py:128
+#, fuzzy
+msgid "Select the previous file"
+msgstr "Slede_ca linija"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "Slede_ca linija"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "Tip alata"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
 #, fuzzy
-msgid "home joints"
-msgstr "P_rikazi program"
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr "_Nuliraj koord. sistem"
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "Po_novo ucitaj tabelu alata"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+#, fuzzy
+msgid "Tool file was modified since it was last read"
+msgstr "Datoteka %r je izmenjena i izmene sacuvane u stepconf"
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Tocak misa"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+#, fuzzy
+msgid "button"
+msgstr "JOG izabrane ose"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "Uklj. Isklj. Emulzija"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "Redosled alata:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "Crna"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "_Referentna pozicija:"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+#, fuzzy
+msgid "G59.1"
+msgstr "P1  G5_4"
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+#, fuzzy
+msgid "G59.2"
+msgstr "P1  G5_4"
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+#, fuzzy
+msgid "G59.3"
+msgstr "P1  G5_4"
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "Test %s-ose"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "Test %s-ose"
+
+#: lib/python/gladevcp/offsetpage.glade:442
+msgid ""
+"Zero\n"
+"G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "_Referentna pozicija:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "JOG izabrane ose"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "Redosled alata:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+msgid "Diameter"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "_Ceoni prikaz"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+#, fuzzy
+msgid "Orientation"
+msgstr "Ubrzanje:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "zadata"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "_Ucitaj ponovo"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "Test %s-ose"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "H_AL-Metar..."
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+msgid "Lathe Wear Offsets"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "Redosled alata:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Redosled alata:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "_Prikazi rastojanja"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "JOG izabrane ose"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "Nepoznat alat%d"
+
+#, fuzzy
+#~ msgid "inch/min"
+#~ msgstr "obr./in"
+
+#, fuzzy
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "Joint rezim"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "AXIS manuelna promena alata"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "Joint rezim"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "Datoteka nije ucitana"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "Obrisi prikaz"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "Perspektiva"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Redosled alata:"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "A smer"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "Prekoraci ogranicenja"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Promena alata"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "Konfiguracija X ose"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Aktivni G-kod:"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Aktivni G-kod:"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "Index. sig. enkodera obr.mot."
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "Prekoracenje brzine obr.motora:"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Prekoracenje posmaka 0-100%"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "Prekoracenje posmaka:"
+
+#, fuzzy
+#~ msgid "Replace"
+#~ msgstr "relativna"
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "_Prikazi rastojanja"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Bocni pogled"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Rela_tivna pozicija"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "HOME sve ose"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "HOME sve ose"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "_Prikazi rastojanja"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "_Prikazi rastojanja"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "Ponovo otvori tekucu datoteku [Ctrl-R]"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "Izaberi JOG brzinu"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Prekoracenje brzine obr.motora:"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "B_rzina"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Prekoracenje posmaka:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Prekoracenje brzine obr.motora:"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "Use unlock code"
+#~ msgstr "Neupotrebljen"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Kocnica obr.mot.uklj."
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Kocnica obr.mot.uklj."
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "Probe Height"
+#~ msgstr "Sonda"
+
+#, fuzzy
+#~ msgid "Max. Probe"
+#~ msgstr "Sonda"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "Search Vel."
+#~ msgstr "Brzina pri _trazenju referentne pozicije:"
+
+#, fuzzy
+#~ msgid "Probe Vel."
+#~ msgstr "Sonda"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "Po_novo ucitaj tabelu alata"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Po_novo ucitaj tabelu alata"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "PAN, rotacija ili izbor linije"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "Homin_g"
+
+#, fuzzy
+#~ msgid "Launch test message"
+#~ msgstr "Rezultat _Latency testa:"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "Maschinenkonfiguration komplett"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Ukljuci masinu"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "Ponovo ucitaj program"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "_Prikazi rastojanja"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "Joint rezim"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Ponovo ucitaj program"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Ponovo ucitaj program"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Zaustavi izvrsenje programa ili"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Zaustavi izvrsenje programa ili"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Zaustavi izvrsenje programa ili"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr "Ponovo ucitaj program"
+
+#, fuzzy
+#~ msgid "delete MDI history"
+#~ msgstr "Obrisi MDI istoriju"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "HA_L-Scope..."
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "_Kalibracija"
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "Po_novo ucitaj tabelu alata"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "Tip alata"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "P_rikazi program"
 
 #, fuzzy
 #~ msgid "Program"
@@ -20097,10 +19596,6 @@ msgstr "P_rikazi program"
 #~ msgstr "Aktivni G-kod:"
 
 #, fuzzy
-#~ msgid "Tool #:"
-#~ msgstr "Redosled alata:"
-
-#, fuzzy
 #~ msgid "Speed:"
 #~ msgstr "Geschwindigkeit 2:"
 
@@ -20123,10 +19618,6 @@ msgstr "P_rikazi program"
 #, fuzzy
 #~ msgid "Show Setup"
 #~ msgstr "EM_C-Status..."
-
-#, fuzzy
-#~ msgid "Axis Offset"
-#~ msgstr "Test %s-ose"
 
 #~ msgid "Home All Axes"
 #~ msgstr "HOME sve ose"

--- a/src/po/sv.po
+++ b/src/po/sv.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2006-04-12 21:33+0200\n"
 "Last-Translator: Jonathan Lock <lerneaen.hydra@gmail.com>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -19,66 +19,66 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr ""
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr ""
 
@@ -188,424 +188,424 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -719,30 +719,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr ""
@@ -857,102 +857,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, c-format
 msgid "cant open ini file '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 msgid "Parameter file name is missing"
 msgstr ""
 
@@ -1372,7 +1372,7 @@ msgid "Negative spindle speed used"
 msgstr "Matnings överjusterning (%): #guessing again"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+msgid "Negative tool id (tool not found)"
 msgstr ""
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1757,24 +1757,23 @@ msgstr ""
 msgid "R less than V in cycle in UW plane"
 msgstr ""
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr ""
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr ""
 
@@ -1786,99 +1785,112 @@ msgstr ""
 msgid "E_xit"
 msgstr ""
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr ""
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr ""
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr ""
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr ""
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr ""
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 msgstr ""
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 #, fuzzy
 msgid "Open Configuration File:"
 msgstr "Hal _configuration"
 
-#: src/hal/utils/scope.c:539
-#, fuzzy
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+msgid "_Cancel"
+msgstr "_Avbryt"
+
+#: src/hal/utils/scope.c:471
+msgid "_Open"
+msgstr "_Öppna"
+
+#: src/hal/utils/scope.c:491
+msgid "Save Configuration File:"
+msgstr "Spara konfigurationsfil:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+msgid "_Save"
+msgstr "_Spara"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
-msgstr "Hal _configuration"
+msgstr "Ladda konfiguration..."
 
-#: src/hal/utils/scope.c:545
-#, fuzzy
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
-msgstr "Hal _configuration"
+msgstr "_Spara konfiguration..."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr ""
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
-#, fuzzy
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "_Avsluta"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
-#, fuzzy
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "_Fil"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
-#, fuzzy
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "_Hjälp"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr ""
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr ""
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr ""
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr ""
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr ""
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr ""
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1887,38 +1899,38 @@ msgstr ""
 msgid "Stop"
 msgstr "Av_bryt"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr ""
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr ""
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 #, fuzzy
 msgid "Zoom"
 msgstr "Zooma in [+]"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1932,11 +1944,41 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+# ***: ../scripts/axis.py:624 ../scripts/axis.py:632 ../scripts/axis.py:931
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr ""
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+#, fuzzy
+msgid "Quit"
+msgstr "_Avsluta"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1949,107 +1991,80 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+msgid "_OK"
+msgstr ""
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
-msgstr ""
+msgstr "Samplingsintervall:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
-msgstr ""
+msgstr "Samplingshastighet:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr ""
 
-# ***: ../scripts/axis.py:624 ../scripts/axis.py:632 ../scripts/axis.py:931
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr ""
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-#, fuzzy
-msgid "Quit"
-msgstr "_Avsluta"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2063,56 +2078,64 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
 "record length that supports more channels."
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
 "per div"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
 "at %s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2128,90 +2151,71 @@ msgstr ""
 msgid "Hz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, fuzzy, c-format
 msgid ""
 "Offset\n"
 "%s"
-msgstr "Försjutning"
+msgstr "Förskjutning"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
-msgstr ""
+msgstr "Skala"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
 "----"
-msgstr "Försjutning"
+msgstr "Förskjutning"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
-msgstr ""
+msgstr "Kanal av"
 
-#: src/hal/utils/scope_vert.c:715
-#, fuzzy
-msgid "Set Offset"
-msgstr "Försjutning"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
 "for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+#, fuzzy
+msgid "Set Offset"
+msgstr "Förskjutning"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
-msgstr ""
+msgstr "AC-kopplad"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "Avbryt"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
-msgstr ""
+msgstr "För många kanaler"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2219,167 +2223,157 @@ msgid ""
 "the record length to allow for more channels"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
 "as the source for channel %d."
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "Välj kanalkälla"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
-msgstr ""
+msgstr "Sjunkande"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
-msgstr ""
+msgstr "Stigande"
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
 "Chan %2d"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
-msgstr ""
+msgstr "Nivå"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr ""
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr ""
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "Triggerkälla"
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
-msgstr ""
+msgstr "Kanal"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
-msgstr ""
+msgstr "Källa"
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr ""
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr ""
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr ""
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+msgid "Probe tripped during non-probe move."
 msgstr ""
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr ""
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr ""
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr ""
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr ""
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr ""
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr ""
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr ""
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr ""
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr ""
@@ -2450,177 +2444,177 @@ msgstr ""
 msgid "all joints must be homed before going into coordinated mode"
 msgstr ""
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr ""
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr ""
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr ""
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr ""
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr ""
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr ""
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr ""
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr ""
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr ""
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr ""
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr ""
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr ""
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr ""
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2709,26 +2703,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2898,7 +2892,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -2988,19 +2982,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr ""
 
@@ -3052,7 +3046,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr ""
 
@@ -3071,7 +3065,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 #, fuzzy
 msgid "Editor"
 msgstr "_Redigera"
@@ -3086,7 +3080,6 @@ msgid "Config"
 msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 #, fuzzy
 msgid "Preview"
 msgstr "Vy ifrån sidan"
@@ -3517,7 +3510,7 @@ msgid "Edit mode..."
 msgstr "_Redigera"
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr ""
 
@@ -3526,7 +3519,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr ""
 
@@ -3537,6 +3530,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr ""
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "Avbryt"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3724,7 +3735,7 @@ msgid "Parameter"
 msgstr ""
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3913,7 +3924,6 @@ msgstr ""
 # ***: ../tcl/axis.tcl:1512
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 #, fuzzy
 msgid "Main"
 msgstr "Maskin"
@@ -3995,11 +4005,13 @@ msgid "Delete section"
 msgstr "Position:"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Down"
 msgstr ""
 
@@ -4521,6 +4533,7 @@ msgid "Exit"
 msgstr "_Redigera"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 #, fuzzy
 msgid "Edit"
 msgstr "_Redigera"
@@ -4567,7 +4580,6 @@ msgid "Renumber File..."
 msgstr ""
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr ""
 
@@ -4844,15 +4856,15 @@ msgstr ""
 msgid "Test HAL command :"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr ""
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr ""
 
@@ -4975,21 +4987,21 @@ msgstr ""
 msgid "SIZE :"
 msgstr ""
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr ""
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr ""
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 msgid "Create Report File"
 msgstr ""
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr ""
 
@@ -5068,7 +5080,7 @@ msgstr ""
 msgid "Tool:"
 msgstr "Kylvätska:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr ""
@@ -5136,18 +5148,18 @@ msgstr ""
 msgid "auto"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5320,7 +5332,7 @@ msgstr ""
 msgid "world"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 #, fuzzy
 msgid "home"
 msgstr "Hemmaläge"
@@ -5410,16 +5422,15 @@ msgstr ""
 msgid "Optional Stop"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr ""
 
@@ -5531,7 +5542,7 @@ msgid "Coordinate System Control Window"
 msgstr ""
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 #, fuzzy
 msgid "Axis "
 msgstr "Axel:"
@@ -6093,9 +6104,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr ""
 
@@ -6115,8 +6126,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr ""
 
@@ -6192,146 +6203,146 @@ msgstr "AXIS (Ingen fil)"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 #, fuzzy
 msgid "no such file"
 msgstr "AXIS (Ingen fil)"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 msgid "LinuxCNC"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 msgid "LinuxCNC version"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7008,47 +7019,47 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "Okänt verktyg %d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "Inget verktyg"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, fuzzy, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "Verktyg %d, förskutning %g, diameter %g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 #, fuzzy
 msgid "Filter failed"
 msgstr "Program_filer %r misslyckades"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
 "produced are shown below:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "G-Kod fel i %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
@@ -7056,175 +7067,173 @@ msgid ""
 msgstr ""
 
 # ***: ../scripts/axis.py:1083 ../scripts/axis.py:1088 ../scripts/axis.py:1562
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 #, fuzzy
 msgid "Size:"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "Program överskrider maskinens undre gräns på axeln %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "Program överskrider maskinens övre gräns på axeln %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "Program överskrider maskinens begränsningar"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "Kör ändå"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
 "%(lines)s gcode lines"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 #, fuzzy
 msgid "G-Code Properties"
 msgstr "G-Kod fel i %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 msgid "File not Writable:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7235,58 +7244,58 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Custom Grid"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 msgid "Touch Off (system)"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, python-format
 msgid "Tool %s TouchOff"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7295,7 +7304,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7304,7 +7313,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7313,91 +7322,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 #, fuzzy
 msgid "Home All"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 msgid "Joint"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr ""
 
@@ -7712,11 +7721,12 @@ msgid "_Properties..."
 msgstr "G-Kod fel i %s"
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
-msgstr ""
+#, fuzzy
+msgid "Edit _tool data..."
+msgstr "_Redigera"
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+msgid "Reload tool _data"
 msgstr ""
 
 #: share/axis/tcl/axis.tcl:96
@@ -8069,12 +8079,12 @@ msgstr ""
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr ""
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 #, fuzzy
 msgid "Zoom in"
 msgstr "Zooma in [+]"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 #, fuzzy
 msgid "Zoom out"
 msgstr "Zooma ut [-]"
@@ -8264,9 +8274,10 @@ msgstr "Matnings överjusterning (%): #guessing again"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr ""
 
@@ -8314,7 +8325,7 @@ msgstr "Position:"
 
 # ***: ../tcl/axis.tcl:1512
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 #, fuzzy
 msgid "Machine"
 msgstr "Maskin"
@@ -8428,22 +8439,21 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 #, fuzzy
 msgid "Spindle CW"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 #, fuzzy
 msgid "Spindle CCW"
@@ -8799,6 +8809,8 @@ msgstr ""
 
 # ***: ../tcl/axis.tcl:1235
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8808,43 +8820,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8907,7 +8964,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 #, fuzzy
 msgid "<b>Spindle</b>"
 msgstr "Spindel:"
@@ -9079,7 +9135,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr ""
 
@@ -9139,8 +9194,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9274,10 +9329,10 @@ msgid "Stepconf"
 msgstr "Stanna #Guessing again"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9295,13 +9350,13 @@ msgid "Parallel Port 1"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 msgid "Parallel Port 2"
 msgstr ""
 
 # ***: ../tcl/axis.tcl:1514
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "Position:"
@@ -9310,248 +9365,299 @@ msgstr "Position:"
 msgid "HALUI"
 msgstr ""
 
+# ***: ../scripts/axis.py:107
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "Scrollhjulsknapp"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "Spindle"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "X Step"
 msgstr "Stanna #Guessing again"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 #, fuzzy
 msgid "Y Step"
 msgstr "Stanna #Guessing again"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "Z Step"
 msgstr "Stanna #Guessing again"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 #, fuzzy
 msgid "A Step"
 msgstr "Stanna #Guessing again"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "Stanna #Guessing again"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "Spindelbroms på"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "Stanna #Guessing again"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "Spindelbroms på"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "Spindel:"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "Spindelbroms på"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "Spindel:"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Spindelbroms på"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 #, fuzzy
 msgid "Spindle ON"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 #, fuzzy
 msgid "Spindle PWM"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Brake"
 msgstr "Spindelbroms på"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 #, fuzzy
 msgid "Coolant Mist"
 msgstr "Kylvätska:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 #, fuzzy
 msgid "Coolant Flood"
 msgstr "Kylvätska:"
 
 # ***: ../tcl/axis.tcl:1470
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "ESTOP Out"
 msgstr "#Nödstopp?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Ohmic Enable"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9563,260 +9669,344 @@ msgid "Unused"
 msgstr ""
 
 # ***: ../tcl/axis.tcl:1470
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 #, fuzzy
 msgid "ESTOP In"
 msgstr "#Nödstopp?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Index"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase A"
 msgstr "Spindelbroms på"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 #, fuzzy
 msgid "Spindle Phase B"
 msgstr "Spindelbroms på"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home X"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Y"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home Z"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home A"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "Hemmaläge"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Hemmaläge"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "Hemmaläge"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Hemmaläge"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits + homes"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Down"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "Spindelbroms på"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9825,40 +10015,40 @@ msgid ""
 "Are you sure?  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
 "Any existing file named custompanel_backup.xml will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9869,42 +10059,42 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9912,34 +10102,34 @@ msgid ""
 "{}"
 msgstr "Hal _configuration"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -9954,8 +10144,8 @@ msgstr ""
 msgid "mm / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -9970,13 +10160,13 @@ msgstr ""
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr ""
 
@@ -9985,19 +10175,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -10009,7 +10199,7 @@ msgstr ""
 msgid "mm / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -10020,28 +10210,28 @@ msgstr ""
 msgid "Steps / mm"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -10049,99 +10239,104 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+msgid "# Include your custom HAL commands here"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
@@ -10213,11 +10408,16 @@ msgstr "Hal _configuration"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 #, fuzzy
 msgid "Back"
 msgstr "Broms"
@@ -10258,17 +10458,6 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:209
@@ -10621,55 +10810,154 @@ msgstr ""
 msgid "Scale %"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+#, fuzzy
+msgid "Axis"
+msgstr "Axel:"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "Försjutning"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "Försjutning"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+msgid "Alignment Laser:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+# ***: ../scripts/axis.py:107
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "Scrollhjulsknapp"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+# ***: ../scripts/axis.py:107
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "Scrollhjulsknapp"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "MDI-Kommando:"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 #, fuzzy
 msgid "Blank program"
 msgstr "Kör program"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 #, fuzzy
 msgid "Spindle speed display  "
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10678,81 +10966,85 @@ msgid ""
 "panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 #, fuzzy
 msgid "Blank ladder program"
 msgstr "Pausa program"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 #, fuzzy
 msgid "Estop ladder program"
 msgstr "Avbryt program"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 #, fuzzy
 msgid "Serial modbus program"
 msgstr "Pausa program"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
 "program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "Hal _configuration"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr ""
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10770,16 +11062,154 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "MDI-Kommando:"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10790,10 +11220,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr "Position:"
@@ -10821,15 +11251,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisv.glade:249
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
@@ -11029,38 +11450,38 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -11068,22 +11489,22 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11093,32 +11514,32 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11127,178 +11548,178 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "Stanna #Guessing again"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "Stanna #Guessing again"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "Blockvis körning av program"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Hal _configuration"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr ""
 
@@ -11316,52 +11737,55 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 msgid "in / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11371,8 +11795,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr ""
@@ -11388,169 +11812,174 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
-#, python-format
-msgid "Generated by PNCconf at %s"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
-msgid "configures LinuxCNC as:\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
-msgid "type CNC\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
-msgid "will be used as the frontend display"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
-msgid " connector"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
-msgid "invrt"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
-#, python-format
-msgid "%(name)s Parport"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
-msgid "-> inverted"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
+msgid "Generated by PNCconf at %s"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
+msgid "configures LinuxCNC as:\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
+msgid "type CNC\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
+msgid "will be used as the frontend display"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
+msgid " connector"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
+msgid "invrt"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
+#, python-format
+msgid "%(name)s Parport"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
+msgid "-> inverted"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
+#, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11566,1580 +11995,1632 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 #, fuzzy
 msgid "External Controls"
 msgstr "Manuell kontroll"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 msgid "Parallel Port"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 msgid "X Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "X Axis"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 msgid "Y Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Y Axis"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 msgid "Z Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 #, fuzzy
 msgid "Z Axis"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 msgid "A Motor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 #, fuzzy
 msgid "A Axis"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "Spindelbroms av"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Dir"
-msgstr "Spindelbroms på"
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Input"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO O Drain"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
+msgid "POT Dir"
+msgstr "Spindelbroms på"
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Input"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Output"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO O Drain"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:117
+#, fuzzy
 msgid "SSR Output"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "muxed Enc I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 #, fuzzy
 msgid "Step Gen-A"
 msgstr "Blockvis körning av program"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-Down"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "Manuell kontroll"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "X Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Y Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "Z Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "A Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 #, fuzzy
 msgid "All Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "X2 Tandem Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Y2 Tandem Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "Z2 Tandem Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 #, fuzzy
 msgid "A2 Tandem Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 #, fuzzy
 msgid "All Limits + Home"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 msgid "A2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select A"
 msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 #, fuzzy
 msgid "Joint select B"
 msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select C"
 msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 #, fuzzy
 msgid "Joint select D"
 msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr A"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 #, fuzzy
 msgid "Feed Override incr B"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr C"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Feed Override incr D"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 #, fuzzy
 msgid "Spindle Override incr A"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr B"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr C"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 #, fuzzy
 msgid "Spindle Override incr D"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CW"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle CCW"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 #, fuzzy
 msgid "Manual Spindle Stop"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Spindle Up-To-Speed"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 #, fuzzy
 msgid "Single Step"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected +"
 msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 #, fuzzy
 msgid "Jog button selected -"
 msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "A2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "Hemmaläge"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Float Switch"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 #, fuzzy
 msgid "Axis Selection"
 msgstr "Hal _configuration"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 #, fuzzy
 msgid "Overrides"
 msgstr "Ignorera Ändlägen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "Operation"
 msgstr "Okänt fel %s"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 #, fuzzy
 msgid "External Control"
 msgstr "Manuell kontroll"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 #, fuzzy
 msgid "Axis rapid"
 msgstr "Axel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
-msgid "A2 Tandem PWM"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "X Axis PWM"
-msgstr "Axel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:460
-#, fuzzy
-msgid "Y Axis PWM"
-msgstr "Axel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "Z Axis PWM"
-msgstr "Axel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:461
-#, fuzzy
-msgid "A Axis PWM"
-msgstr "Axel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-msgid "Unused PWM Gen"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:463
-#, fuzzy
-msgid "Axis PWM"
-msgstr "Axel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:467
-#, fuzzy
-msgid "X Axis StepGen"
-msgstr "Axel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Y Axis StepGen"
-msgstr "Axel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:468
-#, fuzzy
-msgid "Z Axis StepGen"
-msgstr "Axel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:469
-#, fuzzy
-msgid "A Axis StepGen"
-msgstr "Axel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "X2 Tandem StepGen"
-msgstr "Spindel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:470
-#, fuzzy
-msgid "Y2 Tandem StepGen"
-msgstr "Spindel:"
-
-#: src/emc/usr_intf/pncconf/private_data.py:471
-#, fuzzy
-msgid "Z2 Tandem StepGen"
-msgstr "Spindel:"
-
 #: src/emc/usr_intf/pncconf/private_data.py:473
-msgid "Unused StepGen"
+msgid "A2 Tandem PWM"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:474
 #, fuzzy
-msgid "Axis"
+msgid "X Axis PWM"
+msgstr "Axel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:474
+#, fuzzy
+msgid "Y Axis PWM"
 msgstr "Axel:"
 
 #: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "Z Axis PWM"
+msgstr "Axel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:475
+#, fuzzy
+msgid "A Axis PWM"
+msgstr "Axel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+msgid "Unused PWM Gen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:477
+#, fuzzy
+msgid "Axis PWM"
+msgstr "Axel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:481
+#, fuzzy
+msgid "X Axis StepGen"
+msgstr "Axel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Y Axis StepGen"
+msgstr "Axel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:482
+#, fuzzy
+msgid "Z Axis StepGen"
+msgstr "Axel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:483
+#, fuzzy
+msgid "A Axis StepGen"
+msgstr "Axel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "X2 Tandem StepGen"
+msgstr "Spindel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:484
+#, fuzzy
+msgid "Y2 Tandem StepGen"
+msgstr "Spindel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:485
+#, fuzzy
+msgid "Z2 Tandem StepGen"
+msgstr "Spindel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:487
+msgid "Unused StepGen"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 #, fuzzy
 msgid "Spindle StepGen"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Feed Override"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "spindle Override"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 #, fuzzy
 msgid "Spindle Encoder"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "Spindel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 msgid "Unused Unused"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "Spindel:"
 
 # ***: ../tcl/axis.tcl:1512
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "Maskin"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "Spindel:"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+# ***: ../tcl/axis.tcl:1512
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "Maskin"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 #, fuzzy
 msgid "Coolant"
 msgstr "Kylvätska:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 #, fuzzy
 msgid "Spindle Output"
 msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Unused Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13148,15 +13629,15 @@ msgid ""
 "be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 msgid "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13171,82 +13652,91 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr ""
 
 # ***: ../tcl/axis.tcl:1514
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 #, fuzzy
 msgid "revolutions"
 msgstr "Position:"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13261,7 +13751,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "Maskin"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13271,18 +13761,18 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr ""
 
@@ -14945,9 +15435,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15105,6 +15595,13 @@ msgstr ""
 #, fuzzy
 msgid "Mux options"
 msgstr "Position:"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15292,187 +15789,205 @@ msgstr ""
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr ""
 
 # ***: ../tcl/axis.tcl:1514
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 #, fuzzy
 msgid "Position_offset"
 msgstr "Position:"
 
 # ***: ../tcl/axis.tcl:1514
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 #, fuzzy
 msgid "Position_feedback"
 msgstr "Position:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 #, fuzzy
 msgid "Max Spindle Override "
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 #, fuzzy
 msgid "Min Spindle Override"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 #, fuzzy
 msgid "Max Feed Override"
 msgstr "Matnings överjusterning (%): #guessing again"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr ""
 
 # ***: ../tcl/axis.tcl:1514
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 #, fuzzy
 msgid "Position"
 msgstr "Position:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr ""
 
 # ***: ../tcl/axis.tcl:1514
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "Position:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "Hal _configuration"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15574,130 +16089,144 @@ msgstr ""
 msgid "Include custom GladeVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
-msgid "Type 1"
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
-msgid "Type 2"
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
-msgid "Towards Negative Limit"
-msgstr ""
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "Spindel:"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
-msgid "Towards Positive Limit"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
 msgid "Use Encoder Index For Home:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
 msgid "Home Final Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
 msgid "Home Latch Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
 msgid "Home Search Direction:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
 msgid "Home latch Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr ""
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "Hal _configuration"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
 msgid "Use Backlash Compensation:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+msgid "Final Home Position location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
 msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
 msgid "Home Search Velocity:"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
 msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
 msgid "Home Search Sequence:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
+msgid "Type 1"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
+msgid "Type 2"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
+msgid "Towards Negative Limit"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
+msgid "Towards Positive Limit"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
@@ -16634,10 +17163,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 msgid "Number of connectors:"
 msgstr ""
@@ -16723,10 +17248,6 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:1409
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
@@ -17179,7 +17700,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17341,31 +17861,23 @@ msgid "Manual Toolchange"
 msgstr "Manuell kontroll"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 msgid "Restart Entry"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr ""
 
@@ -17444,33 +17956,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17589,7 +18101,6 @@ msgid "<b>Status</b>"
 msgstr "Kylvätska:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
@@ -17597,7 +18108,6 @@ msgstr ""
 
 # ***: ../tcl/axis.tcl:1514
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17605,14 +18115,12 @@ msgid ""
 msgstr "Position:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 msgid ""
 "Replace\n"
 "   All"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17628,7 +18136,6 @@ msgid "Main Level"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17643,12 +18150,10 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17657,7 +18162,6 @@ msgid "Grid Size"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 msgid "Starting RPM"
 msgstr ""
 
@@ -17737,7 +18241,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "Hal _configuration"
@@ -17997,12 +18500,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr ""
 
@@ -18028,6 +18529,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18092,1620 +18595,513 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
+#: lib/python/gladevcp/iconview.py:112
+msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
+#: lib/python/gladevcp/iconview.py:120
 #, fuzzy
-msgid "user mode selected"
+msgid "Move to parent directory"
+msgstr "Hal _configuration"
+
+#: lib/python/gladevcp/iconview.py:128
+msgid "Select the previous file"
+msgstr ""
+
+#: lib/python/gladevcp/iconview.py:136
+msgid "Select the next file"
+msgstr ""
+
+#: lib/python/gladevcp/iconview.py:160
+msgid "Jump to user defined directory"
+msgstr ""
+
+#: lib/python/gladevcp/iconview.py:168
+msgid "select the highlighted file and return the path"
+msgstr ""
+
+#: lib/python/gladevcp/iconview.py:176
+msgid "Close without returning a file path"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+msgid "Tool file was modified since it was last read"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+# ***: ../scripts/axis.py:107
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "Scrollhjulsknapp"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+#, fuzzy
+msgid "button"
 msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
+#: lib/python/gladevcp/gladevcp-test.glade:194
+msgid "togglebutton"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "Okänt verktyg %d"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-msgid "mm/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-msgid "inch/min"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-msgid ""
-" Joint\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-msgid "Classicladder real-time component not detected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-msgid "Enter value for diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-msgid "Set diameter to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-msgid "Enter value for radius"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-msgid "Set radius to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, python-brace-format
-msgid "Set axis {0} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
 #, fuzzy
-msgid "Manual Tool change"
-msgstr "Manuell kontroll"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-msgid "Select the tool to change"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-msgid ""
-"World\n"
-"mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-#, fuzzy
-msgid "no button here"
-msgstr "Flytta vald axel till hemmaläge"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "Pro_gram"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-msgid "clear plot"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-msgid "view perspective"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "Försjutning"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
+msgid "Tool"
 msgstr "Kylvätska:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
 #, fuzzy
-msgid "File Selection"
-msgstr "Hal _configuration"
+msgid "black"
+msgstr "Broms"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-msgid "jog joints"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "Ignorera Ändlägen"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "Hal _configuration"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "Kylvätska:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-msgid "Diameter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "Försjutning"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "Försjutning"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "Hal _configuration"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "Aktiva G-Koder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "Aktiva G-Koder"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "Spindel:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "Kylvätska:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "Spindel:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "Matnings överjusterning (%): #guessing again"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "Matnings överjusterning (%): #guessing again"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "Matnings överjusterning (%): #guessing again"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-msgid "X Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-msgid "Y Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "Spindel:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "Visa EM_C Status"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "Kylvätska:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "Vy ifrån sidan"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "Visa EM_C Status"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
 msgstr ""
 
 # ***: ../tcl/axis.tcl:1514
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
+#: lib/python/gladevcp/offsetpage.glade:88
 #, fuzzy
-msgid "Relative Color"
+msgid "Rotation of Z"
 msgstr "Position:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-msgid "Absolute Color"
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
 #, fuzzy
-msgid "Homed color"
-msgstr "Hemmaläge"
+msgid "Offset"
+msgstr "Försjutning"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
+#: lib/python/gladevcp/offsetpage.glade:416
 #, fuzzy
-msgid "Unhomed color"
-msgstr "Hemmaläge"
+msgid "Offset Name"
+msgstr "Försjutning"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
+#: lib/python/gladevcp/offsetpage.glade:442
 msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
+"Zero\n"
+"G92"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-msgid "<b>DRO</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-msgid "Grid size"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-msgid "Show DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "Visa EM_C Status"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-msgid "Show DTG"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-msgid "<b>Mouse Button mode</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "Vy ifrån sidan"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
+# ***: ../tcl/axis.tcl:1514
+#: lib/python/gladevcp/offsetpage.glade:456
 #, fuzzy
 msgid ""
-"current\n"
-"   file"
-msgstr "Öppna om nuvarande fil [Control-R]"
+"    Zero\n"
+"Rotational"
+msgstr "Position:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-msgid "Select user dir"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-msgid "<b>Select jump to dir</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
 #, fuzzy
-msgid "Scale rapid override"
-msgstr "Matnings överjusterning (%): #guessing again"
+msgid "Select"
+msgstr "Flytta vald axel till hemmaläge"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-msgid "Scale jog velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
 #, fuzzy
-msgid "Scale feed override"
-msgstr "Matnings överjusterning (%): #guessing again"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "Matnings överjusterning (%): #guessing again"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-msgid "<b>Hardware MPG Scale</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-msgid "Use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-msgid "<b>Unlock settings</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "Spindelbroms på"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "Spindelbroms på"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-msgid "<b>Turtle Jog</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-msgid "Z Pos."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "Hal _configuration"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-msgid "Search Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-msgid "<b>Probe velocitys</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
+msgid "Tool#"
 msgstr "Kylvätska:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-msgid "Reload Tool on Start"
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+msgid "Diameter"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
 #, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "Kylvätska:"
+msgid "Front"
+msgstr "Vy _framifrån"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-msgid "Use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
 #, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "Hal _configuration"
+msgid "Orientation"
+msgstr "Okänt fel %s"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-msgid "Launch test message"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
 #, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "Hal _configuration"
+msgid "Comments"
+msgstr "MDI-Kommando:"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "Starta maskin"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "Pausa program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "Visa EM_C Status"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-msgid "open touch off button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-msgid ""
-"World\n"
-"Mode"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "Kör program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "Kör program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "Avbryt program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "Avbryt program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "Avbryt program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr "Kör program"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-msgid "delete MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-msgid "delete MDI history"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-msgid "Hal-Scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "Hal _configuration"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-msgid "add a new tool to tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
+#: lib/python/gladevcp/tooledit_gtk.glade:325
 #, fuzzy
 msgid "Reload"
 msgstr "_Ladda om"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-msgid "reload tool table from file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-msgid "Select a tool by number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-msgid "touch off the tool and set the value to the tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
-msgid "Move to your home directory"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
+#: lib/python/gladevcp/tooledit_gtk.glade:369
 #, fuzzy
-msgid "Move to parrent directory"
-msgstr "Hal _configuration"
+msgid "All Offsets"
+msgstr "Försjutning"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
-msgid "Select the previos file"
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
-msgid "Select the next file"
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
-msgid "Jump to user defined directory"
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+msgid "DIameter"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
-msgid "select the highlighted file and return the path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
-msgid "Close without returning a file path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
+#: lib/python/gladevcp/tooledit_gtk.glade:590
 #, fuzzy
-msgid "Load File"
-msgstr "Pro_gram"
+msgid "Lathe Wear Offsets"
+msgstr "Försjutning"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/tooledit_gtk.glade:646
 #, fuzzy
-msgid "home joints"
-msgstr "Visa _program"
+msgid "X Tool"
+msgstr "Kylvätska:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "Kylvätska:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "Visa EM_C Status"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "Flytta vald axel till hemmaläge"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "Okänt verktyg %d"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "Manuell kontroll"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "Pro_gram"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "Kylvätska:"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "Hal _configuration"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "Ignorera Ändlägen"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "Hal _configuration"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "Kylvätska:"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "Försjutning"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "Försjutning"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "Hal _configuration"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "Aktiva G-Koder"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "Aktiva G-Koder"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "Spindel:"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "Kylvätska:"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "Spindel:"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "Matnings överjusterning (%): #guessing again"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "Matnings överjusterning (%): #guessing again"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "Matnings överjusterning (%): #guessing again"
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "Spindel:"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "Visa EM_C Status"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "Kylvätska:"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "Vy ifrån sidan"
+
+# ***: ../tcl/axis.tcl:1514
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "Position:"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "Hemmaläge"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "Hemmaläge"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "Visa EM_C Status"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "Vy ifrån sidan"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "Öppna om nuvarande fil [Control-R]"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "Matnings överjusterning (%): #guessing again"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "Matnings överjusterning (%): #guessing again"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "Matnings överjusterning (%): #guessing again"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "Spindelbroms på"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "Spindelbroms på"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "Hal _configuration"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "Kylvätska:"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "Kylvätska:"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "Hal _configuration"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "Hal _configuration"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "Starta maskin"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "Pausa program"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "Visa EM_C Status"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "Kör program"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "Kör program"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "Avbryt program"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "Avbryt program"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "Avbryt program"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr "Kör program"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "Hal _configuration"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "Pro_gram"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "Visa _program"
 
 #, fuzzy
 #~ msgid "Program"
@@ -19751,10 +19147,6 @@ msgstr "Visa _program"
 #, fuzzy
 #~ msgid "Show Setup"
 #~ msgstr "Visa EMC Status"
-
-#, fuzzy
-#~ msgid "Axis Offset"
-#~ msgstr "Försjutning"
 
 #, fuzzy
 #~ msgid "%s Axis Configuration"

--- a/src/po/zh_CN.po
+++ b/src/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LinuxCNC EMC2.8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2018-12-14 15:06+0800\n"
 "Last-Translator: David <davidshore@yeah.net>\n"
 "Language-Team: David <davidshore@yeah.net>\n"
@@ -19,66 +19,66 @@ msgstr ""
 "X-Poedit-Country: CHINA\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr "无法执行指令(%s)在机器打开之前"
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "不能这样做(%s:%d) 在手动模式下"
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr "在解释器空闲的情况下，无法在自动模式下执行此操作(%s)"
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr "在解释器阅读时，无法在自动模式下执行该操作(%s)"
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr "解释器暂停后，无法在自动模式下执行该操作 (%s)"
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr "在解释器等待的情况下，无法在自动模式下执行此操作 (%s)"
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "不能这样做(%s:%d)在MDI模式下"
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr "模式为AUTO时不能切换模式，解释器不是IDLE"
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 msgid "failed to close file"
 msgstr "未能关闭文件"
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "无法打开%s"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr "未回零时无法发出MDI指令"
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "必须在MDI模式下才能发出MDI指令"
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr "未回零时无法运行程序"
 
@@ -196,243 +196,243 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr "R值必须在0..360以内与M19"
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr "您必须为控制点指定X和Y坐标"
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr "可以在没有X和Y的情况下指定P，仅用于第一个控制点"
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr "必须为每个控制点指定正的权重P"
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr "无法以0进给率创建NURBS"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr "首先不能使用G5.3而不使用G5.2"
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr "您必须指定至少等于L = %d的控制点数"
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr "不能用刀具半径补偿来转换样条曲线"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr "样条曲线必须位于XY平面中"
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr "样条曲线在Z，A，B或C中可能没有运动"
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr "必须用G5.1指定I和J"
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr "必须同时指定I和J，或者都不指定"
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr "必须用G5指定P和Q."
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr "退出刀具补偿模式之后的移动必须是直线的，而不是弧线"
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr "在平面G17.1，G18.1或G19.1中不能做圆弧"
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr "每转进给模式下无法以主轴转速进给"
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr "绝对中心圆弧缺少%c字"
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr "刀具补偿入口半径不大于刀具半径"
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr "没有刨削槽的刀具无法到达凹角处的弧线"
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr "圆弧到圆弧运动是无效的，因为圆弧具有相同的中心"
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr "圆弧到圆弧运动使拐角补偿的刀具无法适应没有刨削槽"
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr "绝对位置 %5.2f 无效，旋转轴%c"
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr "使用刀具半径补偿时不能改变控制模式"
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr "使用刀具半径补偿时不能改变坐标系"
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr "G%d.1，无D字"
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr "G%d.1和L字，但平面不是 G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr "G%d 要求D字是一个整数"
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr "G%d 与车刀，但平面不是 G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr "刀具补偿生效时不能设置参考点"
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, fuzzy, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr "M7x: restore_settings G20/G21 失败: '%s'"
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr "错误:无法从较低的对话级别(%d)恢复到较高的对话级别(%d)"
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr "错误:从级别%d恢复?"
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr "错误:恢复到级别%d！?"
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr "M7x: restore_settings G20/G21 失败: '%s'"
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr "M7x: restore_settings 执行失败: '%s': %s"
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr "刀具半径补偿打开时，不能设置运动输出"
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr "M62没有有效的P字"
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr "刀具半径补偿打开时，不能设置运动数字输出"
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr "M63没有有效的P字"
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr "刀具半径补偿打开时，不能设置辅助数字输出"
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr "M64没有有效的P字"
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr "M65没有有效的P字"
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr "M66没有有效的P字"
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr "刀具半径补偿开启时，不能等待数字输入"
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr "刀具半径补偿开启时，不能等待模拟输入"
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr "刀具半径补偿开启时，不能设置运动模拟输出"
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr "模拟索引与M67无效"
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr "刀具半径补偿开启时，不能设置辅助模拟输出"
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr "无效的模拟索引与M68"
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr "需要非负的Q字来指定M61的刀具号"
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
@@ -441,7 +441,7 @@ msgstr ""
 "M3命令中的主轴 ($) 编号超出范围\n"
 "num_spindles =%i. $=%d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, fuzzy, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
@@ -450,7 +450,7 @@ msgstr ""
 "M3命令中的主轴 ($) 编号超出范围\n"
 "num_spindles =%i. $=%d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, fuzzy, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
@@ -459,167 +459,167 @@ msgstr ""
 "M3命令中的主轴 ($) 编号超出范围\n"
 "num_spindles =%i. $=%d\n"
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr "M19命令中的主轴 ($) 编号超出范围"
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr "Q字与M19需要值> 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr "无法从无效堆栈帧恢复上下文 - 缺少M70 / M73?"
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr "使用刀具半径补偿时无法启用超速"
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr "使用刀具半径补偿时无法禁用超速"
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr "M51指令中的主轴($) 编号无效"
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr "索引轴%c只能用G0移动"
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr "索引轴%c只能单独移动 "
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr "使用每转进给模式时无法探测"
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr "开启刀具半径补偿后，无法更改退刀模式"
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr "无偏移的G10 L1无效"
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr "G10中的Q号不是一个整数"
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr "无效的刀具定位"
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr "G10 L2不允许使用I J字"
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr "开启刀具半径补偿功能后，不能改变活动坐标系"
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr "R不允许在G10 L20中使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr "错误:从M99到达convert_stop() 作为子程序返回"
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr "G33移动中的主轴($) 编号无效"
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr "在 G33 中主轴未转动"
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr "G33.1移动中的主轴($) 编号无效"
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr "在 G33.1 中主轴未转动"
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr "G76循环中的D编号无效"
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "选择的主轴(%i)未在G76中转动"
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr "错误: 一个轴不正确地与一个索引器一起移动"
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr "错误: 试图索引不正确的轴"
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr "不能使用G76螺紋週期當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr "在 G76，I 不能为 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr "在 G76，J 必须大于 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr "在 G76，K 必须大于 J"
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr "刀具补偿进刀移动的长度不大于刀具半径"
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr "零度内角对刀具补偿无效"
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr "弧到直线运动做的角,刀具补偿不合适会做成刨削槽"
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr "使用刀具半径补偿时无法更换刀具"
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr "使用刀具半径补偿时不能改变刀具偏置"
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 #, fuzzy
 msgid "G43.2: No axes specified and H word missing"
 msgstr "G43.2:缺少H字"
@@ -733,30 +733,30 @@ msgstr "主轴进给命令中的主轴($) 编号无效"
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr "主轴速度命令中的主轴 ($) 编号无效"
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "G53不能使用极坐标"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr "不能用极坐标指定X或Y字"
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr "如果在原点，必须在极坐标中指定角度"
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr "在极坐标下的增量运动在原点时是不确定的"
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr "在极坐标下的G91运动在原点时是不确定的"
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr "请求的刀具%d在刀具表中找不到"
@@ -871,102 +871,102 @@ msgstr "文件:%s 行:%d sub: o|%s| 发现在非法的位置"
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr "文件:%s 行:%d 重新定义 sub: o|%s| 已经在文件:%s中定义"
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "%d:未在子程序定义中: '%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr "%d:重复O字标签:'%s' - 在%d行中定义"
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr "%d:重复O字标签 - 已经在行%d:中定义:'%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr "%d:未定义的O字标签:'%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr "%d:不匹配'if'标签:'%s'(找到'%s'在%d行中) "
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr "%d: 没有匹配的标签: '%s'(找到'%s'在%d行中): '%s'"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr "%d:没有匹配while / do标签:'%s'(找到'%s'在%d行中)"
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr "%d: 没有匹配的标签: '%s'(找到'%s'在%d行中)"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "命名参数 #<%s> 没有定义"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, c-format
 msgid "cant open ini file '%s'"
 msgstr "无法打开ini文件 '%s'"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "在ini文件 '%s'中找不到命名的ini参数#<%s>:错误=0x%x"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr "内部错误:无法分配#<%s>"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr "无法分配给只读参数#<%s>"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr "错误: lookup_named_param(%s): unhandled index=%fn"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "更换刀具后队列不为空"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "无法打开参数文件: '%s'"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 msgid "Parameter file name is missing"
 msgstr ""
 
@@ -1384,7 +1384,8 @@ msgid "Negative spindle speed used"
 msgstr "使用负主轴转速"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "使用负ID刀具"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1766,24 +1767,23 @@ msgstr "R在VW平面上的循环小于U"
 msgid "R less than V in cycle in UW plane"
 msgstr "R在UW 平面上的循环小于V"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "错误:'%s' 不是有效的探测类型\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "错误:无引脚/信号/参数名称\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr "错误:-s 选项需要探测类型和引脚/信号/参数名称\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "HAL 仪表"
 
@@ -1795,27 +1795,27 @@ msgstr "选择"
 msgid "E_xit"
 msgstr "退出"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "选择项目进行探测"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr " 针脚 "
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr " 信号 "
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr " 参数 "
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr "关闭"
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
@@ -1823,67 +1823,89 @@ msgstr ""
 "用法:\n"
 " hal示波器 [-h][-i 文件入][-o 文件出][数字_样本]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "打开配置文件:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "取消"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "打开"
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "打开配置文件:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "保存"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "打开配置..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "保存配置..."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "打开数据文件..."
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "保存数据文件..."
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "退出"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "关于 Halscope"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "文件"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "帮助"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "HAL示波器"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "水平"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "选择通道"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "运行模式"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "触发器"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "垂直"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1891,39 +1913,40 @@ msgstr "垂直"
 msgid "Stop"
 msgstr "停止"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "正常"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "单一"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "翻转"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "缩放"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr " 位置 "
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "-----采样\n"
-" ---- KHz"
+" ---- kHz"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "实时组件未加载"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1946,11 +1969,39 @@ msgstr ""
 "或\n"
 "单击'退出'退出HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "确定"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "退出"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "实时功能未链接"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1970,11 +2021,11 @@ msgstr ""
 "或\n"
 "点击”退出“退出HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "选择采样率"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
@@ -1984,94 +2035,70 @@ msgstr ""
 "或\n"
 "点击退出，以离开HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "确定"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr "线程:"
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr "采样周期:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr "采样率:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr "线程"
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "周期"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "乘数:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr "记录长度"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d 采样(1通道)"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d 采样(2通道)"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d 采样(4通道)"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d 采样(8通道)"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d 采样(16通道)"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "确定"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "退出"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr "实时组件未加载"
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2094,15 +2121,15 @@ msgstr ""
 "或\n"
 "点击“退出”退出HALSCOPE"
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr "选择日志文件写入:"
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr "没有足够的通道"
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
@@ -2111,7 +2138,7 @@ msgstr ""
 "此记录长度无法处理当前启用的通道,\n"
 "选择更短的记录长度，支持更多的通道。"
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
@@ -2120,7 +2147,7 @@ msgstr ""
 "每个分割\n"
 "%s"
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
@@ -2129,27 +2156,35 @@ msgstr ""
 "%s 采样\n"
 " %s"
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr "纳秒"
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr "微秒"
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr "毫秒"
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
 msgstr "秒"
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2165,15 +2200,15 @@ msgstr "秒"
 msgid "Hz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
@@ -2182,24 +2217,25 @@ msgstr ""
 "偏移\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "增益"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr "定位"
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr "比例"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 msgid ""
 "Offset\n"
 "----"
@@ -2207,15 +2243,11 @@ msgstr ""
 "偏移\n"
 "----"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr "通道 关"
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "设置偏移"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
@@ -2224,35 +2256,19 @@ msgstr ""
 "给通道 %d 设置\n"
 "垂直偏移量."
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "设置偏移"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr "交流耦合"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "取消"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr "通道太多"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2263,50 +2279,40 @@ msgstr ""
 "\n"
 "要么关闭一个或多个通道，要么缩短记录长度以允许更多通道。"
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr "下一个搜索: %d\n"
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr "搜索: %d (wrapped=%d)\n"
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr "选择通道来源"
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
 "as the source for channel %d."
 msgstr "选择一个针脚，信号或参数作为通道%d的来源。"
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "选择通道来源"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "针脚"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "信号"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "参数"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr "下降"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr "上升"
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
@@ -2314,7 +2320,7 @@ msgstr ""
 "来源\n"
 "无"
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
@@ -2323,112 +2329,113 @@ msgstr ""
 "来源\n"
 "通道 %2d"
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "自动"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr "強制"
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr "等级"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr "触发源"
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr "选择要用于触发的通道."
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "触发源"
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr "通道"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr "来源"
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr "正在前进的过程中的故障%d"
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr "G38.4 移动完成后不断开接触."
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr "G38.2 移动完成后不接触."
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+#, fuzzy
+msgid "Probe tripped during non-probe move."
 msgstr "在非探测MDI指令期间探头跳闸。"
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr "在回零运动期间探头跳闸."
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 msgid "Probe tripped during a joint jog."
 msgstr "在关节点动期间探头跳闸。"
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 msgid "Probe tripped during a coordinate jog."
 msgstr "在坐标点动期间探头跳闸"
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr "运动停止因为启用了输入"
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, c-format
 msgid "spindle %d amplifier fault"
 msgstr "主轴%d放大器故障"
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "关节%d 限位开关错误"
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "关节 %d 放大器故障"
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "关节 %d 跟随错误"
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr "运动学逆向在关节%d上给出非有限关节位置"
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr "运动学逆向失败"
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr "在关节%d上超过负向软限位(%.5f)\n"
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 #, fuzzy
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr "在进入teleop模式之前，所有关节都必须回零"
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr "提示:切换到关节模式，点动软限位"
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr "超出关节%d的正向软限位(%.5f)\n"
@@ -2495,177 +2502,177 @@ msgstr "%s移动在行%d将超过关节%d's的负极限"
 msgid "all joints must be homed before going into coordinated mode"
 msgstr "所有关节必须在进入坐标模式之前回零"
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr "未启用时不能进行点动关节"
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr "在回零时不能点动任何关节"
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr "在回零时不能点动任何关节"
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr "需要启用才能在坐标模式下进行线性移动"
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr "线性命令中的无效参数"
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr "超出限位，不能做线性移动"
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr "不能在行%d处添加线性移动，错误代码%d"
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr "需要启用才能在坐标模式下进行环形移动"
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr "超出限位，不能做环形移动"
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr "不能在行%d处添加环形移动，错误代码%d"
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr "动作: 在执行时不能STEP "
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr "无法启用运动，使能输入为false "
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr "必须以关节模式回零 "
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr "回零被motion.homing-inhibit joint=%d拒绝\n"
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr "回零序列已在进行中"
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr "必须处于关节模式或禁用才可以消零"
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr "正在回零时不能消零, 关节 %d"
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr "在移动时不能消零, 关节 %d "
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, fuzzy, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr "未启用时不能进行点动关节"
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr "不能消零未激活的关节 %d"
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr "不能消零无效的关节 %d (最大 %d) "
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr "需要启用，在坐标模式下进行探头移动"
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr "超出限制不能做探头移动"
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr "在启动G38.4或G38.5时，探头已经清除"
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr "探头在启动G38.2或G38.3时已经跳闸"
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr "不能添加探头移动"
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr "需要启用，在坐标模式下进行刚性攻丝移动"
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr "超出限制不能做刚性攻丝移动"
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr "不能在%d行添加刚性攻丝移动，错误代码 %d"
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr "尝试启动不存在的主轴"
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, fuzzy, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr "尝试停止不存在的主轴"
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, fuzzy, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr "尝试定位不存在的主轴"
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, fuzzy, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr "尝试增加不存在的主轴"
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, fuzzy, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr "尝试减少不存在的主轴"
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, fuzzy, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr "尝试接合不存在的主轴制动器"
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, fuzzy, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr "尝试释放不存在的主轴制动器"
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr "关节 %d: 补偿项目太多"
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr "关节 %d: 补偿值必须增加"
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr "无法识别的指令 %d"
@@ -2754,27 +2761,27 @@ msgstr "MOTION: hal_exit()() 失败, 返回 %d\n"
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr "MOTION: emcmot_hal_data malloc 失败\n"
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr "MOTION: 主轴%d引脚输出失败"
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr "MOTION: 关节 %d 针脚/参数 导出失败\n"
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 #, fuzzy
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr "MOTION: init_hal_io() 失败\n"
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, fuzzy, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr "MOTION: 关节 %d 针脚/参数 导出失败\n"
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr "MOTION: 轴 %d 针脚/参数 导出失败\n"
@@ -2945,7 +2952,7 @@ msgstr "无法加载项目文件..."
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr "确定"
 
@@ -3037,19 +3044,19 @@ msgstr "好的"
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "确定"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 msgid "No"
 msgstr "取消"
 
@@ -3103,7 +3110,7 @@ msgstr "载入"
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "保存"
 
@@ -3121,7 +3128,7 @@ msgstr "变量"
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "编辑"
 
@@ -3135,7 +3142,6 @@ msgid "Config"
 msgstr "配置"
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 msgid "Preview"
 msgstr "预览"
 
@@ -3560,7 +3566,7 @@ msgid "Edit mode..."
 msgstr "编辑模式..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "删除"
 
@@ -3569,7 +3575,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr "你真的想删除当前的梯级吗?"
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "添加"
 
@@ -3580,6 +3586,24 @@ msgstr "插入"
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "修改"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "取消"
 
 #: src/hal/classicladder/edit_sequential.c:68
 msgid "Step Nbr"
@@ -3763,7 +3787,7 @@ msgid "Parameter"
 msgstr "参数"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr "应用"
 
@@ -3948,7 +3972,6 @@ msgstr "梯形图"
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "主"
 
@@ -4026,11 +4049,13 @@ msgid "Delete section"
 msgstr "删除部件"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr "上移"
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Down"
 msgstr "下移"
 
@@ -4550,6 +4575,7 @@ msgid "Exit"
 msgstr "退出"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "编辑"
 
@@ -4592,7 +4618,6 @@ msgid "Renumber File..."
 msgstr "重新编号文件..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "设置"
 
@@ -4878,15 +4903,15 @@ msgstr "视图"
 msgid "Test HAL command :"
 msgstr "测试HAL指令 :"
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr "加载监视列表"
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr "保存当前监视列表"
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "指令可以在这里测试，但不会被保存"
 
@@ -5007,21 +5032,21 @@ msgstr "方向"
 msgid "SIZE :"
 msgstr "大小:"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr "LinuxCNC 错误"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr "LinuxCNC因错误而终止。 报告问题时，请创建报告文件并包含在您的消息中。"
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 msgid "Create Report File"
 msgstr "创建报告文件"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "关闭"
 
@@ -5095,7 +5120,7 @@ msgstr "设置刀具偏移"
 msgid "Tool:"
 msgstr "刀具:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "所有文件"
@@ -5162,18 +5187,18 @@ msgstr "单位"
 msgid "auto"
 msgstr "自动"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "英寸"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5330,7 +5355,7 @@ msgstr "关节"
 msgid "world"
 msgstr "世界"
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "回零"
 
@@ -5411,16 +5436,15 @@ msgstr "校验"
 msgid "Optional Stop"
 msgstr "选停"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "设置字体"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "字体"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "大小"
 
@@ -5529,7 +5553,7 @@ msgid "Coordinate System Control Window"
 msgstr "坐标系统控制窗口"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "轴 "
 
@@ -6083,9 +6107,9 @@ msgstr "删除"
 msgid "move"
 msgstr "移动"
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr "自定义"
 
@@ -6105,8 +6129,8 @@ msgstr "找到多个匹配"
 msgid "using path"
 msgstr "使用路径"
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr "警告"
 
@@ -6178,119 +6202,119 @@ msgstr "ini 文件"
 msgid "not found"
 msgstr "未找到"
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr "发现truetype-tracer v4 -OK"
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr "注意truetype-tracer v4是必需的"
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr "注意:truetype-tracer v4是必需的"
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr "ngcgui_app.tcl之前必须加载"
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr "从truetype-tracer(V4 reqd)创建一个子例程文件"
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 msgid "problem with"
 msgstr "有问题"
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr "没有条目"
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr "truetype-tracer的错误版本"
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr "不可写，using"
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr "并设置expandsub"
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr "文本"
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 msgid "Linescale"
 msgstr "刻度线"
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr "无"
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr "细分"
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 msgid "default"
 msgstr "默认"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 msgid "Mode"
 msgstr "模式"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 msgid "normal"
 msgstr "正常"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr "日期"
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr "字体"
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 msgid "Switches"
 msgstr "开关"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr "统一码"
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr "允许旋转"
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr "生成ngcgui-compatible子文件和新标签页"
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr "空文本"
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr "使用truetype-tracer默认字体"
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 msgid "no such file"
 msgstr "没有这样的文件"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 msgid "file not readable"
 msgstr "文件不可读"
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr "创建新的标签页"
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
@@ -6298,27 +6322,27 @@ msgstr ""
 "要求指挥inifindall\n"
 "从axis.py(linuxcnc 2.5)或"
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 msgid "not readable"
 msgstr "不可读"
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr "意外:多个ngcgui启动"
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 msgid "LinuxCNC"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr "对于linuxCNC 2.5.xxx，在ini文件中不要包含tkapp.py"
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 msgid "LinuxCNC version"
 msgstr "LinuxCNC版本"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr "对于LinuxCNC 2.5.xxx，在ini文件中不要包含tkapp.py"
 
@@ -6975,176 +6999,174 @@ msgstr "Alt+F, M, V"
 msgid "Open a Menu"
 msgstr "打开一个菜单"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "未定义刀具 %d 号"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "无刀具"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "刀具 %(tool)d, 偏移 %(zo)g, 直径 %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "刀具 %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "筛选...."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "筛选失败"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
 "produced are shown below:"
 msgstr "该程序 %(program)r 退出代码 %(code)d. 它产生的任何错误信息如下所示:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "%s G代码错误"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
 "%(error_str)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "连续"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr "T   刀具表"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "英寸"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr "半径"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr "直径"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "坐标系:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr "夹具"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr "工件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "名称:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "大小:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "刀具顺序"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "空程距离:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "进给距离:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "总距离:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "运行时间:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "X 极限:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Y 极限:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Z 极限:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "A 极限:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "B 极限:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "C 极限:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "程序超出 %s 轴负向行程极限"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "程序超出 %s 轴正向行程极限"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "程序超出机床极限"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "继续运行"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "没有载入文件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "从 %s 来的消息"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
@@ -7153,43 +7175,43 @@ msgstr ""
 "%(size)s 字节\n"
 "%(lines)s 行G代码"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr "%.1f 分钟"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr "%d 秒"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr "%(a)f 到 %(b)f = %(diff)f %(units)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "G-代码属性"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "所有可加工的文件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "rs274ngc 文件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr "轴运行时不能接受远程指令"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 msgid "File not Writable:"
 msgstr "文件不可写:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7203,28 +7225,28 @@ msgstr ""
 "您可以阅读它或将其保存到您自己的目录\n"
 "然后再打开该保存的文件进行编辑"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr "阅读"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Custom Grid"
 msgstr "自定义网格"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr "输入网格大小"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr "关节已经回零了，你确定要重新回零吗?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr "home_joint <%s> 使用关节模式进行回零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
@@ -7233,30 +7255,30 @@ msgstr ""
 "\n"
 "单个轴回零不允许重复的字母:<%s> "
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr "这个关节已经回零了，你确定要重新回零吗?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 msgid "Touch Off (system)"
 msgstr "对刀(系统)"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "输入相对于%%s的%s 坐标:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, python-format
 msgid "Tool %s TouchOff"
 msgstr "刀具%s对刀"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "保存文件时发生错误"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7269,7 +7291,7 @@ msgstr ""
 "%s\n"
 "请参阅“INI配置”文档\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7282,7 +7304,7 @@ msgstr ""
 "%s\n"
 "请参阅“INI配置”文档\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7295,46 +7317,46 @@ msgstr ""
 "%s\n"
 "请参阅“INI配置”文档\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr "轴"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 msgid "Joints"
 msgstr "关节"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "全部回零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "回零全部%s [Ctrl+Home]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, python-format
 msgid "Home All %s"
 msgstr "全部%s回零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, python-format
 msgid "Unhome All %s"
 msgstr "全部%s消零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr "警告：正向运动学必须处理重复的坐标字母:%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, fuzzy, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr "注意:[TRAJ]COORDINATES=%s 的数量超过 [KINS]JOINTS=%d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
@@ -7344,43 +7366,43 @@ msgstr ""
 "注意:\n"
 "目前不支持单轴回原点"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr "KINEMATICS_IDENTITY 带有重复轴字母 <%s>\n"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 msgid "Joint"
 msgstr "关节"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "回零所有关节"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr "回零 %(name)s _%(id)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "消零 %(name)s _%(id)s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "从这里运行"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr "显示/隐藏PYVCP面板"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr "显示pyVCP面板"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "~/.axisrc 错误"
 
@@ -7693,11 +7715,13 @@ msgid "_Properties..."
 msgstr "属性..."
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "编辑刀具表..."
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+#, fuzzy
+msgid "Reload tool _data"
 msgstr "刷新刀具表"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8024,11 +8048,11 @@ msgstr "跳段 '/'[Alt+M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "停止在 M1 [Alt+M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "放大"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "缩小"
 
@@ -8205,9 +8229,10 @@ msgstr "主轴速率:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr ""
 
@@ -8258,7 +8283,7 @@ msgid "Position:"
 msgstr "坐标:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr "机床"
 
@@ -8363,21 +8388,20 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "临时允许机床在极限外点动[L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr "跟随系统主题"
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "主轴正转"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "主轴反转"
@@ -8717,6 +8741,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8726,43 +8752,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8817,7 +8888,6 @@ msgid "label26"
 msgstr "标签26"
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr "<b>主轴</b>"
 
@@ -8981,7 +9051,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr "状态"
 
@@ -9040,8 +9109,8 @@ msgstr "<b>显示选项</b>"
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr "英寸"
@@ -9175,10 +9244,10 @@ msgid "Stepconf"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9196,12 +9265,12 @@ msgid "Parallel Port 1"
 msgstr "并口1"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 msgid "Parallel Port 2"
 msgstr "并口2"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 msgid "Options"
 msgstr "选项"
 
@@ -9210,225 +9279,276 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "X清零按钮"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 msgid "Axis X"
 msgstr "X轴"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 msgid "Axis Y"
 msgstr "Y轴"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 msgid "Axis Z"
 msgstr "Z轴"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 msgid "Axis U"
 msgstr "U轴"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 msgid "Axis V"
 msgstr "V轴"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 msgid "Axis A"
 msgstr "A轴"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "Spindle"
 msgstr "主轴"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr "即将完成"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr "X 轴脉冲"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr "X 轴方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr "Y 轴脉冲"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr "Y 轴方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr "Z 轴脉冲"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr "Z 轴方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr "A 轴脉冲"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr "A 轴方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "U Step"
 msgstr "U 轴脉冲"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "U Direction"
 msgstr "U 轴方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "V Step"
 msgstr "V 轴脉冲"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 msgid "V Direction"
 msgstr "V 轴方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "X2 串联步进"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "X 轴方向"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "X2 串联步进"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "Y 轴方向"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr "主轴启动"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr "主轴 PWM"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr "主轴停止"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr "冷却气"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr "冷却水"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr "急停输出"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr "驱动器使能"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr "电荷泵"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr "数字输出 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr "数字输出 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr "数字输出 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr "数字输出 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+#, fuzzy
+msgid "Plasma Ohmic Enable"
+msgstr "POT启用"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9439,240 +9559,336 @@ msgstr "数字输出 3"
 msgid "Unused"
 msgstr "未使用"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr "急停信号"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr "对刀信号"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr "主轴定向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr "主轴相位A"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr "主轴相位B"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr "X 原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr "Y 原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr "Z 原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr "A 原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home U"
 msgstr "U 原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home V"
 msgstr "V 原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem X"
+msgstr "X 原点"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+#, fuzzy
+msgid "Home Tandem Y"
+msgstr "Y 原点"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr "X 原点+负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr "Y 原点+负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem X"
+msgstr "X 原点+负向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+#, fuzzy
+msgid "Minimum Limit + Home Tandem Y"
+msgstr "Y 原点+负向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr "Z 原点+负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr "A 原点+负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr "U 原点+负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr "V 原点+负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr "X 原点+正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr "Y 原点+正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem X"
+msgstr "X 原点+正向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+#, fuzzy
+msgid "Maximum Limit + Home Tandem Y"
+msgstr "Y 原点+正向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr "Z 原点+正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr " A原点+正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home U"
 msgstr "U 原点+正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home V"
 msgstr "V 原点+正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr "X 原点+正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr "Y 原点+正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr "Z 原点+正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr "A 原点+正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home U"
 msgstr "U 原点+正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home V"
 msgstr "V 原点+正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem X"
+msgstr "X 原点+正/负向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+#, fuzzy
+msgid "Both Limit + Home Tandem Y"
+msgstr "Y 原点+正/负向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit X"
 msgstr "X 负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
+#: src/emc/usr_intf/stepconf/stepconf.py:256
 msgid "Minimum Limit Y"
 msgstr "Y 负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem X"
+msgstr "X 负向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+#, fuzzy
+msgid "Minimum Limit Tandem Y"
+msgstr "Y 负向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit Z"
 msgstr "Z 负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:242
+#: src/emc/usr_intf/stepconf/stepconf.py:258
 msgid "Minimum Limit A"
 msgstr "A 负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit U"
 msgstr "U 负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:243
+#: src/emc/usr_intf/stepconf/stepconf.py:259
 msgid "Minimum Limit V"
 msgstr "V 负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit X"
 msgstr "X 正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:244
+#: src/emc/usr_intf/stepconf/stepconf.py:260
 msgid "Maximum Limit Y"
 msgstr "Y 正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem X"
+msgstr "X 正向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+#, fuzzy
+msgid "Maximum Limit Tandem Y"
+msgstr "Y 正向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit Z"
 msgstr "Z 正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:245
+#: src/emc/usr_intf/stepconf/stepconf.py:262
 msgid "Maximum Limit A"
 msgstr "A 正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit U"
 msgstr "U 正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:246
+#: src/emc/usr_intf/stepconf/stepconf.py:263
 msgid "Maximum Limit V"
 msgstr "V 正向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit X"
 msgstr "X 正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:247
+#: src/emc/usr_intf/stepconf/stepconf.py:264
 msgid "Both Limit Y"
 msgstr "Y 正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit Z"
 msgstr "Z 正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:248
+#: src/emc/usr_intf/stepconf/stepconf.py:265
 msgid "Both Limit A"
 msgstr "A 正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit U"
 msgstr "U 正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:249
+#: src/emc/usr_intf/stepconf/stepconf.py:266
 msgid "Both Limit V"
 msgstr "V 正/负向极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem X"
+msgstr "X 正/负向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+#, fuzzy
+msgid "Both Limit Tandem Y"
+msgstr "Y 正/负向极限"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits"
 msgstr "全部轴极限"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All home"
 msgstr "全部轴回零"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:250
+#: src/emc/usr_intf/stepconf/stepconf.py:268
 msgid "All limits + homes"
 msgstr "全部轴极限+原点"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 0"
 msgstr "数字输入 0"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 1"
 msgstr "数字输入 1"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 2"
 msgstr "数字输入 2"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
 msgid "Digital in 3"
 msgstr "数字输入 3"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Up"
+msgstr "上移"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "下移"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 msgid "Forward"
 msgstr "下一步"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr "完成"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -9682,9 +9898,9 @@ msgstr ""
 "现有的Custom.clp将被重命名为custom_backup.clp。\n"
 "任何名为-custom_backup.clp的现有文件都将丢失。"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9697,14 +9913,14 @@ msgstr ""
 "\n"
 "你确定?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr "您需要在此程序的并行端口设置页面中指定急停输入引脚。"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
 "Existing custompanel.xml will be renamed custompanel_backup.xml.\n"
@@ -9714,12 +9930,12 @@ msgstr ""
 "现有的custompanel.xml将被重命名为custompanel_backup.xml。\n"
 "任何名为custompanel_backup.xml的现有文件都将丢失。"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr "退出Stepconf并放弃更改?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
@@ -9727,15 +9943,15 @@ msgstr ""
 "配置已经建立并保存。\n"
 "你想退出吗?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr "您正在使用LinuxCNC的模拟实时版本，因此硬件的测试/调优不可用。"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, fuzzy, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9749,42 +9965,42 @@ msgstr ""
 "用。\n"
 "这可能是因为您更新了操作系统，并且它不会自动加载RTAI内核。\n"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr "文件%r被修改，因为它是由stepconf写的"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr "保存此配置文件将丢弃在stepconf之外进行的配置更改。"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr "继续?"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr "启动 %s"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr "由Stepconf制作的LinuxCNC配置桌面启动器"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9792,34 +10008,34 @@ msgid ""
 "{}"
 msgstr "Linuxcnc 配置文件选择"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr "其它"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr "%s 轴测试"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr "度/秒"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr "度/秒²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr "度"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -9834,8 +10050,8 @@ msgstr "度"
 msgid "mm / s"
 msgstr "毫米/秒"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -9850,13 +10066,13 @@ msgstr "毫米/秒"
 msgid "mm / s²"
 msgstr "毫米/秒²"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr "英寸/秒"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr "英寸/秒²"
 
@@ -9865,19 +10081,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "LinuxCNC'stepconf'配置文件"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr "修改现有配置"
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr "度/转"
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr "步/度"
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -9889,7 +10105,7 @@ msgstr "步/度"
 msgid "mm / rev"
 msgstr "毫米/转"
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -9900,28 +10116,28 @@ msgstr "毫米/转"
 msgid "Steps / mm"
 msgstr "步/毫米"
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr "转/英寸"
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr "步/英寸"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr "# %s 由 stepconf1.1 生成"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -9929,100 +10145,106 @@ msgstr "# 如果您对此文件进行了更改，那么"
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr "# 当您再次运行stepconf时，它们将被覆盖"
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr "# 在这里添加halui MDI指令(最多64个)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr "# ****设置外部急停梯形图程序 -开始****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr "# ****设置外部急停梯形图程序 -结束****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr "# 加载包含modbus主站的梯形图(GUI必须为Modbus运行)"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr "# 在没有GUI的情况下加载梯形图(可以在AXIS GUI中重新加载LADDER GUI"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr "在这里包含您的PyVCP面板。\n"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr "# 这些文件按照它们出现的顺序在GUI启动后加载"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr "# **** 使用pyvcp设置主轴速度显示 -START ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr "# **** 使用主轴编码器的实际主轴速度"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr "# **** 主轴速度反馈rps反弹，所以我们用低通 "
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr "# **** 主轴速度反馈rps被签名，所以我们使用绝对分量去除符号 "
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr "# **** 实际速度是RPS而不是RPM，因此我们对其进行缩放。"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr "# **** 在速度指示器上设置主轴 ****"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr "# **** 使用来自LinuxCNC的COMMANDED主轴速度，因为未指定主轴编码器"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr "# 在这里包含你的%s HAL命令"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr "# 再次运行stepconf时，不会覆盖此文件"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr "# 该文件设置模拟限位/回零/主轴编码器硬件。"
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
 msgstr "# 这是一个自动生成的文件，不要编辑。"
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+#, fuzzy
+msgid "# Include your custom HAL commands here"
+msgstr "# 在这里包含你的%s HAL命令"
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
 msgid "Mach configuration files"
@@ -10091,11 +10313,16 @@ msgstr "Stepconf - 配置向导"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr "标签"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "返回"
 
@@ -10138,17 +10365,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
 msgstr "毫米"
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
-msgstr "纳秒"
 
 #: src/emc/usr_intf/stepconf/base.glade:209
 msgid "Step _Time:"
@@ -10506,53 +10722,153 @@ msgstr "使用主轴转速:"
 msgid "Scale %"
 msgstr "比例%"
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr "轴"
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
-msgstr "使用AXIS界面"
+#, fuzzy
+msgid "Gmoccapy"
+msgstr "Gmoccapy 默认值"
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
-msgstr "使用Gmoccapy界面"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
+msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+#, fuzzy
+msgid "Screen:  "
+msgstr "屏幕2"
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "偏移:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "偏移:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+#, fuzzy
+msgid "Alignment Laser:"
+msgstr "校准电流"
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "急停按下"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+#, fuzzy
+msgid "Hidden"
+msgstr "隐藏ColNbr!"
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "按钮"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "模式"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr "屏幕提示手动换刀"
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr "包括Halui用户界面组件"
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr "包括自定义PyVCP GUI面板"
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr "空白程序"
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 msgid "Spindle speed display  "
 msgstr "主轴转速显示"
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr "现有的自定义程序"
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr "包括连接到HAL"
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10564,68 +10880,68 @@ msgstr ""
 "示例\n"
 "面板"
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 msgid "Set pyVCP options"
 msgstr "设置pyVCP选项"
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr "包括_Classic梯形图PLC"
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr "数字输入针脚编号:"
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr "数字输出针脚编号:"
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr "模拟输入针脚编号(s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr "模拟输出针脚编号(s32):"
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr "模拟输入针脚编号(浮点):"
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr "模拟输出针脚编号(浮点):"
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr "设置外部引脚编号"
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr "包括modbus主机支持"
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr "空白梯形图程序"
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr "急停梯形图程序"
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr "串行MODBUS程序"
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
@@ -10634,9 +10950,13 @@ msgstr ""
 "编辑梯形图\n"
 "程序"
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 msgid "Set Ladder Options"
 msgstr "设置梯形图选项"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr "包括Halui用户界面组件"
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10654,16 +10974,154 @@ msgstr "删除"
 msgid "Move UP"
 msgstr "上移"
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "模式"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr "同向"
 
@@ -10673,10 +11131,10 @@ msgstr "同向"
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 msgid "Opposite"
 msgstr "反向"
 
@@ -10704,15 +11162,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
 msgstr "到"
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
-msgstr "秒"
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
 #: src/emc/usr_intf/stepconf/axisy.glade:402
@@ -10926,24 +11375,24 @@ msgstr "**** PNCCONF 错误:    自定义固件加载错误"
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr "**** PNCCONF 信息:    在文件中找到额外的固件"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr "Pncconf 设置"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr "Pncconf 正在打开"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
@@ -10951,15 +11400,15 @@ msgstr ""
 "\n"
 "**** 调试暂停! ****"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 msgid "Specific Help page is unavailable\n"
 msgstr "特定帮助页面不可用\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr "帮助"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -10970,22 +11419,22 @@ msgstr ""
 "%s\n"
 "PNCconf将使用内部固件数据"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "LinuxCNC 'PNCconf' 配置文件"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr "看来这个文件中的数据是从太旧版的PNCConf继续。"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr "没有找到板\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -10995,36 +11444,36 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 msgid "Discovery is  unavailable\n"
 msgstr "发现不可用\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr "USB设备信息搜索"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr "USB设备页面不可用\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 "引脚名称不可用\n"
 "\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 "设备名称不可用\n"
 "\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr "没有找到Pncconf的设备规则\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11036,7 +11485,7 @@ msgstr ""
 "并添加到”备份“文件夹中，点击”现有的自定义程序“将避免此警告，\n"
 " 但是如果稍后更改相关选项，如主轴反馈，则HAL连接将不会更新"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
@@ -11046,167 +11495,167 @@ msgstr ""
 "现有的pyvcp-panel.xml将被重命名并添加到”备份“文件夹中\n"
 "单击”现有的自定义程序“将会提示此警告。"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "Unused Channel"
 msgstr "选择通道"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr "您不能同时使用步进和pwm信号进行主轴控制\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr "您没有为轴%s指定步进或pwm信号\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr "您没有为%s轴伺服器指定编码器/旋转变压器信号\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr "您没有为%s轴指定pwm信号或步进信号\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr "您不能同时使用步进和pwm信号控制%s轴。\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr "如果使用串联式步进电机，则必须为%s轴选择主步进电机\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr "Touchy需要一个外部循环启动信号\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr "Touchy需要一个外部中断信号\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr "Touchy需要一个外部的单步信号\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr "Touchy在Mesa页面上需要一个外部多手轮MPG编码器信号\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr "Touchy需要在外部控制页面上选择“外部手轮点动”\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr "Touchy要求外部控制页面上的外部手轮处于“共享手轮”模式\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr "Touchy需要可选的增量在外部控制页面上取消选中\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr "7i29子板需要PWM型发生器，PWM基频为20 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr "7i30子板需要PWM型发生器，PWM基频为20 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr "7i33子板需要PDM型发生器，PDM基频为6 Mhz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr "7i40子板需要PWM型发生器，PWM基频为50 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr "7i48子板需要UDM型发生器，PWM基频为24 khz\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr "减速机减速比"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr "减速比"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr "丝杆螺距"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr "丝杆TPI"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 msgid " / min"
 msgstr "/分钟"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 msgid " / sec²"
 msgstr "/秒²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 msgid " / Step"
 msgstr "/步"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 msgid "Steps / "
 msgstr "步 / "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 msgid " / encoder pulse"
 msgstr "/编码器脉冲"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 msgid "Encoder pulses / "
 msgstr "编码器脉冲/"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 msgid "Resolver Scale:"
 msgstr "解析器比例:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 msgid "Spindle Scale Calculation"
 msgstr "主轴比例计算"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr "轴比例计算"
 
@@ -11224,18 +11673,21 @@ msgstr "在继续之前，您需要指定并口或mesa I/O设备。"
 msgid "PCI search page is unavailable\n"
 msgstr "PCI搜索页面不可用\n"
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 msgid "in / min"
 msgstr "英寸/分钟"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr "毫米/分钟"
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11244,7 +11696,7 @@ msgstr ""
 "您需要配置mesa0页面。\n"
 " 选择电路板类型，固件，组件数量，然后按'接受组件更改'按钮"
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
@@ -11252,7 +11704,7 @@ msgstr ""
 "所选的Mesa0板与当前显示的板不同。\n"
 "请按'接受组件更改'按钮"
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11261,7 +11713,7 @@ msgstr ""
 "您需要配置mesa1页面。\n"
 " 选择电路板类型，固件，组件数量，然后按'接受组件更改'按钮"
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
@@ -11269,15 +11721,15 @@ msgstr ""
 "所选的Mesa1板与当前显示的板不同。\n"
 "请按'接受组件更改'按钮"
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr "您需要为此梯形图程序指定一个急停输入引脚。"
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr "您需要为此梯形图程序指定一个探针输入引脚。"
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
@@ -11291,8 +11743,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr "# 由PNCconf在%s生成"
@@ -11308,169 +11760,175 @@ msgstr "LinuxCNC版本"
 msgid "# overwritten when you run PNCconf again"
 msgstr "# 再次运行PNCconf时会被覆盖"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr "# 连接杂项信号"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr "#  ---HALUI 信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr "# ---电荷泵信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr "#  ---冷却水信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr "#  ---探针信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr "# ---点动按钮信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr "# ---USB设备点动按钮信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr "#  ---mpg信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr "#  ---运动控制信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr "#  ---数字输入/输出信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr "#  ---急停信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr "#  ---手动换刀信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+#, fuzzy
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr "#  ---手动换刀信号---"
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr "#  ---用于自定义换刀装置的换刀信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr "#  --- Z轴自动触发程序的梯形图信号---"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr "# 这些文件在GalDeVCP之后以它们出现的顺序加载。"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr "# _不要_ 在此处包含您的HAL命令。"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr "# 把自定义HAL命令放在custom_gvcp.hal中"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr "# **** 使用gladevcp设置主轴速度显示 ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr "# **** 设置GLADE MDI按钮 ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr "# ****Z 轴触发按钮-需要触发的梯形图程序 ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr "# 把自定义HAL命令放在custom_postgui.hal中"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr "# GUI加载后运行此文件中的命令"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr "# **** 使用pyvcp设置主轴速度显示-END ****"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr "# 再次运行PNCconf时，不会覆盖此文件"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
 msgstr "# Touchy GUI需要这些命令"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
+#: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
 msgid "Generated by PNCconf at %s"
 msgstr "由%s的PNCconf生成"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
 msgid "configures LinuxCNC as:\n"
 msgstr "将LinuxCNC配置为:\n"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
 msgid "type CNC\n"
 msgstr "CNC型号\n"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
 msgid "will be used as the frontend display"
 msgstr "将用作前端显示"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
 msgid " connector"
 msgstr "连接器"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
 msgid "invrt"
 msgstr "反向"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
 #, python-format
 msgid "%(name)s Parport"
 msgstr "%(name)s的端口"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
 msgid "-> inverted"
 msgstr "->反向"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1059
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
 #, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr "引脚# %(pinnum)d 连接到输入信号:'%(data)s' %(mesag)s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr "引脚# %(pinnum)d 连接到输出信号:'%(data)s' %(mesag)s"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr "# 使用主轴编码器的ACTUAL主轴速度"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr "# spindle-velocity会反弹，所以我们用低通滤波"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr "#  strin-velocity已签名，因此我们使用绝对组件删除符号"
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr "# ACTUAL速度是RPS而不是RPM，所以我们缩放它。"
 
@@ -11486,1388 +11944,1444 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 msgid "External Controls"
 msgstr "外部控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr "Mesa 卡 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr "Mesa 卡 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 msgid "Parallel Port"
 msgstr "并口"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 msgid "X Motor"
 msgstr "X 电机"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "X Axis"
 msgstr "X 轴"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 msgid "Y Motor"
 msgstr "Y 电机"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Y Axis"
 msgstr "Y 轴"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 msgid "Z Motor"
 msgstr "Z 电机"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Z Axis"
 msgstr "Z 轴"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 msgid "A Motor"
 msgstr "A 电机"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "A Axis"
 msgstr "A 轴"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 msgid "Spindle Motor"
 msgstr "主轴电机"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr "实时"
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr "不使用"
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr "假的"
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
 msgstr "8i20伺服驱动器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Output"
 msgstr "POT输出"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Enable"
 msgstr "POT启用"
 
-#: src/emc/usr_intf/pncconf/private_data.py:109
+#: src/emc/usr_intf/pncconf/private_data.py:113
 msgid "POT Dir"
 msgstr "POT方向"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Input"
 msgstr "GPIO输入"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO Output"
 msgstr "GPIO输出"
 
-#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:115
 msgid "GPIO O Drain"
 msgstr "GPIO O 开漏"
 
-#: src/emc/usr_intf/pncconf/private_data.py:113
+#: src/emc/usr_intf/pncconf/private_data.py:117
 #, fuzzy
 msgid "SSR Output"
 msgstr "输出"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr "Quad编编码器-A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr "Quad编编码器-B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr "Quad编编码器-I"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr "Quad编编码器-M"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "muxed Enc I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "Muxed Enc M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 msgid "mux select"
 msgstr "全选"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 0 Encoder"
 msgstr "旋转编码器 0"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 1 Encoder"
 msgstr "旋转编码器 1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 msgid "Resolver 2 Encoder"
 msgstr "旋转编码器 2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 3 Encoder"
 msgstr "旋转编码器 3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 4 Encoder"
 msgstr "旋转编码器 4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 msgid "Resolver 5 Encoder"
 msgstr "旋转编码器 5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step Gen-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-Down"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr "电机A相"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr "电机B相"
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr "电机C相"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr "电机A相不行"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr "电机B相不行"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr "电机C相不行"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr "电机启用"
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr "电机故障"
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr "7i77 模拟-SS1"
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr "7i77 模拟-SS4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Analog Input"
 msgstr "模拟输入"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "X Home"
 msgstr "X 原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Y Home"
 msgstr "Y 原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Z Home"
 msgstr "Z 原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "A Home"
 msgstr "A 原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "All Home"
 msgstr "所有原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "X2 Tandem Home"
 msgstr "X2 串联原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Y2 Tandem Home"
 msgstr "Y2 串联原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Z2 Tandem Home"
 msgstr "Z2 串联原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "A2 Tandem Home"
 msgstr "A2 串联原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr "X 原点+负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr "Y 原点+负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr "Z 原点+负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr "A 原点+负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr "X 原点+正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr "Y 原点+正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr "Z 原点+正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr "A 原点+正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr "X 原点+正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr "Y 原点+正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr "Z 原点+正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr "A 原点+正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "All Limits + Home"
 msgstr "全部极限+原点"
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr "X2 原点+负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr "Y2 原点+负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr "Z2 原点+负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr "A2 原点+负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr "X2 原点+正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr "Y2 原点+正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr "Z2 原点+正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr "A2 原点+正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr "X2 原点+正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr "Y2 原点+正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr "Z2 原点+正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 msgid "A2 Both Limit + Home"
 msgstr "A2 原点+正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr "关节选择 A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr "关节选择 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr "关节选择 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr "关节选择 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr "点动增量 A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr "点动增量 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr "点动增量 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr "点动增量 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr A"
 msgstr "进给倍率增量 A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr B"
 msgstr "进给倍率增量 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr C"
 msgstr "进给倍率增量 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr D"
 msgstr "进给倍率增量 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Spindle Override incr A"
 msgstr "主轴倍率增量 A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr B"
 msgstr "主轴倍率增量 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr C"
 msgstr "主轴倍率增量 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr D"
 msgstr "主轴倍率增量 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr A"
 msgstr "最大速度倍率增量 \tA"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr B"
 msgstr "最大速度倍率增量 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 msgid "Max Vel Override incr C"
 msgstr "最大速度倍率增量 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Max Vel Override incr D"
 msgstr "最大速度倍率增量 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Feed Override enable"
 msgstr "进给倍率启用"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 msgid "Spindle Override enable"
 msgstr "主轴倍率启用"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 msgid "Max Vel Override enable"
 msgstr "最大速度倍率启用"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CW"
 msgstr "手动主轴 CW"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CCW"
 msgstr "手动主轴 CCW"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle Stop"
 msgstr "手动主轴停止"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Spindle Up-To-Speed"
 msgstr "主轴最高速"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Gear Select A"
 msgstr "齿轮选择A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr "循环启动"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr "退出"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Single Step"
 msgstr "单步执行"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr "点动 X +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr "点动 X -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr "点动 Y +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr "点动 Y -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr "点动 Z +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr "点动 Z -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr "点动 A +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr "点动 A -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr "点动按钮选择 +"
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr "点动按钮选择 -"
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr "X 负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr "Y 负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr "Z 负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr "A 负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr "X 正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr "Y 正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr "Z 正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr "A 正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr "X 正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr "Y 正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr "Z 正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr "A 正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr "所有限位"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr "X2 负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr "Y2 负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr "Z2 负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr "A2 负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr "X2 正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr "Y2 正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr "Z2 正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr "A2 正向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr "X2 正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr "Y2 正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr "Z2 正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "A2 Both Limit"
 msgstr "A2 正/负向极限"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 msgid "Main Axis"
 msgstr "主要轴"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 msgid "Tandem Axis"
 msgstr "串联轴"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Arc OK"
+msgstr "主轴正转"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Ohmic Probe"
+msgstr "探测"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "开关"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr "未使用输入"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Limits"
 msgstr "限位"
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr "限位/原点共用"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr "数字接口"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr "轴选择"
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 msgid "Overrides"
 msgstr "速率"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "Operation"
 msgstr "操作"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "External Control"
 msgstr "外部控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 msgid "Axis rapid"
 msgstr "轴动作"
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr "X BLDC 控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr "Y BLDC 控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr "Z BLDC 控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr "A BLDC 控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr "S BLDC 控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr "自定义信号"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr "X2 串联 PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr "Y2 串联 PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr "Z2 串联 PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr "A2 串联 PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "X Axis PWM"
 msgstr "X 轴 PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "Y Axis PWM"
 msgstr "Y 轴 PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "Z Axis PWM"
 msgstr "Z 轴 PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "A Axis PWM"
 msgstr "A 轴 PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Unused PWM Gen"
 msgstr "未使用PWM Gen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Axis PWM"
 msgstr "轴 PWM"
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 msgid "X Axis StepGen"
 msgstr "X 轴步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Y Axis StepGen"
 msgstr "Y 轴步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Z Axis StepGen"
 msgstr "Z 轴步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 msgid "A Axis StepGen"
 msgstr "A 轴步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "X2 Tandem StepGen"
 msgstr "X2 串联步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 msgid "Y2 Tandem StepGen"
 msgstr "Y2 串联步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 msgid "Z2 Tandem StepGen"
 msgstr "Z2 串联步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 msgid "Unused StepGen"
 msgstr "未使用步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr "轴"
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr "电荷泵步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Spindle StepGen"
 msgstr "主轴步进"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr "X 编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr "Y 编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr "Z 编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr "A 编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 msgid "X2 Tandem Encoder"
 msgstr "X2 串联编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 msgid "Y2 Tandem Encoder"
 msgstr "Y2 串联编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 msgid "Z2 Tandem Encoder"
 msgstr "Z2 串联编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 msgid "A2 Tandem Encoder"
 msgstr "A2 串联编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr "X 手轮"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr "Y 手轮"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr "Z 手轮"
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr "A 手轮"
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr "多手轮"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Feed Override"
 msgstr "进给倍率"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "spindle Override"
 msgstr "主轴倍率"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Max Vel Override"
 msgstr "最大速度倍率"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr "未使用编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr "轴编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Spindle Encoder"
 msgstr "主轴编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr "MPG点动控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr "MPG倍率控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "X 编码器"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 msgid "Unused Unused"
 msgstr "未使用"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "主轴编码器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "Machine Is Enabled"
 msgstr "机器启用"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr "X 放大器使能"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr "Y 放大器使能"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr "Z 放大器使能"
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr "A 放大器使能"
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr "强制引脚微调"
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "POT启用"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "电源开启"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "对刀"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr "未使用输出"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Coolant"
 msgstr "冷却"
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr "控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr "S BLDC 控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr "未使用8I20"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "Unused Resolver"
 msgstr "未使用旋转"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr "X 旋转"
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr "Y 旋转"
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr "Z 旋转"
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr "A 旋转"
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr "S 旋转"
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr "未使用模拟输出"
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Spindle Output"
 msgstr "主轴输出"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr "未使用TPPWM Gen"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr "X 轴 BL 驱动器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr "Y 轴 BL 驱动器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr "Z 轴 BL 驱动器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr "A 轴 BL 驱动器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr "S 轴 BL 驱动器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr "8I20放大卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr "7i64 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr "7i69 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr "7i70 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr "7i71 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr "7i76 Mode 0 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr "7i76 Mode 2 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr "7i77 Mode 0 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr "7i77 Mode 3 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr "7i73 Mode 1 Pendant 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr "7i84 Mode 1 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr "7i84 Mode 3 I/O 卡"
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Unused Analog In"
 msgstr "未使用模拟输入"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
@@ -12875,7 +13389,7 @@ msgstr ""
 "7i64-输入\n"
 "P3 和 P4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
@@ -12883,23 +13397,23 @@ msgstr ""
 "7i64-输出\n"
 "P2 和 P5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr "7i64-模拟输入"
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
@@ -12907,7 +13421,7 @@ msgstr ""
 "7i70-输入\n"
 "TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
@@ -12915,7 +13429,7 @@ msgstr ""
 "7i70-输入\n"
 "TB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
@@ -12923,7 +13437,7 @@ msgstr ""
 "7i71-输出\n"
 "TB3"
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
@@ -12931,22 +13445,22 @@ msgstr ""
 "7i71-输出\n"
 "TB2"
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
@@ -12954,22 +13468,22 @@ msgstr ""
 "7i76-模拟输出\n"
 "TB4"
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
@@ -12977,30 +13491,30 @@ msgstr ""
 "7i77-模拟输出\n"
 "TB5"
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13013,16 +13527,16 @@ msgstr ""
 "postgui_backup.hal。\n"
 "任何名为custompanel_backup.xml和custom_postgui.hal的现有文件都将丢失。"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr "退出PNCconf并放弃更改?"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 #, fuzzy
 msgid "Do you want to quit?"
 msgstr "你真的想退出吗?            \n"
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13037,80 +13551,89 @@ msgid ""
 "machine-named folder.."
 msgstr "您指定有一个现有的gladile，但是在机器命名文件夹中没有gladile。"
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr "伺服调谐在PNCconf尚未测试\n"
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr "度"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr "度/分钟"
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr "度/秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr "旋转"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr "转数"
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr "转/秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr "毫米/分钟"
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr "毫米/秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr "英寸/分钟"
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr "英寸/秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr "%s 轴微调"
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr "您必须为此轴测试指定ENCODER / RESOLVER信号和ANALOG SPINDLE信号"
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr "您必须为此轴测试指定ENCODER / RESOLVER信号和PWM信号"
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13127,7 +13650,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr "我的LinuxCNC机床"
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13142,18 +13665,18 @@ msgstr ""
 "如果你有一个真正的大型配置，你希望转换到这个较新版本的PNConf  - 在LinuxCNC论"
 "坛上询问 - 这可能是..."
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr "文件%r 被修改，因为它是由PNCconf写的"
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr "保存此配置文件将丢弃PNCconf以外的配置更改。"
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr "由PNCconf制作的LinuxCNC配置桌面启动器"
 
@@ -14892,9 +15415,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15049,6 +15572,13 @@ msgstr "使用去抖动"
 #: src/emc/usr_intf/pncconf/external.glade:5401
 msgid "Mux options"
 msgstr "Mux选项"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "秒"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15229,176 +15759,194 @@ msgstr "关机后恢复关节位置"
 msgid "<b>Defaults and Options</b>"
 msgstr "<b>默认值和选项</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 msgid "<b>GUI Screen list</b>"
 msgstr "<b>GUI屏幕列表</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr "位置偏移"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr "位置反馈"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr "最大主轴倍率:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr "最小主轴倍率:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr "最大进给倍率:"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 msgid "Display Geometry"
 msgstr "显示几何"
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr "<b>通用GUI默认值</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr "默认线速度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr "最小线速度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr "最大线速度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr "默认角速度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr "编辑"
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr "最小角速度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr "增量"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr "最大角速度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr "度/分钟"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr "大小"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr "坐标"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr "宽"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr "高"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr "Axis 强制最大化"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 msgid "AXIS Defaults"
 msgstr "AXIS 默认值"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr "Touchy 定位后强制最大化"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr "GTK主题"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr "绝对颜色"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 msgid "Absolute Textcolor"
 msgstr "绝对颜色"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 msgid "Relative Textcolor"
 msgstr "相对颜色"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr "DTG颜色"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr "错误颜色"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 msgid "Touchy Defaults"
 msgstr "Touchy 默认值"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr "定位后强制Gmoccapy最大化"
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr "Gmoccapy 默认值"
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "示例选项"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15488,133 +16036,150 @@ msgstr "Gladevcp细节"
 msgid "Include custom GladeVCP GUI panel"
 msgstr "包括自定义GladeVCP GUI面板"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "X 编码器"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
+msgid "Use Encoder Index For Home:"
+msgstr "使用编码器索引回零:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
+msgid "Home Final Velocity:"
+msgstr "回零最终速度:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
+msgid "Home Latch Direction:"
+msgstr "原点锁定方向:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
+msgid "Home Search Direction:"
+msgstr "原点搜索方向:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
+msgid "Home latch Velocity:"
+msgstr "原点锁定速度:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "使用补偿文件:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
+msgid "Use Backlash Compensation:"
+msgstr "使用间隙补偿:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+#, fuzzy
+msgid "Final Home Position location   (Offset from machine zero Origin):"
+msgstr "原点坐标位置(偏移机器原点):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
+msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
+msgstr "负行程距离(机器原点到行程结束):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+#, fuzzy
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
+msgstr "原点开关位置(偏移机器原点):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
+msgid "Home Search Velocity:"
+msgstr "原点搜索速度:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
+msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
+msgstr "正行程距离(机器原点到+行程结束):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
+msgid "Home Search Sequence:"
+msgstr "原点搜索顺序:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+#, fuzzy
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr "原点开关位置(偏移机器原点):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
 #, fuzzy
 msgid "Type 1"
 msgstr "类型   "
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
 #, fuzzy
 msgid "Type 2"
 msgstr "类型   "
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
 msgid "Towards Negative Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
 msgid "Towards Positive Limit"
 msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
-msgid "Use Encoder Index For Home:"
-msgstr "使用编码器索引回零:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
-msgid "Home Final Velocity:"
-msgstr "回零最终速度:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
-msgid "Home Latch Direction:"
-msgstr "原点锁定方向:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
-msgid "Home Search Direction:"
-msgstr "原点搜索方向:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
-msgid "Home latch Velocity:"
-msgstr "原点锁定速度:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr "文件名称:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr "使用补偿文件:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
-msgid "Use Backlash Compensation:"
-msgstr "使用间隙补偿:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
-msgstr "原点坐标位置(偏移机器原点):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
-msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
-msgstr "负行程距离(机器原点到行程结束):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
-msgstr "原点开关位置(偏移机器原点):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
-msgid "Home Search Velocity:"
-msgstr "原点搜索速度:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
-msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
-msgstr "正行程距离(机器原点到+行程结束):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
-msgid "Home Search Sequence:"
-msgstr "原点搜索顺序:"
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -16547,10 +17112,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 #, fuzzy
 msgid "Number of connectors:"
@@ -16642,10 +17203,6 @@ msgstr "微步乘法因子:"
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr "每转电机数:"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
-msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17115,7 +17672,6 @@ msgstr "请更改为刀具# %s，然后单击确定。"
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr "信息:"
 
@@ -17272,31 +17828,23 @@ msgid "Manual Toolchange"
 msgstr "手动换刀"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr "操作员信息"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 msgid "Restart Entry"
 msgstr "重新启动条目"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr "向上"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr "输入"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr "向下"
 
@@ -17374,33 +17922,33 @@ msgstr "信息"
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr "刀具 %(t)s     %(l)s"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, python-format
 msgid "%4.2f mm/min"
 msgstr "%4.2f 毫米/分钟"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr "%(n)s   视图-%(v)s               %(t)s"
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr "毫米"
 
@@ -17515,7 +18063,6 @@ msgid "<b>Status</b>"
 msgstr "<b>状态</b>"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
@@ -17524,7 +18071,6 @@ msgstr ""
 "内容:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 msgid ""
 "Replace\n"
 "  Text:"
@@ -17533,7 +18079,6 @@ msgstr ""
 "内容:"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 msgid ""
 "Replace\n"
 "   All"
@@ -17542,7 +18087,6 @@ msgstr ""
 "全部"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17559,7 +18103,6 @@ msgid "Main Level"
 msgstr "主界面"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr "主题"
 
@@ -17572,12 +18115,10 @@ msgid "DTG Text Color"
 msgstr "DTG颜色"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 msgid "Warning Audio"
 msgstr "警告声音"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr "报警声音"
 
@@ -17586,7 +18127,6 @@ msgid "Grid Size"
 msgstr "网格大小"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 msgid "Starting RPM"
 msgstr "启动转速"
 
@@ -17681,7 +18221,6 @@ msgstr ""
 "Hal显示"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 msgid "Calibration"
 msgstr "轴调校"
 
@@ -17991,12 +18530,10 @@ msgstr ""
 "搜索"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "撤消"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "重做"
 
@@ -18021,6 +18558,8 @@ msgstr ""
 "状态"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18090,1714 +18629,892 @@ msgstr ""
 msgid "screen 2"
 msgstr "屏幕2"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
+#: lib/python/gladevcp/iconview.py:112
+msgid "Move to your home directory"
+msgstr "移动到您的主目录"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
+#: lib/python/gladevcp/iconview.py:120
 #, fuzzy
-msgid "user mode selected"
-msgstr "选择回零"
+msgid "Move to parent directory"
+msgstr "移动到父目录"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
+#: lib/python/gladevcp/iconview.py:128
+#, fuzzy
+msgid "Select the previous file"
+msgstr "选择上一个文件"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
+#: lib/python/gladevcp/iconview.py:136
+msgid "Select the next file"
+msgstr "选择下一个文件"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
+#: lib/python/gladevcp/iconview.py:160
+msgid "Jump to user defined directory"
+msgstr "跳转到用户定义的目录"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
+#: lib/python/gladevcp/iconview.py:168
+msgid "select the highlighted file and return the path"
+msgstr "选择突出显示的文件并返回路径"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
+#: lib/python/gladevcp/iconview.py:176
+msgid "Close without returning a file path"
+msgstr "关闭而不返回文件路径"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
+#: lib/python/gladevcp/offsetpage_widget.py:142
 msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr "****偏移页面小部件错误:在INI的TRAJ部分中找不到LINEAR_UNITS"
+
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr "偏移页面小部件错误:无法识别的浮点输入"
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr "偏移页面窗口小部件错误:MDI调用错误"
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr "偏移页面小部件中的MDI错误-置零 G92"
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr "偏移页面中的MDI错误 - 置零旋转偏移"
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr "偏移页面小部件错误:无法选择坐标系"
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr "刀具编辑小部件错误:无法选择刀具编号"
+
+#: lib/python/gladevcp/tooledit_widget.py:244
+msgid "Toolfile does not exist"
+msgstr "刀具文件不存在"
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr "刀具编辑小部件初始化错误"
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr "刀具编辑小部件浮动错误"
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "将刀具表重新加载到linuxcnc失败"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+msgid "Tool file was modified since it was last read"
+msgstr "刀具文件自上次读取后被修改"
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr "单选按钮"
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+msgid "checkbutton"
+msgstr "检查按钮"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+msgid "button"
+msgstr "按钮"
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+msgid "togglebutton"
+msgstr "切换按钮"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "刀具:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "黑"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr "旋转"
+
+#: lib/python/gladevcp/offsetpage.glade:88
+msgid "Rotation of Z"
+msgstr "Z的旋转"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "偏移:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+msgid "Offset Name"
+msgstr "偏移名称"
+
+#: lib/python/gladevcp/offsetpage.glade:442
 #, fuzzy
 msgid ""
-"zero\n"
-" G92"
+"Zero\n"
+"G92"
 msgstr ""
 "置零\n"
 "G92"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-#, fuzzy
+#: lib/python/gladevcp/offsetpage.glade:456
 msgid ""
-" Block\n"
-"Height"
-msgstr ""
-"块\n"
-"删除"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "使用未知的g代码"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-#, fuzzy
-msgid "this is not a usual config\n"
-msgstr "轴没有响应"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-#, fuzzy
-msgid "mm/min"
-msgstr "毫米/分钟"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-#, fuzzy
-msgid "inch/min"
-msgstr "英寸/分钟"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-#, fuzzy
-msgid "**** Invalid embedded tab configuration ****"
-msgstr "嵌入式标签配置无效"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-#, fuzzy
-msgid "**** audio available! ****"
-msgstr ""
-"\n"
-"**** 调试暂停! ****"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "关节模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-#, fuzzy
-msgid "**** Error with launching virtual keyboard,"
-msgstr "启动“Onboard”屏幕键盘程序%s时出错"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "还没有参数"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-#, fuzzy
-msgid "conversion error"
-msgstr "第一个var. 表达式错误"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-#, fuzzy
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr "在解释器空闲的情况下，无法在自动模式下执行此操作(%s)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-#, fuzzy
-msgid "No tool description available"
-msgstr "没有可用的描述"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-#, fuzzy
-msgid "Classicladder real-time component not detected"
-msgstr "未检测到ClassicLadder实时组件"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-#, fuzzy
-msgid "Do you really want to delete the MDI history?\n"
-msgstr "你真的想删除这个部件吗?"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-#, fuzzy
-msgid "Enter value for diameter"
-msgstr "整数的非整数值"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-#, fuzzy
-msgid "Set diameter to:"
-msgstr "直径"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-#, fuzzy
-msgid "Enter value for radius"
-msgstr "整数的非整数值"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr "半径"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, fuzzy, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr "整数的非整数值"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, fuzzy, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "设定轴偏移量:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-#, fuzzy
-msgid "Important Warning!"
-msgstr "警告!"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, fuzzy, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr "请更改为刀具# %s，然后单击确定。"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "手动换刀"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-#, fuzzy
-msgid "Please select only one tool in the table"
-msgstr "请选择要保存的项目"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-#, fuzzy
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr "使用刀具半径补偿时不能改变刀具偏置"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-#, fuzzy
-msgid "Please emit an G40 before tool touch off"
-msgstr "未选择用于刀具对刀的轴"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "选择项目进行探测"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "世界模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-#, fuzzy
-msgid "no button here"
-msgstr "点动按钮选择 +"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-#, fuzzy
-msgid "Enter value"
-msgstr "输入"
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "程序加载: %s"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "清除走刀轨迹"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "等轴侧视图"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-#, fuzzy
-msgid "Show or hide dimensions"
-msgstr "显示键绑定"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "偏移量"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "刀具表"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-#, fuzzy
-msgid "File Selection"
-msgstr "轴选择"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-#, fuzzy
-msgid "jog joints"
-msgstr "关节"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr ""
-"忽略\n"
-"限制"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "<b>USB 点动</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "刀具"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
+"    Zero\n"
+"Rotational"
+msgstr ""
+"置零\n"
+"旋转"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+msgid "Select"
+msgstr "选择"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+msgid "Tool#"
+msgstr "刀号#"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr "刀袋"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
 msgid "Diameter"
 msgstr "直径"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "偏移"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "偏移"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "<b>配置</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "当前指令集:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "当前指令集:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "运行模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "<b>冷卻液</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "<b>主轴</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "<b>主轴倍率</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "设置进给倍率 0%-100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "<b>外部进给倍率</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-#, fuzzy
-msgid ""
-"Search\n"
-" back"
-msgstr "搜索路径"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-#, fuzzy
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-"向前\n"
-"搜索"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-#, fuzzy
-msgid "Replace"
-msgstr "替换:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-#, fuzzy
-msgid "Start maximized"
-msgstr "强制最大化"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-#, fuzzy
-msgid "Start as window"
-msgstr "位状态窗口"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-#, fuzzy
-msgid "X Pos."
-msgstr " 位置 "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-#, fuzzy
-msgid "Y Pos."
-msgstr " 位置 "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "<b>基本设置</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "显示偏移量"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "键盘"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "预览"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "显示偏移量"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "相对颜色"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-#, fuzzy
-msgid "Absolute Color"
-msgstr "绝对颜色"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-#, fuzzy
-msgid "DTG Color"
-msgstr "DTG颜色"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "全部回零"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "全部消零"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-#, fuzzy
-msgid "Digits"
-msgstr "数字接口"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr "<b>页</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-#, fuzzy
-msgid "Grid size"
-msgstr "网格大小"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "显示"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "显示偏移量"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-#, fuzzy
-msgid "Show DTG"
-msgstr ""
-"显示\n"
-"DTG"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "<b>选择按钮</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<b>页</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "关于当前子文件"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "选择点动速度"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "<b>选择按钮</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-#, fuzzy
-msgid "<b>Themes and sound</b>"
-msgstr "<b>默认值和选项</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "设定主轴倍率"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "选择最大速度"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "设定进给速率:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "设定主轴倍率"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "<b>步进电机比例</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-#, fuzzy
-msgid "Use unlock code"
-msgstr "未使用编码器"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "<b>刀具设置</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "主轴刹车开"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "主轴停止"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "<b>USB 点动</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-#, fuzzy
-msgid "Probe Height"
-msgstr "对刀信号"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-#, fuzzy
-msgid "Z Pos."
-msgstr " 位置 "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-#, fuzzy
-msgid "Max. Probe"
-msgstr "探测"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "<b>程序选项</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-#, fuzzy
-msgid "Search Vel."
-msgstr ""
-"搜索\n"
-"内容:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-#, fuzzy
-msgid "Probe Vel."
-msgstr "对刀信号"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-#, fuzzy
-msgid "<b>Probe velocitys</b>"
-msgstr "<b>最大速度倍率</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "<b>冷卻液</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "刷新刀具表"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "刷新刀具表"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "从选定的行运行"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "<b>回零</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-#, fuzzy
-msgid "Launch test message"
-msgstr "启动测试面板"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "显示高级选项"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "开机"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-#, fuzzy
-msgid "enter auto mode to run programs"
-msgstr "串行MODBUS程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "显示状态栏"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-#, fuzzy
-msgid "open touch off button list"
-msgstr "刀具对刀到夹具"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "世界模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "重新载入程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "重新载入程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "停止运行程序, 或"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "停止运行程序, 或"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "停止运行程序, 或"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr ""
-"编辑梯形图\n"
-"程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-#, fuzzy
-msgid "delete MDI"
-msgstr "删除"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-#, fuzzy
-msgid "delete MDI history"
-msgstr "清除 MDI 历史"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-#, fuzzy
-msgid "Cl.-ladder"
-msgstr "梯形图"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-#, fuzzy
-msgid "Open classicladder"
-msgstr "包括_Classic梯形图PLC"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "HAL示波器"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-#, fuzzy
-msgid "launch hal scope"
-msgstr "启动 %s"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-#, fuzzy
-msgid "launch linuxcnc status"
-msgstr ""
-"linuxcnc\n"
-"   状态"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "轴调校"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-#, fuzzy
-msgid "Halshow"
-msgstr "Hal示波器"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "刷新刀具表"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+msgid "Front"
+msgstr "正面"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+msgid "Orientation"
+msgstr "方向"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+msgid "Comments"
+msgstr "注释"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
 msgid "Reload"
 msgstr "刷新"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+msgid "All Offsets"
+msgstr "所有补偿"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr "X 磨损"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr "Z 磨损"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+msgid "DIameter"
+msgstr "直径"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+msgid "Lathe Wear Offsets"
+msgstr "车床磨损补偿"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+msgid "X Tool"
+msgstr "X 刀具"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+msgid "Z Tool"
+msgstr "Z 刀具"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+msgid "Lathe Tool Offsets"
+msgstr "车床刀具补偿"
+
+#~ msgid "nSec"
+#~ msgstr "纳秒"
+
+#~ msgid "uSec"
+#~ msgstr "微秒"
+
+#~ msgid "mSec"
+#~ msgstr "毫秒"
+
+#~ msgid "next search: %d\n"
+#~ msgstr "下一个搜索: %d\n"
+
+#~ msgid "search: %d (wrapped=%d)\n"
+#~ msgstr "搜索: %d (wrapped=%d)\n"
+
+#~ msgid "Use AXIS Screen"
+#~ msgstr "使用AXIS界面"
+
+#~ msgid "Use Gmoccapy Screen"
+#~ msgstr "使用Gmoccapy界面"
+
+#~ msgid "filename:"
+#~ msgstr "文件名称:"
+
 #, fuzzy
-msgid "reload tool table from file"
-msgstr "刷新刀具表"
+#~ msgid "user mode selected"
+#~ msgstr "选择回零"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
 #, fuzzy
-msgid "Select a tool by number"
-msgstr "设置刀具编号"
+#~ msgid ""
+#~ " Block\n"
+#~ "Height"
+#~ msgstr ""
+#~ "块\n"
+#~ "删除"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
 #, fuzzy
-msgid "change tool to the selected one"
-msgstr "当前所选梯级的标签"
+#~ msgid "unknown jog command {0}"
+#~ msgstr "使用未知的g代码"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
 #, fuzzy
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr "刀具对刀到夹具"
+#~ msgid "this is not a usual config\n"
+#~ msgstr "轴没有响应"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
 #, fuzzy
-msgid "touch off the tool and set the value to the tool table"
-msgstr "请求的刀具%d在刀具表中找不到"
+#~ msgid "mm/min"
+#~ msgstr "毫米/分钟"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
-msgid "Move to your home directory"
-msgstr "移动到您的主目录"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
 #, fuzzy
-msgid "Move to parrent directory"
-msgstr "移动到父目录"
+#~ msgid "inch/min"
+#~ msgstr "英寸/分钟"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
 #, fuzzy
-msgid "Select the previos file"
-msgstr "选择上一个文件"
+#~ msgid "**** Invalid embedded tab configuration ****"
+#~ msgstr "嵌入式标签配置无效"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
-msgid "Select the next file"
-msgstr "选择下一个文件"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
-msgid "Jump to user defined directory"
-msgstr "跳转到用户定义的目录"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
-msgid "select the highlighted file and return the path"
-msgstr "选择突出显示的文件并返回路径"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
-msgid "Close without returning a file path"
-msgstr "关闭而不返回文件路径"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
 #, fuzzy
-msgid "Load File"
-msgstr "加载文件:"
+#~ msgid "**** audio available! ****"
+#~ msgstr ""
+#~ "\n"
+#~ "**** 调试暂停! ****"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
 #, fuzzy
-msgid "home joints"
-msgstr "回零所有关节"
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "关节模式"
+
+#, fuzzy
+#~ msgid "**** Error with launching virtual keyboard,"
+#~ msgstr "启动“Onboard”屏幕键盘程序%s时出错"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "还没有参数"
+
+#, fuzzy
+#~ msgid "conversion error"
+#~ msgstr "第一个var. 表达式错误"
+
+#, fuzzy
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr "在解释器空闲的情况下，无法在自动模式下执行此操作(%s)"
+
+#, fuzzy
+#~ msgid "No tool description available"
+#~ msgstr "没有可用的描述"
+
+#, fuzzy
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "未检测到ClassicLadder实时组件"
+
+#, fuzzy
+#~ msgid "Do you really want to delete the MDI history?\n"
+#~ msgstr "你真的想删除这个部件吗?"
+
+#, fuzzy
+#~ msgid "Enter value for diameter"
+#~ msgstr "整数的非整数值"
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr "直径"
+
+#, fuzzy
+#~ msgid "Enter value for radius"
+#~ msgstr "整数的非整数值"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "半径"
+
+#, fuzzy
+#~ msgid "Enter value for axis {0}"
+#~ msgstr "整数的非整数值"
+
+#, fuzzy
+#~ msgid "Set axis {0} to:"
+#~ msgstr "设定轴偏移量:"
+
+#, fuzzy
+#~ msgid "Important Warning!"
+#~ msgstr "警告!"
+
+#, fuzzy
+#~ msgid ""
+#~ "Please change to tool\n"
+#~ "\n"
+#~ "# {0:d}     {1}\n"
+#~ "\n"
+#~ " then click OK."
+#~ msgstr "请更改为刀具# %s，然后单击确定。"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "手动换刀"
+
+#, fuzzy
+#~ msgid "Please select only one tool in the table"
+#~ msgstr "请选择要保存的项目"
+
+#, fuzzy
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr "使用刀具半径补偿时不能改变刀具偏置"
+
+#, fuzzy
+#~ msgid "Please emit an G40 before tool touch off"
+#~ msgstr "未选择用于刀具对刀的轴"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "选择项目进行探测"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "世界模式"
+
+#, fuzzy
+#~ msgid "no button here"
+#~ msgstr "点动按钮选择 +"
+
+#, fuzzy
+#~ msgid "Enter value"
+#~ msgstr "输入"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "程序加载: %s"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "清除走刀轨迹"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "等轴侧视图"
+
+#, fuzzy
+#~ msgid "Show or hide dimensions"
+#~ msgstr "显示键绑定"
+
+#, fuzzy
+#~ msgid "Offset Page"
+#~ msgstr "偏移量"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "刀具表"
+
+#, fuzzy
+#~ msgid "File Selection"
+#~ msgstr "轴选择"
+
+#, fuzzy
+#~ msgid "jog joints"
+#~ msgstr "关节"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr ""
+#~ "忽略\n"
+#~ "限制"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "<b>USB 点动</b>"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "刀具"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "偏移"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "偏移"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "<b>配置</b>"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "当前指令集:"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "当前指令集:"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "运行模式"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "<b>冷卻液</b>"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "<b>主轴</b>"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "<b>主轴倍率</b>"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "设置进给倍率 0%-100%"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "<b>外部进给倍率</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "Search\n"
+#~ " back"
+#~ msgstr "搜索路径"
+
+#, fuzzy
+#~ msgid ""
+#~ "Search\n"
+#~ "  fwd"
+#~ msgstr ""
+#~ "向前\n"
+#~ "搜索"
+
+#, fuzzy
+#~ msgid "Replace"
+#~ msgstr "替换:"
+
+#, fuzzy
+#~ msgid "Start maximized"
+#~ msgstr "强制最大化"
+
+#, fuzzy
+#~ msgid "Start as window"
+#~ msgstr "位状态窗口"
+
+#, fuzzy
+#~ msgid "X Pos."
+#~ msgstr " 位置 "
+
+#, fuzzy
+#~ msgid "Y Pos."
+#~ msgstr " 位置 "
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "<b>基本设置</b>"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "显示偏移量"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "键盘"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "预览"
+
+#, fuzzy
+#~ msgid "show offsets"
+#~ msgstr "显示偏移量"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "相对颜色"
+
+#, fuzzy
+#~ msgid "Absolute Color"
+#~ msgstr "绝对颜色"
+
+#, fuzzy
+#~ msgid "DTG Color"
+#~ msgstr "DTG颜色"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "全部回零"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "全部消零"
+
+#, fuzzy
+#~ msgid "Digits"
+#~ msgstr "数字接口"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr "<b>页</b>"
+
+#, fuzzy
+#~ msgid "Grid size"
+#~ msgstr "网格大小"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "显示"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "显示偏移量"
+
+#, fuzzy
+#~ msgid "Show DTG"
+#~ msgstr ""
+#~ "显示\n"
+#~ "DTG"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "<b>选择按钮</b>"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>页</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "关于当前子文件"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "选择点动速度"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "<b>选择按钮</b>"
+
+#, fuzzy
+#~ msgid "<b>Themes and sound</b>"
+#~ msgstr "<b>默认值和选项</b>"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "设定主轴倍率"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "选择最大速度"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "设定进给速率:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "设定主轴倍率"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "<b>步进电机比例</b>"
+
+#, fuzzy
+#~ msgid "Use unlock code"
+#~ msgstr "未使用编码器"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "<b>刀具设置</b>"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "主轴刹车开"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "主轴停止"
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "<b>USB 点动</b>"
+
+#, fuzzy
+#~ msgid "Probe Height"
+#~ msgstr "对刀信号"
+
+#, fuzzy
+#~ msgid "Z Pos."
+#~ msgstr " 位置 "
+
+#, fuzzy
+#~ msgid "Max. Probe"
+#~ msgstr "探测"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "<b>程序选项</b>"
+
+#, fuzzy
+#~ msgid "Search Vel."
+#~ msgstr ""
+#~ "搜索\n"
+#~ "内容:"
+
+#, fuzzy
+#~ msgid "Probe Vel."
+#~ msgstr "对刀信号"
+
+#, fuzzy
+#~ msgid "<b>Probe velocitys</b>"
+#~ msgstr "<b>最大速度倍率</b>"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "<b>冷卻液</b>"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "刷新刀具表"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "刷新刀具表"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "从选定的行运行"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "<b>回零</b>"
+
+#, fuzzy
+#~ msgid "Launch test message"
+#~ msgstr "启动测试面板"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "显示高级选项"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "开机"
+
+#, fuzzy
+#~ msgid "enter auto mode to run programs"
+#~ msgstr "串行MODBUS程序"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "显示状态栏"
+
+#, fuzzy
+#~ msgid "open touch off button list"
+#~ msgstr "刀具对刀到夹具"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "世界模式"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "重新载入程序"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "重新载入程序"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "停止运行程序, 或"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "停止运行程序, 或"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "停止运行程序, 或"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr ""
+#~ "编辑梯形图\n"
+#~ "程序"
+
+#, fuzzy
+#~ msgid "delete MDI"
+#~ msgstr "删除"
+
+#, fuzzy
+#~ msgid "delete MDI history"
+#~ msgstr "清除 MDI 历史"
+
+#, fuzzy
+#~ msgid "Cl.-ladder"
+#~ msgstr "梯形图"
+
+#, fuzzy
+#~ msgid "Open classicladder"
+#~ msgstr "包括_Classic梯形图PLC"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "HAL示波器"
+
+#, fuzzy
+#~ msgid "launch hal scope"
+#~ msgstr "启动 %s"
+
+#, fuzzy
+#~ msgid "launch linuxcnc status"
+#~ msgstr ""
+#~ "linuxcnc\n"
+#~ "   状态"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "轴调校"
+
+#, fuzzy
+#~ msgid "Halshow"
+#~ msgstr "Hal示波器"
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "刷新刀具表"
+
+#, fuzzy
+#~ msgid "reload tool table from file"
+#~ msgstr "刷新刀具表"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "设置刀具编号"
+
+#, fuzzy
+#~ msgid "change tool to the selected one"
+#~ msgstr "当前所选梯级的标签"
+
+#, fuzzy
+#~ msgid ""
+#~ "touchoff\n"
+#~ "  tool x"
+#~ msgstr "刀具对刀到夹具"
+
+#, fuzzy
+#~ msgid "touch off the tool and set the value to the tool table"
+#~ msgstr "请求的刀具%d在刀具表中找不到"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "加载文件:"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "回零所有关节"
 
 #~ msgid "Substituting"
 #~ msgstr "替代"
@@ -19823,107 +19540,6 @@ msgstr "回零所有关节"
 #~ msgid "Function code-%X ) "
 #~ msgstr "功能代码-%X ) "
 
-#~ msgid ""
-#~ "**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
-#~ msgstr "****偏移页面小部件错误:在INI的TRAJ部分中找不到LINEAR_UNITS"
-
-#~ msgid "offsetpage widget error: unrecognized float input"
-#~ msgstr "偏移页面小部件错误:无法识别的浮点输入"
-
-#~ msgid "offsetpage widget error: MDI call error"
-#~ msgstr "偏移页面窗口小部件错误:MDI调用错误"
-
-#~ msgid "MDI error in offsetpage widget -zero G92"
-#~ msgstr "偏移页面小部件中的MDI错误-置零 G92"
-
-#~ msgid "MDI error in offsetpage widget-zero rotational offset"
-#~ msgstr "偏移页面中的MDI错误 - 置零旋转偏移"
-
-#~ msgid "offsetpage_widget error: cannot select coordinate system"
-#~ msgstr "偏移页面小部件错误:无法选择坐标系"
-
-#~ msgid "tooledit_widget error: cannot select tool number"
-#~ msgstr "刀具编辑小部件错误:无法选择刀具编号"
-
-#~ msgid "Toolfile does not exist"
-#~ msgstr "刀具文件不存在"
-
-#~ msgid "Tooledit widget int error"
-#~ msgstr "刀具编辑小部件初始化错误"
-
-#~ msgid "Tooledit_widget float error"
-#~ msgstr "刀具编辑小部件浮动错误"
-
-#~ msgid "Reloading tooltable into linuxcnc failed"
-#~ msgstr "将刀具表重新加载到linuxcnc失败"
-
-#~ msgid "Tool file was modified since it was last read"
-#~ msgstr "刀具文件自上次读取后被修改"
-
-#~ msgid "radiobutton"
-#~ msgstr "单选按钮"
-
-#~ msgid "checkbutton"
-#~ msgstr "检查按钮"
-
-#~ msgid "button"
-#~ msgstr "按钮"
-
-#~ msgid "togglebutton"
-#~ msgstr "切换按钮"
-
-#~ msgid "Offset Name"
-#~ msgstr "偏移名称"
-
-#~ msgid ""
-#~ "    Zero\n"
-#~ "Rotational"
-#~ msgstr ""
-#~ "置零\n"
-#~ "旋转"
-
-#~ msgid "Select"
-#~ msgstr "选择"
-
-#~ msgid "Tool#"
-#~ msgstr "刀号#"
-
-#~ msgid "Pocket"
-#~ msgstr "刀袋"
-
-#~ msgid "Front"
-#~ msgstr "正面"
-
-#~ msgid "Orientation"
-#~ msgstr "方向"
-
-#~ msgid "Comments"
-#~ msgstr "注释"
-
-#~ msgid "All Offsets"
-#~ msgstr "所有补偿"
-
-#~ msgid "X Wear"
-#~ msgstr "X 磨损"
-
-#~ msgid "Z Wear"
-#~ msgstr "Z 磨损"
-
-#~ msgid "DIameter"
-#~ msgstr "直径"
-
-#~ msgid "Lathe Wear Offsets"
-#~ msgstr "车床磨损补偿"
-
-#~ msgid "X Tool"
-#~ msgstr "X 刀具"
-
-#~ msgid "Z Tool"
-#~ msgstr "Z 刀具"
-
-#~ msgid "Lathe Tool Offsets"
-#~ msgstr "车床刀具补偿"
-
 #~ msgid "Spindle ($) number out of range in M4 Command"
 #~ msgstr "M4命令中的主轴 ($) 编号超出范围"
 
@@ -19932,9 +19548,3 @@ msgstr "回零所有关节"
 
 #~ msgid "Invalid spindle ($) numberin G74/G84 cycle"
 #~ msgstr "G74 / G84循环中的主轴($) 编号无效"
-
-#~ msgid "Rot"
-#~ msgstr "旋转"
-
-#~ msgid "Rotation of Z"
-#~ msgstr "Z的旋转"

--- a/src/po/zh_HK.po
+++ b/src/po/zh_HK.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: 2012-03-11 12:55+0200\n"
 "Last-Translator: k.t. chan <eddie692962@netvigator.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,67 +18,67 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 0.5\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr "命令 (%s) 不能執行 直到機器 離開 急停 並開動"
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "不能做到這一點（%s）在手動模式"
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr "不能做到這一點（%s）在自動模式與翻譯空閒"
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr "不能做到這一點（%s）在自動模式與翻譯閱讀"
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr "不能做到這一點（%s）在自動模式與翻譯暫停"
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr "不能做到這一點（%s）在自動模式與翻譯等待"
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "不能做到這一點（%s）在MDI模式"
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr "無法切換模式，而模式是AUTO和解釋是沒有閒著"
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 #, fuzzy
 msgid "failed to close file"
 msgstr "無法打開文件 <%s>"
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "不能打開 %s"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr "不能發出 MDI命令當沒有歸零"
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "必須在MDI模式下發出 MDI命令"
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr "不能運行程序，當沒有歸零"
 
@@ -199,425 +199,425 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr "您必須指定X和Y坐標對控制點"
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr "可以指定P沒有 X和Y只對第一個控制點"
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr "必須指定積極重量P為每一個控制點"
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr "不能作出NURBS使用進給速度0"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr "不能使用 G5.3沒有 G5.2先行"
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr "您必須指定一個數字控制點至少等於順序L =％d"
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr "無法轉換 樣條曲線 有刀具半徑補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr "樣條曲線必須在XY平面"
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr "樣條曲線 無法 有動作 在 Z，A，B  或  C"
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr "必須同時指定I和J使用 G5.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr "必須同時指定 I和J，或者兩者都不要"
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr "必須同時指定P和Q使用 G5"
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr "移動只是在退出刀具補償模式必須是直的，而不是一個弧"
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr "不能進給 用 零速度主軸 在 進給每轉 模式下"
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr "%c 字中 缺少 在 絕對的中心弧"
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr "刀具半徑補償進入弧不大於刀具半徑"
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr "弧移動無法到達凹角 使用該工具 而沒有刨削槽"
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr "弧至弧移動是無效的，因為有相同的弧中心"
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr "弧至弧運動 做一個角落 補償工具 不適合 有刨削槽"
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr "無效的絕對位置 %5.2f 給包裹 旋轉軸 %c"
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr "不能改變控制模式 當 使用刀具半徑補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr "不能改變坐標系 當 使用刀具半徑補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr "G%d 與車刀，但平面不是 G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr "無法設置 參考點 當 使用刀具補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr "無法設置 運動 輸出 當 刀具半徑補償 開"
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr "沒有有效的P字使用 M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr "沒有有效的P字使用 M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr "無法設置附屬數碼輸出當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr "沒有有效的P字使用 M64"
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr "沒有有效的P字使用 M65"
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr "沒有有效的P字使用 M66"
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr "不能等待數碼輸入當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr "不能等待模擬輸入當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr "無法設置運動模擬輸出當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr "無效的模擬指標使用 M67"
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr "無法設置輔助模擬輸出當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr "無效的模擬指標使用 M68"
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 #, fuzzy
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr "需要正的 Q-字 指定刀具號 當使用M61"
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr "無法啟用超速 當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr "無法禁用超速 當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr "指標軸 %c 只能 用 G0 移動"
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr "指標軸 %c 只能單獨移動 "
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr "無法 探測 使用 進給每轉 模式"
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr "不能改變回縮模式當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr "Q 編號在 G10 是不是整數"
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr "無效的刀具定位"
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr "不能改變激活的坐標系當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr "R 不容許在 G10 L20"
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr "在 G33 主軸不轉動"
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr "在 G33.1 主軸不轉動"
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, fuzzy, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "在 G33 主軸不轉動"
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr "BUG: 一軸錯誤地和索引器一起移動"
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr "BUG: 試圖指標不正確軸"
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr "不能使用G76螺紋週期當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr "在 G76，I 不能為 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr "在 G76，J 必須大於 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr "在 G76，K 必須大於 J"
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr "刀具長度補償 進入移動 不大於刀具半徑"
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr "零度內角 是無效的刀具補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr "弧到直線運動做的角,補償工具不適合會做成刨削槽"
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr "不能更改工具，刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr "不能改變刀具補償當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -732,30 +732,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "不能用極坐標使用 G53"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr "無法指定X或Y字當使用極坐標"
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr "必須指定角度在極坐標如過在原點"
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr "增量運動使用極坐標是不確定的，當在原點"
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr "G91運動使用極坐標是不確定的，當在原點"
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr "請求工具 %d 刀具表找不到"
@@ -870,102 +870,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, fuzzy, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "未在子程序定義"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "命名參數 #<%s> 沒有定義"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, fuzzy, c-format
 msgid "cant open ini file '%s'"
 msgstr "不能打開 %s"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, fuzzy, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "命名參數 #<%s> 沒有定義"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr "內部錯誤：無法指派 #<%S>"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "換刀後隊列不空"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "無法打開參數文件: '%s'"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 #, fuzzy
 msgid "Parameter file name is missing"
 msgstr "參數 文件 是　%s"
@@ -1390,7 +1390,8 @@ msgid "Negative spindle speed used"
 msgstr "在使用主軸轉速負值"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "負ID的刀具"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1772,24 +1773,23 @@ msgstr "R小於 U在週期VW平面"
 msgid "R less than V in cycle in UW plane"
 msgstr "R小於 V的週期在UW平面"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "故障: '%s' 不是有效的探查類型\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "故障: 沒有 針腳/信號/參數  名字\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr "故障: -s 選項需要一個探頭類型和 針/信號​​/參數 名稱\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "HAL 儀表"
 
@@ -1801,27 +1801,27 @@ msgstr "選擇(_S)"
 msgid "E_xit"
 msgstr "退出(_x)"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "選擇項目 以探測"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr " 針(_P) "
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr " 信號​​(_S) "
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr " 參數(_m) "
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr " 關閉(_C) "
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
@@ -1829,67 +1829,89 @@ msgstr ""
 "用法:\n"
 " hal示波器 [-h][-i 文件入][-o 文件出][數字_樣本]\n"
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "打開配置文件:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "取消"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "打開..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "打開配置文件:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "保存"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "打開配置(_O)..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "保存配置(_S)...."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "打開數據文件(_p)..."
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "保存數據文件(_a)..."
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "退出(_Q)"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "關於 Halscope(_A)"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "文件(_F)"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "求助(_H)"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "HAL示波器"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "水平"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "選擇通道"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "運行模式"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "觸發"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "垂直"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1897,39 +1919,40 @@ msgstr "垂直"
 msgid "Stop"
 msgstr "停"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "正常"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "單"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "翻滾"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "縮放"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr "位置"
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "-----選樣\n"
-"於 ---- KHz"
+"於 ---- kHz"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "實時元件沒有加載"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1943,11 +1966,39 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr "可以"
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "退出"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "實時功能沒有鏈接"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1960,11 +2011,11 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "選擇採樣率"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
@@ -1974,94 +2025,70 @@ msgstr ""
 "或\n"
 "點擊 '退出' 以離開 HAL示波器"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+#, fuzzy
+msgid "_OK"
+msgstr "可以"
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr "線程:"
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr "採樣 時段:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr "採樣率:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr "線程"
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "期段"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "倍增:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr "記錄長度"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d 樣品（1通道）"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d 樣品 （2通道）"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d 樣品 （4通道）"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d 樣品 （8通道）"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d 樣品 （16通道）"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr "可以"
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "退出"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr "實時線程沒有運行"
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2075,15 +2102,15 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr "選擇日誌文件寫入:"
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr "沒有足夠的通道"
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
@@ -2093,7 +2120,7 @@ msgstr ""
 "選擇一個較短的記錄長度\n"
 "支持更多的頻道."
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
@@ -2102,7 +2129,7 @@ msgstr ""
 "%s\n"
 "每分度"
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
@@ -2111,27 +2138,35 @@ msgstr ""
 "%s 樣本\n"
 "在 %s"
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr "納秒"
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr "微秒"
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr "毫秒"
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
 msgstr "秒"
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2147,15 +2182,17 @@ msgstr "秒"
 msgid "Hz"
 msgstr "赫茲"
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+#, fuzzy
+msgid "kHz"
 msgstr "千赫"
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+#, fuzzy
+msgid "MHz"
 msgstr "兆赫"
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
@@ -2164,24 +2201,25 @@ msgstr ""
 "偏移\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "增益"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr "定位"
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr "尺度"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
@@ -2190,15 +2228,11 @@ msgstr ""
 "偏移\n"
 "%s"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr "通道 關"
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "設置偏移"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
@@ -2207,35 +2241,19 @@ msgstr ""
 "設置垂直偏移量\n"
 "對通道 %d."
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "設置偏移"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr "交流耦合"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "取消"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr "太多的通道"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2247,21 +2265,7 @@ msgstr ""
 "要么關閉一個或多個通道，或縮短的記錄長度，\n"
 "以便有更多的通道"
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr "選擇通道來源"
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
@@ -2270,29 +2274,33 @@ msgstr ""
 "選擇一個 針，信號或參數\n"
 "作為源通道 %d."
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "選擇通道來源"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "針"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "信號"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "參數"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr "下降"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr "上升"
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
@@ -2300,7 +2308,7 @@ msgstr ""
 "來源\n"
 "沒有"
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
@@ -2309,114 +2317,115 @@ msgstr ""
 "來源\n"
 "通道 %2d"
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "自動"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr "強制"
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr "等級"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr "觸發源"
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr "選擇一個通道用於觸發"
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "觸發源"
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr "通道"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr "來源"
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, c-format
 msgid "fault %d during orient in progress"
 msgstr "故障 %d 在進行取向時"
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr "G38.4 移動完成後不阻斷接觸."
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr "G38.2 移動完成後不作出接觸."
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+#, fuzzy
+msgid "Probe tripped during non-probe move."
 msgstr "探頭跳閘在非探測 MDI 命令."
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr "探頭跳閘在歸零運動."
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 #, fuzzy
 msgid "Probe tripped during a joint jog."
 msgstr "探頭跳閘當正在慢步."
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 #, fuzzy
 msgid "Probe tripped during a coordinate jog."
 msgstr "探頭跳閘當正在慢步."
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr "運動停止因有 允許 輸入"
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, fuzzy, c-format
 msgid "spindle %d amplifier fault"
 msgstr "Joint %d 放大器故障"
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "Joint %d 在限位開關 故障"
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "Joint %d 放大器故障"
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "Joint %d 跟隨 故障"
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, fuzzy, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr "超出 正 軟極限在 Joint %d"
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 #, fuzzy
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr "所有 Joint 一定 要在 零點 才能  進入 遠程操作 模式"
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, fuzzy, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr "超出 正 軟極限在 Joint %d"
@@ -2485,177 +2494,177 @@ msgstr "%s 在線 %d 移動 將超過 Joint %d 的 負 極限"
 msgid "all joints must be homed before going into coordinated mode"
 msgstr "所有 joint 一定 要在 零點 才能 進入 坐標 模式"
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr "不能 慢步 Joint 未有 允許 "
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr "不能 慢步 Joint 當 在 歸零 時"
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr "不能 慢步 Joint 當 在 歸零 時"
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr "要有 允許 才能在 坐標 模式 作直線移動"
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr "不能 加入 直線 移動 當 超出 極限"
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, fuzzy, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr "不能 加入 直線 移動 當 超出 極限"
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr "需要允許才能 作 坐標模式 的環形移動"
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr "不能作 環形的 移動 當 超出 極限"
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, fuzzy, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr "不能作 環形的 移動 當 超出 極限"
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr "動作: 不能 STEP 當 已 在 執行 "
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr "不能 允許 的動作, 允許 輸入 是 偽 "
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr "一定 要在 Joint 模式 才能 歸零 "
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr "歸零 序列 已在 進行中"
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr "一定 要在 Joint 模式 或 不允許 才 可以 離零"
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr "不能 離零 當 在 歸零中, Joint %d"
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr "不能 離零 當 在 移動 中, Joint %d "
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, fuzzy, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr "不能 慢步 Joint 未有 允許 "
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr "不能 離零 未激活的 Joint %d"
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr "不能 離零 無效的 Joint %d (max %d) "
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr "需要允許,以坐標模式 移動探頭    "
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr "不能做探頭移動當有超限"
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr "探測已經清徐當啟動 G38.4或G38.5 移動"
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr "探測已經被脫扣當起動G38.2 或G38.3 移動"
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr "不能添加探測移動"
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr "在坐標模式做剛性攻絲移動,需要啟動指令"
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr "不能做剛性攻絲移動當超過極限"
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, fuzzy, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr "不能做剛性攻絲移動當超過極限"
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, fuzzy, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr "試圖提高負對非整數冪"
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr "joint %d: 太多的補償條目"
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr "joint %d: 補償值必須增加"
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr "無法識別的命令 %d"
@@ -2744,26 +2753,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2934,7 +2943,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -3024,19 +3033,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "是"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 #, fuzzy
 msgid "No"
 msgstr "無"
@@ -3090,7 +3099,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "保存"
 
@@ -3109,7 +3118,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "編輯器"
 
@@ -3124,7 +3133,6 @@ msgid "Config"
 msgstr "HAL 設定"
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 msgid "Preview"
 msgstr "預演"
 
@@ -3556,7 +3564,7 @@ msgid "Edit mode..."
 msgstr "編輯..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "刪除"
 
@@ -3565,7 +3573,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "添加"
 
@@ -3576,6 +3584,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "修改"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "取消"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3765,7 +3791,7 @@ msgid "Parameter"
 msgstr "參數"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3954,7 +3980,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "主頁"
 
@@ -4036,11 +4061,13 @@ msgid "Delete section"
 msgstr "相對位置"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 #, fuzzy
 msgid "Move Down"
 msgstr "向下"
@@ -4562,6 +4589,7 @@ msgid "Exit"
 msgstr "退出"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "修訂"
 
@@ -4604,7 +4632,6 @@ msgid "Renumber File..."
 msgstr "重新編號文件..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "設定"
 
@@ -4880,15 +4907,15 @@ msgstr "樹狀觀看"
 msgid "Test HAL command :"
 msgstr "測試 HAL 指令 ："
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr "加載觀察名單"
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr "保存當前觀察名單"
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "指令可以在這兒測試但不會被保存"
 
@@ -5002,23 +5029,23 @@ msgstr "方向"
 msgid "SIZE :"
 msgstr "規格 :"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 msgid "LinuxCNC Errors"
 msgstr "LinuxCNC 故障"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 #, fuzzy
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr "LinuxCNC 因故障 結束. 如要 報告問題, 請包括下面 的所有信息 在您的 消息"
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 #, fuzzy
 msgid "Create Report File"
 msgstr "創建 或 修改"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "結束"
 
@@ -5092,7 +5119,7 @@ msgstr "設置 刀具 偏移量"
 msgid "Tool:"
 msgstr "刀具:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "所有文件"
@@ -5159,18 +5186,18 @@ msgstr "單位"
 msgid "auto"
 msgstr "自動"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "英寸"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5328,7 +5355,7 @@ msgstr ""
 msgid "world"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "零點"
 
@@ -5409,16 +5436,15 @@ msgstr "校驗"
 msgid "Optional Stop"
 msgstr "可選 的 停止"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "字體 設為"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "字體"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "大小"
 
@@ -5527,7 +5553,7 @@ msgid "Coordinate System Control Window"
 msgstr "坐標 系統 控制 窗口"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "軸 "
 
@@ -6107,9 +6133,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr "自訂"
 
@@ -6129,8 +6155,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr "警告"
 
@@ -6207,156 +6233,156 @@ msgstr "（無文件）"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 #, fuzzy
 msgid "problem with"
 msgstr "替換："
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 #, fuzzy
 msgid "Linescale"
 msgstr "比例"
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 #, fuzzy
 msgid "default"
 msgstr "AXIS 預 置 值"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 #, fuzzy
 msgid "Mode"
 msgstr "運行模式"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 #, fuzzy
 msgid "normal"
 msgstr "正常"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 #, fuzzy
 msgid "Switches"
 msgstr "英寸"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 #, fuzzy
 msgid "no such file"
 msgstr "（無文件）"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 #, fuzzy
 msgid "file not readable"
 msgstr "文件未打開"
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 #, fuzzy
 msgid "not readable"
 msgstr "文件未打開"
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 #, fuzzy
 msgid "LinuxCNC"
 msgstr "Linuxcnc 排錯"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "LinuxCNC 故障"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7031,220 +7057,218 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "未知的刀具 %d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "沒有刀具"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "刀具 %(tool)d, 偏移 %(zo)g, 直徑 %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "刀具 %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "篩選...."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "篩選 失敗"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
 "produced are shown below:"
 msgstr "該程序 %(program)r 退出 的 程式碼 %(code)d. 所有 錯誤信息 產生 如下:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "G 代碼 錯誤 在 %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
 "%(error_str)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "連續"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr "T    刀具表"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "英寸"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr "  半徑"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr "  直徑"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "坐標系:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr "夾具"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr "工件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "名稱:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "尺寸:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "刀具秩序:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "快速的距離:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "進給距離:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "總距離:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "運行時間:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "X 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Y 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Z 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "A 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "B 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "C 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "程序 超出 机床 最低 限度 在 軸 %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "程序 超出 机床 最高 限度 在 軸 %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "程序 超出 机床 極限"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "運行 無論如何"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "沒有 文件 加載"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "產生 於　%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
 "%(lines)s gcode lines"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "G 代碼 性質"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "所有 可 加工 文件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "rs274ngc 文件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr "軸 不能接受 遠程 指令 在 運行時"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 #, fuzzy
 msgid "File not Writable:"
 msgstr "文件未打開"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7255,62 +7279,62 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Custom Grid"
 msgstr "自訂"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 #, fuzzy
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr "軸 已經 在零，你一定要 重新 再 歸零?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, fuzzy, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr "一定 要在 Joint 模式 才能 歸零 "
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 #, fuzzy
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr "這軸 已經 在零，你一定要 重新 再 歸零?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 #, fuzzy
 msgid "Touch Off (system)"
 msgstr "對刀"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "輸入 %s 坐標相對於 %%s:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, fuzzy, python-format
 msgid "Tool %s TouchOff"
 msgstr "對刀"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "保存 文件 時出錯"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7319,7 +7343,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7328,7 +7352,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7337,91 +7361,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "輸入輸出點"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "全部 歸零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, fuzzy, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "所有軸 歸零 [Ctrl-Home]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "全部 歸零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "離零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "Joint 模式"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "軸回零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, fuzzy, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "離零 軸 _%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "從 這裡 運行"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "錯誤 joi ~/.axisrc"
 
@@ -7732,11 +7756,13 @@ msgid "_Properties..."
 msgstr "屬性(_P)......"
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "編輯刀具表(_t)...."
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+#, fuzzy
+msgid "Reload tool _data"
 msgstr "重新載入刀具表(_b)"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8065,11 +8091,11 @@ msgstr "切換 跳 行 用 '/' [Alt-M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "切換 任擇 停頓 [Alt-M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "放大"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "縮小"
 
@@ -8248,9 +8274,10 @@ msgstr "設定主軸超速:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr ""
 
@@ -8293,7 +8320,7 @@ msgid "Position:"
 msgstr "位置:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr ""
 
@@ -8399,21 +8426,20 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "暫時 讓 機器 在 極限外 慢步 [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "主軸 順時針"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "主軸 逆時針"
@@ -8756,6 +8782,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8765,43 +8793,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8856,7 +8929,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr "<b>主軸</b>"
 
@@ -9020,7 +9092,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr ""
 
@@ -9080,8 +9151,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9214,10 +9285,10 @@ msgid "Stepconf"
 msgstr "步進"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9238,13 +9309,13 @@ msgid "Parallel Port 1"
 msgstr "第一並行端口設置"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 #, fuzzy
 msgid "Parallel Port 2"
 msgstr "第一並行端口設置"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "GUI 的選項 "
@@ -9254,235 +9325,286 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "左 按鈕"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "Spindle"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "步進"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "掃描方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "步進"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "掃描方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "主 軸 步進產生器"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "掃描方向"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "主 軸 步進產生器"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "掃描方向"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+#, fuzzy
+msgid "Plasma Ohmic Enable"
+msgstr "啟用"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9493,252 +9615,333 @@ msgstr ""
 msgid "Unused"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "零點"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "零點"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+msgid "Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+msgid "Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-msgid "All limits"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-msgid "All home"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-msgid "All limits + homes"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 0"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 1"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 2"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 3"
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+msgid "Both Limit + Home Tandem X"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+msgid "Both Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
+msgid "All limits"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
+msgid "All home"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
+msgid "All limits + homes"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 0"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 1"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 2"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "向下"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "主軸 前轉"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9747,14 +9950,14 @@ msgid ""
 "Are you sure?  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
@@ -9765,26 +9968,26 @@ msgstr ""
 "現有 Custom.clp將改名custom_backup.clp.(_b)\n"
 "任何現有的 文件命名 -custom_backup.clp- 將會丟失."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9795,43 +9998,43 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr "創建一個桌面 啟動器 啟動 LinuxCNC 與 此配置."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9839,34 +10042,34 @@ msgid ""
 "{}"
 msgstr "Linuxcnc 配置文件選擇器"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -9881,8 +10084,8 @@ msgstr ""
 msgid "mm / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -9897,13 +10100,13 @@ msgstr ""
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr ""
 
@@ -9913,19 +10116,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "打開配置文件:"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -9937,7 +10140,7 @@ msgstr ""
 msgid "mm / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -9948,28 +10151,28 @@ msgstr ""
 msgid "Steps / mm"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -9977,99 +10180,104 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+msgid "# Include your custom HAL commands here"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
@@ -10141,11 +10349,16 @@ msgstr "樣辦配置"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr "標　籤"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "向後"
 
@@ -10185,17 +10398,6 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:209
@@ -10545,53 +10747,150 @@ msgstr ""
 msgid "Scale %"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "位移:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "位移:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+#, fuzzy
+msgid "Alignment Laser:"
+msgstr "對準電流"
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "急停 開"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "左 按鈕"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "運行模式"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 msgid "Spindle speed display  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10600,79 +10899,83 @@ msgid ""
 "panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 #, fuzzy
 msgid "Set pyVCP options"
 msgstr "幾何　的選項"
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
 "program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "樣辦配置"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr ""
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10690,16 +10993,154 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "運行模式"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10709,10 +11150,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr "正"
@@ -10740,15 +11181,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisv.glade:249
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
@@ -10947,39 +11379,39 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 #, fuzzy
 msgid "Specific Help page is unavailable\n"
 msgstr "PCI 搜索頁面 無法使用\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -10987,23 +11419,23 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 #, fuzzy
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "打開配置文件:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11013,33 +11445,33 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 #, fuzzy
 msgid "Discovery is  unavailable\n"
 msgstr "PCI 搜索頁面 無法使用\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11048,183 +11480,183 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 #, fuzzy
 msgid "Unused Channel"
 msgstr "選擇通道"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr "你不能 同時 擁有 步進電機 和 PWM信號 給主軸控制\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr "你忘了 指定 步進電機 或 PWM 信號 給軸 %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, fuzzy, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr "你忘了 指定 編碼器 信號 給軸 %s 伺服\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr "你忘了 指定 一個 PWM 信號 或步進信號 給軸 %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr "你 不能 擁有 同時 用 步進電機 和PWM信號 的軸 %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr "Touchy 需要 外部 循環 啟動 信號\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr "Touchy 需要 一個 外部 中斷 信號\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr "Touchy 需要 一個 外部 單步信號\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr "Touchy 需要 外部 多手輪 MPG 編碼器 信號 在 mesa 頁面\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr "Touchy 要求“外部MPG慢步”被選中的外部控制 頁面\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr "Touchy 要求外部MPG將在“共享MPG”模式對外部 控制 頁面\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr "Touchy 需要 可選擇 增量 將未選中 的外部 控制 頁面\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr "齒輪箱 減速比"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr "減速比"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr "丝杆 螺距"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr "丝杆 TPI"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 #, fuzzy
 msgid " / min"
 msgstr "毫米 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 #, fuzzy
 msgid " / sec²"
 msgstr "毫米 / 秒²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "毫米 / 步"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "步 / 英寸"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 #, fuzzy
 msgid " / encoder pulse"
 msgstr "毫米 / 編碼器脈衝 "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 #, fuzzy
 msgid "Encoder pulses / "
 msgstr "編碼器 脈衝 / 毫米"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "編碼器比例"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Axis 比例計算"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr "Axis 比例計算"
 
@@ -11242,32 +11674,35 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr "PCI 搜索頁面 無法使用\n"
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr "毫米 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr "毫米 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11276,7 +11711,7 @@ msgstr ""
 "您需要配置mesa1頁. \n"
 "選擇板型，固件組件 數量，並按下 '接受 組件更改' 按鈕"
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 #, fuzzy
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
@@ -11285,16 +11720,16 @@ msgstr ""
 "所選擇的Mesa1板不同於當前顯示.\n"
 "請按 '接受組件 更改' 按鈕"
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr "你需要指定一個 E-stop 輸入 端子 給這個梯形邏輯方案."
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 #, fuzzy
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr "你需要指定一個 E-stop 輸入 端子 給這個梯形邏輯方案."
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 #, fuzzy
 msgid ""
 "OK to replace existing custom ladder program?\n"
@@ -11308,8 +11743,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr ""
@@ -11325,169 +11760,174 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
-#, python-format
-msgid "Generated by PNCconf at %s"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
-msgid "configures LinuxCNC as:\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
-msgid "type CNC\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
-msgid "will be used as the frontend display"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
-msgid " connector"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
-msgid "invrt"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
-#, python-format
-msgid "%(name)s Parport"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
-msgid "-> inverted"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
+msgid "Generated by PNCconf at %s"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
+msgid "configures LinuxCNC as:\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
+msgid "type CNC\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
+msgid "will be used as the frontend display"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
+msgid " connector"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
+msgid "invrt"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
+#, python-format
+msgid "%(name)s Parport"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
+msgid "-> inverted"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
+#, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11503,1551 +11943,1606 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 msgid "External Controls"
 msgstr "外部控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 #, fuzzy
 msgid "Parallel Port"
 msgstr "第一並行端口設置"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 #, fuzzy
 msgid "X Motor"
 msgstr "反轉電機"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "X Axis"
 msgstr "X 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 #, fuzzy
 msgid "Y Motor"
 msgstr "反轉電機"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Y Axis"
 msgstr "Y 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 #, fuzzy
 msgid "Z Motor"
 msgstr "反轉電機"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Z Axis"
 msgstr "Z 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 #, fuzzy
 msgid "A Motor"
 msgstr "反轉電機"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "A Axis"
 msgstr "A 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "主軸 停"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Output"
-msgstr "輸出"
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Enable"
-msgstr "啟用"
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Dir"
-msgstr "掃描方向"
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Input"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO O Drain"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
+msgid "POT Output"
+msgstr "輸出"
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+#, fuzzy
+msgid "POT Enable"
+msgstr "啟用"
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+#, fuzzy
+msgid "POT Dir"
+msgstr "掃描方向"
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Input"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Output"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO O Drain"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:117
+#, fuzzy
 msgid "SSR Output"
 msgstr "輸出"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 0"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 1"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "muxed Enc I"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc M"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "mux select"
 msgstr "選擇歸零"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 0 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 1 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 2 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 3 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 4 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 5 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step Gen-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 #, fuzzy
 msgid "UDM-Down"
 msgstr "向下"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "模擬控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "X Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Y Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Z Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "A Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "All Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "X2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Y2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Z2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "A2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "All Limits + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 msgid "A2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr "關節 選 A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr "Joint 選 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr "Joint 選 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr "Joint 選 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr A"
 msgstr "進給超速 遞增 A "
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr B"
 msgstr "進給超速 遞增 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr C"
 msgstr "進給超速 遞增 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr D"
 msgstr "進給超速 遞增 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Spindle Override incr A"
 msgstr "主軸超速 遞增 A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr B"
 msgstr "主軸超速 遞增 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr C"
 msgstr "主軸超速 遞增 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr D"
 msgstr "主軸超速 遞增 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr A"
 msgstr "進給超速 遞增 A "
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr B"
 msgstr "進給超速 遞增 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr C"
 msgstr "進給超速 遞增 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Max Vel Override incr D"
 msgstr "進給超速 遞增 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "進給 超速"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "設定主軸超速:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "最大　進給　超越"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CW"
 msgstr "手動 主軸 CW"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CCW"
 msgstr "手動 主軸 CCW"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle Stop"
 msgstr "手動 主軸 停"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Spindle Up-To-Speed"
 msgstr "主軸 達速"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "全選"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Single Step"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "A2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "X 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "軸回零"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Arc OK"
+msgstr "弧 順時針"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "英寸"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 msgid "Overrides"
 msgstr "超速"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "Operation"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "External Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 msgid "Axis rapid"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "X Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "Y Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "Z Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "A Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Unused PWM Gen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Axis PWM"
 msgstr "軸 "
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 msgid "X Axis StepGen"
 msgstr "X 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Y Axis StepGen"
 msgstr "Y 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Z Axis StepGen"
 msgstr "Z 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 msgid "A Axis StepGen"
 msgstr "A 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "X2 Tandem StepGen"
 msgstr "主 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "Y2 Tandem StepGen"
 msgstr "主 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 #, fuzzy
 msgid "Z2 Tandem StepGen"
 msgstr "主 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 msgid "Unused StepGen"
 msgstr "未使用的 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Spindle StepGen"
 msgstr "主 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Feed Override"
 msgstr "進給 超速"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "spindle Override"
 msgstr "主軸 超越"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "最大　進給　超越"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr "軸編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Spindle Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr "MPG　慢步　操控"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr "超速 MPG　操控"
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "軸編碼器"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 #, fuzzy
 msgid "Unused Unused"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "主軸 慢些"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "機器 名稱:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "啟用"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "機器開"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "對刀"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Coolant"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 #, fuzzy
 msgid "Unused Resolver"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 #, fuzzy
 msgid "Spindle Output"
 msgstr "主軸 關"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr "未使用的 TPPWM　產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Unused Analog In"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13056,15 +13551,15 @@ msgid ""
 "be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 msgid "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13079,83 +13574,92 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 #, fuzzy
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr "伺服 調整 還沒有完成 / 在工作\n"
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr "度"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr "度 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr "度 / 秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr "轉"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr "轉速"
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr "轉速 / 秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr "毫米 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr "毫米 / 秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr "英寸 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr "英寸 / 秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr "%s 軸 調整"
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 #, fuzzy
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr "您必須指定  一個 編碼器 信號  和  PWM 信號  給此軸測試"
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 #, fuzzy
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr "您必須指定  一個 編碼器 信號  和  PWM 信號  給此軸測試"
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13168,7 +13672,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13178,18 +13682,18 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr "創建一個桌面 啟動器 啟動 LinuxCNC 與 此配置."
@@ -14858,9 +15362,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15015,6 +15519,13 @@ msgstr "用　防抖動"
 #: src/emc/usr_intf/pncconf/external.glade:5401
 msgid "Mux options"
 msgstr "MUX　的選項"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "秒"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15203,182 +15714,200 @@ msgstr "停機後　恢復　Joint　的位置"
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 #, fuzzy
 msgid "<b>GUI Screen list</b>"
 msgstr "<b>GUI前台列表</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr "位置 偏移量 (_o)"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr "定 位 反 饋 (_f)"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr "設定 主軸超速"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr "最小　主軸超速"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr "最大　進給　超越"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 #, fuzzy
 msgid "Display Geometry"
 msgstr "幾　　何"
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr "<b>一　般　GUI　預　設　值</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr " 線 性  速 度  預 置 值   "
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr "最　小　線 性  速 度　"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr "最　大　線 性  速 度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr "　角  速 度  預 置 值 　"
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr "最　小　角  速 度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr "　增　量　"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr "最　大　角  速 度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr "角度　/　分"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr "大小"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr "位置"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 #, fuzzy
 msgid "AXIS Defaults"
 msgstr "AXIS 預 置 值"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 #, fuzzy
 msgid "Absolute Textcolor"
 msgstr "絕對反饋"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "相對位置"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 #, fuzzy
 msgid "Touchy Defaults"
 msgstr "使用預置值"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "樣辦配置"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15476,138 +16005,155 @@ msgstr "GladeVCP　詳情"
 msgid "Include custom GladeVCP GUI panel"
 msgstr "包括自訂 GladeVCP GUI面板"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "軸編碼器"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
+msgid "Use Encoder Index For Home:"
+msgstr "使用編碼器指標為零點:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
+msgid "Home Final Velocity:"
+msgstr "歸零最終速度"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
+msgid "Home Latch Direction:"
+msgstr "歸零閉鎖方向:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
+msgid "Home Search Direction:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
+msgid "Home latch Velocity:"
+msgstr "零點鎖定速率:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "使用補償文件:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
+msgid "Use Backlash Compensation:"
+msgstr "使用反向間隙補償:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+#, fuzzy
+msgid "Final Home Position location   (Offset from machine zero Origin):"
+msgstr "零點定位 (從機床零點的偏移):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
+msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
+msgstr "負移動距離 (機床 零點到 負 行程尾): "
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+#, fuzzy
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
+msgstr "歸零開關的位置 (從機床零點的偏移):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
+msgid "Home Search Velocity:"
+msgstr "零點搜索速率:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
+msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
+msgstr "正移動距離 (機床 零點到 正 行程尾): "
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
+#, fuzzy
+msgid "Home Search Sequence:"
+msgstr "零點搜索速率:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+#, fuzzy
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr "歸零開關的位置 (從機床零點的偏移):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
 msgid "Type 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
 msgid "Type 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
 #, fuzzy
 msgid "Towards Negative Limit"
 msgstr ""
 "朝向負極限\n"
 "朝向正極限"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
 #, fuzzy
 msgid "Towards Positive Limit"
 msgstr ""
 "朝向負極限\n"
 "朝向正極限"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
-msgid "Use Encoder Index For Home:"
-msgstr "使用編碼器指標為零點:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
-msgid "Home Final Velocity:"
-msgstr "歸零最終速度"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
-msgid "Home Latch Direction:"
-msgstr "歸零閉鎖方向:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
-msgid "Home Search Direction:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
-msgid "Home latch Velocity:"
-msgstr "零點鎖定速率:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr "文件名:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr "使用補償文件:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
-msgid "Use Backlash Compensation:"
-msgstr "使用反向間隙補償:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
-msgstr "零點定位 (從機床零點的偏移):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
-msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
-msgstr "負移動距離 (機床 零點到 負 行程尾): "
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
-msgstr "歸零開關的位置 (從機床零點的偏移):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
-msgid "Home Search Velocity:"
-msgstr "零點搜索速率:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
-msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
-msgstr "正移動距離 (機床 零點到 正 行程尾): "
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
-#, fuzzy
-msgid "Home Search Sequence:"
-msgstr "零點搜索速率:"
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -16551,10 +17097,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 #, fuzzy
 msgid "Number of connectors:"
@@ -16645,10 +17187,6 @@ msgstr "微步乘係數:"
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr "電機步每轉:"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
-msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17101,7 +17639,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17269,32 +17806,24 @@ msgid "Manual Toolchange"
 msgstr "AXIS 手動 換刀"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 #, fuzzy
 msgid "Restart Entry"
 msgstr "重新 起動"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr "向上"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr "向下"
 
@@ -17374,33 +17903,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, fuzzy, python-format
 msgid "%4.2f mm/min"
 msgstr "mm/分"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17522,14 +18051,12 @@ msgid "<b>Status</b>"
 msgstr "<b>冷卻液</b>"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17537,7 +18064,6 @@ msgid ""
 msgstr "替換："
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17545,7 +18071,6 @@ msgid ""
 msgstr "全部替換"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17562,7 +18087,6 @@ msgid "Main Level"
 msgstr "等級"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17576,13 +18100,11 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 #, fuzzy
 msgid "Warning Audio"
 msgstr "警告"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17592,7 +18114,6 @@ msgid "Grid Size"
 msgstr "大小"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 #, fuzzy
 msgid "Starting RPM"
 msgstr "設定"
@@ -17674,7 +18195,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "校準(_C)"
@@ -17952,12 +18472,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "復原"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "重做"
 
@@ -17982,6 +18500,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18046,1664 +18566,733 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-#, fuzzy
-msgid "user mode selected"
-msgstr "選擇歸零"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "未知的G代碼在使用"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-#, fuzzy
-msgid "mm/min"
-msgstr "mm/分"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-#, fuzzy
-msgid "inch/min"
-msgstr "英寸 / 分鐘"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "Joint 模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr "還沒有任何參數"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-#, fuzzy
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr "不能做到這一點（%s）在自動模式與翻譯空閒"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-#, fuzzy
-msgid "Classicladder real-time component not detected"
-msgstr "實時元件沒有加載"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-#, fuzzy
-msgid "Enter value for diameter"
-msgstr "非整數值對整數"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-#, fuzzy
-msgid "Set diameter to:"
-msgstr "  直徑"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-#, fuzzy
-msgid "Enter value for radius"
-msgstr "非整數值對整數"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr "  半徑"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, fuzzy, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr "非整數值對整數"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, fuzzy, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "設定軸 偏移量:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "AXIS 手動 換刀"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-#, fuzzy
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr "不能改變刀具補償當刀具半徑補償在使用"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "選擇項目 以探測"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "World 模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-msgid "no button here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "程序檔案"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "清除 現場 繪圖"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "透視 視圖"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "偏移 值 "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "刀具"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-msgid "File Selection"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-#, fuzzy
-msgid "jog joints"
-msgstr "輸入輸出點"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "超速 極限"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "<b>歸零</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "刀具訊息"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-#, fuzzy
-msgid "Diameter"
-msgstr "  直徑"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "偏移"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "偏移"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "<b>配置</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "代碼中使用負值m"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "代碼中使用負值g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "<b>電源</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "<b>冷卻液</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "<b>主軸</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "<b>外部 主軸 超速</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "進給 超速設為從　0% 至　100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "<b>外部　進給 超速</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr "替換"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-#, fuzzy
-msgid "X Pos."
-msgstr "位置"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-#, fuzzy
-msgid "Y Pos."
-msgstr "位置"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "<b>機器 基本</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "顯示 偏移量(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "<b>電源</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "預演"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "顯示 偏移量(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "相對位置"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-#, fuzzy
-msgid "Absolute Color"
-msgstr "絕對反饋"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "全部 歸零"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "離零"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr "<b>電源</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-#, fuzzy
-msgid "Grid size"
-msgstr "大小"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "展示"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "顯示 偏移量(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-#, fuzzy
-msgid "Show DTG"
-msgstr "展示"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "<b>外部　按鈕　慢步</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<b>電源</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "重新打開 當前 文件 [Control-R]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "選擇 慢步 速度"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "選擇項目 以探測"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "設定 主軸超速"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "顯示 速率(_e)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "設定 超速調整:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "設定 主軸超速"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "<b>步進馬達比例</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-#, fuzzy
-msgid "Use unlock code"
-msgstr "未使用的編碼器"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "<b>歸零</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "主軸 剎車 開"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "主軸 剎車 開"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "<b>　前　台　</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-#, fuzzy
-msgid "Z Pos."
-msgstr "位置"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "<b>配置</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-#, fuzzy
-msgid "Search Vel."
-msgstr "零點搜索速率:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-#, fuzzy
-msgid "<b>Probe velocitys</b>"
-msgstr "<b>GUI前台列表</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "<b>冷卻液</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "重新 載入 刀具表"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "重新 載入 刀具表"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "運行選定的行(_n)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "<b>歸零</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-#, fuzzy
-msgid "Launch test message"
-msgstr "啟動測試面板"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "進階選項"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "開動 機器"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-msgid "enter auto mode to run programs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "顯示重開"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-#, fuzzy
-msgid "open touch off button list"
-msgstr "刀具 對 夾具 對刀(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "World 模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "重裝 程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "重裝 程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "停止 正在 運行 的程序, 或"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "停止 正在 運行 的程序, 或"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "停止 正在 運行 的程序, 或"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr "重裝 程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-#, fuzzy
-msgid "delete MDI"
-msgstr "刪除"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-#, fuzzy
-msgid "delete MDI history"
-msgstr "清除 MDI 歷史"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "HAL 顯示器"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "校準(_C)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "重新載入刀具表(_b)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "重新載入(_R)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "重新載入刀具表(_b)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "選擇項目 以探測"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-#, fuzzy
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr "刀具 對 夾具 對刀(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-#, fuzzy
-msgid "touch off the tool and set the value to the tool table"
-msgstr "請求工具 %d 刀具表找不到"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
-msgid "Move to parrent directory"
+#: lib/python/gladevcp/iconview.py:120
+msgid "Move to parent directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "選擇項目 以探測"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "選擇項目 以探測"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "程序檔案"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
 #, fuzzy
-msgid "home joints"
-msgstr "輸入輸出點"
+msgid "Toolfile does not exist"
+msgstr "刀具文件是　%s"
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "重新載入刀具表(_b)"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+msgid "Tool file was modified since it was last read"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "滾輪 按鍵"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+msgid "button"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "切換 淹浸"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "刀具:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "黑"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "旋轉 或 平移"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "位移:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "偏移 值 "
+
+#: lib/python/gladevcp/offsetpage.glade:442
+#, fuzzy
+msgid ""
+"Zero\n"
+"G92"
+msgstr "置零 于 所有G5"
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "水平"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "選擇(_S)"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "刀具 #:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+#, fuzzy
+msgid "Diameter"
+msgstr "  直徑"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "正面 視圖"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+msgid "Orientation"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "指令："
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "重新載入(_R)"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "軸向的 偏置"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "  直徑"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "工件 位移:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "刀具:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "刀具:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "設置 刀具 偏移量"
+
+#~ msgid "nSec"
+#~ msgstr "納秒"
+
+#~ msgid "uSec"
+#~ msgstr "微秒"
+
+#~ msgid "mSec"
+#~ msgstr "毫秒"
+
+#~ msgid "KHz"
+#~ msgstr "千赫"
+
+#~ msgid "Mhz"
+#~ msgstr "兆赫"
+
+#~ msgid "filename:"
+#~ msgstr "文件名:"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "選擇歸零"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "未知的G代碼在使用"
+
+#, fuzzy
+#~ msgid "mm/min"
+#~ msgstr "mm/分"
+
+#, fuzzy
+#~ msgid "inch/min"
+#~ msgstr "英寸 / 分鐘"
+
+#, fuzzy
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "Joint 模式"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr "還沒有任何參數"
+
+#, fuzzy
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr "不能做到這一點（%s）在自動模式與翻譯空閒"
+
+#, fuzzy
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "實時元件沒有加載"
+
+#, fuzzy
+#~ msgid "Enter value for diameter"
+#~ msgstr "非整數值對整數"
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr "  直徑"
+
+#, fuzzy
+#~ msgid "Enter value for radius"
+#~ msgstr "非整數值對整數"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "  半徑"
+
+#, fuzzy
+#~ msgid "Enter value for axis {0}"
+#~ msgstr "非整數值對整數"
+
+#, fuzzy
+#~ msgid "Set axis {0} to:"
+#~ msgstr "設定軸 偏移量:"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "AXIS 手動 換刀"
+
+#, fuzzy
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr "不能改變刀具補償當刀具半徑補償在使用"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "選擇項目 以探測"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "World 模式"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "程序檔案"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "清除 現場 繪圖"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "透視 視圖"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "刀具"
+
+#, fuzzy
+#~ msgid "jog joints"
+#~ msgstr "輸入輸出點"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "超速 極限"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "<b>歸零</b>"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "刀具訊息"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "偏移"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "偏移"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "<b>配置</b>"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "代碼中使用負值m"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "代碼中使用負值g"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "<b>電源</b>"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "<b>冷卻液</b>"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "<b>主軸</b>"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "<b>外部 主軸 超速</b>"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "進給 超速設為從　0% 至　100%"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "<b>外部　進給 超速</b>"
+
+#~ msgid "Replace"
+#~ msgstr "替換"
+
+#, fuzzy
+#~ msgid "X Pos."
+#~ msgstr "位置"
+
+#, fuzzy
+#~ msgid "Y Pos."
+#~ msgstr "位置"
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "<b>機器 基本</b>"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "顯示 偏移量(_f)"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "<b>電源</b>"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "預演"
+
+#, fuzzy
+#~ msgid "show offsets"
+#~ msgstr "顯示 偏移量(_f)"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "相對位置"
+
+#, fuzzy
+#~ msgid "Absolute Color"
+#~ msgstr "絕對反饋"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "全部 歸零"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "離零"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr "<b>電源</b>"
+
+#, fuzzy
+#~ msgid "Grid size"
+#~ msgstr "大小"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "展示"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "顯示 偏移量(_f)"
+
+#, fuzzy
+#~ msgid "Show DTG"
+#~ msgstr "展示"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "<b>外部　按鈕　慢步</b>"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>電源</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "重新打開 當前 文件 [Control-R]"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "選擇 慢步 速度"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "選擇項目 以探測"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "設定 主軸超速"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "顯示 速率(_e)"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "設定 超速調整:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "設定 主軸超速"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "<b>步進馬達比例</b>"
+
+#, fuzzy
+#~ msgid "Use unlock code"
+#~ msgstr "未使用的編碼器"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "<b>歸零</b>"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "主軸 剎車 開"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "主軸 剎車 開"
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "<b>　前　台　</b>"
+
+#, fuzzy
+#~ msgid "Z Pos."
+#~ msgstr "位置"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "<b>配置</b>"
+
+#, fuzzy
+#~ msgid "Search Vel."
+#~ msgstr "零點搜索速率:"
+
+#, fuzzy
+#~ msgid "<b>Probe velocitys</b>"
+#~ msgstr "<b>GUI前台列表</b>"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "<b>冷卻液</b>"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "重新 載入 刀具表"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "重新 載入 刀具表"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "運行選定的行(_n)"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "<b>歸零</b>"
+
+#, fuzzy
+#~ msgid "Launch test message"
+#~ msgstr "啟動測試面板"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "進階選項"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "開動 機器"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "顯示重開"
+
+#, fuzzy
+#~ msgid "open touch off button list"
+#~ msgstr "刀具 對 夾具 對刀(_f)"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "World 模式"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "重裝 程序"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "重裝 程序"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "停止 正在 運行 的程序, 或"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "停止 正在 運行 的程序, 或"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "停止 正在 運行 的程序, 或"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr "重裝 程序"
+
+#, fuzzy
+#~ msgid "delete MDI"
+#~ msgstr "刪除"
+
+#, fuzzy
+#~ msgid "delete MDI history"
+#~ msgstr "清除 MDI 歷史"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "HAL 顯示器"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "校準(_C)"
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "重新載入刀具表(_b)"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "選擇項目 以探測"
+
+#, fuzzy
+#~ msgid ""
+#~ "touchoff\n"
+#~ "  tool x"
+#~ msgstr "刀具 對 夾具 對刀(_f)"
+
+#, fuzzy
+#~ msgid "touch off the tool and set the value to the tool table"
+#~ msgstr "請求工具 %d 刀具表找不到"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "程序檔案"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "輸入輸出點"
 
 #, fuzzy
 #~ msgid "Substituting"
@@ -19799,9 +19388,6 @@ msgstr "輸入輸出點"
 #~ msgid "Tool File"
 #~ msgstr "刀具文件"
 
-#~ msgid "Tool file is %s"
-#~ msgstr "刀具文件是　%s"
-
 #~ msgid "Active G Codes"
 #~ msgstr "激活 G Codes"
 
@@ -19814,9 +19400,6 @@ msgstr "輸入輸出點"
 
 #~ msgid "CONTINUE"
 #~ msgstr "繼續"
-
-#~ msgid "Tool #:"
-#~ msgstr "刀具 #:"
 
 #~ msgid "Length :"
 #~ msgstr "長度 :"
@@ -19956,9 +19539,6 @@ msgstr "輸入輸出點"
 #~ msgid "Zero All G59.1"
 #~ msgstr "置零 于 所有G59.1"
 
-#~ msgid "Zero All G59.2"
-#~ msgstr "置零 于 所有G5"
-
 #~ msgid "Zero All G59.3"
 #~ msgstr "置零 于 所有G59.3"
 
@@ -20009,9 +19589,6 @@ msgstr "輸入輸出點"
 
 #~ msgid "Show Setup"
 #~ msgstr "顯示 設定"
-
-#~ msgid "Axis Offset"
-#~ msgstr "軸向的 偏置"
 
 #~ msgid "Home All Axes"
 #~ msgstr "所有軸 歸零"

--- a/src/po/zh_TW.po
+++ b/src/po/zh_TW.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-04 21:38+0100\n"
+"POT-Creation-Date: 2021-06-26 19:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,67 +17,67 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/emc/task/emctaskmain.cc:860
+#: src/emc/task/emctaskmain.cc:870
 #, c-format
 msgid ""
 "command (%s) cannot be executed until the machine is out of E-stop and "
 "turned on"
 msgstr "命令 (%s) 不能執行 直到機器 離開 急停 並開動"
 
-#: src/emc/task/emctaskmain.cc:990
+#: src/emc/task/emctaskmain.cc:1000
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in manual mode"
 msgstr "不能做到這一點（%s）在手動模式"
 
-#: src/emc/task/emctaskmain.cc:1097
+#: src/emc/task/emctaskmain.cc:1107
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter idle"
 msgstr "不能做到這一點（%s）在自動模式與翻譯空閒"
 
-#: src/emc/task/emctaskmain.cc:1166
+#: src/emc/task/emctaskmain.cc:1176
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter reading"
 msgstr "不能做到這一點（%s）在自動模式與翻譯閱讀"
 
-#: src/emc/task/emctaskmain.cc:1253
+#: src/emc/task/emctaskmain.cc:1263
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter paused"
 msgstr "不能做到這一點（%s）在自動模式與翻譯暫停"
 
-#: src/emc/task/emctaskmain.cc:1324
+#: src/emc/task/emctaskmain.cc:1334
 #, c-format
 msgid "can't do that (%s) in auto mode with the interpreter waiting"
 msgstr "不能做到這一點（%s）在自動模式與翻譯等待"
 
-#: src/emc/task/emctaskmain.cc:1445
+#: src/emc/task/emctaskmain.cc:1455
 #, fuzzy, c-format
 msgid "can't do that (%s:%d) in MDI mode"
 msgstr "不能做到這一點（%s）在MDI模式"
 
-#: src/emc/task/emctaskmain.cc:2116
+#: src/emc/task/emctaskmain.cc:2126
 msgid "Can't switch mode while mode is AUTO and interpreter is not IDLE"
 msgstr "無法切換模式，而模式是AUTO和解釋是沒有閒著"
 
-#: src/emc/task/emctaskmain.cc:2169
+#: src/emc/task/emctaskmain.cc:2179
 #, fuzzy
 msgid "failed to close file"
 msgstr "無法打開文件 <%s>"
 
-#: src/emc/task/emctaskmain.cc:2183 tcl/bin/genedit.tcl:197
+#: src/emc/task/emctaskmain.cc:2193 tcl/bin/genedit.tcl:197
 #: tcl/tklinuxcnc.tcl:452
 #, c-format, tcl-format
 msgid "can't open %s"
 msgstr "不能打開 %s"
 
-#: src/emc/task/emctaskmain.cc:2195
+#: src/emc/task/emctaskmain.cc:2205
 msgid "Can't issue MDI command when not homed"
 msgstr "不能發出 MDI命令當沒有歸零"
 
-#: src/emc/task/emctaskmain.cc:2200
+#: src/emc/task/emctaskmain.cc:2210
 msgid "Must be in MDI mode to issue MDI command"
 msgstr "必須在MDI模式下發出 MDI命令"
 
-#: src/emc/task/emctaskmain.cc:2282
+#: src/emc/task/emctaskmain.cc:2292
 msgid "Can't run a program when not homed"
 msgstr "不能運行程序，當沒有歸零"
 
@@ -198,425 +198,425 @@ msgstr ""
 msgid "R value must be within 0..360 with M19"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:143
+#: src/emc/rs274ngc/interp_convert.cc:149
 msgid "You must specify both X and Y coordinates for Control Points"
 msgstr "您必須指定X和Y坐標對控制點"
 
-#: src/emc/rs274ngc/interp_convert.cc:146
+#: src/emc/rs274ngc/interp_convert.cc:152
 msgid "Can specify P without X and Y only for the first control point"
 msgstr "可以指定P沒有 X和Y只對第一個控制點"
 
-#: src/emc/rs274ngc/interp_convert.cc:149
+#: src/emc/rs274ngc/interp_convert.cc:155
 msgid "Must specify positive weight P for every Control Point"
 msgstr "必須指定積極重量P為每一個控制點"
 
-#: src/emc/rs274ngc/interp_convert.cc:152
+#: src/emc/rs274ngc/interp_convert.cc:158
 msgid "Cannot make a NURBS with 0 feedrate"
 msgstr "不能作出NURBS使用進給速度0"
 
-#: src/emc/rs274ngc/interp_convert.cc:189
+#: src/emc/rs274ngc/interp_convert.cc:195
 msgid "Cannot use G5.3 without G5.2 first"
 msgstr "不能使用 G5.3沒有 G5.2先行"
 
-#: src/emc/rs274ngc/interp_convert.cc:190
+#: src/emc/rs274ngc/interp_convert.cc:196
 #, c-format
 msgid ""
 "You must specify a number of control points at least equal to the order L = "
 "%d"
 msgstr "您必須指定一個數字控制點至少等於順序L =％d"
 
-#: src/emc/rs274ngc/interp_convert.cc:219
+#: src/emc/rs274ngc/interp_convert.cc:225
 msgid "Cannot convert spline with cutter radius compensation"
 msgstr "無法轉換 樣條曲線 有刀具半徑補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:229
+#: src/emc/rs274ngc/interp_convert.cc:235
 msgid "Splines must be in the XY plane"
 msgstr "樣條曲線必須在XY平面"
 
-#: src/emc/rs274ngc/interp_convert.cc:234
+#: src/emc/rs274ngc/interp_convert.cc:240
 msgid "Splines may not have motion in Z, A, B, or C"
 msgstr "樣條曲線 無法 有動作 在 Z，A，B  或  C"
 
-#: src/emc/rs274ngc/interp_convert.cc:238
+#: src/emc/rs274ngc/interp_convert.cc:244
 msgid "Must specify both I and J with G5.1"
 msgstr "必須同時指定I和J使用 G5.1"
 
-#: src/emc/rs274ngc/interp_convert.cc:260
+#: src/emc/rs274ngc/interp_convert.cc:266
 msgid "Must specify both I and J, or neither"
 msgstr "必須同時指定 I和J，或者兩者都不要"
 
-#: src/emc/rs274ngc/interp_convert.cc:271
+#: src/emc/rs274ngc/interp_convert.cc:277
 msgid "Must specify both P and Q with G5"
 msgstr "必須同時指定P和Q使用 G5"
 
-#: src/emc/rs274ngc/interp_convert.cc:376
+#: src/emc/rs274ngc/interp_convert.cc:382
 msgid ""
 "The move just after exiting cutter compensation mode must be straight, not "
 "an arc"
 msgstr "移動只是在退出刀具補償模式必須是直的，而不是一個弧"
 
-#: src/emc/rs274ngc/interp_convert.cc:384
+#: src/emc/rs274ngc/interp_convert.cc:390
 msgid "Cannot do an arc in planes G17.1, G18.1, or G19.1"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:396
-#: src/emc/rs274ngc/interp_convert.cc:4692
+#: src/emc/rs274ngc/interp_convert.cc:402
+#: src/emc/rs274ngc/interp_convert.cc:4701
 msgid "Cannot feed with zero spindle speed in feed per rev mode"
 msgstr "不能進給 用 零速度主軸 在 進給每轉 模式下"
 
-#: src/emc/rs274ngc/interp_convert.cc:407
 #: src/emc/rs274ngc/interp_convert.cc:413
-#: src/emc/rs274ngc/interp_convert.cc:422
+#: src/emc/rs274ngc/interp_convert.cc:419
 #: src/emc/rs274ngc/interp_convert.cc:428
-#: src/emc/rs274ngc/interp_convert.cc:437
+#: src/emc/rs274ngc/interp_convert.cc:434
 #: src/emc/rs274ngc/interp_convert.cc:443
+#: src/emc/rs274ngc/interp_convert.cc:449
 #, c-format
 msgid "%c word missing in absolute center arc"
 msgstr "%c 字中 缺少 在 絕對的中心弧"
 
-#: src/emc/rs274ngc/interp_convert.cc:670
+#: src/emc/rs274ngc/interp_convert.cc:676
 msgid ""
 "Radius of cutter compensation entry arc is not greater than the tool radius"
 msgstr "刀具半徑補償進入弧不大於刀具半徑"
 
-#: src/emc/rs274ngc/interp_convert.cc:889
-#: src/emc/rs274ngc/interp_convert.cc:899 src/emc/rs274ngc/interp_queue.cc:607
+#: src/emc/rs274ngc/interp_convert.cc:895
+#: src/emc/rs274ngc/interp_convert.cc:905 src/emc/rs274ngc/interp_queue.cc:607
 msgid ""
 "Arc move in concave corner cannot be reached by the tool without gouging"
 msgstr "弧移動無法到達凹角 使用該工具 而沒有刨削槽"
 
-#: src/emc/rs274ngc/interp_convert.cc:925
+#: src/emc/rs274ngc/interp_convert.cc:931
 msgid "Arc to arc motion is invalid because the arcs have the same center"
 msgstr "弧至弧移動是無效的，因為有相同的弧中心"
 
-#: src/emc/rs274ngc/interp_convert.cc:928
+#: src/emc/rs274ngc/interp_convert.cc:934
 msgid ""
 "Arc to arc motion makes a corner the compensated tool can't fit in without "
 "gouging"
 msgstr "弧至弧運動 做一個角落 補償工具 不適合 有刨削槽"
 
-#: src/emc/rs274ngc/interp_convert.cc:1060
-#: src/emc/rs274ngc/interp_convert.cc:1064
-#: src/emc/rs274ngc/interp_convert.cc:1068
-#: src/emc/rs274ngc/interp_convert.cc:4111
-#: src/emc/rs274ngc/interp_convert.cc:4114
-#: src/emc/rs274ngc/interp_convert.cc:4117 src/emc/rs274ngc/interp_find.cc:98
+#: src/emc/rs274ngc/interp_convert.cc:1066
+#: src/emc/rs274ngc/interp_convert.cc:1070
+#: src/emc/rs274ngc/interp_convert.cc:1074
+#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4123
+#: src/emc/rs274ngc/interp_convert.cc:4126 src/emc/rs274ngc/interp_find.cc:99
 #, c-format
 msgid "Invalid absolute position %5.2f for wrapped rotary axis %c"
 msgstr "無效的絕對位置 %5.2f 給包裹 旋轉軸 %c"
 
-#: src/emc/rs274ngc/interp_convert.cc:1572
+#: src/emc/rs274ngc/interp_convert.cc:1579
 msgid "Cannot change control mode with cutter radius compensation on"
 msgstr "不能改變控制模式 當 使用刀具半徑補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:1690
+#: src/emc/rs274ngc/interp_convert.cc:1697
 msgid "Cannot change coordinate systems with cutter radius compensation on"
 msgstr "不能改變坐標系 當 使用刀具半徑補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:1935
+#: src/emc/rs274ngc/interp_convert.cc:1942
 #, c-format
 msgid "G%d.1 with no D word"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1938
+#: src/emc/rs274ngc/interp_convert.cc:1945
 #, c-format
 msgid "G%d.1 with L word, but plane is not G18"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1949
+#: src/emc/rs274ngc/interp_convert.cc:1956
 #, c-format
 msgid "G%d requires D word to be a whole number"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:1956
+#: src/emc/rs274ngc/interp_convert.cc:1963
 #, c-format
 msgid "G%d with lathe tool, but plane is not G18"
 msgstr "G%d 與車刀，但平面不是 G18"
 
-#: src/emc/rs274ngc/interp_convert.cc:2358
+#: src/emc/rs274ngc/interp_convert.cc:2365
 msgid "Cannot set reference point with cutter compensation in effect"
 msgstr "無法設置 參考點 當 使用刀具補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:2936
+#: src/emc/rs274ngc/interp_convert.cc:2945
 #, c-format
 msgid "gen_restore G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2986
+#: src/emc/rs274ngc/interp_convert.cc:2995
 #, c-format
 msgid ""
 "BUG: cannot restore from a lower call level (%d) to a higher call level (%d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2987
+#: src/emc/rs274ngc/interp_convert.cc:2996
 #, c-format
 msgid "BUG: restore from level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:2988
+#: src/emc/rs274ngc/interp_convert.cc:2997
 #, c-format
 msgid "BUG: restore to level %d !?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3007
+#: src/emc/rs274ngc/interp_convert.cc:3016
 #, c-format
 msgid "M7x: restore_settings G20/G21 failed: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3032
+#: src/emc/rs274ngc/interp_convert.cc:3041
 #, c-format
 msgid "M7x: restore_settings failed executing: '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3101
+#: src/emc/rs274ngc/interp_convert.cc:3110
 #, c-format
 msgid "Failed to restore interp state on abort '%s': %s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3172
+#: src/emc/rs274ngc/interp_convert.cc:3181
 msgid "Cannot set motion output with cutter radius compensation on"
 msgstr "無法設置 運動 輸出 當 刀具半徑補償 開"
 
-#: src/emc/rs274ngc/interp_convert.cc:3173
+#: src/emc/rs274ngc/interp_convert.cc:3182
 msgid "No valid P word with M62"
 msgstr "沒有有效的P字使用 M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:3177
+#: src/emc/rs274ngc/interp_convert.cc:3186
 msgid "Cannot set motion digital output with cutter radius compensation on"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3178
+#: src/emc/rs274ngc/interp_convert.cc:3187
 msgid "No valid P word with M63"
 msgstr "沒有有效的P字使用 M62"
 
-#: src/emc/rs274ngc/interp_convert.cc:3182
-#: src/emc/rs274ngc/interp_convert.cc:3187
+#: src/emc/rs274ngc/interp_convert.cc:3191
+#: src/emc/rs274ngc/interp_convert.cc:3196
 msgid "Cannot set auxiliary digital output with cutter radius compensation on"
 msgstr "無法設置附屬數碼輸出當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3183
+#: src/emc/rs274ngc/interp_convert.cc:3192
 msgid "No valid P word with M64"
 msgstr "沒有有效的P字使用 M64"
 
-#: src/emc/rs274ngc/interp_convert.cc:3188
+#: src/emc/rs274ngc/interp_convert.cc:3197
 msgid "No valid P word with M65"
 msgstr "沒有有效的P字使用 M65"
 
-#: src/emc/rs274ngc/interp_convert.cc:3219
+#: src/emc/rs274ngc/interp_convert.cc:3228
 msgid "invalid P-word with M66"
 msgstr "沒有有效的P字使用 M66"
 
-#: src/emc/rs274ngc/interp_convert.cc:3234
+#: src/emc/rs274ngc/interp_convert.cc:3243
 msgid "Cannot wait for digital input with cutter radius compensation on"
 msgstr "不能等待數碼輸入當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3246
+#: src/emc/rs274ngc/interp_convert.cc:3255
 msgid "Cannot wait for analog input with cutter radius compensation on"
 msgstr "不能等待模擬輸入當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3261
+#: src/emc/rs274ngc/interp_convert.cc:3270
 msgid "Cannot set motion analog output with cutter radius compensation on"
 msgstr "無法設置運動模擬輸出當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3262
+#: src/emc/rs274ngc/interp_convert.cc:3271
 msgid "Invalid analog index with M67"
 msgstr "無效的模擬指標使用 M67"
 
-#: src/emc/rs274ngc/interp_convert.cc:3268
+#: src/emc/rs274ngc/interp_convert.cc:3277
 msgid "Cannot set auxiliary analog output with cutter radius compensation on"
 msgstr "無法設置輔助模擬輸出當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3269
+#: src/emc/rs274ngc/interp_convert.cc:3278
 msgid "Invalid analog index with M68"
 msgstr "無效的模擬指標使用 M68"
 
-#: src/emc/rs274ngc/interp_convert.cc:3300
+#: src/emc/rs274ngc/interp_convert.cc:3309
 #, fuzzy
 msgid "Need non-negative Q-word to specify tool number with M61"
 msgstr "需要正的 Q-字 指定刀具號 當使用M61"
 
-#: src/emc/rs274ngc/interp_convert.cc:3344
+#: src/emc/rs274ngc/interp_convert.cc:3353
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M3 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3361
+#: src/emc/rs274ngc/interp_convert.cc:3370
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M4 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3378
+#: src/emc/rs274ngc/interp_convert.cc:3387
 #, c-format
 msgid ""
 "Spindle ($) number out of range in M5 Command\n"
 "num_spindles =%i. $=%d\n"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3397
+#: src/emc/rs274ngc/interp_convert.cc:3406
 msgid "Spindle ($) number out of range in M19 Command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3404
+#: src/emc/rs274ngc/interp_convert.cc:3413
 msgid "Q word with M19 requires a value > 0"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3433
+#: src/emc/rs274ngc/interp_convert.cc:3442
 msgid "Cannot restore context from invalid stack frame - missing M70/M73?"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3474
-#: src/emc/rs274ngc/interp_convert.cc:3495
-#: src/emc/rs274ngc/interp_convert.cc:3515
-#: src/emc/rs274ngc/interp_convert.cc:3537
-#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3483
+#: src/emc/rs274ngc/interp_convert.cc:3504
+#: src/emc/rs274ngc/interp_convert.cc:3524
+#: src/emc/rs274ngc/interp_convert.cc:3546
+#: src/emc/rs274ngc/interp_convert.cc:3560
 msgid "Cannot enable overrides with cutter radius compensation on"
 msgstr "無法啟用超速 當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3483
-#: src/emc/rs274ngc/interp_convert.cc:3500
-#: src/emc/rs274ngc/interp_convert.cc:3524
-#: src/emc/rs274ngc/interp_convert.cc:3542
-#: src/emc/rs274ngc/interp_convert.cc:3556
+#: src/emc/rs274ngc/interp_convert.cc:3492
+#: src/emc/rs274ngc/interp_convert.cc:3509
+#: src/emc/rs274ngc/interp_convert.cc:3533
+#: src/emc/rs274ngc/interp_convert.cc:3551
+#: src/emc/rs274ngc/interp_convert.cc:3565
 msgid "Cannot disable overrides with cutter radius compensation on"
 msgstr "無法禁用超速 當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3510
+#: src/emc/rs274ngc/interp_convert.cc:3519
 msgid "Invalid spindle ($) number in M51 command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3667
-#: src/emc/rs274ngc/interp_convert.cc:3668
-#: src/emc/rs274ngc/interp_convert.cc:3669
+#: src/emc/rs274ngc/interp_convert.cc:3676
+#: src/emc/rs274ngc/interp_convert.cc:3677
+#: src/emc/rs274ngc/interp_convert.cc:3678
 #, c-format
 msgid "Indexing axis %c can only be moved with G0"
 msgstr "指標軸 %c 只能 用 G0 移動"
 
-#: src/emc/rs274ngc/interp_convert.cc:3676
-#: src/emc/rs274ngc/interp_convert.cc:3678
-#: src/emc/rs274ngc/interp_convert.cc:3680
+#: src/emc/rs274ngc/interp_convert.cc:3685
+#: src/emc/rs274ngc/interp_convert.cc:3687
+#: src/emc/rs274ngc/interp_convert.cc:3689
 #, c-format
 msgid "Indexing axis %c can only be moved alone"
 msgstr "指標軸 %c 只能單獨移動 "
 
-#: src/emc/rs274ngc/interp_convert.cc:3787
+#: src/emc/rs274ngc/interp_convert.cc:3796
 msgid "Cannot probe with feed per rev mode"
 msgstr "無法 探測 使用 進給每轉 模式"
 
-#: src/emc/rs274ngc/interp_convert.cc:3835
+#: src/emc/rs274ngc/interp_convert.cc:3844
 msgid "Cannot change retract mode with cutter radius compensation on"
 msgstr "不能改變回縮模式當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:3869
+#: src/emc/rs274ngc/interp_convert.cc:3878
 msgid "G10 L1 without offsets has no effect"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:3975
+#: src/emc/rs274ngc/interp_convert.cc:3984
 msgid "Q number in G10 is not an integer"
 msgstr "Q 編號在 G10 是不是整數"
 
-#: src/emc/rs274ngc/interp_convert.cc:3976
+#: src/emc/rs274ngc/interp_convert.cc:3985
 msgid "Invalid tool orientation"
 msgstr "無效的刀具定位"
 
-#: src/emc/rs274ngc/interp_convert.cc:4099
+#: src/emc/rs274ngc/interp_convert.cc:4108
 msgid "I J words not allowed with G10 L2"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4120
+#: src/emc/rs274ngc/interp_convert.cc:4129
 msgid ""
 "Cannot change the active coordinate system with cutter radius compensation on"
 msgstr "不能改變激活的坐標系當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:4128
+#: src/emc/rs274ngc/interp_convert.cc:4137
 msgid "R not allowed in G10 L20"
 msgstr "R 不容許在 G10 L20"
 
-#: src/emc/rs274ngc/interp_convert.cc:4472
+#: src/emc/rs274ngc/interp_convert.cc:4481
 msgid "Bug:  Reached convert_stop() from M99 as subprogram return"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4752
+#: src/emc/rs274ngc/interp_convert.cc:4761
 msgid "Invalid spindle ($) number in G33 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4757
+#: src/emc/rs274ngc/interp_convert.cc:4766
 msgid "Spindle not turning in G33"
 msgstr "在 G33 主軸不轉動"
 
-#: src/emc/rs274ngc/interp_convert.cc:4767
+#: src/emc/rs274ngc/interp_convert.cc:4776
 msgid "Invalid spindle ($) number in G33.1 move"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4772
+#: src/emc/rs274ngc/interp_convert.cc:4781
 msgid "Spindle not turning in G33.1"
 msgstr "在 G33.1 主軸不轉動"
 
-#: src/emc/rs274ngc/interp_convert.cc:4787
+#: src/emc/rs274ngc/interp_convert.cc:4796
 msgid "Invalid D-number in G76 cycle"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:4792
+#: src/emc/rs274ngc/interp_convert.cc:4801
 #, fuzzy, c-format
 msgid "Chosen spindle (%i) not turning in G76"
 msgstr "在 G33 主軸不轉動"
 
-#: src/emc/rs274ngc/interp_convert.cc:4830
+#: src/emc/rs274ngc/interp_convert.cc:4839
 msgid "BUG: An axis incorrectly moved along with an indexer"
 msgstr "BUG: 一軸錯誤地和索引器一起移動"
 
-#: src/emc/rs274ngc/interp_convert.cc:4843
+#: src/emc/rs274ngc/interp_convert.cc:4852
 msgid "BUG: trying to index incorrect axis"
 msgstr "BUG: 試圖指標不正確軸"
 
-#: src/emc/rs274ngc/interp_convert.cc:4938
+#: src/emc/rs274ngc/interp_convert.cc:4947
 msgid "Cannot use G76 threading cycle with cutter radius compensation on"
 msgstr "不能使用G76螺紋週期當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:4941
+#: src/emc/rs274ngc/interp_convert.cc:4950
 msgid "In G76, I must not be 0"
 msgstr "在 G76，I 不能為 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4943
+#: src/emc/rs274ngc/interp_convert.cc:4952
 msgid "In G76, J must be greater than 0"
 msgstr "在 G76，J 必須大於 0"
 
-#: src/emc/rs274ngc/interp_convert.cc:4945
+#: src/emc/rs274ngc/interp_convert.cc:4954
 msgid "In G76, K must be greater than J"
 msgstr "在 G76，K 必須大於 J"
 
-#: src/emc/rs274ngc/interp_convert.cc:5088
+#: src/emc/rs274ngc/interp_convert.cc:5097
 msgid ""
 "Length of cutter compensation entry move is not greater than the tool radius"
 msgstr "刀具長度補償 進入移動 不大於刀具半徑"
 
-#: src/emc/rs274ngc/interp_convert.cc:5307
+#: src/emc/rs274ngc/interp_convert.cc:5316
 msgid "Zero degree inside corner is invalid for cutter compensation"
 msgstr "零度內角 是無效的刀具補償"
 
-#: src/emc/rs274ngc/interp_convert.cc:5345
-#: src/emc/rs274ngc/interp_convert.cc:5353
+#: src/emc/rs274ngc/interp_convert.cc:5354
+#: src/emc/rs274ngc/interp_convert.cc:5362
 msgid ""
 "Arc to straight motion makes a corner the compensated tool can't fit in "
 "without gouging"
 msgstr "弧到直線運動做的角,補償工具不適合會做成刨削槽"
 
-#: src/emc/rs274ngc/interp_convert.cc:5437
+#: src/emc/rs274ngc/interp_convert.cc:5446
 msgid "Cannot change tools with cutter radius compensation on"
 msgstr "不能更改工具，刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:5561
+#: src/emc/rs274ngc/interp_convert.cc:5570
 msgid "Cannot change tool offset with cutter radius compensation on"
 msgstr "不能改變刀具補償當刀具半徑補償在使用"
 
-#: src/emc/rs274ngc/interp_convert.cc:5605
+#: src/emc/rs274ngc/interp_convert.cc:5621
 msgid "G43.2: Can not have both H and axis words"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_convert.cc:5608
+#: src/emc/rs274ngc/interp_convert.cc:5624
 msgid "G43.2: No axes specified and H word missing"
 msgstr ""
 
@@ -731,30 +731,30 @@ msgstr ""
 msgid "Invalid spindle ($) number in Spindle speed command"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_find.cc:171
+#: src/emc/rs274ngc/interp_find.cc:172
 msgid "Cannot use polar coordinates with G53"
 msgstr "不能用極坐標使用 G53"
 
-#: src/emc/rs274ngc/interp_find.cc:267 src/emc/rs274ngc/interp_find.cc:272
-#: src/emc/rs274ngc/interp_find.cc:279 src/emc/rs274ngc/interp_find.cc:338
-#: src/emc/rs274ngc/interp_find.cc:348
+#: src/emc/rs274ngc/interp_find.cc:268 src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:280 src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:349
 msgid "Cannot specify X or Y words with polar coordinate"
 msgstr "無法指定X或Y字當使用極坐標"
 
-#: src/emc/rs274ngc/interp_find.cc:273
+#: src/emc/rs274ngc/interp_find.cc:274
 msgid "Must specify angle in polar coordinate if at the origin"
 msgstr "必須指定角度在極坐標如過在原點"
 
-#: src/emc/rs274ngc/interp_find.cc:339
+#: src/emc/rs274ngc/interp_find.cc:340
 msgid ""
 "Incremental motion with polar coordinates is indeterminate when at the origin"
 msgstr "增量運動使用極坐標是不確定的，當在原點"
 
-#: src/emc/rs274ngc/interp_find.cc:349
+#: src/emc/rs274ngc/interp_find.cc:350
 msgid "G91 motion with polar coordinates is indeterminate when at the origin"
 msgstr "G91運動使用極坐標是不確定的，當在原點"
 
-#: src/emc/rs274ngc/interp_find.cc:721 src/emc/rs274ngc/interp_find.cc:737
+#: src/emc/rs274ngc/interp_find.cc:724 src/emc/rs274ngc/interp_find.cc:740
 #, c-format
 msgid "Requested tool %d not found in the tool table"
 msgstr "請求工具 %d 刀具表找不到"
@@ -869,102 +869,102 @@ msgstr ""
 msgid "File:%s line:%d redefining sub: o|%s| already defined in file:%s"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:822
+#: src/emc/rs274ngc/interp_o_word.cc:823
 #, fuzzy, c-format
 msgid "%d: not in a subroutine definition: '%s'"
 msgstr "未在子程序定義"
 
-#: src/emc/rs274ngc/interp_o_word.cc:871 src/emc/rs274ngc/interp_o_word.cc:921
+#: src/emc/rs274ngc/interp_o_word.cc:872 src/emc/rs274ngc/interp_o_word.cc:922
 #, c-format
 msgid "%d: duplicate O-word label: '%s' - defined in line %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:974
+#: src/emc/rs274ngc/interp_o_word.cc:975
 #, c-format
 msgid "%d: duplicate O-word label - already defined in line %d: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:998 src/emc/rs274ngc/interp_o_word.cc:1056
-#: src/emc/rs274ngc/interp_o_word.cc:1090
-#: src/emc/rs274ngc/interp_o_word.cc:1108
-#: src/emc/rs274ngc/interp_o_word.cc:1125
-#: src/emc/rs274ngc/interp_o_word.cc:1150
+#: src/emc/rs274ngc/interp_o_word.cc:999 src/emc/rs274ngc/interp_o_word.cc:1057
+#: src/emc/rs274ngc/interp_o_word.cc:1091
+#: src/emc/rs274ngc/interp_o_word.cc:1109
+#: src/emc/rs274ngc/interp_o_word.cc:1126
+#: src/emc/rs274ngc/interp_o_word.cc:1151
 #, c-format
 msgid "%d: undefined O-word label: '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1001
-#: src/emc/rs274ngc/interp_o_word.cc:1059
+#: src/emc/rs274ngc/interp_o_word.cc:1002
+#: src/emc/rs274ngc/interp_o_word.cc:1060
 #, c-format
 msgid "%d: no matching 'if' label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1093
+#: src/emc/rs274ngc/interp_o_word.cc:1094
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d): '%s'"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1111
-#: src/emc/rs274ngc/interp_o_word.cc:1128
+#: src/emc/rs274ngc/interp_o_word.cc:1112
+#: src/emc/rs274ngc/interp_o_word.cc:1129
 #, c-format
 msgid "%d: no matching while/do label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_o_word.cc:1154
+#: src/emc/rs274ngc/interp_o_word.cc:1155
 #, c-format
 msgid "%d: no matching label: '%s' (found '%s' in line %d)"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:172
+#: src/emc/rs274ngc/interp_namedparams.cc:177
 #, c-format
 msgid "Named parameter #<%s> not defined"
 msgstr "命名參數 #<%s> 沒有定義"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:202
+#: src/emc/rs274ngc/interp_namedparams.cc:207
 #, fuzzy, c-format
 msgid "cant open ini file '%s'"
 msgstr "不能打開 %s"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:219
+#: src/emc/rs274ngc/interp_namedparams.cc:224
 #, fuzzy, c-format
 msgid "Named ini parameter #<%s> not found in inifile '%s': error=0x%x"
 msgstr "命名參數 #<%s> 沒有定義"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:244
+#: src/emc/rs274ngc/interp_namedparams.cc:249
 #, c-format
 msgid "fetch_hal_param: hal_init(%s): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:245
+#: src/emc/rs274ngc/interp_namedparams.cc:250
 #, c-format
 msgid "fetch_hal_param: hal_ready(): %d"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:409
+#: src/emc/rs274ngc/interp_namedparams.cc:414
 #, c-format
 msgid "Internal error: Could not assign #<%s>"
 msgstr "內部錯誤：無法指派 #<%S>"
 
-#: src/emc/rs274ngc/interp_namedparams.cc:417
+#: src/emc/rs274ngc/interp_namedparams.cc:422
 #, c-format
 msgid "Cannot assign to read-only parameter #<%s>"
 msgstr ""
 
-#: src/emc/rs274ngc/interp_namedparams.cc:736
+#: src/emc/rs274ngc/interp_namedparams.cc:740
 #, c-format
 msgid "BUG: lookup_named_param(%s): unhandled index=%fn"
 msgstr ""
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1459 src/emc/rs274ngc/rs274ngc_pre.cc:1534
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1449 src/emc/rs274ngc/rs274ngc_pre.cc:1524
 msgid "Queue is not empty after tool change"
 msgstr "換刀後隊列不空"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:1849
+#: src/emc/rs274ngc/rs274ngc_pre.cc:1840
 #, c-format
 msgid "Unable to open parameter file: '%s'"
 msgstr "無法打開參數文件: '%s'"
 
-#: src/emc/rs274ngc/rs274ngc_pre.cc:2511
+#: src/emc/rs274ngc/rs274ngc_pre.cc:2507
 #, fuzzy
 msgid "Parameter file name is missing"
 msgstr "參數 文件 是　%s"
@@ -1389,7 +1389,8 @@ msgid "Negative spindle speed used"
 msgstr "在使用主軸轉速負值"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:124
-msgid "Negative tool id used"
+#, fuzzy
+msgid "Negative tool id (tool not found)"
 msgstr "負ID的刀具"
 
 #: src/emc/rs274ngc/rs274ngc_return.hh:125
@@ -1771,24 +1772,23 @@ msgstr "R小於 U在週期VW平面"
 msgid "R less than V in cycle in UW plane"
 msgstr "R小於 V的週期在UW平面"
 
-#: src/hal/utils/meter.c:202
+#: src/hal/utils/meter.c:205
 #, c-format
 msgid "ERROR: '%s' is not a valid probe type\n"
 msgstr "故障: '%s' 不是 有效 的 探查 類型\n"
 
-#: src/hal/utils/meter.c:210
+#: src/hal/utils/meter.c:213
 #, c-format
 msgid "ERROR: no pin/signal/parameter name\n"
 msgstr "故障: 沒有 針腳/信號/參數  名字\n"
 
-#: src/hal/utils/meter.c:216
+#: src/hal/utils/meter.c:219
 #, c-format
 msgid ""
 "ERROR: -s option requires a probe type and a pin/signal/parameter name\n"
 msgstr "故障: -s 選項需要一個探頭類型和 針/信號​​/參數 名稱\n"
 
-#: src/hal/utils/meter.c:242 tcl/tklinuxcnc.tcl:793
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6646
+#: src/hal/utils/meter.c:243 tcl/tklinuxcnc.tcl:793
 msgid "Hal Meter"
 msgstr "HAL 儀表"
 
@@ -1800,93 +1800,115 @@ msgstr "選擇(_S)"
 msgid "E_xit"
 msgstr "退出(_x)"
 
-#: src/hal/utils/meter.c:341 src/hal/utils/meter.c:369
+#: src/hal/utils/meter.c:336 src/hal/utils/meter.c:364
 msgid "Select Item to Probe"
 msgstr "選擇項目 以探測"
 
-#: src/hal/utils/meter.c:647
+#: src/hal/utils/meter.c:616
 msgid " _Pins "
 msgstr " 針(_P) "
 
-#: src/hal/utils/meter.c:648
+#: src/hal/utils/meter.c:617
 msgid " _Signals "
 msgstr " 信號​​(_S) "
 
-#: src/hal/utils/meter.c:649
+#: src/hal/utils/meter.c:618
 msgid " Para_meters "
 msgstr " 參數(_m) "
 
-#: src/hal/utils/meter.c:694
+#: src/hal/utils/meter.c:649
 msgid "_Close"
 msgstr " 關閉(_C) "
 
-#: src/hal/utils/scope.c:127
+#: src/hal/utils/scope.c:126
 msgid ""
 "Usage:\n"
 "  halscope [-h] [-i infile] [-o outfile] [num_samples]\n"
 msgstr ""
 
-#: src/hal/utils/scope.c:478 src/hal/utils/scope.c:505
+#: src/hal/utils/scope.c:468
 msgid "Open Configuration File:"
 msgstr "打開配置文件:"
 
-#: src/hal/utils/scope.c:539
+#: src/hal/utils/scope.c:470 src/hal/utils/scope.c:493
+#: src/hal/utils/scope_horiz.c:780 src/hal/utils/scope_vert.c:713
+#: src/hal/utils/scope_vert.c:934 src/hal/utils/scope_trig.c:315
+#, fuzzy
+msgid "_Cancel"
+msgstr "取消"
+
+#: src/hal/utils/scope.c:471
+#, fuzzy
+msgid "_Open"
+msgstr "打開..."
+
+#: src/hal/utils/scope.c:491
+#, fuzzy
+msgid "Save Configuration File:"
+msgstr "打開配置文件:"
+
+#: src/hal/utils/scope.c:494 src/hal/utils/scope_horiz.c:781
+#, fuzzy
+msgid "_Save"
+msgstr "保存"
+
+#: src/hal/utils/scope.c:525
 msgid "_Open Configuration..."
 msgstr "打開配置(_O)..."
 
-#: src/hal/utils/scope.c:545
+#: src/hal/utils/scope.c:531
 msgid "_Save Configuration..."
 msgstr "保存配置(_S)...."
 
-#: src/hal/utils/scope.c:554
+#: src/hal/utils/scope.c:540
 msgid "O_pen Data File..."
 msgstr "打開數據文件(_p)..."
 
-#: src/hal/utils/scope.c:561
+#: src/hal/utils/scope.c:547
 msgid "S_ave Data File..."
 msgstr "保存數據文件(_a)..."
 
-#: src/hal/utils/scope.c:570 share/axis/tcl/axis.tcl:102
+#: src/hal/utils/scope.c:556 share/axis/tcl/axis.tcl:102
 msgid "_Quit"
 msgstr "退出(_Q)"
 
-#: src/hal/utils/scope.c:576
+#: src/hal/utils/scope.c:562
 msgid "_About Halscope"
 msgstr "關於 Halscope(_A)"
 
-#: src/hal/utils/scope.c:582 share/axis/tcl/axis.tcl:470
+#: src/hal/utils/scope.c:568 share/axis/tcl/axis.tcl:470
 msgid "_File"
 msgstr "文件(_F)"
 
-#: src/hal/utils/scope.c:586 share/axis/tcl/axis.tcl:482
+#: src/hal/utils/scope.c:572 share/axis/tcl/axis.tcl:482
 msgid "_Help"
 msgstr "求助(_H)"
 
-#: src/hal/utils/scope.c:645
+#: src/hal/utils/scope.c:627
 msgid "HAL Oscilloscope"
 msgstr "HAL示波器"
 
-#: src/hal/utils/scope.c:673
+#: src/hal/utils/scope.c:655
 msgid "Horizontal"
 msgstr "水平"
 
-#: src/hal/utils/scope.c:681
+#: src/hal/utils/scope.c:665
 msgid "Selected Channel"
 msgstr "選擇通道"
 
-#: src/hal/utils/scope.c:687
+#: src/hal/utils/scope.c:671
 msgid "Run Mode"
 msgstr "運行模式"
 
-#: src/hal/utils/scope.c:690
+#: src/hal/utils/scope.c:674
 msgid "Trigger"
 msgstr "觸發"
 
-#: src/hal/utils/scope.c:696
+#: src/hal/utils/scope.c:680
 msgid "Vertical"
 msgstr "垂直"
 
-#: src/hal/utils/scope.c:704 src/hal/classicladder/classicladder_gtk.c:343
+#: src/hal/utils/scope.c:688 src/hal/classicladder/classicladder_gtk.c:343
 #: src/hal/classicladder/classicladder_gtk.c:856 share/axis/tcl/axis.tcl:144
 #: share/axis/tcl/axis.tcl:1044 src/emc/usr_intf/gscreen/gscreen.py:4458
 #: src/emc/usr_intf/gscreen/gscreen.py:4459
@@ -1894,39 +1916,40 @@ msgstr "垂直"
 msgid "Stop"
 msgstr "停"
 
-#: src/hal/utils/scope.c:707 src/hal/utils/scope_trig.c:196
+#: src/hal/utils/scope.c:690 src/hal/utils/scope_trig.c:201
 msgid "Normal"
 msgstr "正常"
 
-#: src/hal/utils/scope.c:710
+#: src/hal/utils/scope.c:692
 msgid "Single"
 msgstr "單"
 
-#: src/hal/utils/scope.c:713
+#: src/hal/utils/scope.c:694
 msgid "Roll"
 msgstr "翻滾"
 
-#: src/hal/utils/scope_horiz.c:131 src/emc/usr_intf/gscreen/gscreen.glade:3454
+#: src/hal/utils/scope_horiz.c:138 src/emc/usr_intf/gscreen/gscreen.glade:3454
 msgid "Zoom"
 msgstr "縮放"
 
-#: src/hal/utils/scope_horiz.c:132
+#: src/hal/utils/scope_horiz.c:139
 msgid " Pos "
 msgstr "位置"
 
-#: src/hal/utils/scope_horiz.c:165
+#: src/hal/utils/scope_horiz.c:174
+#, fuzzy
 msgid ""
 "----- Samples\n"
-"at ---- KHz"
+"at ---- kHz"
 msgstr ""
 "-----選樣\n"
-"於 ---- KHz"
+"於 ---- kHz"
 
-#: src/hal/utils/scope_horiz.c:460
+#: src/hal/utils/scope_horiz.c:473
 msgid "Realtime component not loaded"
 msgstr "實時元件沒有加載"
 
-#: src/hal/utils/scope_horiz.c:461
+#: src/hal/utils/scope_horiz.c:476
 msgid ""
 "HALSCOPE uses a realtime component called scope_rt'\n"
 "to sample signals for display.  It is not currently loaded\n"
@@ -1940,11 +1963,39 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:496
+#: src/hal/utils/scope_horiz.c:484 src/hal/utils/scope_horiz.c:761
+#: tcl/bin/emccalib.tcl:276 tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180
+#: tcl/bin/genedit.tcl:450 tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
+#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
+#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
+#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
+#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
+#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
+#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
+#: src/emc/usr_intf/axis/scripts/axis.py:1173
+#: src/emc/usr_intf/axis/scripts/axis.py:1274
+#: src/emc/usr_intf/axis/scripts/axis.py:1634
+#: src/emc/usr_intf/axis/scripts/axis.py:2930
+#: src/emc/usr_intf/axis/scripts/axis.py:4171
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
+#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
+#: share/axis/tcl/axis.tcl:1617
+msgid "OK"
+msgstr ""
+
+#: src/hal/utils/scope_horiz.c:485 src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:762
+#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
+#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
+#: src/emc/usr_intf/pncconf/dialogs.glade:600
+msgid "Quit"
+msgstr "退出"
+
+#: src/hal/utils/scope_horiz.c:518
 msgid "Realtime function not linked"
 msgstr "實時功能沒有鏈接"
 
-#: src/hal/utils/scope_horiz.c:497
+#: src/hal/utils/scope_horiz.c:519
 msgid ""
 "The HALSCOPE realtime sampling function\n"
 "must be called from a HAL thread in to\n"
@@ -1957,11 +2008,11 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:504
+#: src/hal/utils/scope_horiz.c:526
 msgid "Select Sample Rate"
 msgstr "選擇採樣率"
 
-#: src/hal/utils/scope_horiz.c:505
+#: src/hal/utils/scope_horiz.c:527
 msgid ""
 "Select a thread name and multiplier then click 'OK'\n"
 "or\n"
@@ -1971,94 +2022,69 @@ msgstr ""
 "或\n"
 "點擊 '退出' 以離開 HAL示波器"
 
-#: src/hal/utils/scope_horiz.c:527
+#: src/hal/utils/scope_horiz.c:534 src/hal/utils/scope_vert.c:712
+msgid "_OK"
+msgstr ""
+
+#: src/hal/utils/scope_horiz.c:554
 msgid "Thread:"
 msgstr "線程:"
 
-#: src/hal/utils/scope_horiz.c:535
+#: src/hal/utils/scope_horiz.c:563
 msgid "Sample Period:"
 msgstr "採樣 時段:"
 
-#: src/hal/utils/scope_horiz.c:543
+#: src/hal/utils/scope_horiz.c:572
 msgid "Sample Rate:"
 msgstr "採樣率:"
 
-#: src/hal/utils/scope_horiz.c:559 src/emc/usr_intf/touchy/mdi.py:80
+#: src/hal/utils/scope_horiz.c:588 src/emc/usr_intf/touchy/mdi.py:80
 #: src/emc/usr_intf/gscreen/mdi.py:78
 msgid "Thread"
 msgstr "線清"
 
-#: src/hal/utils/scope_horiz.c:560
+#: src/hal/utils/scope_horiz.c:589
 msgid "Period"
 msgstr "期段"
 
-#: src/hal/utils/scope_horiz.c:620
+#: src/hal/utils/scope_horiz.c:636
 msgid "Multiplier:"
 msgstr "倍增:"
 
-#: src/hal/utils/scope_horiz.c:637
+#: src/hal/utils/scope_horiz.c:656
 msgid "Record Length"
 msgstr "記錄長度"
 
-#: src/hal/utils/scope_horiz.c:640
+#: src/hal/utils/scope_horiz.c:661
 #, c-format
 msgid "%5d samples (1 channel)"
 msgstr "%5d 樣品（1通道）"
 
-#: src/hal/utils/scope_horiz.c:642
+#: src/hal/utils/scope_horiz.c:663
 #, c-format
 msgid "%5d samples (2 channels)"
 msgstr "%5d 樣品 （2通道）"
 
-#: src/hal/utils/scope_horiz.c:646
+#: src/hal/utils/scope_horiz.c:667
 #, c-format
 msgid "%5d samples (4 channels)"
 msgstr "%5d 樣品 （4通道）"
 
-#: src/hal/utils/scope_horiz.c:650
+#: src/hal/utils/scope_horiz.c:671
 #, c-format
 msgid "%5d samples (8 channels)"
 msgstr "%5d 樣品 （8通道）"
 
-#: src/hal/utils/scope_horiz.c:654
+#: src/hal/utils/scope_horiz.c:675
 #, c-format
 msgid "%5d samples (16 channels)"
 msgstr "%5d 樣品 （16通道）"
 
-#: src/hal/utils/scope_horiz.c:709 src/hal/utils/scope_horiz.c:755
-#: src/hal/utils/scope_horiz.c:967 src/hal/utils/scope_vert.c:763
-#: src/hal/utils/scope_vert.c:855 tcl/bin/emccalib.tcl:276
-#: tcl/bin/emcdebug.tcl:201 tcl/bin/genedit.tcl:180 tcl/bin/genedit.tcl:450
-#: tcl/bin/halconfig.tcl:682 tcl/bin/halconfig.tcl:733
-#: tcl/bin/pickconfig.tcl:429 tcl/bin/pickconfig.tcl:813
-#: tcl/bin/pickconfig.tcl:864 tcl/tklinuxcnc.tcl:161 tcl/tklinuxcnc.tcl:246
-#: tcl/tklinuxcnc.tcl:334 tcl/tklinuxcnc.tcl:354 tcl/tklinuxcnc.tcl:420
-#: tcl/tklinuxcnc.tcl:1225 tcl/tklinuxcnc.tcl:1296 tcl/tklinuxcnc.tcl:1327
-#: tcl/tklinuxcnc.tcl:1358 tcl/tklinuxcnc.tcl:1892 tcl/tklinuxcnc.tcl:1911
-#: tcl/tklinuxcnc.tcl:1930 tcl/tklinuxcnc.tcl:1977
-#: src/emc/usr_intf/axis/scripts/axis.py:1159
-#: src/emc/usr_intf/axis/scripts/axis.py:1260
-#: src/emc/usr_intf/axis/scripts/axis.py:1620
-#: src/emc/usr_intf/axis/scripts/axis.py:2913
-#: src/emc/usr_intf/axis/scripts/axis.py:4139
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:732
-#: lib/python/propertywindow.py:38 share/axis/tcl/axis.tcl:1580
-#: share/axis/tcl/axis.tcl:1617
-msgid "OK"
-msgstr ""
-
-#: src/hal/utils/scope_horiz.c:714 src/hal/utils/scope_horiz.c:755
-#: src/hal/classicladder/classicladder_gtk.c:899 tcl/bin/emccalib.tcl:104
-#: tcl/bin/halconfig.tcl:103 tcl/tooledit.tcl:468
-#: src/emc/usr_intf/pncconf/dialogs.glade:600
-msgid "Quit"
-msgstr "退出"
-
-#: src/hal/utils/scope_horiz.c:746
+#: src/hal/utils/scope_horiz.c:750
 msgid "Realtime thread(s) not running"
 msgstr "實時線程沒有運行"
 
-#: src/hal/utils/scope_horiz.c:747
+#: src/hal/utils/scope_horiz.c:753
 msgid ""
 "HALSCOPE uses code in a realtime HAL thread to sample\n"
 "signals for display.  The HAL thread(s) are not running.\n"
@@ -2072,15 +2098,15 @@ msgid ""
 "Click 'Quit' to exit HALSCOPE"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:780
+#: src/hal/utils/scope_horiz.c:778
 msgid "Pick log file to write to:"
 msgstr "選擇日誌文件寫入:"
 
-#: src/hal/utils/scope_horiz.c:963
+#: src/hal/utils/scope_horiz.c:948
 msgid "Not enough channels"
 msgstr "沒有足夠的通道"
 
-#: src/hal/utils/scope_horiz.c:964
+#: src/hal/utils/scope_horiz.c:951
 msgid ""
 "This record length cannot handle the channels\n"
 "that are currently enabled.  Pick a shorter\n"
@@ -2090,41 +2116,49 @@ msgstr ""
 "選擇一個較短的記錄長度\n"
 "支持更多的頻道."
 
-#: src/hal/utils/scope_horiz.c:1052
+#: src/hal/utils/scope_horiz.c:1039
 #, c-format
 msgid ""
 "%s\n"
 "per div"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1067
+#: src/hal/utils/scope_horiz.c:1054
 #, c-format
 msgid ""
 "%s samples\n"
 "at %s"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1171
-msgid "nSec"
+#: src/hal/utils/scope_horiz.c:1158 src/emc/usr_intf/stepconf/base.glade:113
+#: src/emc/usr_intf/stepconf/base.glade:141
+#: src/emc/usr_intf/stepconf/base.glade:169
+#: src/emc/usr_intf/stepconf/base.glade:197
+#: src/emc/usr_intf/stepconf/base.glade:415
+#: src/emc/usr_intf/pncconf/mesa0.glade:487
+#: src/emc/usr_intf/pncconf/mesa1.glade:487
+#: src/emc/usr_intf/pncconf/base.glade:389
+msgid "ns"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1174
-msgid "uSec"
+#: src/hal/utils/scope_horiz.c:1161
+msgid "µs"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1178
-msgid "mSec"
+#: src/hal/utils/scope_horiz.c:1165
+msgid "ms"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1182
-#: src/emc/usr_intf/pncconf/external.glade:2562
-#: src/emc/usr_intf/pncconf/external.glade:3534
-#: src/emc/usr_intf/pncconf/external.glade:4511
-#: src/emc/usr_intf/pncconf/external.glade:5488
-msgid "Sec"
+#: src/hal/utils/scope_horiz.c:1169 src/emc/usr_intf/stepconf/axisx.glade:345
+#: src/emc/usr_intf/stepconf/axisy.glade:343
+#: src/emc/usr_intf/stepconf/axisz.glade:343
+#: src/emc/usr_intf/stepconf/axisu.glade:346
+#: src/emc/usr_intf/stepconf/axisv.glade:345
+#: src/emc/usr_intf/stepconf/axisa.glade:343
+msgid "s"
 msgstr "秒"
 
-#: src/hal/utils/scope_horiz.c:1199 src/emc/usr_intf/stepconf/spindle.glade:112
+#: src/hal/utils/scope_horiz.c:1186 src/emc/usr_intf/stepconf/spindle.glade:112
 #: src/emc/usr_intf/stepconf/axisx.glade:359
 #: src/emc/usr_intf/stepconf/axisy.glade:357
 #: src/emc/usr_intf/stepconf/axisz.glade:357
@@ -2140,54 +2174,51 @@ msgstr "秒"
 msgid "Hz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1202
-msgid "KHz"
+#: src/hal/utils/scope_horiz.c:1189
+msgid "kHz"
 msgstr ""
 
-#: src/hal/utils/scope_horiz.c:1206
-msgid "Mhz"
+#: src/hal/utils/scope_horiz.c:1193
+msgid "MHz"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:405 src/hal/utils/scope_vert.c:1259
+#: src/hal/utils/scope_vert.c:411 src/hal/utils/scope_vert.c:1127
 #, c-format
 msgid ""
 "Offset\n"
 "%s"
 msgstr ""
 
-#: src/hal/utils/scope_vert.c:620
+#: src/hal/utils/scope_vert.c:607
 msgid "Gain"
 msgstr "增益"
 
-#: src/hal/utils/scope_vert.c:632 src/hal/utils/scope_trig.c:252
+#: src/hal/utils/scope_vert.c:620 src/hal/utils/scope_trig.c:257
 msgid "Pos"
 msgstr "定位"
 
-#: src/hal/utils/scope_vert.c:646 tcl/ngcgui_ttt.tcl:214
+#: src/hal/utils/scope_vert.c:635 tcl/ngcgui_ttt.tcl:215
 #: src/emc/usr_intf/pncconf/x_motor.glade:1337
 #: src/emc/usr_intf/pncconf/y_motor.glade:1337
 #: src/emc/usr_intf/pncconf/z_motor.glade:1337
 #: src/emc/usr_intf/pncconf/a_motor.glade:1337
 #: src/emc/usr_intf/pncconf/s_motor.glade:1932
+#: lib/python/gladevcp/gladevcp-test.glade:222
 msgid "Scale"
 msgstr "尺度"
 
-#: src/hal/utils/scope_vert.c:651
+#: src/hal/utils/scope_vert.c:640
 #, fuzzy
 msgid ""
 "Offset\n"
 "----"
 msgstr "偏移"
 
-#: src/hal/utils/scope_vert.c:659
+#: src/hal/utils/scope_vert.c:648
 msgid "Chan Off"
 msgstr "通道 關"
 
-#: src/hal/utils/scope_vert.c:715
-msgid "Set Offset"
-msgstr "設置偏移"
-
-#: src/hal/utils/scope_vert.c:716
+#: src/hal/utils/scope_vert.c:706
 #, c-format
 msgid ""
 "Set the vertical offset\n"
@@ -2196,35 +2227,19 @@ msgstr ""
 "設置垂直偏移量\n"
 "對通道 %d."
 
-#: src/hal/utils/scope_vert.c:736
+#: src/hal/utils/scope_vert.c:710
+msgid "Set Offset"
+msgstr "設置偏移"
+
+#: src/hal/utils/scope_vert.c:729
 msgid "AC Coupled"
 msgstr "交流耦合"
 
-#: src/hal/utils/scope_vert.c:771 src/hal/utils/scope_vert.c:1172
-#: src/hal/utils/scope_trig.c:367 src/hal/classicladder/edit_gtk.c:374
-#: tcl/bin/emccalib.tcl:278 tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294
-#: tcl/bin/halconfig.tcl:103 tcl/bin/halconfig.tcl:684
-#: tcl/bin/halconfig.tcl:735 tcl/bin/pickconfig.tcl:432
-#: tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163 tcl/tklinuxcnc.tcl:214
-#: tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227 tcl/tklinuxcnc.tcl:1297
-#: tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359 tcl/tklinuxcnc.tcl:1978
-#: src/emc/usr_intf/axis/scripts/axis.py:1565
-#: src/emc/usr_intf/axis/scripts/axis.py:1621
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
-#: src/emc/usr_intf/axis/scripts/axis.py:2269
-#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
-#: src/emc/usr_intf/stepconf/main_page.glade:475
-#: src/emc/usr_intf/pncconf/main_page.glade:98
-#: src/emc/usr_intf/pncconf/dialogs.glade:574
-#: src/emc/usr_intf/gscreen/gscreen.glade:4030
-msgid "Cancel"
-msgstr "取消"
-
-#: src/hal/utils/scope_vert.c:851
+#: src/hal/utils/scope_vert.c:832
 msgid "Too many channels"
 msgstr "太多的通道"
 
-#: src/hal/utils/scope_vert.c:852
+#: src/hal/utils/scope_vert.c:835
 msgid ""
 "You cannot add another channel.\n"
 "\n"
@@ -2236,21 +2251,7 @@ msgstr ""
 "要么關閉一個或多個通道，或縮短的記錄長度，\n"
 "以便有更多的通道"
 
-#: src/hal/utils/scope_vert.c:975
-#, c-format
-msgid "next search: %d\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:983
-#, c-format
-msgid "search: %d (wrapped=%d)\n"
-msgstr ""
-
-#: src/hal/utils/scope_vert.c:1028
-msgid "Select Channel Source"
-msgstr "選擇通道來源"
-
-#: src/hal/utils/scope_vert.c:1029
+#: src/hal/utils/scope_vert.c:928
 #, c-format
 msgid ""
 "Select a pin, signal, or parameter\n"
@@ -2259,29 +2260,33 @@ msgstr ""
 "選擇一個 針，信號或參數\n"
 "作為源通道 %d."
 
-#: src/hal/utils/scope_vert.c:1061
+#: src/hal/utils/scope_vert.c:932
+msgid "Select Channel Source"
+msgstr "選擇通道來源"
+
+#: src/hal/utils/scope_vert.c:956
 msgid "Pins"
 msgstr "針"
 
-#: src/hal/utils/scope_vert.c:1062
+#: src/hal/utils/scope_vert.c:957
 msgid "Signals"
 msgstr "信號"
 
-#: src/hal/utils/scope_vert.c:1063
+#: src/hal/utils/scope_vert.c:958
 msgid "Parameters"
 msgstr "參數"
 
-#: src/hal/utils/scope_trig.c:110
+#: src/hal/utils/scope_trig.c:115
 #, c-format
 msgid "Falling"
 msgstr "下降"
 
-#: src/hal/utils/scope_trig.c:112 src/hal/utils/scope_trig.c:275
+#: src/hal/utils/scope_trig.c:117 src/hal/utils/scope_trig.c:281
 #, c-format
 msgid "Rising"
 msgstr "上升"
 
-#: src/hal/utils/scope_trig.c:119 src/hal/utils/scope_trig.c:283
+#: src/hal/utils/scope_trig.c:124 src/hal/utils/scope_trig.c:289
 msgid ""
 "Source\n"
 "None"
@@ -2289,7 +2294,7 @@ msgstr ""
 "來源\n"
 "沒有"
 
-#: src/hal/utils/scope_trig.c:124
+#: src/hal/utils/scope_trig.c:129
 #, c-format
 msgid ""
 "Source\n"
@@ -2298,114 +2303,115 @@ msgstr ""
 "來源\n"
 "通道 %2d"
 
-#: src/hal/utils/scope_trig.c:199 tcl/tklinuxcnc.tcl:856
+#: src/hal/utils/scope_trig.c:203 tcl/tklinuxcnc.tcl:856
 #: src/emc/usr_intf/touchy/touchy.glade:2469
 msgid "Auto"
 msgstr "自動"
 
-#: src/hal/utils/scope_trig.c:201
+#: src/hal/utils/scope_trig.c:205
 msgid "Force"
 msgstr "強制"
 
-#: src/hal/utils/scope_trig.c:235 src/hal/utils/scope_trig.c:269
+#: src/hal/utils/scope_trig.c:239 src/hal/utils/scope_trig.c:275
 msgid "Level"
 msgstr "等級"
 
-#: src/hal/utils/scope_trig.c:303
-msgid "Trigger Source"
-msgstr "觸發源"
-
-#: src/hal/utils/scope_trig.c:304
+#: src/hal/utils/scope_trig.c:310
 msgid "Select a channel to use for triggering."
 msgstr "選擇一個通道用於觸發"
 
-#: src/hal/utils/scope_trig.c:327
+#: src/hal/utils/scope_trig.c:313
+msgid "Trigger Source"
+msgstr "觸發源"
+
+#: src/hal/utils/scope_trig.c:336
 msgid "Chan"
 msgstr "通道"
 
-#: src/hal/utils/scope_trig.c:328
+#: src/hal/utils/scope_trig.c:337
 msgid "Source"
 msgstr "來源"
 
-#: src/emc/motion/control.c:454
+#: src/emc/motion/control.c:526
 #, fuzzy, c-format
 msgid "fault %d during orient in progress"
 msgstr "歸零 已在 進行中"
 
-#: src/emc/motion/control.c:613
+#: src/emc/motion/control.c:685
 msgid "G38.4 move finished without breaking contact."
 msgstr "G38.4 移動完成後不阻斷接觸."
 
-#: src/emc/motion/control.c:616
+#: src/emc/motion/control.c:688
 msgid "G38.2 move finished without making contact."
 msgstr "G38.2 移動完成後不作出接觸."
 
-#: src/emc/motion/control.c:630
-msgid "Probe tripped during non-probe MDI command."
+#: src/emc/motion/control.c:701
+#, fuzzy
+msgid "Probe tripped during non-probe move."
 msgstr "探頭跳閘在非探測 MDI 命令."
 
-#: src/emc/motion/control.c:668
+#: src/emc/motion/control.c:739
 msgid "Probe tripped during homing motion."
 msgstr "探頭跳閘在歸零運動."
 
-#: src/emc/motion/control.c:672
+#: src/emc/motion/control.c:743
 #, fuzzy
 msgid "Probe tripped during a joint jog."
 msgstr "探頭跳閘當正在慢步."
 
-#: src/emc/motion/control.c:675
+#: src/emc/motion/control.c:746
 #, fuzzy
 msgid "Probe tripped during a coordinate jog."
 msgstr "探頭跳閘當正在慢步."
 
-#: src/emc/motion/control.c:691
+#: src/emc/motion/control.c:762
 msgid "motion stopped by enable input"
 msgstr "運動停止因有 允許 輸入"
 
-#: src/emc/motion/control.c:698
+#: src/emc/motion/control.c:769
 #, fuzzy, c-format
 msgid "spindle %d amplifier fault"
 msgstr "Joint %d 放大器故障"
 
-#: src/emc/motion/control.c:721
+#: src/emc/motion/control.c:792
 #, c-format
 msgid "joint %d on limit switch error"
 msgstr "Joint %d 在限位開關 故障"
 
-#: src/emc/motion/control.c:733
+#: src/emc/motion/control.c:804
 #, c-format
 msgid "joint %d amplifier fault"
 msgstr "Joint %d 放大器故障"
 
-#: src/emc/motion/control.c:742
+#: src/emc/motion/control.c:813
 #, c-format
 msgid "joint %d following error"
 msgstr "Joint %d 跟隨 故障"
 
-#: src/emc/motion/control.c:1333 src/emc/motion/control.c:1419
+#: src/emc/motion/control.c:1412 src/emc/motion/control.c:1498
 #, c-format
 msgid "kinematicsInverse gave non-finite joint location on joint %d"
 msgstr ""
 
-#: src/emc/motion/control.c:1350 src/emc/motion/control.c:1438
+#: src/emc/motion/control.c:1429 src/emc/motion/control.c:1517
 msgid "kinematicsInverse failed"
 msgstr ""
 
-#: src/emc/motion/control.c:1515
+#: src/emc/motion/control.c:1594
 #, fuzzy, c-format
 msgid "Exceeded NEGATIVE soft limit (%.5f) on joint %d\n"
 msgstr "超出 正 軟極限在 Joint %d"
 
-#: src/emc/motion/control.c:1518 src/emc/motion/control.c:1527
+#: src/emc/motion/control.c:1597 src/emc/motion/control.c:1606
 #, fuzzy
 msgid "Joint must be unhomed, jogged into limits, rehomed"
 msgstr "所有 joint 一定 要在 零點 才能  進入 遠程操作 模式"
 
-#: src/emc/motion/control.c:1520 src/emc/motion/control.c:1529
+#: src/emc/motion/control.c:1599 src/emc/motion/control.c:1608
 msgid "Hint: switch to joint mode to jog off soft limit"
 msgstr ""
 
-#: src/emc/motion/control.c:1524
+#: src/emc/motion/control.c:1603
 #, fuzzy, c-format
 msgid "Exceeded POSITIVE soft limit (%.5f) on joint %d\n"
 msgstr "超出 正 軟極限在 Joint %d"
@@ -2474,177 +2480,177 @@ msgstr "%s 在線 %d 移動 將超過 joint %d 的 負 極限"
 msgid "all joints must be homed before going into coordinated mode"
 msgstr "所有 joint 一定 要在 零點 才能 進入 坐標 模式"
 
-#: src/emc/motion/command.c:819 src/emc/motion/command.c:915
-#: src/emc/motion/command.c:1017
+#: src/emc/motion/command.c:819 src/emc/motion/command.c:909
+#: src/emc/motion/command.c:1008
 msgid "Can't jog joint when not enabled."
 msgstr "不能 慢步 joint 當 未有 允許 "
 
-#: src/emc/motion/command.c:824 src/emc/motion/command.c:1022
+#: src/emc/motion/command.c:824 src/emc/motion/command.c:1013
 msgid "Can't jog any joints while homing."
 msgstr "不能 慢步 joint 當 在 歸零 時"
 
-#: src/emc/motion/command.c:920
+#: src/emc/motion/command.c:914
 msgid "Can't jog any joint while homing."
 msgstr "不能 慢步 joint 當 在 歸零 時"
 
-#: src/emc/motion/command.c:1104
+#: src/emc/motion/command.c:1091
 msgid "need to be enabled, in coord mode for linear move"
 msgstr "要有 允許 才 能 在 坐標 模式 作 直線 移動"
 
-#: src/emc/motion/command.c:1109
+#: src/emc/motion/command.c:1096
 msgid "invalid params in linear command"
 msgstr ""
 
-#: src/emc/motion/command.c:1115
+#: src/emc/motion/command.c:1102
 msgid "can't do linear move with limits exceeded"
 msgstr "不能 加入 直線 移動 當 超出 極限"
 
-#: src/emc/motion/command.c:1145
+#: src/emc/motion/command.c:1132
 #, fuzzy, c-format
 msgid "can't add linear move at line %d, error code %d"
 msgstr "不能 加入 直線 移動 當 超出 極限"
 
-#: src/emc/motion/command.c:1172
+#: src/emc/motion/command.c:1159
 msgid "need to be enabled, in coord mode for circular move"
 msgstr "需要允許才能 作 坐標模式 的環形移動"
 
-#: src/emc/motion/command.c:1182
+#: src/emc/motion/command.c:1169
 msgid "can't do circular move with limits exceeded"
 msgstr "不能作 環形的 移動 當 超出 極限"
 
-#: src/emc/motion/command.c:1201
+#: src/emc/motion/command.c:1188
 #, fuzzy, c-format
 msgid "can't add circular move at line %d, error code %d"
 msgstr "不能作 環形的 移動 當 超出 極限"
 
-#: src/emc/motion/command.c:1316
+#: src/emc/motion/command.c:1303
 msgid "MOTION: can't STEP while already executing"
 msgstr "動作: 不能 STEP 當 已 在 執行 "
 
-#: src/emc/motion/command.c:1418
+#: src/emc/motion/command.c:1405
 msgid "can't enable motion, enable input is false"
 msgstr "不能 允許 的動作, 允許 輸入 是 偽 "
 
-#: src/emc/motion/command.c:1482
+#: src/emc/motion/command.c:1469
 msgid "must be in joint mode to home"
 msgstr "一定 要在 Joint 模式 才能 歸零 "
 
-#: src/emc/motion/command.c:1486
+#: src/emc/motion/command.c:1473
 #, c-format
 msgid "Homing denied by motion.homing-inhibit joint=%d\n"
 msgstr ""
 
-#: src/emc/motion/command.c:1500
+#: src/emc/motion/command.c:1487
 msgid "homing sequence already in progress"
 msgstr "歸零 序列 已在 進行中"
 
-#: src/emc/motion/command.c:1533
+#: src/emc/motion/command.c:1520
 msgid "must be in joint mode or disabled to unhome"
 msgstr "一定 要在 Joint 模式 或 不允許 才 可以 離零"
 
-#: src/emc/motion/command.c:1545 src/emc/motion/command.c:1588
+#: src/emc/motion/command.c:1532 src/emc/motion/command.c:1575
 #, c-format
 msgid "Cannot unhome while homing, joint %d"
 msgstr "不能 離零 當 在 歸零中, Joint %d"
 
-#: src/emc/motion/command.c:1549 src/emc/motion/command.c:1592
+#: src/emc/motion/command.c:1536 src/emc/motion/command.c:1579
 #, c-format
 msgid "Cannot unhome while moving, joint %d"
 msgstr "不能 離零 當 在 移動 中, Joint %d "
 
-#: src/emc/motion/command.c:1555 src/emc/motion/command.c:1583
+#: src/emc/motion/command.c:1542 src/emc/motion/command.c:1570
 #, fuzzy, c-format
 msgid "Cannot unhome extrajoint <%d> with motion enabled"
 msgstr "不能 慢步 joint 當 未有 允許 "
 
-#: src/emc/motion/command.c:1597
+#: src/emc/motion/command.c:1584
 #, c-format
 msgid "Cannot unhome inactive joint %d"
 msgstr "不能 離零 未激活的 Joint %d"
 
-#: src/emc/motion/command.c:1601
+#: src/emc/motion/command.c:1588
 #, c-format
 msgid "Cannot unhome invalid joint %d (max %d)"
 msgstr "不能 離零 無效的 Joint %d (max %d) "
 
-#: src/emc/motion/command.c:1619
+#: src/emc/motion/command.c:1606
 msgid "need to be enabled, in coord mode for probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1629
+#: src/emc/motion/command.c:1616
 msgid "can't do probe move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1643
+#: src/emc/motion/command.c:1630
 msgid "Probe is already clear when starting G38.4 or G38.5 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1645
+#: src/emc/motion/command.c:1632
 msgid "Probe is already tripped when starting G38.2 or G38.3 move"
 msgstr ""
 
-#: src/emc/motion/command.c:1666
+#: src/emc/motion/command.c:1653
 msgid "can't add probe move"
 msgstr ""
 
-#: src/emc/motion/command.c:1688
+#: src/emc/motion/command.c:1675
 msgid "need to be enabled, in coord mode for rigid tap move"
 msgstr ""
 
-#: src/emc/motion/command.c:1698
+#: src/emc/motion/command.c:1685
 msgid "can't do rigid tap move with limits exceeded"
 msgstr ""
 
-#: src/emc/motion/command.c:1717
+#: src/emc/motion/command.c:1704
 #, c-format
 msgid "can't add rigid tap move at line %d, error code %d"
 msgstr ""
 
-#: src/emc/motion/command.c:1759
+#: src/emc/motion/command.c:1746
 msgid "Attempt to start non-existent spindle"
 msgstr ""
 
-#: src/emc/motion/command.c:1807
+#: src/emc/motion/command.c:1796
 #, c-format
 msgid "Attempt to stop non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1837
+#: src/emc/motion/command.c:1827
 #, c-format
 msgid "Attempt to orient non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1883
+#: src/emc/motion/command.c:1873
 #, c-format
 msgid "Attempt to increase non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1906
+#: src/emc/motion/command.c:1896
 #, c-format
 msgid "Attempt to decreasenon-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1921
+#: src/emc/motion/command.c:1911
 #, c-format
 msgid "Attempt to engage brake of non-existent spindle <%d>"
 msgstr ""
 
-#: src/emc/motion/command.c:1943
+#: src/emc/motion/command.c:1933
 #, fuzzy, c-format
 msgid "Attempt to release brake of non-existent spindle <%d>"
 msgstr "試圖提高負對非整數冪"
 
-#: src/emc/motion/command.c:1965
+#: src/emc/motion/command.c:1955
 #, c-format
 msgid "joint %d: too many compensation entries"
 msgstr "joint %d: 太多的補償條目"
 
-#: src/emc/motion/command.c:1971
+#: src/emc/motion/command.c:1961
 #, c-format
 msgid "joint %d: compensation values must increase"
 msgstr "joint %d: 補償值必須增加"
 
-#: src/emc/motion/command.c:2049
+#: src/emc/motion/command.c:2039
 #, c-format
 msgid "unrecognized command %d"
 msgstr ""
@@ -2733,26 +2739,26 @@ msgstr ""
 msgid "MOTION: emcmot_hal_data malloc failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:479
+#: src/emc/motion/motion.c:482
 #, c-format
 msgid "MOTION: spindle %d pin export failed"
 msgstr ""
 
-#: src/emc/motion/motion.c:490
+#: src/emc/motion/motion.c:493
 #, c-format
 msgid "MOTION: joint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:502
+#: src/emc/motion/motion.c:505
 msgid "MOTION: export_joint_home_pins failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:510
+#: src/emc/motion/motion.c:513
 #, c-format
 msgid "MOTION: ejoint %d pin/param export failed\n"
 msgstr ""
 
-#: src/emc/motion/motion.c:546
+#: src/emc/motion/motion.c:549
 #, c-format
 msgid "MOTION: axis %c pin/param export failed\n"
 msgstr ""
@@ -2923,7 +2929,7 @@ msgstr ""
 #: src/hal/classicladder/symbols_gtk.c:122
 #: src/hal/classicladder/symbols_gtk.c:138
 #: src/hal/classicladder/symbols_gtk.c:140
-#: src/emc/usr_intf/axis/scripts/axis.py:1564
+#: src/emc/usr_intf/axis/scripts/axis.py:1578
 msgid "Ok"
 msgstr ""
 
@@ -3013,19 +3019,19 @@ msgstr ""
 #: src/hal/classicladder/classicladder_gtk.c:649 tcl/bin/pickconfig.tcl:625
 #: tcl/tooledit.tcl:906 src/emc/usr_intf/axis/scripts/axis.py:163
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:577
-#: src/emc/usr_intf/pncconf/x_axis.glade:33
-#: src/emc/usr_intf/pncconf/y_axis.glade:33
-#: src/emc/usr_intf/pncconf/z_axis.glade:33
-#: src/emc/usr_intf/pncconf/a_axis.glade:33
+#: src/emc/usr_intf/pncconf/x_axis.glade:690
+#: src/emc/usr_intf/pncconf/y_axis.glade:690
+#: src/emc/usr_intf/pncconf/z_axis.glade:690
+#: src/emc/usr_intf/pncconf/a_axis.glade:690
 msgid "Yes"
 msgstr "是"
 
 #: src/hal/classicladder/classicladder_gtk.c:650 tcl/tooledit.tcl:906
 #: src/emc/usr_intf/axis/scripts/axis.py:163
-#: src/emc/usr_intf/pncconf/x_axis.glade:30
-#: src/emc/usr_intf/pncconf/y_axis.glade:30
-#: src/emc/usr_intf/pncconf/z_axis.glade:30
-#: src/emc/usr_intf/pncconf/a_axis.glade:30
+#: src/emc/usr_intf/pncconf/x_axis.glade:687
+#: src/emc/usr_intf/pncconf/y_axis.glade:687
+#: src/emc/usr_intf/pncconf/z_axis.glade:687
+#: src/emc/usr_intf/pncconf/a_axis.glade:687
 #, fuzzy
 msgid "No"
 msgstr "無"
@@ -3079,7 +3085,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:841 tcl/bin/emccalib.tcl:123
 #: tcl/bin/genedit.tcl:82 tcl/bin/halconfig.tcl:155
-#: src/emc/usr_intf/axis/scripts/axis.py:2268
+#: src/emc/usr_intf/axis/scripts/axis.py:2282
 msgid "Save"
 msgstr "保存"
 
@@ -3098,7 +3104,7 @@ msgstr ""
 
 #: src/hal/classicladder/classicladder_gtk.c:867
 #: src/hal/classicladder/edit_gtk.c:344
-#: src/emc/usr_intf/pncconf/screen.glade:827
+#: src/emc/usr_intf/pncconf/screen.glade:855
 msgid "Editor"
 msgstr "編輯器"
 
@@ -3113,7 +3119,6 @@ msgid "Config"
 msgstr "HAL 設定"
 
 #: src/hal/classicladder/classicladder_gtk.c:883 share/axis/tcl/axis.tcl:1301
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:880
 msgid "Preview"
 msgstr "預演"
 
@@ -3545,7 +3550,7 @@ msgid "Edit mode..."
 msgstr "編輯..."
 
 #: src/hal/classicladder/edit_gtk.c:186 src/hal/classicladder/edit_gtk.c:360
-#: tcl/tooledit.tcl:488 src/emc/usr_intf/gmoccapy/gmoccapy.glade:6929
+#: tcl/tooledit.tcl:488 lib/python/gladevcp/tooledit_gtk.glade:295
 msgid "Delete"
 msgstr "刪除"
 
@@ -3554,7 +3559,7 @@ msgid "Do you really want to delete the current rung ?"
 msgstr ""
 
 #: src/hal/classicladder/edit_gtk.c:350
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6947
+#: lib/python/gladevcp/tooledit_gtk.glade:310
 msgid "Add"
 msgstr "添加"
 
@@ -3565,6 +3570,24 @@ msgstr ""
 #: src/hal/classicladder/edit_gtk.c:365 tcl/bin/halconfig.tcl:134
 msgid "Modify"
 msgstr "修改"
+
+#: src/hal/classicladder/edit_gtk.c:374 tcl/bin/emccalib.tcl:278
+#: tcl/bin/emcdebug.tcl:202 tcl/bin/genedit.tcl:294 tcl/bin/halconfig.tcl:103
+#: tcl/bin/halconfig.tcl:684 tcl/bin/halconfig.tcl:735
+#: tcl/bin/pickconfig.tcl:432 tcl/bin/pickconfig.tcl:625 tcl/tklinuxcnc.tcl:163
+#: tcl/tklinuxcnc.tcl:214 tcl/tklinuxcnc.tcl:421 tcl/tklinuxcnc.tcl:1227
+#: tcl/tklinuxcnc.tcl:1297 tcl/tklinuxcnc.tcl:1328 tcl/tklinuxcnc.tcl:1359
+#: tcl/tklinuxcnc.tcl:1978 src/emc/usr_intf/axis/scripts/axis.py:1579
+#: src/emc/usr_intf/axis/scripts/axis.py:1635
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
+#: src/emc/usr_intf/axis/scripts/axis.py:2283
+#: src/emc/usr_intf/axis/scripts/image-to-gcode.py:734
+#: src/emc/usr_intf/stepconf/main_page.glade:475
+#: src/emc/usr_intf/pncconf/main_page.glade:98
+#: src/emc/usr_intf/pncconf/dialogs.glade:574
+#: src/emc/usr_intf/gscreen/gscreen.glade:4030
+msgid "Cancel"
+msgstr "取消"
 
 #: src/hal/classicladder/edit_sequential.c:68
 #, fuzzy
@@ -3754,7 +3777,7 @@ msgid "Parameter"
 msgstr "參數"
 
 #: src/hal/classicladder/editproperties_gtk.c:213
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6983
+#: lib/python/gladevcp/tooledit_gtk.glade:340
 msgid "Apply"
 msgstr ""
 
@@ -3943,7 +3966,6 @@ msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:72
 #: src/hal/classicladder/manager_gtk.c:234 tcl/bin/halconfig.tcl:196
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2867
 msgid "Main"
 msgstr "主頁"
 
@@ -4025,11 +4047,13 @@ msgid "Delete section"
 msgstr "相對位置"
 
 #: src/hal/classicladder/manager_gtk.c:345
+#: src/emc/usr_intf/pncconf/private_data.py:461
 msgid "Move Up"
 msgstr ""
 
 #: src/hal/classicladder/manager_gtk.c:350
 #: src/emc/usr_intf/stepconf/halui_page.glade:156
+#: src/emc/usr_intf/pncconf/private_data.py:461
 #, fuzzy
 msgid "Move Down"
 msgstr "向下"
@@ -4552,6 +4576,7 @@ msgid "Exit"
 msgstr "退出"
 
 #: tcl/bin/genedit.tcl:91 src/emc/usr_intf/gscreen/gscreen.glade:2720
+#: lib/python/gladevcp/offsetpage.glade:476
 msgid "Edit"
 msgstr "修訂"
 
@@ -4594,7 +4619,6 @@ msgid "Renumber File..."
 msgstr "重新編號文件..."
 
 #: tcl/bin/genedit.tcl:140 tcl/tklinuxcnc.tcl:775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5681
 msgid "Settings"
 msgstr "設定"
 
@@ -4870,15 +4894,15 @@ msgstr "樹狀觀看"
 msgid "Test HAL command :"
 msgstr "測試 HAL 指令 ："
 
-#: tcl/bin/halshow.tcl:504
+#: tcl/bin/halshow.tcl:508
 msgid "Load a watch list"
 msgstr "加載觀察名單"
 
-#: tcl/bin/halshow.tcl:536
+#: tcl/bin/halshow.tcl:540
 msgid "Save current watch list"
 msgstr "保存當前觀察名單"
 
-#: tcl/bin/halshow.tcl:560
+#: tcl/bin/halshow.tcl:564
 msgid "Commands may be tested here but they will NOT be saved"
 msgstr "指令可以在這兒測試但不會被保存"
 
@@ -4994,24 +5018,24 @@ msgstr "方向"
 msgid "SIZE :"
 msgstr "規格 :"
 
-#: tcl/show_errors.tcl:77
+#: tcl/show_errors.tcl:78
 #, fuzzy
 msgid "LinuxCNC Errors"
 msgstr "EMC2 故障"
 
-#: tcl/show_errors.tcl:80
+#: tcl/show_errors.tcl:81
 #, fuzzy
 msgid ""
 "LinuxCNC terminated with an error.  When reporting problems, please create a "
 "report file and include in your message."
 msgstr "EMC2 因故障 結束. 如要 報告問題, 請包括下面 的所有信息 在您的 消息"
 
-#: tcl/show_errors.tcl:106
+#: tcl/show_errors.tcl:107
 #, fuzzy
 msgid "Create Report File"
 msgstr "創建 或 修改"
 
-#: tcl/show_errors.tcl:108 tcl/scripts/Set_Coordinates.tcl:107
+#: tcl/show_errors.tcl:109 tcl/scripts/Set_Coordinates.tcl:107
 msgid "Close"
 msgstr "結束"
 
@@ -5087,7 +5111,7 @@ msgstr "設置 刀具 偏移量"
 msgid "Tool:"
 msgstr "刀具:"
 
-#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2189
+#: tcl/tklinuxcnc.tcl:466 src/emc/usr_intf/axis/scripts/axis.py:2203
 #: src/emc/usr_intf/axis/scripts/image-to-gcode.py:774
 msgid "All files"
 msgstr "所有文件"
@@ -5154,18 +5178,18 @@ msgstr "單位"
 msgid "auto"
 msgstr "自動"
 
-#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:512
+#: tcl/tklinuxcnc.tcl:785 src/emc/usr_intf/pncconf/tests.py:516
 msgid "inches"
 msgstr "英寸"
 
-#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1720
-#: src/emc/usr_intf/axis/scripts/axis.py:2006
-#: src/emc/usr_intf/axis/scripts/axis.py:2577
+#: tcl/tklinuxcnc.tcl:786 src/emc/usr_intf/axis/scripts/axis.py:1734
+#: src/emc/usr_intf/axis/scripts/axis.py:2020
+#: src/emc/usr_intf/axis/scripts/axis.py:2594
 #: src/emc/usr_intf/touchy/touchy.glade:3301
-#: src/emc/usr_intf/stepconf/stepconf.py:1478
-#: src/emc/usr_intf/stepconf/pages.py:828
+#: src/emc/usr_intf/stepconf/stepconf.py:1566
+#: src/emc/usr_intf/stepconf/pages.py:938
 #: src/emc/usr_intf/stepconf/main_page.glade:240
-#: src/emc/usr_intf/pncconf/tests.py:507
+#: src/emc/usr_intf/pncconf/tests.py:511
 #: src/emc/usr_intf/pncconf/external.glade:1998
 #: src/emc/usr_intf/pncconf/external.glade:2213
 #: src/emc/usr_intf/pncconf/base.glade:57
@@ -5323,7 +5347,7 @@ msgstr ""
 msgid "world"
 msgstr ""
 
-#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:450
+#: tcl/tklinuxcnc.tcl:1167 src/emc/usr_intf/pncconf/private_data.py:464
 msgid "home"
 msgstr "零點"
 
@@ -5404,16 +5428,15 @@ msgstr "校驗"
 msgid "Optional Stop"
 msgstr "可選 的 停止"
 
-#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:46
+#: tcl/tklinuxcnc.tcl:1945 tcl/ngcgui_ttt.tcl:47
 msgid "Set Font"
 msgstr "字體 設為"
 
-#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:283
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5421
+#: tcl/tklinuxcnc.tcl:1954 tcl/ngcgui_ttt.tcl:284
 msgid "Font"
 msgstr "字體"
 
-#: tcl/tklinuxcnc.tcl:1961 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3565
+#: tcl/tklinuxcnc.tcl:1961
 msgid "Size"
 msgstr "大小"
 
@@ -5523,7 +5546,7 @@ msgid "Coordinate System Control Window"
 msgstr "坐標 系統 控制 窗口"
 
 #: tcl/scripts/Set_Coordinates.tcl:83
-#: src/emc/usr_intf/axis/scripts/axis.py:3586
+#: src/emc/usr_intf/axis/scripts/axis.py:3616
 msgid "Axis "
 msgstr "軸 "
 
@@ -6113,9 +6136,9 @@ msgstr ""
 msgid "move"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3862
-#: src/emc/usr_intf/pncconf/pncconf.py:3968
-#: src/emc/usr_intf/pncconf/pncconf.py:4128
+#: tcl/ngcgui.tcl:3716 src/emc/usr_intf/pncconf/pncconf.py:3900
+#: src/emc/usr_intf/pncconf/pncconf.py:4006
+#: src/emc/usr_intf/pncconf/pncconf.py:4170
 msgid "Custom"
 msgstr "自訂"
 
@@ -6135,8 +6158,8 @@ msgstr ""
 msgid "using path"
 msgstr ""
 
-#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2638
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: tcl/ngcgui.tcl:3802 src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 msgid "Warning"
 msgstr "警告"
 
@@ -6213,156 +6236,156 @@ msgstr "（無文件）"
 msgid "not found"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:67
+#: tcl/ngcgui_ttt.tcl:68
 msgid "found truetype-tracer v4 -OK"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:70
+#: tcl/ngcgui_ttt.tcl:71
 msgid "Note truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:71
+#: tcl/ngcgui_ttt.tcl:72
 msgid "Note: truetype-tracer v4 is required"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:81
+#: tcl/ngcgui_ttt.tcl:82
 msgid "ngcgui_app.tcl must be loaded before"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:89
+#: tcl/ngcgui_ttt.tcl:90
 msgid "Create a subroutine file from truetype-tracer (V4 reqd)"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:102 tcl/ngcgui_ttt.tcl:115
+#: tcl/ngcgui_ttt.tcl:103 tcl/ngcgui_ttt.tcl:116
 #, fuzzy
 msgid "problem with"
 msgstr "替換："
 
-#: tcl/ngcgui_ttt.tcl:106
+#: tcl/ngcgui_ttt.tcl:107
 msgid "No entry for"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:109
+#: tcl/ngcgui_ttt.tcl:110
 msgid "wrong version of truetype-tracer"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "not writable, using"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:125
+#: tcl/ngcgui_ttt.tcl:126
 msgid "and setting expandsub"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:161 src/emc/usr_intf/pncconf/external.glade:721
+#: tcl/ngcgui_ttt.tcl:162 src/emc/usr_intf/pncconf/external.glade:721
 msgid "Text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:171
+#: tcl/ngcgui_ttt.tcl:172
 #, fuzzy
 msgid "Linescale"
 msgstr "比例"
 
-#: tcl/ngcgui_ttt.tcl:177 src/emc/usr_intf/gmoccapy/gmoccapy.glade:3956
+#: tcl/ngcgui_ttt.tcl:178
 msgid "none"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:192
+#: tcl/ngcgui_ttt.tcl:193
 msgid "Subdiv"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:199
+#: tcl/ngcgui_ttt.tcl:200
 #, fuzzy
 msgid "default"
 msgstr "AXIS 預 置 值"
 
-#: tcl/ngcgui_ttt.tcl:239
+#: tcl/ngcgui_ttt.tcl:240
 #, fuzzy
 msgid "Mode"
 msgstr "運行模式"
 
-#: tcl/ngcgui_ttt.tcl:247
+#: tcl/ngcgui_ttt.tcl:248
 #, fuzzy
 msgid "normal"
 msgstr "正常"
 
-#: tcl/ngcgui_ttt.tcl:248
+#: tcl/ngcgui_ttt.tcl:249
 msgid "date"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:249
+#: tcl/ngcgui_ttt.tcl:250
 msgid "fontname"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:262
+#: tcl/ngcgui_ttt.tcl:263
 #, fuzzy
 msgid "Switches"
 msgstr "英寸"
 
-#: tcl/ngcgui_ttt.tcl:270
+#: tcl/ngcgui_ttt.tcl:271
 msgid "Unicode"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:275
+#: tcl/ngcgui_ttt.tcl:276
 msgid "Allow Rotation"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:295
+#: tcl/ngcgui_ttt.tcl:296
 msgid "Make ngcgui-compatible subfile and new tab page"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:353
+#: tcl/ngcgui_ttt.tcl:354
 msgid "Null text"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:384
+#: tcl/ngcgui_ttt.tcl:385
 msgid "Using truetype-tracer default font"
 msgstr ""
 
-#: tcl/ngcgui_ttt.tcl:388
+#: tcl/ngcgui_ttt.tcl:389
 #, fuzzy
 msgid "no such file"
 msgstr "（無文件）"
 
-#: tcl/ngcgui_ttt.tcl:393
+#: tcl/ngcgui_ttt.tcl:394
 #, fuzzy
 msgid "file not readable"
 msgstr "文件未打開"
 
-#: tcl/ngcgui_ttt.tcl:507
+#: tcl/ngcgui_ttt.tcl:508
 msgid "Creating new tab page"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:25
+#: tcl/ngcgui_app.tcl:26
 msgid ""
 "requires command inifindall\n"
 "from axis.py (LinuxCNC 2.5) or"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:42
+#: tcl/ngcgui_app.tcl:43
 #, fuzzy
 msgid "not readable"
 msgstr "文件未打開"
 
-#: tcl/ngcgui_app.tcl:48 tcl/ngcgui_app.tcl:51
+#: tcl/ngcgui_app.tcl:49 tcl/ngcgui_app.tcl:52
 msgid "Unexpected: multiple startups for ngcgui"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:49
+#: tcl/ngcgui_app.tcl:50
 #, fuzzy
 msgid "LinuxCNC"
 msgstr "EMC 排錯"
 
-#: tcl/ngcgui_app.tcl:50
+#: tcl/ngcgui_app.tcl:51
 msgid "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
-#: tcl/ngcgui_app.tcl:69
+#: tcl/ngcgui_app.tcl:70
 #, fuzzy
 msgid "LinuxCNC version"
 msgstr "EMC2 故障"
 
-#: tcl/ngcgui_app.tcl:70
+#: tcl/ngcgui_app.tcl:71
 msgid "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"
 msgstr ""
 
@@ -7037,220 +7060,218 @@ msgstr ""
 msgid "Open a Menu"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:901
+#: src/emc/usr_intf/axis/scripts/axis.py:915
 #, python-format
 msgid "Unknown tool %d"
 msgstr "未知的刀具 %d"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:903 share/axis/tcl/axis.tcl:1872
+#: src/emc/usr_intf/axis/scripts/axis.py:917 share/axis/tcl/axis.tcl:1872
 msgid "No tool"
 msgstr "沒有刀具"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:905
+#: src/emc/usr_intf/axis/scripts/axis.py:919
 #, python-format
 msgid "Tool %(tool)d, offset %(zo)g, diameter %(dia)g"
 msgstr "刀具 %(tool)d, 偏移 %(zo)g, 直徑 %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:907
+#: src/emc/usr_intf/axis/scripts/axis.py:921
 #, python-format
 msgid "Tool %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 msgstr "刀具 %(tool)d, zo %(zo)g, xo %(xo)g, dia %(dia)g"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1091
+#: src/emc/usr_intf/axis/scripts/axis.py:1105
 msgid "Filtering..."
 msgstr "篩選...."
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1155
+#: src/emc/usr_intf/axis/scripts/axis.py:1169
 msgid "Filter failed"
 msgstr "篩選 失敗"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1156
+#: src/emc/usr_intf/axis/scripts/axis.py:1170
 #, python-format
 msgid ""
 "The program %(program)r exited with code %(code)d.  Any error messages it "
 "produced are shown below:"
 msgstr "該程序 %(program)r 退出 的 程式碼 %(code)d. 所有 錯誤信息 產生 如下:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1258
+#: src/emc/usr_intf/axis/scripts/axis.py:1272
 #, python-format
 msgid "G-Code error in %s"
 msgstr "G 代碼 錯誤 在 %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1259
+#: src/emc/usr_intf/axis/scripts/axis.py:1273
 #, python-format
 msgid ""
 "Near line %(seq)d of %(f)s:\n"
 "%(error_str)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1448
-#: src/emc/usr_intf/axis/scripts/axis.py:3203 share/axis/tcl/axis.tcl:922
+#: src/emc/usr_intf/axis/scripts/axis.py:1462
+#: src/emc/usr_intf/axis/scripts/axis.py:3220 share/axis/tcl/axis.tcl:922
 #: share/axis/tcl/axis.tcl:924 share/axis/tcl/axis.tcl:2051
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1018
 msgid "Continuous"
 msgstr "連續"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1711
+#: src/emc/usr_intf/axis/scripts/axis.py:1725
 msgid "T    Tool Table"
 msgstr "T    刀具表"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1721
-#: src/emc/usr_intf/axis/scripts/axis.py:2010
-#: src/emc/usr_intf/axis/scripts/axis.py:2578
-#: src/emc/usr_intf/stepconf/stepconf.py:1492
-#: src/emc/usr_intf/stepconf/pages.py:834
+#: src/emc/usr_intf/axis/scripts/axis.py:1735
+#: src/emc/usr_intf/axis/scripts/axis.py:2024
+#: src/emc/usr_intf/axis/scripts/axis.py:2595
+#: src/emc/usr_intf/stepconf/stepconf.py:1580
+#: src/emc/usr_intf/stepconf/pages.py:944
 msgid "in"
 msgstr "英寸"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1724
+#: src/emc/usr_intf/axis/scripts/axis.py:1738
 msgid " radius"
 msgstr "  半徑"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1726
+#: src/emc/usr_intf/axis/scripts/axis.py:1740
 msgid " diameter"
 msgstr "  直徑"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1727
+#: src/emc/usr_intf/axis/scripts/axis.py:1741
 msgid "°"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1737
+#: src/emc/usr_intf/axis/scripts/axis.py:1751
 msgid "Coordinate System:"
 msgstr "坐標系:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1755
+#: src/emc/usr_intf/axis/scripts/axis.py:1769
 msgid "fixture"
 msgstr "夾具"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1756
+#: src/emc/usr_intf/axis/scripts/axis.py:1770
 msgid "workpiece"
 msgstr "工件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Name:"
 msgstr "名稱:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1777
+#: src/emc/usr_intf/axis/scripts/axis.py:1791
 msgid "Size:"
 msgstr "尺寸:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Tool order:"
 msgstr "刀具秩序:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1778
+#: src/emc/usr_intf/axis/scripts/axis.py:1792
 msgid "Rapid distance:"
 msgstr "快速的距離:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Feed distance:"
 msgstr "進給距離:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1779
+#: src/emc/usr_intf/axis/scripts/axis.py:1793
 msgid "Total distance:"
 msgstr "總距離:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "Run time:"
 msgstr "運行時間:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1780
+#: src/emc/usr_intf/axis/scripts/axis.py:1794
 msgid "X bounds:"
 msgstr "X 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Y bounds:"
 msgstr "Y 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1781
+#: src/emc/usr_intf/axis/scripts/axis.py:1795
 msgid "Z bounds:"
 msgstr "Z 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "A bounds:"
 msgstr "A 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1782
+#: src/emc/usr_intf/axis/scripts/axis.py:1796
 msgid "B bounds:"
 msgstr "B 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1783
+#: src/emc/usr_intf/axis/scripts/axis.py:1797
 msgid "C bounds:"
 msgstr "C 範圍:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1840
+#: src/emc/usr_intf/axis/scripts/axis.py:1854
 #, python-format
 msgid "Program exceeds machine minimum on axis %s"
 msgstr "程序 超出 机床 最低 限度 在 軸 %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1843
+#: src/emc/usr_intf/axis/scripts/axis.py:1857
 #, python-format
 msgid "Program exceeds machine maximum on axis %s"
 msgstr "程序 超出 机床 最高 限度 在 軸 %s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1848
+#: src/emc/usr_intf/axis/scripts/axis.py:1862
 msgid "Program exceeds machine limits"
 msgstr "程序 超出 机床 極限"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1851
+#: src/emc/usr_intf/axis/scripts/axis.py:1865
 msgid "Run Anyway"
 msgstr "運行 無論如何"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1988
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2395
+#: src/emc/usr_intf/axis/scripts/axis.py:2002
 msgid "No file loaded"
 msgstr "沒有 文件 加載"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:1996
+#: src/emc/usr_intf/axis/scripts/axis.py:2010
 #, python-format
 msgid "generated from %s"
 msgstr "產生 於　%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2002
+#: src/emc/usr_intf/axis/scripts/axis.py:2016
 #, python-format
 msgid ""
 "%(size)s bytes\n"
 "%(lines)s gcode lines"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2028
+#: src/emc/usr_intf/axis/scripts/axis.py:2042
 #, python-format
 msgid "%.1f minutes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2030
+#: src/emc/usr_intf/axis/scripts/axis.py:2044
 #, python-format
 msgid "%d seconds"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2038
+#: src/emc/usr_intf/axis/scripts/axis.py:2052
 #, python-format
 msgid "%(a)f to %(b)f = %(diff)f %(units)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2039
+#: src/emc/usr_intf/axis/scripts/axis.py:2053
 msgid "G-Code Properties"
 msgstr "G 代碼 性質"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2187
+#: src/emc/usr_intf/axis/scripts/axis.py:2201
 msgid "All machinable files"
 msgstr "所有 可 加工 文件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2188
-#: src/emc/usr_intf/axis/scripts/axis.py:2900
+#: src/emc/usr_intf/axis/scripts/axis.py:2202
+#: src/emc/usr_intf/axis/scripts/axis.py:2917
 msgid "rs274ngc files"
 msgstr "rs274ngc 文件"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2204
+#: src/emc/usr_intf/axis/scripts/axis.py:2218
 msgid "axis cannot accept remote command while running"
 msgstr "軸 不能接受 遠程 指令 在 運行時"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2259
+#: src/emc/usr_intf/axis/scripts/axis.py:2273
 #, fuzzy
 msgid "File not Writable:"
 msgstr "文件未打開"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2260
+#: src/emc/usr_intf/axis/scripts/axis.py:2274
 msgid ""
 "This file is not writable\n"
 "You can Edit-readonly\n"
@@ -7261,62 +7282,62 @@ msgid ""
 "then open that saved, writable file"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2267
+#: src/emc/usr_intf/axis/scripts/axis.py:2281
 msgid "Edit-readonly"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 #, fuzzy
 msgid "Custom Grid"
 msgstr "自訂"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2579
+#: src/emc/usr_intf/axis/scripts/axis.py:2596
 msgid "Enter grid size"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2638
+#: src/emc/usr_intf/axis/scripts/axis.py:2655
 #, fuzzy
 msgid "Joint is already homed, are you sure you want to re-home?"
 msgstr "軸 已經 在零，你一定要 重新 再 歸零?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2652
+#: src/emc/usr_intf/axis/scripts/axis.py:2669
 #, fuzzy, python-format
 msgid "home_joint <%s> Use joint mode for homing"
 msgstr "一定 要在 Joint 模式 才能 歸零 "
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2655
+#: src/emc/usr_intf/axis/scripts/axis.py:2672
 #, python-format
 msgid ""
 "\n"
 "Individual axis homing disallowed for duplicated letter:<%s> "
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2664
+#: src/emc/usr_intf/axis/scripts/axis.py:2681
 #, fuzzy
 msgid "This joint is already homed, are you sure you want to re-home?"
 msgstr "這軸 已經 在零，你一定要 重新 再 歸零?"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2702
+#: src/emc/usr_intf/axis/scripts/axis.py:2719
 #, fuzzy
 msgid "Touch Off (system)"
 msgstr "對刀"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2703
-#: src/emc/usr_intf/axis/scripts/axis.py:2744
+#: src/emc/usr_intf/axis/scripts/axis.py:2720
+#: src/emc/usr_intf/axis/scripts/axis.py:2761
 #, python-format
 msgid "Enter %s coordinate relative to %%s:"
 msgstr "輸入 %s 坐標相對於 %%s:"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2743
+#: src/emc/usr_intf/axis/scripts/axis.py:2760
 #, fuzzy, python-format
 msgid "Tool %s TouchOff"
 msgstr "對刀"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:2912
+#: src/emc/usr_intf/axis/scripts/axis.py:2929
 msgid "Error saving file"
 msgstr "保存 文件 時出錯"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3371
+#: src/emc/usr_intf/axis/scripts/axis.py:3388
 #, python-format
 msgid ""
 "\n"
@@ -7325,7 +7346,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3384
+#: src/emc/usr_intf/axis/scripts/axis.py:3401
 #, python-format
 msgid ""
 "\n"
@@ -7334,7 +7355,7 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3397
+#: src/emc/usr_intf/axis/scripts/axis.py:3414
 #, python-format
 msgid ""
 "\n"
@@ -7343,91 +7364,91 @@ msgid ""
 "See the 'INI Configuration' documents\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3503
+#: src/emc/usr_intf/axis/scripts/axis.py:3533
 msgid "Axes"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3505
+#: src/emc/usr_intf/axis/scripts/axis.py:3535
 #, fuzzy
 msgid "Joints"
 msgstr "輸入輸出點"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3507
+#: src/emc/usr_intf/axis/scripts/axis.py:3537
 #: src/emc/usr_intf/touchy/touchy.glade:577
 #: src/emc/usr_intf/gscreen/gscreen.glade:2968
 msgid "Home All"
 msgstr "全部 歸零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3509
+#: src/emc/usr_intf/axis/scripts/axis.py:3539
 #, fuzzy, python-format
 msgid "Home all %s [Ctrl-Home]"
 msgstr "所有軸 歸零 [Ctrl-Home]"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3512
+#: src/emc/usr_intf/axis/scripts/axis.py:3542
 #, fuzzy, python-format
 msgid "Home All %s"
 msgstr "全部 歸零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3514
+#: src/emc/usr_intf/axis/scripts/axis.py:3544
 #, fuzzy, python-format
 msgid "Unhome All %s"
 msgstr "離零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3555
+#: src/emc/usr_intf/axis/scripts/axis.py:3585
 #, python-format
 msgid "Warning: Forward kinematics must handle duplicate coordinate letters:%s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3558
+#: src/emc/usr_intf/axis/scripts/axis.py:3588
 #, python-format
 msgid "Note: number of [TRAJ]COORDINATES=%(t)s exceeds [KINS]JOINTS=%(l)d"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3590
+#: src/emc/usr_intf/axis/scripts/axis.py:3620
 msgid ""
 "\n"
 "Note:\n"
 "Individual axis homing is not currently supported for"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3591
+#: src/emc/usr_intf/axis/scripts/axis.py:3621
 #, python-format
 msgid "KINEMATICS_IDENTITY with duplicate axis letter <%s>\n"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3603
+#: src/emc/usr_intf/axis/scripts/axis.py:3633
 #, fuzzy
 msgid "Joint"
 msgstr "Joint 模式"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3605
+#: src/emc/usr_intf/axis/scripts/axis.py:3635
 #, fuzzy
 msgid "Home Joint"
 msgstr "軸回零"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3613
+#: src/emc/usr_intf/axis/scripts/axis.py:3643
 #, python-format
 msgid "Home %(name)s _%(id)s"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3615
+#: src/emc/usr_intf/axis/scripts/axis.py:3645
 #, fuzzy, python-format
 msgid "Unhome %(name)s _%(id)s"
 msgstr "離零 軸 _%s"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3809
+#: src/emc/usr_intf/axis/scripts/axis.py:3839
 msgid "Run from here"
 msgstr "從 這裡 運行"
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3867
+#: src/emc/usr_intf/axis/scripts/axis.py:3898
 msgid "toggle PYVCP panel visibility"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:3869 share/axis/tcl/axis.tcl:387
+#: src/emc/usr_intf/axis/scripts/axis.py:3900 share/axis/tcl/axis.tcl:387
 msgid "Show pyVCP pan_el"
 msgstr ""
 
-#: src/emc/usr_intf/axis/scripts/axis.py:4138
+#: src/emc/usr_intf/axis/scripts/axis.py:4170
 msgid "Error in ~/.axisrc"
 msgstr "錯誤 joi ~/.axisrc"
 
@@ -7738,11 +7759,13 @@ msgid "_Properties..."
 msgstr "屬性(_P)......"
 
 #: share/axis/tcl/axis.tcl:86
-msgid "Edit _tool table..."
+#, fuzzy
+msgid "Edit _tool data..."
 msgstr "編輯刀具表(_t)...."
 
 #: share/axis/tcl/axis.tcl:90
-msgid "Reload tool ta_ble"
+#, fuzzy
+msgid "Reload tool _data"
 msgstr "重新載入刀具表(_b)"
 
 #: share/axis/tcl/axis.tcl:96
@@ -8071,11 +8094,11 @@ msgstr "切換 跳 行 用 '/' [Alt-M /]"
 msgid "Toggle optional pause [Alt-M 1]"
 msgstr "切換 任擇 停頓 [Alt-M 1]"
 
-#: share/axis/tcl/axis.tcl:586 src/emc/usr_intf/gmoccapy/gmoccapy.glade:638
+#: share/axis/tcl/axis.tcl:586
 msgid "Zoom in"
 msgstr "放大"
 
-#: share/axis/tcl/axis.tcl:594 src/emc/usr_intf/gmoccapy/gmoccapy.glade:657
+#: share/axis/tcl/axis.tcl:594
 msgid "Zoom out"
 msgstr "縮小"
 
@@ -8254,9 +8277,10 @@ msgstr "設定主軸超速:"
 #: src/emc/usr_intf/pncconf/external.glade:5088
 #: src/emc/usr_intf/pncconf/external.glade:5102
 #: src/emc/usr_intf/pncconf/external.glade:5116
-#: src/emc/usr_intf/pncconf/screen.glade:450
-#: src/emc/usr_intf/pncconf/screen.glade:463
-#: src/emc/usr_intf/pncconf/screen.glade:518
+#: src/emc/usr_intf/pncconf/screen.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:491
+#: src/emc/usr_intf/pncconf/screen.glade:546
+#: src/emc/usr_intf/pncconf/screen.glade:3111
 msgid "%"
 msgstr ""
 
@@ -8299,7 +8323,7 @@ msgid "Position:"
 msgstr "位置:"
 
 #: share/axis/tcl/axis.tcl:1835 src/emc/usr_intf/pncconf/screen.glade:89
-#: src/emc/usr_intf/gscreen/gscreen.py:4564
+#: src/emc/usr_intf/gscreen/gscreen.py:4563
 msgid "Machine"
 msgstr ""
 
@@ -8405,21 +8429,20 @@ msgid "Temporarily allow jogging outside machine limits [L]"
 msgstr "暫時 讓 機器 在 極限外 慢步 [L]"
 
 #: src/emc/usr_intf/touchy/touchy.py:142
-#: src/emc/usr_intf/pncconf/pncconf.py:1689
-#: src/emc/usr_intf/pncconf/pncconf.py:1692
+#: src/emc/usr_intf/pncconf/pncconf.py:1720
+#: src/emc/usr_intf/pncconf/pncconf.py:1723
 #: src/emc/usr_intf/gscreen/gscreen.py:1324
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1821
 msgid "Follow System Theme"
 msgstr ""
 
-#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:47 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:47
 msgid "Spindle CW"
 msgstr "主軸 順時針"
 
-#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/touchy/mdi.py:48 src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #: src/emc/usr_intf/gscreen/mdi.py:48
 msgid "Spindle CCW"
 msgstr "主軸 逆時針"
@@ -8762,6 +8785,8 @@ msgid "."
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:963
+#: src/emc/usr_intf/stepconf/options.glade:402
+#: src/emc/usr_intf/pncconf/screen.glade:2806
 #: src/emc/usr_intf/pncconf/dialogs.glade:2856
 #: src/emc/usr_intf/pncconf/dialogs.glade:4037
 #: src/emc/usr_intf/pncconf/dialogs.glade:4050
@@ -8771,43 +8796,88 @@ msgstr ""
 #: src/emc/usr_intf/pncconf/dialogs.glade:4102
 #: src/emc/usr_intf/pncconf/dialogs.glade:4257
 #: src/emc/usr_intf/pncconf/dialogs.glade:4270
+#: lib/python/gladevcp/offsetpage.glade:94
 msgid "0"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:980
+#: src/emc/usr_intf/stepconf/ubuttons.glade:93
+#: src/emc/usr_intf/pncconf/ubuttons.glade:96
+#: lib/python/gladevcp/offsetpage.glade:43
+#: lib/python/gladevcp/offsetpage.glade:60
 msgid "3"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:997
+#: src/emc/usr_intf/stepconf/options.glade:426
+#: src/emc/usr_intf/stepconf/ubuttons.glade:81
+#: src/emc/usr_intf/pncconf/screen.glade:2831
+#: src/emc/usr_intf/pncconf/ubuttons.glade:83
+#: lib/python/gladevcp/offsetpage.glade:42
+#: lib/python/gladevcp/offsetpage.glade:59
 msgid "2"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1014
+#: src/emc/usr_intf/stepconf/options.glade:412
+#: src/emc/usr_intf/stepconf/ubuttons.glade:69
+#: src/emc/usr_intf/stepconf/thcad.glade:29
+#: src/emc/usr_intf/pncconf/screen.glade:2816
+#: src/emc/usr_intf/pncconf/ubuttons.glade:70
+#: src/emc/usr_intf/pncconf/thcad.glade:29
+#: lib/python/gladevcp/offsetpage.glade:41
+#: lib/python/gladevcp/offsetpage.glade:58
 msgid "1"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1031
+#: src/emc/usr_intf/stepconf/ubuttons.glade:129
+#: src/emc/usr_intf/pncconf/ubuttons.glade:135
+#: lib/python/gladevcp/offsetpage.glade:46
+#: lib/python/gladevcp/offsetpage.glade:63
 msgid "6"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1048
+#: src/emc/usr_intf/stepconf/ubuttons.glade:117
+#: src/emc/usr_intf/stepconf/thcad.glade:56
+#: src/emc/usr_intf/pncconf/ubuttons.glade:122
+#: src/emc/usr_intf/pncconf/thcad.glade:56
 #: src/emc/usr_intf/pncconf/dialogs.glade:1458
+#: lib/python/gladevcp/offsetpage.glade:45
+#: lib/python/gladevcp/offsetpage.glade:62
 msgid "5"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1065
+#: src/emc/usr_intf/stepconf/ubuttons.glade:105
+#: src/emc/usr_intf/pncconf/ubuttons.glade:109
+#: lib/python/gladevcp/offsetpage.glade:44
+#: lib/python/gladevcp/offsetpage.glade:61
 msgid "4"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1082
+#: src/emc/usr_intf/stepconf/ubuttons.glade:165
+#: src/emc/usr_intf/pncconf/ubuttons.glade:174
+#: lib/python/gladevcp/offsetpage.glade:49
+#: lib/python/gladevcp/offsetpage.glade:66
 msgid "9"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1097
+#: src/emc/usr_intf/stepconf/ubuttons.glade:153
+#: src/emc/usr_intf/pncconf/ubuttons.glade:161
+#: lib/python/gladevcp/offsetpage.glade:48
+#: lib/python/gladevcp/offsetpage.glade:65
 msgid "8"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1112
+#: src/emc/usr_intf/stepconf/ubuttons.glade:141
+#: src/emc/usr_intf/pncconf/ubuttons.glade:148
+#: lib/python/gladevcp/offsetpage.glade:47
+#: lib/python/gladevcp/offsetpage.glade:64
 msgid "7"
 msgstr ""
 
@@ -8862,7 +8932,6 @@ msgid "label26"
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:1539
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4662
 msgid "<b>Spindle</b>"
 msgstr "<b>主軸</b>"
 
@@ -9026,7 +9095,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/touchy/touchy.glade:3009
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6628
 msgid "Status"
 msgstr ""
 
@@ -9086,8 +9154,8 @@ msgstr ""
 #: src/emc/usr_intf/touchy/touchy.glade:3286
 #: src/emc/usr_intf/stepconf/base.glade:69
 #: src/emc/usr_intf/pncconf/base.glade:54
+#: src/emc/usr_intf/gscreen/gscreen.py:4623
 #: src/emc/usr_intf/gscreen/gscreen.py:4624
-#: src/emc/usr_intf/gscreen/gscreen.py:4625
 #: src/emc/usr_intf/gscreen/gscreen.glade:3708
 msgid "Inch"
 msgstr ""
@@ -9220,10 +9288,10 @@ msgid "Stepconf"
 msgstr "步進"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:153
-#: src/emc/usr_intf/stepconf/stepconf.py:254
+#: src/emc/usr_intf/stepconf/stepconf.py:274
 #: src/emc/usr_intf/stepconf/main_page.glade:581
 #: src/emc/usr_intf/pncconf/private_data.py:39
-#: src/emc/usr_intf/pncconf/private_data.py:998
+#: src/emc/usr_intf/pncconf/private_data.py:1066
 #: src/emc/usr_intf/pncconf/main_page.glade:226
 #: src/emc/usr_intf/gscreen/gscreen.py:4456
 #: src/emc/usr_intf/gscreen/gscreen.py:4457
@@ -9244,13 +9312,13 @@ msgid "Parallel Port 1"
 msgstr "第一並行端口設置"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:155
-#: src/emc/usr_intf/pncconf/private_data.py:47
+#: src/emc/usr_intf/pncconf/private_data.py:48
 #, fuzzy
 msgid "Parallel Port 2"
 msgstr "第一並行端口設置"
 
 #: src/emc/usr_intf/stepconf/stepconf.py:156
-#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:59
 #, fuzzy
 msgid "Options"
 msgstr "GUI 的選項 "
@@ -9260,235 +9328,286 @@ msgid "HALUI"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:43
+#, fuzzy
+msgid "User Buttons"
+msgstr "左 按鈕"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:158
+msgid "QtPlasmaC THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:159
 #, fuzzy
 msgid "Axis X"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Y"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:158
+#: src/emc/usr_intf/stepconf/stepconf.py:160
 #, fuzzy
 msgid "Axis Z"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis U"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:159
+#: src/emc/usr_intf/stepconf/stepconf.py:161
 #, fuzzy
 msgid "Axis V"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:160
+#: src/emc/usr_intf/stepconf/stepconf.py:162
 #, fuzzy
 msgid "Axis A"
 msgstr "軸 "
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:452
-#: src/emc/usr_intf/pncconf/private_data.py:511
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:466
+#: src/emc/usr_intf/pncconf/private_data.py:527
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "Spindle"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:161
-#: src/emc/usr_intf/pncconf/private_data.py:59
+#: src/emc/usr_intf/stepconf/stepconf.py:163
+#: src/emc/usr_intf/pncconf/private_data.py:61
 msgid "Almost Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:165
-#: src/emc/usr_intf/pncconf/private_data.py:959
+#: src/emc/usr_intf/stepconf/stepconf.py:167
+#: src/emc/usr_intf/pncconf/private_data.py:1027
 msgid "Gecko 201"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:166
-#: src/emc/usr_intf/pncconf/private_data.py:960
+#: src/emc/usr_intf/stepconf/stepconf.py:168
+#: src/emc/usr_intf/pncconf/private_data.py:1028
 msgid "Gecko 202"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:167
-#: src/emc/usr_intf/pncconf/private_data.py:961
+#: src/emc/usr_intf/stepconf/stepconf.py:169
+#: src/emc/usr_intf/pncconf/private_data.py:1029
 msgid "Gecko 203v"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:168
-#: src/emc/usr_intf/pncconf/private_data.py:962
+#: src/emc/usr_intf/stepconf/stepconf.py:170
+#: src/emc/usr_intf/pncconf/private_data.py:1030
 msgid "Gecko 210"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:169
-#: src/emc/usr_intf/pncconf/private_data.py:963
+#: src/emc/usr_intf/stepconf/stepconf.py:171
+#: src/emc/usr_intf/pncconf/private_data.py:1031
 msgid "Gecko 212"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:170
-#: src/emc/usr_intf/pncconf/private_data.py:964
+#: src/emc/usr_intf/stepconf/stepconf.py:172
+#: src/emc/usr_intf/pncconf/private_data.py:1032
 msgid "Gecko 320"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:171
-#: src/emc/usr_intf/pncconf/private_data.py:965
+#: src/emc/usr_intf/stepconf/stepconf.py:173
+#: src/emc/usr_intf/pncconf/private_data.py:1033
 msgid "Gecko 540"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:172
-#: src/emc/usr_intf/pncconf/private_data.py:966
+#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/pncconf/private_data.py:1034
 msgid "L297"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:173
-#: src/emc/usr_intf/pncconf/private_data.py:967
+#: src/emc/usr_intf/stepconf/stepconf.py:175
+#: src/emc/usr_intf/pncconf/private_data.py:1035
 msgid "PMDX-150"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:174
+#: src/emc/usr_intf/stepconf/stepconf.py:176
 #: src/emc/usr_intf/stepconf/pport1.glade:43
-#: src/emc/usr_intf/pncconf/private_data.py:968
+#: src/emc/usr_intf/pncconf/private_data.py:1036
 msgid "Sherline"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:175
-#: src/emc/usr_intf/pncconf/private_data.py:969
+#: src/emc/usr_intf/stepconf/stepconf.py:177
+#: src/emc/usr_intf/pncconf/private_data.py:1037
 msgid "Xylotex 8S-3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:176
-#: src/emc/usr_intf/pncconf/private_data.py:970
+#: src/emc/usr_intf/stepconf/stepconf.py:178
+#: src/emc/usr_intf/pncconf/private_data.py:1038
 msgid "Parker-Compumotor oem750"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:177
-#: src/emc/usr_intf/pncconf/private_data.py:971
+#: src/emc/usr_intf/stepconf/stepconf.py:179
+#: src/emc/usr_intf/pncconf/private_data.py:1039
 msgid "JVL-SMD41 or 42"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:178
-#: src/emc/usr_intf/pncconf/private_data.py:972
+#: src/emc/usr_intf/stepconf/stepconf.py:180
+#: src/emc/usr_intf/pncconf/private_data.py:1040
 msgid "Hobbycnc Pro Chopper"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:179
-#: src/emc/usr_intf/pncconf/private_data.py:973
+#: src/emc/usr_intf/stepconf/stepconf.py:181
+#: src/emc/usr_intf/pncconf/private_data.py:1041
 msgid "Keling 4030"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "X Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:220
+#: src/emc/usr_intf/stepconf/stepconf.py:229
 msgid "Y Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "Z Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Step"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:221
+#: src/emc/usr_intf/stepconf/stepconf.py:230
 msgid "A Direction"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Step"
 msgstr "步進"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "U Direction"
 msgstr "掃描方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Step"
 msgstr "步進"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:222
+#: src/emc/usr_intf/stepconf/stepconf.py:231
 #, fuzzy
 msgid "V Direction"
 msgstr "掃描方向"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Step"
+msgstr "主 軸 步進產生器"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem X Direction"
+msgstr "掃描方向"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Step"
+msgstr "主 軸 步進產生器"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:232
+#, fuzzy
+msgid "Tandem Y Direction"
+msgstr "掃描方向"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:233
 msgid "Spindle ON"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:464
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:478
 msgid "Spindle PWM"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:223
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/pncconf/private_data.py:509
 msgid "Spindle Brake"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Mist"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:495
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:510
 msgid "Coolant Flood"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "ESTOP Out"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:224
+#: src/emc/usr_intf/stepconf/stepconf.py:234
 msgid "Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:225
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Charge Pump"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 0"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 1"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 2"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:226
-#: src/emc/usr_intf/pncconf/private_data.py:499
+#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/pncconf/private_data.py:514
 msgid "Digital out 3"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:227
-#: src/emc/usr_intf/stepconf/stepconf.py:252
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+#, fuzzy
+msgid "Plasma Ohmic Enable"
+msgstr "啟用"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Scribe On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Torch On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:237
+msgid "Plasma Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:272
 #: src/emc/usr_intf/stepconf/pport1.glade:18
 #: src/emc/usr_intf/stepconf/pport2.glade:12
 #: src/emc/usr_intf/stepconf/pport2.glade:23
@@ -9499,252 +9618,333 @@ msgstr ""
 msgid "Unused"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "ESTOP In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:229
-#: src/emc/usr_intf/pncconf/private_data.py:424
+#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/pncconf/private_data.py:435
 msgid "Probe In"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Index"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:230
+#: src/emc/usr_intf/stepconf/stepconf.py:241
 msgid "Spindle Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 msgid "Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home U"
 msgstr "零點"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:231
+#: src/emc/usr_intf/stepconf/stepconf.py:242
 #, fuzzy
 msgid "Home V"
 msgstr "零點"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+msgid "Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:243
+msgid "Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:232
+#: src/emc/usr_intf/stepconf/stepconf.py:244
 msgid "Minimum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:245
+msgid "Minimum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:233
+#: src/emc/usr_intf/stepconf/stepconf.py:246
 msgid "Minimum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:234
+#: src/emc/usr_intf/stepconf/stepconf.py:247
 msgid "Minimum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:235
+#: src/emc/usr_intf/stepconf/stepconf.py:248
 msgid "Maximum Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:249
+msgid "Maximum Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:236
+#: src/emc/usr_intf/stepconf/stepconf.py:250
 msgid "Maximum Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:237
+#: src/emc/usr_intf/stepconf/stepconf.py:251
 msgid "Maximum Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home X"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:238
+#: src/emc/usr_intf/stepconf/stepconf.py:252
 msgid "Both Limit + Home Y"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home Z"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:239
+#: src/emc/usr_intf/stepconf/stepconf.py:253
 msgid "Both Limit + Home A"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home U"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:240
+#: src/emc/usr_intf/stepconf/stepconf.py:254
 msgid "Both Limit + Home V"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:241
-msgid "Minimum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:242
-msgid "Minimum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:243
-msgid "Minimum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:244
-msgid "Maximum Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:245
-msgid "Maximum Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:246
-msgid "Maximum Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit X"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:247
-msgid "Both Limit Y"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit Z"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:248
-msgid "Both Limit A"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit U"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:249
-msgid "Both Limit V"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-msgid "All limits"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-msgid "All home"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:250
-msgid "All limits + homes"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 0"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 1"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 2"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/stepconf.py:251
-#: src/emc/usr_intf/pncconf/private_data.py:411
-msgid "Digital in 3"
+#: src/emc/usr_intf/stepconf/stepconf.py:255
+msgid "Both Limit + Home Tandem X"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/stepconf.py:255
-#: src/emc/usr_intf/pncconf/private_data.py:999
+msgid "Both Limit + Home Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:256
+msgid "Minimum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:257
+msgid "Minimum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:258
+msgid "Minimum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:259
+msgid "Minimum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:260
+msgid "Maximum Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:261
+msgid "Maximum Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:262
+msgid "Maximum Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:263
+msgid "Maximum Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:264
+msgid "Both Limit Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit Z"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:265
+msgid "Both Limit A"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit U"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:266
+msgid "Both Limit V"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem X"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:267
+msgid "Both Limit Tandem Y"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
+msgid "All limits"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
+msgid "All home"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:268
+msgid "All limits + homes"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 0"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 1"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 2"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:269
+#: src/emc/usr_intf/pncconf/private_data.py:422
+msgid "Digital in 3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Arc OK"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:270
+msgid "Plasma Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+msgid "Plasma Move Up"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/stepconf.py:271
+#, fuzzy
+msgid "Plasma Move Down"
+msgstr "向下"
+
+#: src/emc/usr_intf/stepconf/stepconf.py:275
+#: src/emc/usr_intf/pncconf/private_data.py:1067
 #, fuzzy
 msgid "Forward"
 msgstr "主軸 前轉"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:256
-#: src/emc/usr_intf/pncconf/private_data.py:1000
+#: src/emc/usr_intf/stepconf/stepconf.py:276
+#: src/emc/usr_intf/pncconf/private_data.py:1068
 msgid "Done"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:257
-#: src/emc/usr_intf/pncconf/private_data.py:1001
+#: src/emc/usr_intf/stepconf/stepconf.py:277
+#: src/emc/usr_intf/pncconf/private_data.py:1069
 msgid ""
 "OK to replace existing custom ladder program?\n"
 "Existing Custom.clp will be renamed custom_backup.clp.\n"
 "Any existing file named -custom_backup.clp- will be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:258
-#: src/emc/usr_intf/pncconf/pages.py:1342
-#: src/emc/usr_intf/pncconf/private_data.py:1002
+#: src/emc/usr_intf/stepconf/stepconf.py:278
+#: src/emc/usr_intf/pncconf/pages.py:1452
+#: src/emc/usr_intf/pncconf/private_data.py:1070
 msgid ""
 "You edited a ladder program and have selected a different program to copy to "
 "your configuration file.\n"
@@ -9753,14 +9953,14 @@ msgid ""
 "Are you sure?  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:259
-#: src/emc/usr_intf/pncconf/private_data.py:1003
+#: src/emc/usr_intf/stepconf/stepconf.py:279
+#: src/emc/usr_intf/pncconf/private_data.py:1071
 msgid ""
 "You need to designate an E-stop input pin in the Parallel Port Setup page "
 "for this program."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:260
+#: src/emc/usr_intf/stepconf/stepconf.py:280
 #, fuzzy
 msgid ""
 "OK to replace existing custom pyvcp panel file ?\n"
@@ -9771,26 +9971,26 @@ msgstr ""
 "現有 Custom.clp將改名custom_backup.clp.(_b)\n"
 "任何現有的 文件命名 -custom_backup.clp- 將會丟失."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:261
+#: src/emc/usr_intf/stepconf/stepconf.py:281
 msgid "Quit Stepconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:262
-#: src/emc/usr_intf/pncconf/private_data.py:1007
+#: src/emc/usr_intf/stepconf/stepconf.py:282
+#: src/emc/usr_intf/pncconf/private_data.py:1075
 msgid ""
 "The configuration has been built and saved.\n"
 "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:263
-#: src/emc/usr_intf/pncconf/private_data.py:1008
+#: src/emc/usr_intf/stepconf/stepconf.py:283
+#: src/emc/usr_intf/pncconf/private_data.py:1076
 msgid ""
 "You are using a simulated-realtime version of LinuxCNC, so testing / tuning "
 "of hardware is unavailable."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:264
-#: src/emc/usr_intf/pncconf/private_data.py:1009
+#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/pncconf/private_data.py:1077
 #, python-format
 msgid ""
 "You are using a realtime version of LinuxCNC but didn't load a realtime "
@@ -9801,43 +10001,43 @@ msgid ""
 "You need to use kernel:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:284
+#: src/emc/usr_intf/stepconf/stepconf.py:304
 msgid "my-mill"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:604
+#: src/emc/usr_intf/stepconf/stepconf.py:650
 #, python-format
 msgid "File %r was modified since it was written by stepconf"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:607
+#: src/emc/usr_intf/stepconf/stepconf.py:653
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside stepconf."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:622
-#: src/emc/usr_intf/pncconf/data.py:883
+#: src/emc/usr_intf/stepconf/stepconf.py:668
+#: src/emc/usr_intf/pncconf/data.py:907
 msgid "Continue? "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:623
-#: src/emc/usr_intf/pncconf/data.py:884
+#: src/emc/usr_intf/stepconf/stepconf.py:669
+#: src/emc/usr_intf/pncconf/data.py:908
 msgid "yY"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:708
-#: src/emc/usr_intf/pncconf/data.py:1064
+#: src/emc/usr_intf/stepconf/stepconf.py:754
+#: src/emc/usr_intf/pncconf/data.py:1088
 #, python-format
 msgid "launch %s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:712
+#: src/emc/usr_intf/stepconf/stepconf.py:758
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by Stepconf"
 msgstr "創建一個桌面 啟動器 啟動 LinuxCNC 與 此配置."
 
-#: src/emc/usr_intf/stepconf/stepconf.py:780
+#: src/emc/usr_intf/stepconf/stepconf.py:826
 #, fuzzy
 msgid ""
 "Loading configuration error:\n"
@@ -9845,34 +10045,34 @@ msgid ""
 "{}"
 msgstr "EMC2 配置文件選擇器"
 
-#: src/emc/usr_intf/stepconf/stepconf.py:902
+#: src/emc/usr_intf/stepconf/stepconf.py:968
 #: src/emc/usr_intf/stepconf/pages.py:157
 msgid "Other"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1459
-#: src/emc/usr_intf/pncconf/tests.py:1026
+#: src/emc/usr_intf/stepconf/stepconf.py:1547
+#: src/emc/usr_intf/pncconf/tests.py:1032
 #, python-format
 msgid "%s Axis Test"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1462
-#: src/emc/usr_intf/stepconf/pages.py:820
+#: src/emc/usr_intf/stepconf/stepconf.py:1550
+#: src/emc/usr_intf/stepconf/pages.py:930
 msgid "deg / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1463
-#: src/emc/usr_intf/stepconf/pages.py:821
+#: src/emc/usr_intf/stepconf/stepconf.py:1551
+#: src/emc/usr_intf/stepconf/pages.py:931
 msgid "deg / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1464
-#: src/emc/usr_intf/stepconf/pages.py:822
+#: src/emc/usr_intf/stepconf/stepconf.py:1552
+#: src/emc/usr_intf/stepconf/pages.py:932
 msgid "deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1476
-#: src/emc/usr_intf/stepconf/pages.py:826
+#: src/emc/usr_intf/stepconf/stepconf.py:1564
+#: src/emc/usr_intf/stepconf/pages.py:936
 #: src/emc/usr_intf/stepconf/axisx.glade:304
 #: src/emc/usr_intf/stepconf/axisy.glade:302
 #: src/emc/usr_intf/stepconf/axisz.glade:302
@@ -9887,8 +10087,8 @@ msgstr ""
 msgid "mm / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1477
-#: src/emc/usr_intf/stepconf/pages.py:827
+#: src/emc/usr_intf/stepconf/stepconf.py:1565
+#: src/emc/usr_intf/stepconf/pages.py:937
 #: src/emc/usr_intf/stepconf/axisx.glade:317
 #: src/emc/usr_intf/stepconf/axisy.glade:315
 #: src/emc/usr_intf/stepconf/axisz.glade:315
@@ -9903,13 +10103,13 @@ msgstr ""
 msgid "mm / s²"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1490
-#: src/emc/usr_intf/stepconf/pages.py:832
+#: src/emc/usr_intf/stepconf/stepconf.py:1578
+#: src/emc/usr_intf/stepconf/pages.py:942
 msgid "in / s"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/stepconf.py:1491
-#: src/emc/usr_intf/stepconf/pages.py:833
+#: src/emc/usr_intf/stepconf/stepconf.py:1579
+#: src/emc/usr_intf/stepconf/pages.py:943
 msgid "in / s²"
 msgstr ""
 
@@ -9919,19 +10119,19 @@ msgid "LinuxCNC 'stepconf' configuration files"
 msgstr "打開配置文件:"
 
 #: src/emc/usr_intf/stepconf/pages.py:236
-#: src/emc/usr_intf/pncconf/pncconf.py:858
+#: src/emc/usr_intf/pncconf/pncconf.py:891
 msgid "Modify Existing Configuration"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:819
+#: src/emc/usr_intf/stepconf/pages.py:929
 msgid "degree / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:823
+#: src/emc/usr_intf/stepconf/pages.py:933
 msgid "Steps / deg"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:825
+#: src/emc/usr_intf/stepconf/pages.py:935
 #: src/emc/usr_intf/stepconf/axisx.glade:291
 #: src/emc/usr_intf/stepconf/axisy.glade:289
 #: src/emc/usr_intf/stepconf/axisz.glade:289
@@ -9943,7 +10143,7 @@ msgstr ""
 msgid "mm / rev"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:829
+#: src/emc/usr_intf/stepconf/pages.py:939
 #: src/emc/usr_intf/stepconf/axisx.glade:28
 #: src/emc/usr_intf/stepconf/axisy.glade:28
 #: src/emc/usr_intf/stepconf/axisz.glade:28
@@ -9954,28 +10154,28 @@ msgstr ""
 msgid "Steps / mm"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:831
+#: src/emc/usr_intf/stepconf/pages.py:941
 msgid "rev / in"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/pages.py:835
+#: src/emc/usr_intf/stepconf/pages.py:945
 msgid "Steps / in"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:55
 #: src/emc/usr_intf/stepconf/build_HAL.py:42
-#: src/emc/usr_intf/stepconf/build_HAL.py:342
-#: src/emc/usr_intf/stepconf/build_HAL.py:356
-#: src/emc/usr_intf/stepconf/build_HAL.py:397
+#: src/emc/usr_intf/stepconf/build_HAL.py:357
+#: src/emc/usr_intf/stepconf/build_HAL.py:375
+#: src/emc/usr_intf/stepconf/build_HAL.py:416
 #, python-format
 msgid "# Generated by stepconf 1.1 at %s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:56
 #: src/emc/usr_intf/stepconf/build_HAL.py:43
-#: src/emc/usr_intf/stepconf/build_HAL.py:343
-#: src/emc/usr_intf/stepconf/build_HAL.py:357
-#: src/emc/usr_intf/stepconf/build_HAL.py:398
+#: src/emc/usr_intf/stepconf/build_HAL.py:358
+#: src/emc/usr_intf/stepconf/build_HAL.py:376
+#: src/emc/usr_intf/stepconf/build_HAL.py:417
 #: src/emc/usr_intf/pncconf/build_INI.py:20
 #: src/emc/usr_intf/pncconf/build_HAL.py:56
 msgid "# If you make changes to this file, they will be"
@@ -9983,99 +10183,104 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/build_INI.py:57
 #: src/emc/usr_intf/stepconf/build_HAL.py:44
-#: src/emc/usr_intf/stepconf/build_HAL.py:344
-#: src/emc/usr_intf/stepconf/build_HAL.py:358
-#: src/emc/usr_intf/stepconf/build_HAL.py:399
+#: src/emc/usr_intf/stepconf/build_HAL.py:359
+#: src/emc/usr_intf/stepconf/build_HAL.py:377
+#: src/emc/usr_intf/stepconf/build_HAL.py:418
 msgid "# overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_INI.py:171
+#: src/emc/usr_intf/stepconf/build_INI.py:233
 msgid "# add halui MDI commands here (max 64) "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:288
-#: src/emc/usr_intf/pncconf/build_HAL.py:727
+#: src/emc/usr_intf/stepconf/build_HAL.py:290
+#: src/emc/usr_intf/pncconf/build_HAL.py:747
 msgid "# **** Setup for external estop ladder program -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:295
-#: src/emc/usr_intf/pncconf/build_HAL.py:734
+#: src/emc/usr_intf/stepconf/build_HAL.py:297
+#: src/emc/usr_intf/pncconf/build_HAL.py:754
 msgid "# **** Setup for external estop ladder program -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:315
-#: src/emc/usr_intf/pncconf/build_HAL.py:761
+#: src/emc/usr_intf/stepconf/build_HAL.py:328
+#: src/emc/usr_intf/pncconf/build_HAL.py:806
 msgid ""
 "# Load Classicladder with modbus master included (GUI must run for Modbus)"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:318
-#: src/emc/usr_intf/pncconf/build_HAL.py:766
+#: src/emc/usr_intf/stepconf/build_HAL.py:331
+#: src/emc/usr_intf/pncconf/build_HAL.py:811
 msgid "# Load Classicladder without GUI (can reload LADDER GUI in AXIS GUI"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:328
-#: src/emc/usr_intf/pncconf/build_HAL.py:848
+#: src/emc/usr_intf/stepconf/build_HAL.py:341
+#: src/emc/usr_intf/pncconf/build_HAL.py:893
 msgid "Include your PyVCP panel here.\n"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:341
-#: src/emc/usr_intf/stepconf/build_HAL.py:355
-#: src/emc/usr_intf/stepconf/build_HAL.py:396
-#: src/emc/usr_intf/pncconf/build_HAL.py:861
+#: src/emc/usr_intf/stepconf/build_HAL.py:356
+#: src/emc/usr_intf/stepconf/build_HAL.py:374
+#: src/emc/usr_intf/stepconf/build_HAL.py:415
+#: src/emc/usr_intf/pncconf/build_HAL.py:906
 msgid "# These files are loaded post GUI, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:359
-#: src/emc/usr_intf/pncconf/build_HAL.py:882
+#: src/emc/usr_intf/stepconf/build_HAL.py:378
+#: src/emc/usr_intf/pncconf/build_HAL.py:929
 msgid "# **** Setup of spindle speed display using pyvcp -START ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:361
+#: src/emc/usr_intf/stepconf/build_HAL.py:380
 msgid "# **** Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:362
+#: src/emc/usr_intf/stepconf/build_HAL.py:381
 msgid ""
 "# **** spindle-velocity-feedback-rps bounces around so we filter it with "
 "lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:363
+#: src/emc/usr_intf/stepconf/build_HAL.py:382
 msgid ""
 "# **** spindle-velocity-feedback-rps is signed so we use absolute component "
 "to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:364
+#: src/emc/usr_intf/stepconf/build_HAL.py:383
 msgid "# **** ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:373
+#: src/emc/usr_intf/stepconf/build_HAL.py:392
 msgid "# **** set up spindle at speed indicator ****"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:386
+#: src/emc/usr_intf/stepconf/build_HAL.py:405
 msgid ""
 "# **** Use COMMANDED spindle velocity from LinuxCNC because no spindle "
 "encoder was specified"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:409
+#: src/emc/usr_intf/stepconf/build_HAL.py:428
 #, python-format
 msgid "# Include your %s HAL commands here"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:410
+#: src/emc/usr_intf/stepconf/build_HAL.py:429
+#: src/emc/usr_intf/stepconf/build_HAL.py:715
 msgid "# This file will not be overwritten when you run stepconf again"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:454
+#: src/emc/usr_intf/stepconf/build_HAL.py:477
 msgid "# This file sets up simulated limits/home/spindle encoder hardware."
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/build_HAL.py:455
+#: src/emc/usr_intf/stepconf/build_HAL.py:478
 msgid "# This is a generated file do not edit."
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/build_HAL.py:714
+msgid "# Include your custom HAL commands here"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/import_mach.py:32
@@ -10147,11 +10352,16 @@ msgstr "樣辦配置"
 #: src/emc/usr_intf/gscreen/gscreen.glade:1342
 #: src/emc/usr_intf/gscreen/gscreen.glade:1360
 #: src/emc/usr_intf/gscreen/gscreen.glade:1378
+#: lib/python/gladevcp/gladevcp-test.glade:80
+#: lib/python/gladevcp/gladevcp-test.glade:94
 msgid "label"
 msgstr "標　籤"
 
 #: src/emc/usr_intf/stepconf/main_page.glade:553
 #: src/emc/usr_intf/pncconf/main_page.glade:198
+#: lib/python/gladevcp/tooledit_gtk.glade:248
+#: lib/python/gladevcp/tooledit_gtk.glade:549
+#: lib/python/gladevcp/tooledit_gtk.glade:771
 msgid "Back"
 msgstr "向後"
 
@@ -10191,17 +10401,6 @@ msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:72
 msgid "MM"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/base.glade:113
-#: src/emc/usr_intf/stepconf/base.glade:141
-#: src/emc/usr_intf/stepconf/base.glade:169
-#: src/emc/usr_intf/stepconf/base.glade:197
-#: src/emc/usr_intf/stepconf/base.glade:415
-#: src/emc/usr_intf/pncconf/mesa0.glade:487
-#: src/emc/usr_intf/pncconf/mesa1.glade:487
-#: src/emc/usr_intf/pncconf/base.glade:389
-msgid "ns"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/base.glade:209
@@ -10551,53 +10750,150 @@ msgstr ""
 msgid "Scale %"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/options.glade:48
+#: src/emc/usr_intf/pncconf/private_data.py:488
+msgid "Axis"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/options.glade:51
-msgid "Use AXIS Screen"
+msgid "Gmoccapy"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:67
-msgid "Use Gmoccapy Screen"
+#: src/emc/usr_intf/stepconf/options.glade:54
+msgid "Qtdragon"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:91
+#: src/emc/usr_intf/stepconf/options.glade:57
+#: src/emc/usr_intf/pncconf/screen.glade:145
+msgid "QtPlasmaC"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:73
+msgid "Screen:  "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:126
+#: src/emc/usr_intf/stepconf/options.glade:159
+#: src/emc/usr_intf/stepconf/options.glade:178
+#: src/emc/usr_intf/stepconf/options.glade:225
+msgid "0.000"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:144
+#: src/emc/usr_intf/stepconf/options.glade:242
+#: src/emc/usr_intf/pncconf/screen.glade:2546
+#: src/emc/usr_intf/pncconf/screen.glade:2647
+#, fuzzy
+msgid "  Y Offset"
+msgstr "位移:"
+
+#: src/emc/usr_intf/stepconf/options.glade:196
+#: src/emc/usr_intf/stepconf/options.glade:210
+#: src/emc/usr_intf/pncconf/screen.glade:2600
+#: src/emc/usr_intf/pncconf/screen.glade:2614
+#, fuzzy
+msgid " X Offset"
+msgstr "位移:"
+
+#: src/emc/usr_intf/stepconf/options.glade:256
+#: src/emc/usr_intf/pncconf/screen.glade:2661
+msgid "Alignment Camera:   "
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:268
+#: src/emc/usr_intf/pncconf/screen.glade:2673
+#, fuzzy
+msgid "Alignment Laser:"
+msgstr "對準電流"
+
+#: src/emc/usr_intf/stepconf/options.glade:281
+#: src/emc/usr_intf/pncconf/screen.glade:2686
+msgid "Screen Aspect:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:294
+#: src/emc/usr_intf/pncconf/screen.glade:2699
+#, fuzzy
+msgid "Estop Button:"
+msgstr "急停 開"
+
+#: src/emc/usr_intf/stepconf/options.glade:310
+#: src/emc/usr_intf/pncconf/screen.glade:2714
+msgid "4:3"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:326
+#: src/emc/usr_intf/pncconf/screen.glade:2730
+msgid "Hidden"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:342
+#: src/emc/usr_intf/pncconf/screen.glade:2746
+msgid "9:16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:358
+#: src/emc/usr_intf/pncconf/screen.glade:2762
+#, fuzzy
+msgid "Button"
+msgstr "左 按鈕"
+
+#: src/emc/usr_intf/stepconf/options.glade:374
+#: src/emc/usr_intf/pncconf/screen.glade:2778
+msgid "16:9"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:388
+#: src/emc/usr_intf/pncconf/screen.glade:2792
+msgid "Indicator"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:450
+#: src/emc/usr_intf/pncconf/screen.glade:2857
+msgid "Powermax Port:"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/options.glade:478
+#: src/emc/usr_intf/pncconf/screen.glade:2887
+#, fuzzy
+msgid "Mode:"
+msgstr "運行模式"
+
+#: src/emc/usr_intf/stepconf/options.glade:491
 msgid "_Onscreen prompt for manual tool change"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:107
-msgid "Include Halui user interface component"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/options.glade:125
+#: src/emc/usr_intf/stepconf/options.glade:507
 #: src/emc/usr_intf/pncconf/vcp.glade:434
 msgid "Include custom PyVCP GUI panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:183
+#: src/emc/usr_intf/stepconf/options.glade:565
 #: src/emc/usr_intf/pncconf/vcp.glade:79
 msgid "Blank program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:200
+#: src/emc/usr_intf/stepconf/options.glade:582
 #: src/emc/usr_intf/pncconf/vcp.glade:96
 msgid "Spindle speed display  "
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:217
-#: src/emc/usr_intf/stepconf/options.glade:691
+#: src/emc/usr_intf/stepconf/options.glade:599
+#: src/emc/usr_intf/stepconf/options.glade:1073
 #: src/emc/usr_intf/pncconf/vcp.glade:129
 #: src/emc/usr_intf/pncconf/vcp.glade:512
 #: src/emc/usr_intf/pncconf/options.glade:1034
 msgid "Existing custom program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:234
-#: src/emc/usr_intf/stepconf/options.glade:708
+#: src/emc/usr_intf/stepconf/options.glade:616
+#: src/emc/usr_intf/stepconf/options.glade:1090
 #: src/emc/usr_intf/pncconf/vcp.glade:146
 #: src/emc/usr_intf/pncconf/options.glade:1051
 msgid "Include connections to HAL"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:282
+#: src/emc/usr_intf/stepconf/options.glade:664
 #: src/emc/usr_intf/pncconf/vcp.glade:369
 #: src/emc/usr_intf/pncconf/vcp.glade:1021
 msgid ""
@@ -10606,79 +10902,83 @@ msgid ""
 "panel"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:323
+#: src/emc/usr_intf/stepconf/options.glade:705
 #, fuzzy
 msgid "Set pyVCP options"
 msgstr "幾何　的選項"
 
-#: src/emc/usr_intf/stepconf/options.glade:347
+#: src/emc/usr_intf/stepconf/options.glade:729
 #: src/emc/usr_intf/pncconf/options.glade:1144
 msgid "Include _Classicladder PLC"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:486
+#: src/emc/usr_intf/stepconf/options.glade:867
 msgid "Number of digital in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:502
+#: src/emc/usr_intf/stepconf/options.glade:883
 msgid "Number of digital  out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:517
+#: src/emc/usr_intf/stepconf/options.glade:898
 #: src/emc/usr_intf/pncconf/options.glade:669
 msgid " Number of analog (s32) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:533
+#: src/emc/usr_intf/stepconf/options.glade:914
 #: src/emc/usr_intf/pncconf/options.glade:686
 msgid " Number of analog (s32) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:548
+#: src/emc/usr_intf/stepconf/options.glade:929
 #: src/emc/usr_intf/pncconf/options.glade:702
 msgid " Number of analog (float) in pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:563
+#: src/emc/usr_intf/stepconf/options.glade:944
 #: src/emc/usr_intf/pncconf/options.glade:718
 msgid " Number of analog (float) out pins:"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:578
+#: src/emc/usr_intf/stepconf/options.glade:960
 msgid "setup number of external pins"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:593
+#: src/emc/usr_intf/stepconf/options.glade:975
 #: src/emc/usr_intf/pncconf/options.glade:762
 msgid "Include modbus master support"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:645
+#: src/emc/usr_intf/stepconf/options.glade:1026
 #: src/emc/usr_intf/pncconf/options.glade:971
 msgid "Blank ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:658
+#: src/emc/usr_intf/stepconf/options.glade:1040
 #: src/emc/usr_intf/pncconf/options.glade:984
 msgid "Estop ladder program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:674
+#: src/emc/usr_intf/stepconf/options.glade:1056
 #: src/emc/usr_intf/pncconf/options.glade:1017
 msgid "Serial modbus program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:759
+#: src/emc/usr_intf/stepconf/options.glade:1141
 #: src/emc/usr_intf/pncconf/options.glade:1103
 msgid ""
 "Edit ladder\n"
 "program"
 msgstr ""
 
-#: src/emc/usr_intf/stepconf/options.glade:800
+#: src/emc/usr_intf/stepconf/options.glade:1182
 #, fuzzy
 msgid "Set Ladder Options"
 msgstr "樣辦配置"
+
+#: src/emc/usr_intf/stepconf/options.glade:1198
+msgid "Include Halui user interface component"
+msgstr ""
 
 #: src/emc/usr_intf/stepconf/halui_page.glade:24
 msgid "Insert here some commands to put after MDI_COMMAND"
@@ -10696,16 +10996,154 @@ msgstr ""
 msgid "Move UP"
 msgstr ""
 
+#: src/emc/usr_intf/stepconf/ubuttons.glade:31
+#: src/emc/usr_intf/pncconf/ubuttons.glade:37
+msgid "NUM"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:41
+#: src/emc/usr_intf/pncconf/ubuttons.glade:46
+msgid "NAME"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:55
+#: src/emc/usr_intf/pncconf/ubuttons.glade:58
+msgid "CODE"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:177
+#: src/emc/usr_intf/stepconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/ubuttons.glade:187
+#: src/emc/usr_intf/pncconf/thcad.glade:59
+#: src/emc/usr_intf/pncconf/dialogs.glade:1443
+msgid "10"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:189
+#: src/emc/usr_intf/pncconf/ubuttons.glade:200
+msgid "11"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:201
+#: src/emc/usr_intf/pncconf/ubuttons.glade:213
+msgid "12"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:213
+#: src/emc/usr_intf/pncconf/ubuttons.glade:226
+msgid "13"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:225
+#: src/emc/usr_intf/pncconf/ubuttons.glade:239
+msgid "14"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:237
+#: src/emc/usr_intf/pncconf/ubuttons.glade:252
+msgid "15"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:249
+#: src/emc/usr_intf/pncconf/ubuttons.glade:265
+msgid "16"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:261
+#: src/emc/usr_intf/pncconf/ubuttons.glade:278
+#: src/emc/usr_intf/pncconf/dialogs.glade:374
+msgid "17"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:273
+#: src/emc/usr_intf/pncconf/ubuttons.glade:291
+msgid "18"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:285
+#: src/emc/usr_intf/pncconf/ubuttons.glade:304
+msgid "19"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/ubuttons.glade:297
+#: src/emc/usr_intf/pncconf/ubuttons.glade:317
+msgid "20"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:12
+#: src/emc/usr_intf/pncconf/thcad.glade:12
+msgid "ENCA"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:15
+#: src/emc/usr_intf/pncconf/thcad.glade:15
+msgid "ENCB"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:18
+#: src/emc/usr_intf/pncconf/thcad.glade:18
+msgid "IDX"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:32
+#: src/emc/usr_intf/pncconf/thcad.glade:32
+msgid "32"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:35
+#: src/emc/usr_intf/pncconf/thcad.glade:35
+msgid "64"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:38
+#: src/emc/usr_intf/pncconf/thcad.glade:38
+msgid "128"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:62
+#: src/emc/usr_intf/pncconf/thcad.glade:62
+msgid "300"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:111
+msgid "Full Scale Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:125
+#: src/emc/usr_intf/pncconf/thcad.glade:134
+msgid "F Jumper"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:137
+#: src/emc/usr_intf/pncconf/thcad.glade:146
+msgid "Divider Ratio or Series Resistance"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:150
+msgid "0V Freq (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/stepconf/thcad.glade:162
+#: src/emc/usr_intf/pncconf/thcad.glade:171
+#, fuzzy
+msgid "Model"
+msgstr "運行模式"
+
+#: src/emc/usr_intf/stepconf/thcad.glade:261
+#: src/emc/usr_intf/pncconf/thcad.glade:308
+msgid "THCAD For Arc Voltage"
+msgstr ""
+
 #: src/emc/usr_intf/stepconf/axisx.glade:12
 #: src/emc/usr_intf/stepconf/axisy.glade:12
 #: src/emc/usr_intf/stepconf/axisz.glade:12
 #: src/emc/usr_intf/stepconf/axisu.glade:12
 #: src/emc/usr_intf/stepconf/axisv.glade:12
 #: src/emc/usr_intf/stepconf/axisa.glade:12
-#: src/emc/usr_intf/pncconf/x_axis.glade:44
-#: src/emc/usr_intf/pncconf/y_axis.glade:44
-#: src/emc/usr_intf/pncconf/z_axis.glade:44
-#: src/emc/usr_intf/pncconf/a_axis.glade:44
+#: src/emc/usr_intf/pncconf/x_axis.glade:701
+#: src/emc/usr_intf/pncconf/y_axis.glade:701
+#: src/emc/usr_intf/pncconf/z_axis.glade:701
+#: src/emc/usr_intf/pncconf/a_axis.glade:701
 msgid "Same"
 msgstr ""
 
@@ -10715,10 +11153,10 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisu.glade:15
 #: src/emc/usr_intf/stepconf/axisv.glade:15
 #: src/emc/usr_intf/stepconf/axisa.glade:15
-#: src/emc/usr_intf/pncconf/x_axis.glade:47
-#: src/emc/usr_intf/pncconf/y_axis.glade:47
-#: src/emc/usr_intf/pncconf/z_axis.glade:47
-#: src/emc/usr_intf/pncconf/a_axis.glade:47
+#: src/emc/usr_intf/pncconf/x_axis.glade:704
+#: src/emc/usr_intf/pncconf/y_axis.glade:704
+#: src/emc/usr_intf/pncconf/z_axis.glade:704
+#: src/emc/usr_intf/pncconf/a_axis.glade:704
 #, fuzzy
 msgid "Opposite"
 msgstr "正"
@@ -10746,15 +11184,6 @@ msgstr ""
 #: src/emc/usr_intf/stepconf/axisv.glade:249
 #: src/emc/usr_intf/stepconf/axisa.glade:248
 msgid "t_o"
-msgstr ""
-
-#: src/emc/usr_intf/stepconf/axisx.glade:345
-#: src/emc/usr_intf/stepconf/axisy.glade:343
-#: src/emc/usr_intf/stepconf/axisz.glade:343
-#: src/emc/usr_intf/stepconf/axisu.glade:346
-#: src/emc/usr_intf/stepconf/axisv.glade:345
-#: src/emc/usr_intf/stepconf/axisa.glade:343
-msgid "s"
 msgstr ""
 
 #: src/emc/usr_intf/stepconf/axisx.glade:403
@@ -10953,39 +11382,39 @@ msgstr ""
 msgid "**** PNCCONF INFO:    Found extra firmware in file"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:331
+#: src/emc/usr_intf/pncconf/pncconf.py:364
 msgid "Discovery metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:367
+#: src/emc/usr_intf/pncconf/pncconf.py:400
 #, python-format
 msgid "%s metadata update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:387
+#: src/emc/usr_intf/pncconf/pncconf.py:420
 msgid "Pncconf setup"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:399
+#: src/emc/usr_intf/pncconf/pncconf.py:432
 msgid "Pncconf is setting up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:413
+#: src/emc/usr_intf/pncconf/pncconf.py:446
 msgid ""
 "\n"
 "**** Debug Pause! ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:486
+#: src/emc/usr_intf/pncconf/pncconf.py:519
 #, fuzzy
 msgid "Specific Help page is unavailable\n"
 msgstr "PCI 搜索頁面 無法使用\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:488
+#: src/emc/usr_intf/pncconf/pncconf.py:521
 msgid "Help Pages"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:540
+#: src/emc/usr_intf/pncconf/pncconf.py:573
 #, python-format
 msgid ""
 "You have no hostmot2 firmware downloaded in folder:\n"
@@ -10993,23 +11422,23 @@ msgid ""
 "PNCconf will use internal firmware data"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:857
+#: src/emc/usr_intf/pncconf/pncconf.py:890
 #, fuzzy
 msgid "LinuxCNC 'PNCconf' configuration files"
 msgstr "打開配置文件:"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:887
+#: src/emc/usr_intf/pncconf/pncconf.py:920
 msgid ""
 "It seems data in this file is from too old of a version of PNCConf to "
 "continue.\n"
 "."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1252
+#: src/emc/usr_intf/pncconf/pncconf.py:1283
 msgid "No board was found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1290
+#: src/emc/usr_intf/pncconf/pncconf.py:1321
 #, python-format
 msgid ""
 "Discovery is  got an error\n"
@@ -11019,33 +11448,33 @@ msgid ""
 " %s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1304
+#: src/emc/usr_intf/pncconf/pncconf.py:1335
 #, fuzzy
 msgid "Discovery is  unavailable\n"
 msgstr "PCI 搜索頁面 無法使用\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1561
+#: src/emc/usr_intf/pncconf/pncconf.py:1592
 msgid "USB device Info Search"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1575
+#: src/emc/usr_intf/pncconf/pncconf.py:1606
 msgid "USB device  page is unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1640
+#: src/emc/usr_intf/pncconf/pncconf.py:1671
 #: src/emc/usr_intf/pncconf/tests.py:87
 msgid "Pin names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1663
+#: src/emc/usr_intf/pncconf/pncconf.py:1694
 msgid "Device names are unavailable\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1666
+#: src/emc/usr_intf/pncconf/pncconf.py:1697
 msgid "No Pncconf made device rules were found\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1711
+#: src/emc/usr_intf/pncconf/pncconf.py:1742
 msgid ""
 "OK to replace existing glade panel ?\n"
 "It will be renamed and added to 'backups' folder.\n"
@@ -11054,183 +11483,183 @@ msgid ""
 "will not update"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:1718
+#: src/emc/usr_intf/pncconf/pncconf.py:1749
 msgid ""
 "OK to replace existing custom pyvcp panel?\n"
 "Existing pyvcp-panel.xml will be renamed and added to 'backups' folder\n"
 "Clicking 'existing custom program' will aviod this warning. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3491
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/pncconf.py:3529
+#: src/emc/usr_intf/pncconf/private_data.py:550
 #, fuzzy
 msgid "Unused Channel"
 msgstr "選擇通道"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3762
+#: src/emc/usr_intf/pncconf/pncconf.py:3800
 msgid "You can not have both steppers and pwm signals for spindle control\n"
 msgstr "你不能 同時 擁有 步進電機 和 PWM信號 給主軸控制\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3766
+#: src/emc/usr_intf/pncconf/pncconf.py:3804
 #, python-format
 msgid "You forgot to designate a stepper or pwm signal for axis %s\n"
 msgstr "你忘了 指定 步進電機 或 PWM 信號 給軸 %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3769
+#: src/emc/usr_intf/pncconf/pncconf.py:3807
 #, fuzzy, python-format
 msgid "You forgot to designate an encoder /resolver signal for axis %s servo\n"
 msgstr "你忘了 指定 編碼器 信號 給軸 %s 伺服\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3772
+#: src/emc/usr_intf/pncconf/pncconf.py:3810
 #, python-format
 msgid "You forgot to designate a pwm signal or stepper signal for axis %s\n"
 msgstr "你忘了 指定 一個 PWM 信號 或步進信號 給軸 %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3775
+#: src/emc/usr_intf/pncconf/pncconf.py:3813
 #, python-format
 msgid "You can not have both steppers and pwm signals for axis %s\n"
 msgstr "你 不能 擁有 同時 用 步進電機 和PWM信號 的軸 %s\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3778
+#: src/emc/usr_intf/pncconf/pncconf.py:3816
 #, python-format
 msgid ""
 "If using a tandem axis stepper, you must select a master stepgen for axis "
 "%s\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3786
+#: src/emc/usr_intf/pncconf/pncconf.py:3824
 msgid "Touchy require an external cycle start signal\n"
 msgstr "Touchy 需要 外部 循環 啟動 信號\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3789
+#: src/emc/usr_intf/pncconf/pncconf.py:3827
 msgid "Touchy require an external abort signal\n"
 msgstr "Touchy 需要 一個 外部 中斷 信號\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3792
+#: src/emc/usr_intf/pncconf/pncconf.py:3830
 msgid "Touchy require an external single-step signal\n"
 msgstr "Touchy 需要 一個 外部 單步信號\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3795
+#: src/emc/usr_intf/pncconf/pncconf.py:3833
 msgid ""
 "Touchy require an external multi handwheel MPG encoder signal on the mesa "
 "page\n"
 msgstr "Touchy 需要 外部 多手輪 MPG 編碼器 信號 在 mesa 頁面\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3798
+#: src/emc/usr_intf/pncconf/pncconf.py:3836
 msgid ""
 "Touchy require 'external mpg jogging' to be selected on the external control "
 "page\n"
 msgstr "Touchy 要求“外部MPG慢步”被選中的外部控制 頁面\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3801
+#: src/emc/usr_intf/pncconf/pncconf.py:3839
 msgid ""
 "Touchy require the external mpg to be in 'shared mpg' mode on the external "
 "controls page\n"
 msgstr "Touchy 要求外部MPG將在“共享MPG”模式對外部 控制 頁面\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3804
+#: src/emc/usr_intf/pncconf/pncconf.py:3842
 msgid ""
 "Touchy require selectable increments to be unchecked on the external "
 "controls page\n"
 msgstr "Touchy 需要 可選擇 增量 將未選中 的外部 控制 頁面\n"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3817
+#: src/emc/usr_intf/pncconf/pncconf.py:3855
 msgid ""
 "The 7i29 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3820
+#: src/emc/usr_intf/pncconf/pncconf.py:3858
 msgid ""
 "The 7i30 daughter board requires PWM type generators and a PWM base "
 "frequency of 20 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3823
+#: src/emc/usr_intf/pncconf/pncconf.py:3861
 msgid ""
 "The 7i33 daughter board requires PDM type generators and a PDM base "
 "frequency of 6 Mhz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3826
+#: src/emc/usr_intf/pncconf/pncconf.py:3864
 msgid ""
 "The 7i40 daughter board requires PWM type generators and a PWM base "
 "frequency of 50 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3829
+#: src/emc/usr_intf/pncconf/pncconf.py:3867
 msgid ""
 "The 7i48 daughter board requires UDM type generators and a PWM base "
 "frequency of 24 khz\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3977
+#: src/emc/usr_intf/pncconf/pncconf.py:4015
 msgid "Gearbox Reduction Ratio"
 msgstr "齒輪箱 減速比"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3980
+#: src/emc/usr_intf/pncconf/pncconf.py:4018
 msgid "Reduction Ratio"
 msgstr "減速比"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3983
+#: src/emc/usr_intf/pncconf/pncconf.py:4021
 msgid "Leadscrew Pitch"
 msgstr "丝杆 螺距"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3986
+#: src/emc/usr_intf/pncconf/pncconf.py:4024
 #: src/emc/usr_intf/pncconf/dialogs.glade:2004
 #: src/emc/usr_intf/pncconf/dialogs.glade:2385
 msgid "Leadscrew TPI"
 msgstr "丝杆 TPI"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3990
-#: src/emc/usr_intf/pncconf/pncconf.py:3991
+#: src/emc/usr_intf/pncconf/pncconf.py:4028
+#: src/emc/usr_intf/pncconf/pncconf.py:4029
 msgid "("
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3992
-#: src/emc/usr_intf/pncconf/pncconf.py:4002
-#: src/emc/usr_intf/pncconf/pncconf.py:4003
-#: src/emc/usr_intf/pncconf/pncconf.py:4004
+#: src/emc/usr_intf/pncconf/pncconf.py:4030
+#: src/emc/usr_intf/pncconf/pncconf.py:4040
+#: src/emc/usr_intf/pncconf/pncconf.py:4041
+#: src/emc/usr_intf/pncconf/pncconf.py:4042
 #, fuzzy
 msgid " / min"
 msgstr "毫米 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3993
+#: src/emc/usr_intf/pncconf/pncconf.py:4031
 #, fuzzy
 msgid " / sec²"
 msgstr "毫米 / 秒²"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3996
+#: src/emc/usr_intf/pncconf/pncconf.py:4034
 #, fuzzy
 msgid " / Step"
 msgstr "毫米 / 步"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3997
+#: src/emc/usr_intf/pncconf/pncconf.py:4035
 #, fuzzy
 msgid "Steps / "
 msgstr "步 / 英寸"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:3999
+#: src/emc/usr_intf/pncconf/pncconf.py:4037
 #, fuzzy
 msgid " / encoder pulse"
 msgstr "毫米 / 編碼器脈衝 "
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4000
+#: src/emc/usr_intf/pncconf/pncconf.py:4038
 #, fuzzy
 msgid "Encoder pulses / "
 msgstr "編碼器 脈衝 / 毫米"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4008
+#: src/emc/usr_intf/pncconf/pncconf.py:4046
 #, fuzzy
 msgid "Resolver Scale:"
 msgstr "編碼器比例"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4341
+#: src/emc/usr_intf/pncconf/pncconf.py:4384
 #, fuzzy
 msgid "Spindle Scale Calculation"
 msgstr "Axis 比例計算"
 
-#: src/emc/usr_intf/pncconf/pncconf.py:4453
+#: src/emc/usr_intf/pncconf/pncconf.py:4496
 msgid "Axis Scale Calculation"
 msgstr "Axis 比例計算"
 
@@ -11248,32 +11677,35 @@ msgstr ""
 msgid "PCI search page is unavailable\n"
 msgstr "PCI 搜索頁面 無法使用\n"
 
-#: src/emc/usr_intf/pncconf/pages.py:435
+#: src/emc/usr_intf/pncconf/pages.py:436
 #, fuzzy
 msgid "in / min"
 msgstr "毫米 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/pages.py:438
-#: src/emc/usr_intf/pncconf/screen.glade:784
-#: src/emc/usr_intf/pncconf/screen.glade:1001
-#: src/emc/usr_intf/pncconf/screen.glade:1014
+#: src/emc/usr_intf/pncconf/pages.py:440
+#: src/emc/usr_intf/pncconf/screen.glade:812
+#: src/emc/usr_intf/pncconf/screen.glade:1029
+#: src/emc/usr_intf/pncconf/screen.glade:1042
+#: src/emc/usr_intf/pncconf/screen.glade:3018
+#: src/emc/usr_intf/pncconf/screen.glade:3031
+#: src/emc/usr_intf/pncconf/screen.glade:3044
 msgid "mm / min"
 msgstr "毫米 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/pages.py:892
+#: src/emc/usr_intf/pncconf/pages.py:981
 msgid ""
 "You need to configure the mesa0 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
 "component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:895
+#: src/emc/usr_intf/pncconf/pages.py:984
 msgid ""
 "The chosen Mesa0 board is different from the current displayed.\n"
 "please press 'Accept component changes' button'"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/pages.py:944
+#: src/emc/usr_intf/pncconf/pages.py:1033
 msgid ""
 "You need to configure the mesa1 page.\n"
 " Choose the board type, firmware, component amounts and press 'Accept "
@@ -11282,7 +11714,7 @@ msgstr ""
 "您需要配置mesa1頁. \n"
 "選擇板型，固件組件 數量，並按下 '接受 組件更改' 按鈕"
 
-#: src/emc/usr_intf/pncconf/pages.py:947
+#: src/emc/usr_intf/pncconf/pages.py:1036
 #, fuzzy
 msgid ""
 "The chosen Mesa1 board is different from the current displayed.\n"
@@ -11291,16 +11723,16 @@ msgstr ""
 "所選擇的Mesa1板不同於當前顯示.\n"
 "請按 '接受組件 更改' 按鈕"
 
-#: src/emc/usr_intf/pncconf/pages.py:1315
+#: src/emc/usr_intf/pncconf/pages.py:1425
 msgid "You need to designate an E-stop input pin for this ladder program."
 msgstr "你需要指定一個 E-stop 輸入 端子 給這個梯形邏輯方案."
 
-#: src/emc/usr_intf/pncconf/pages.py:1326
+#: src/emc/usr_intf/pncconf/pages.py:1436
 #, fuzzy
 msgid "You need to designate a probe input pin for this ladder program."
 msgstr "你需要指定一個 E-stop 輸入 端子 給這個梯形邏輯方案."
 
-#: src/emc/usr_intf/pncconf/pages.py:1336
+#: src/emc/usr_intf/pncconf/pages.py:1446
 #, fuzzy
 msgid ""
 "OK to replace existing custom ladder program?\n"
@@ -11314,8 +11746,8 @@ msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_INI.py:18
 #: src/emc/usr_intf/pncconf/build_HAL.py:54
-#: src/emc/usr_intf/pncconf/build_HAL.py:980
-#: src/emc/usr_intf/pncconf/build_HAL.py:1000
+#: src/emc/usr_intf/pncconf/build_HAL.py:1031
+#: src/emc/usr_intf/pncconf/build_HAL.py:1051
 #, python-format
 msgid "# Generated by PNCconf at %s"
 msgstr ""
@@ -11331,169 +11763,174 @@ msgstr ""
 msgid "# overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:408
+#: src/emc/usr_intf/pncconf/build_HAL.py:426
 msgid "# connect miscellaneous signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:411
+#: src/emc/usr_intf/pncconf/build_HAL.py:429
 msgid "#  ---HALUI signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:439
+#: src/emc/usr_intf/pncconf/build_HAL.py:457
 msgid "#  ---charge pump signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:443
+#: src/emc/usr_intf/pncconf/build_HAL.py:461
 msgid "#  ---coolant signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:448
+#: src/emc/usr_intf/pncconf/build_HAL.py:466
 msgid "#  ---probe signal---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:453
+#: src/emc/usr_intf/pncconf/build_HAL.py:471
 msgid "# ---jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:458
+#: src/emc/usr_intf/pncconf/build_HAL.py:476
 msgid "# ---USB device jog button signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:499
-#: src/emc/usr_intf/pncconf/build_HAL.py:525
+#: src/emc/usr_intf/pncconf/build_HAL.py:517
+#: src/emc/usr_intf/pncconf/build_HAL.py:543
 msgid "#  ---mpg signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:707
+#: src/emc/usr_intf/pncconf/build_HAL.py:727
 msgid "#  ---motion control signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:712
+#: src/emc/usr_intf/pncconf/build_HAL.py:732
 msgid "#  ---digital in / out signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:722
+#: src/emc/usr_intf/pncconf/build_HAL.py:742
 msgid "#  ---estop signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:741
+#: src/emc/usr_intf/pncconf/build_HAL.py:763
 msgid "#  ---manual tool change signals---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:750
+#: src/emc/usr_intf/pncconf/build_HAL.py:779
+msgid "#  ---manual tool change signals to qtdragon---"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:787
 msgid "#  ---toolchange signals for custom tool changer---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:772
+#: src/emc/usr_intf/pncconf/build_HAL.py:817
 msgid "#  --- Classicladder signals for Z axis Auto touch off program---"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:791
+#: src/emc/usr_intf/pncconf/build_HAL.py:836
 msgid "# These files are loaded post gladeVCP, in the order they appear"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:805
-#: src/emc/usr_intf/pncconf/build_HAL.py:878
+#: src/emc/usr_intf/pncconf/build_HAL.py:850
+#: src/emc/usr_intf/pncconf/build_HAL.py:925
 msgid "# _DO NOT_ include your HAL commands here."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:806
+#: src/emc/usr_intf/pncconf/build_HAL.py:851
 msgid "# Put custom HAL commands in custom_gvcp.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:809
+#: src/emc/usr_intf/pncconf/build_HAL.py:854
 msgid "# **** Setup of spindle speed display using gladevcp ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:818
+#: src/emc/usr_intf/pncconf/build_HAL.py:863
 msgid "# **** Setup GLADE MDI buttons ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:831
+#: src/emc/usr_intf/pncconf/build_HAL.py:876
 msgid ""
 "# **** Z axis touch-off button - requires the touch-off classicladder "
 "program ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:879
+#: src/emc/usr_intf/pncconf/build_HAL.py:926
 msgid "# Put custom HAL commands in custom_postgui.hal"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:880
+#: src/emc/usr_intf/pncconf/build_HAL.py:927
 msgid "# The commands in this file are run after the GUI loads"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:890
+#: src/emc/usr_intf/pncconf/build_HAL.py:937
 msgid "# **** Setup of spindle speed display using pyvcp -END ****"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:902
+#: src/emc/usr_intf/pncconf/build_HAL.py:953
+#: src/emc/usr_intf/pncconf/build_HAL.py:1858
 msgid "# This file will not be overwritten when you run PNCconf again"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:908
+#: src/emc/usr_intf/pncconf/build_HAL.py:959
 msgid "# These commands are required for Touchy GUI"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1008
-#, python-format
-msgid "Generated by PNCconf at %s"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1020
-msgid "configures LinuxCNC as:\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1021
-msgid "type CNC\n"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1022
-msgid "will be used as the frontend display"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1031
-msgid " connector"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1043
-msgid "invrt"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1052
-#, python-format
-msgid "%(name)s Parport"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/build_HAL.py:1057
-#: src/emc/usr_intf/pncconf/build_HAL.py:1065
-msgid "-> inverted"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/build_HAL.py:1059
 #, python-format
+msgid "Generated by PNCconf at %s"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1071
+msgid "configures LinuxCNC as:\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1072
+msgid "type CNC\n"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1073
+msgid "will be used as the frontend display"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1082
+msgid " connector"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1094
+msgid "invrt"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1103
+#, python-format
+msgid "%(name)s Parport"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1108
+#: src/emc/usr_intf/pncconf/build_HAL.py:1116
+msgid "-> inverted"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/build_HAL.py:1110
+#, python-format
 msgid "pin# %(pinnum)d is connected to input signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1067
+#: src/emc/usr_intf/pncconf/build_HAL.py:1118
 #, python-format
 msgid "pin# %(pinnum)d is connected to output signal:'%(data)s' %(mesag)s"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1474
+#: src/emc/usr_intf/pncconf/build_HAL.py:1527
 msgid "#  Use ACTUAL spindle velocity from spindle encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1475
+#: src/emc/usr_intf/pncconf/build_HAL.py:1528
 msgid "#  spindle-velocity bounces around so we filter it with lowpass"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1476
+#: src/emc/usr_intf/pncconf/build_HAL.py:1529
 msgid ""
 "#  spindle-velocity is signed so we use absolute component to remove sign"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/build_HAL.py:1477
+#: src/emc/usr_intf/pncconf/build_HAL.py:1530
 msgid "#  ACTUAL velocity is in RPS not RPM so we scale it."
 msgstr ""
 
@@ -11509,1551 +11946,1606 @@ msgstr ""
 msgid "VCP"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:43
+#: src/emc/usr_intf/pncconf/private_data.py:44
 msgid "External Controls"
 msgstr "外部控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:44
+#: src/emc/usr_intf/pncconf/private_data.py:45
 msgid "Mesa Card 0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:45
+#: src/emc/usr_intf/pncconf/private_data.py:46
 msgid "Mesa Card 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:46
+#: src/emc/usr_intf/pncconf/private_data.py:47
 #: src/emc/usr_intf/pncconf/dialogs.glade:44
 #, fuzzy
 msgid "Parallel Port"
 msgstr "第一並行端口設置"
 
-#: src/emc/usr_intf/pncconf/private_data.py:48
+#: src/emc/usr_intf/pncconf/private_data.py:49
+msgid "Mesa THCAD"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:50
 #, fuzzy
 msgid "X Motor"
 msgstr "反轉電機"
 
-#: src/emc/usr_intf/pncconf/private_data.py:49
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:51
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "X Axis"
 msgstr "X 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:50
+#: src/emc/usr_intf/pncconf/private_data.py:52
 #, fuzzy
 msgid "Y Motor"
 msgstr "反轉電機"
 
-#: src/emc/usr_intf/pncconf/private_data.py:51
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:53
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Y Axis"
 msgstr "Y 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:52
+#: src/emc/usr_intf/pncconf/private_data.py:54
 #, fuzzy
 msgid "Z Motor"
 msgstr "反轉電機"
 
-#: src/emc/usr_intf/pncconf/private_data.py:53
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:55
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Z Axis"
 msgstr "Z 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:54
+#: src/emc/usr_intf/pncconf/private_data.py:56
 #, fuzzy
 msgid "A Motor"
 msgstr "反轉電機"
 
-#: src/emc/usr_intf/pncconf/private_data.py:55
-#: src/emc/usr_intf/pncconf/private_data.py:519
+#: src/emc/usr_intf/pncconf/private_data.py:57
+#: src/emc/usr_intf/pncconf/private_data.py:535
 msgid "A Axis"
 msgstr "A 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:56
+#: src/emc/usr_intf/pncconf/private_data.py:58
 #, fuzzy
 msgid "Spindle Motor"
 msgstr "主軸 停"
 
-#: src/emc/usr_intf/pncconf/private_data.py:58
+#: src/emc/usr_intf/pncconf/private_data.py:60
 msgid "Realtime"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
+#: src/emc/usr_intf/pncconf/private_data.py:110
 msgid "Not Used"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:106
-#: src/emc/usr_intf/pncconf/private_data.py:107
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:110
+#: src/emc/usr_intf/pncconf/private_data.py:111
+#: src/emc/usr_intf/pncconf/private_data.py:164
 msgid "Dummy"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:107
+#: src/emc/usr_intf/pncconf/private_data.py:111
 msgid "8i20 Servo Drive"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Output"
-msgstr "輸出"
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Enable"
-msgstr "啟用"
-
-#: src/emc/usr_intf/pncconf/private_data.py:109
-#, fuzzy
-msgid "POT Dir"
-msgstr "掃描方向"
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Input"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO Output"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:111
-msgid "GPIO O Drain"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/private_data.py:113
 #, fuzzy
+msgid "POT Output"
+msgstr "輸出"
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+#, fuzzy
+msgid "POT Enable"
+msgstr "啟用"
+
+#: src/emc/usr_intf/pncconf/private_data.py:113
+#, fuzzy
+msgid "POT Dir"
+msgstr "掃描方向"
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Input"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO Output"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:115
+msgid "GPIO O Drain"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:117
+#, fuzzy
 msgid "SSR Output"
 msgstr "輸出"
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-I"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:116
+#: src/emc/usr_intf/pncconf/private_data.py:120
 msgid "Quad Enc-M"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 0"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc 1"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "muxed Enc I"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "Muxed Enc M"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:119
+#: src/emc/usr_intf/pncconf/private_data.py:123
 #, fuzzy
 msgid "mux select"
 msgstr "選擇歸零"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 0 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 1 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:122
+#: src/emc/usr_intf/pncconf/private_data.py:126
 #, fuzzy
 msgid "Resolver 2 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 3 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 4 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:123
+#: src/emc/usr_intf/pncconf/private_data.py:127
 #, fuzzy
 msgid "Resolver 5 Encoder"
 msgstr "復位編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step Gen-A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Dir Gen-B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:127
+#: src/emc/usr_intf/pncconf/private_data.py:131
 msgid "Step/Dir Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/Dir Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:128
+#: src/emc/usr_intf/pncconf/private_data.py:132
 msgid "Step/dir Gen-F"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:130
+#: src/emc/usr_intf/pncconf/private_data.py:134
 msgid "PWM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-P"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:131
+#: src/emc/usr_intf/pncconf/private_data.py:135
 msgid "PDM Gen-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM -Up"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 #, fuzzy
 msgid "UDM-Down"
 msgstr "向下"
 
-#: src/emc/usr_intf/pncconf/private_data.py:132
+#: src/emc/usr_intf/pncconf/private_data.py:136
 msgid "UDM-E"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:136
+#: src/emc/usr_intf/pncconf/private_data.py:140
 msgid "Motor Phase C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase A Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase B Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Phase C Not"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:137
+#: src/emc/usr_intf/pncconf/private_data.py:141
 msgid "Motor Fault"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:149
+#: src/emc/usr_intf/pncconf/private_data.py:153
 msgid "SSERIAL-P0-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:150
+#: src/emc/usr_intf/pncconf/private_data.py:154
 msgid "SSERIAL-P1-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:151
+#: src/emc/usr_intf/pncconf/private_data.py:155
 msgid "SSERIAL-P2-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:152
+#: src/emc/usr_intf/pncconf/private_data.py:156
 msgid "SSERIAL-P3-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:153
+#: src/emc/usr_intf/pncconf/private_data.py:157
 msgid "SSERIAL-P4-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:154
+#: src/emc/usr_intf/pncconf/private_data.py:158
 msgid "SSERIAL-P5-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:155
+#: src/emc/usr_intf/pncconf/private_data.py:159
 msgid "SSERIAL-P6-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-TX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-RX"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:156
+#: src/emc/usr_intf/pncconf/private_data.py:160
 msgid "SSERIAL-P7-EN"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS0)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS2)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:157
+#: src/emc/usr_intf/pncconf/private_data.py:161
 msgid "7i76 I/O (SS3)"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS0"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 I/O-SS3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:158
+#: src/emc/usr_intf/pncconf/private_data.py:162
 msgid "7i77 Analog-SS4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:160
+#: src/emc/usr_intf/pncconf/private_data.py:164
 #, fuzzy
 msgid "Analog Input"
 msgstr "模擬控制"
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "X Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Y Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "Z Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "A Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:394
+#: src/emc/usr_intf/pncconf/private_data.py:405
 msgid "All Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "X2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Y2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "Z2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:395
+#: src/emc/usr_intf/pncconf/private_data.py:406
 msgid "A2 Tandem Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:396
+#: src/emc/usr_intf/pncconf/private_data.py:407
 msgid "X Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Y Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:397
+#: src/emc/usr_intf/pncconf/private_data.py:408
 msgid "Z Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "A Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:398
+#: src/emc/usr_intf/pncconf/private_data.py:409
 msgid "X Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Y Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:399
+#: src/emc/usr_intf/pncconf/private_data.py:410
 msgid "Z Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "A Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:400
+#: src/emc/usr_intf/pncconf/private_data.py:411
 msgid "X Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Y Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:401
+#: src/emc/usr_intf/pncconf/private_data.py:412
 msgid "Z Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "A Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:402
+#: src/emc/usr_intf/pncconf/private_data.py:413
 msgid "All Limits + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:403
+#: src/emc/usr_intf/pncconf/private_data.py:414
 msgid "X2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Y2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:404
+#: src/emc/usr_intf/pncconf/private_data.py:415
 msgid "Z2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "A2 Minimum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:405
+#: src/emc/usr_intf/pncconf/private_data.py:416
 msgid "X2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Y2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:406
+#: src/emc/usr_intf/pncconf/private_data.py:417
 msgid "Z2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "A2 Maximum Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:407
+#: src/emc/usr_intf/pncconf/private_data.py:418
 msgid "X2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Y2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:408
+#: src/emc/usr_intf/pncconf/private_data.py:419
 msgid "Z2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:409
+#: src/emc/usr_intf/pncconf/private_data.py:420
 msgid "A2 Both Limit + Home"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select A"
 msgstr "關節 選 A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:412
+#: src/emc/usr_intf/pncconf/private_data.py:423
 msgid "Joint select B"
 msgstr "Joint 選 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select C"
 msgstr "Joint 選 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:413
+#: src/emc/usr_intf/pncconf/private_data.py:424
 msgid "Joint select D"
 msgstr "Joint 選 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr A"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr B"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:414
+#: src/emc/usr_intf/pncconf/private_data.py:425
 msgid "Jog incr C"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Jog incr D"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr A"
 msgstr "進給超速 遞增 A "
 
-#: src/emc/usr_intf/pncconf/private_data.py:415
+#: src/emc/usr_intf/pncconf/private_data.py:426
 msgid "Feed Override incr B"
 msgstr "進給超速 遞增 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr C"
 msgstr "進給超速 遞增 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Feed Override incr D"
 msgstr "進給超速 遞增 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:416
+#: src/emc/usr_intf/pncconf/private_data.py:427
 msgid "Spindle Override incr A"
 msgstr "主軸超速 遞增 A"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr B"
 msgstr "主軸超速 遞增 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr C"
 msgstr "主軸超速 遞增 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:417
+#: src/emc/usr_intf/pncconf/private_data.py:428
 msgid "Spindle Override incr D"
 msgstr "主軸超速 遞增 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr A"
 msgstr "進給超速 遞增 A "
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr B"
 msgstr "進給超速 遞增 B"
 
-#: src/emc/usr_intf/pncconf/private_data.py:418
+#: src/emc/usr_intf/pncconf/private_data.py:429
 #, fuzzy
 msgid "Max Vel Override incr C"
 msgstr "進給超速 遞增 C"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Max Vel Override incr D"
 msgstr "進給超速 遞增 D"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Feed Override enable"
 msgstr "進給 超速"
 
-#: src/emc/usr_intf/pncconf/private_data.py:419
+#: src/emc/usr_intf/pncconf/private_data.py:430
 #, fuzzy
 msgid "Spindle Override enable"
 msgstr "設定主軸超速:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:420
+#: src/emc/usr_intf/pncconf/private_data.py:431
 #, fuzzy
 msgid "Max Vel Override enable"
 msgstr "最大　進給　超越"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CW"
 msgstr "手動 主軸 CW"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle CCW"
 msgstr "手動 主軸 CCW"
 
-#: src/emc/usr_intf/pncconf/private_data.py:421
+#: src/emc/usr_intf/pncconf/private_data.py:432
 msgid "Manual Spindle Stop"
 msgstr "手動 主軸 停"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 msgid "Spindle Up-To-Speed"
 msgstr "主軸 達速"
 
-#: src/emc/usr_intf/pncconf/private_data.py:422
+#: src/emc/usr_intf/pncconf/private_data.py:433
 #, fuzzy
 msgid "Gear Select A"
 msgstr "全選"
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Cycle Start"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Abort"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:423
+#: src/emc/usr_intf/pncconf/private_data.py:434
 msgid "Single Step"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog X -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:425
+#: src/emc/usr_intf/pncconf/private_data.py:436
 msgid "Jog Y -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog Z -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:426
+#: src/emc/usr_intf/pncconf/private_data.py:437
 msgid "Jog A -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected +"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:427
+#: src/emc/usr_intf/pncconf/private_data.py:438
 msgid "Jog button selected -"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:428
-#: src/emc/usr_intf/pncconf/private_data.py:500
+#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:515
 msgid "X HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:429
-#: src/emc/usr_intf/pncconf/private_data.py:501
+#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:516
 msgid "X Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:430
-#: src/emc/usr_intf/pncconf/private_data.py:502
+#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:517
 msgid "Y HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:431
-#: src/emc/usr_intf/pncconf/private_data.py:503
+#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:518
 msgid "Y Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:432
-#: src/emc/usr_intf/pncconf/private_data.py:504
+#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:519
 msgid "Z HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:433
-#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:520
 msgid "Z Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:434
-#: src/emc/usr_intf/pncconf/private_data.py:506
+#: src/emc/usr_intf/pncconf/private_data.py:445
+#: src/emc/usr_intf/pncconf/private_data.py:521
 msgid "A HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:435
-#: src/emc/usr_intf/pncconf/private_data.py:507
+#: src/emc/usr_intf/pncconf/private_data.py:446
+#: src/emc/usr_intf/pncconf/private_data.py:522
 msgid "A Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:436
-#: src/emc/usr_intf/pncconf/private_data.py:508
+#: src/emc/usr_intf/pncconf/private_data.py:447
+#: src/emc/usr_intf/pncconf/private_data.py:523
 msgid "S HALL 3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:437
-#: src/emc/usr_intf/pncconf/private_data.py:509
+#: src/emc/usr_intf/pncconf/private_data.py:448
+#: src/emc/usr_intf/pncconf/private_data.py:524
 msgid "S Gray C8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "X Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Y Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "Z Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:438
+#: src/emc/usr_intf/pncconf/private_data.py:449
 msgid "A Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "X Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Y Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "Z Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:439
+#: src/emc/usr_intf/pncconf/private_data.py:450
 msgid "A Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "X Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Y Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "Z Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:440
+#: src/emc/usr_intf/pncconf/private_data.py:451
 msgid "A Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:441
+#: src/emc/usr_intf/pncconf/private_data.py:452
 msgid "All Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "X2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Y2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "Z2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:442
+#: src/emc/usr_intf/pncconf/private_data.py:453
 msgid "A2 Minimum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "X2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Y2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "Z2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:443
+#: src/emc/usr_intf/pncconf/private_data.py:454
 msgid "A2 Maximum Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "X2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Y2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "Z2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:444
+#: src/emc/usr_intf/pncconf/private_data.py:455
 msgid "A2 Both Limit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Main Axis"
 msgstr "X 軸"
 
-#: src/emc/usr_intf/pncconf/private_data.py:446
-#: src/emc/usr_intf/pncconf/private_data.py:447
-#: src/emc/usr_intf/pncconf/private_data.py:448
-#: src/emc/usr_intf/pncconf/private_data.py:462
-#: src/emc/usr_intf/pncconf/private_data.py:472
-#: src/emc/usr_intf/pncconf/private_data.py:487
+#: src/emc/usr_intf/pncconf/private_data.py:457
+#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:476
+#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:502
 #, fuzzy
 msgid "Tandem Axis"
 msgstr "軸回零"
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Arc OK"
+msgstr "弧 順時針"
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+msgid "Ohmic Probe"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:460
+#, fuzzy
+msgid "Float Switch"
+msgstr "英寸"
+
+#: src/emc/usr_intf/pncconf/private_data.py:461
+msgid "Breakaway"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Unused Input"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:449
+#: src/emc/usr_intf/pncconf/private_data.py:463
 msgid "Limits"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:450
+#: src/emc/usr_intf/pncconf/private_data.py:464
 msgid "Limts/Home Shared"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "Digital"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
-#: src/emc/usr_intf/pncconf/private_data.py:806
+#: src/emc/usr_intf/pncconf/private_data.py:465
+#: src/emc/usr_intf/pncconf/private_data.py:874
 msgid "Axis Selection"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:451
+#: src/emc/usr_intf/pncconf/private_data.py:465
 msgid "Overrides"
 msgstr "超速"
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "Operation"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:452
+#: src/emc/usr_intf/pncconf/private_data.py:466
 msgid "External Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
+#: src/emc/usr_intf/pncconf/private_data.py:467
 msgid "Axis rapid"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:453
-#: src/emc/usr_intf/pncconf/private_data.py:513
+#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:529
 msgid "X BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Y BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:454
-#: src/emc/usr_intf/pncconf/private_data.py:514
+#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:530
 msgid "Z BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:455
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid "A BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
+#: src/emc/usr_intf/pncconf/private_data.py:469
 msgid "S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:456
-#: src/emc/usr_intf/pncconf/private_data.py:465
-#: src/emc/usr_intf/pncconf/private_data.py:476
-#: src/emc/usr_intf/pncconf/private_data.py:490
-#: src/emc/usr_intf/pncconf/private_data.py:516
-#: src/emc/usr_intf/pncconf/private_data.py:519
-#: src/emc/usr_intf/pncconf/private_data.py:523
-#: src/emc/usr_intf/pncconf/private_data.py:526
+#: src/emc/usr_intf/pncconf/private_data.py:470
 #: src/emc/usr_intf/pncconf/private_data.py:532
+msgid "Plasma"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:490
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#: src/emc/usr_intf/pncconf/private_data.py:532
+#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:539
 #: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:548
+#: src/emc/usr_intf/pncconf/private_data.py:558
 msgid "Custom Signals"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "X2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:458
+#: src/emc/usr_intf/pncconf/private_data.py:472
 msgid "Y2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "Z2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:459
+#: src/emc/usr_intf/pncconf/private_data.py:473
 msgid "A2 Tandem PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "X Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:460
+#: src/emc/usr_intf/pncconf/private_data.py:474
 msgid "Y Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "Z Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:461
+#: src/emc/usr_intf/pncconf/private_data.py:475
 msgid "A Axis PWM"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 msgid "Unused PWM Gen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:463
+#: src/emc/usr_intf/pncconf/private_data.py:477
 #, fuzzy
 msgid "Axis PWM"
 msgstr "軸 "
 
-#: src/emc/usr_intf/pncconf/private_data.py:467
+#: src/emc/usr_intf/pncconf/private_data.py:481
 msgid "X Axis StepGen"
 msgstr "X 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Y Axis StepGen"
 msgstr "Y 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:468
+#: src/emc/usr_intf/pncconf/private_data.py:482
 msgid "Z Axis StepGen"
 msgstr "Z 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:469
+#: src/emc/usr_intf/pncconf/private_data.py:483
 msgid "A Axis StepGen"
 msgstr "A 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "X2 Tandem StepGen"
 msgstr "主 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:470
+#: src/emc/usr_intf/pncconf/private_data.py:484
 #, fuzzy
 msgid "Y2 Tandem StepGen"
 msgstr "主 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:471
+#: src/emc/usr_intf/pncconf/private_data.py:485
 #, fuzzy
 msgid "Z2 Tandem StepGen"
 msgstr "主 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:473
+#: src/emc/usr_intf/pncconf/private_data.py:487
 msgid "Unused StepGen"
 msgstr "未使用的 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:474
-msgid "Axis"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Charge Pump StepGen"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:475
+#: src/emc/usr_intf/pncconf/private_data.py:489
 msgid "Spindle StepGen"
 msgstr "主 軸 步進產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "X Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:478
+#: src/emc/usr_intf/pncconf/private_data.py:492
 msgid "Y Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "Z Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:479
+#: src/emc/usr_intf/pncconf/private_data.py:493
 msgid "A Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "X2 Tandem Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:481
+#: src/emc/usr_intf/pncconf/private_data.py:495
 #, fuzzy
 msgid "Y2 Tandem Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "Z2 Tandem Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:482
+#: src/emc/usr_intf/pncconf/private_data.py:496
 #, fuzzy
 msgid "A2 Tandem Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "X Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:483
+#: src/emc/usr_intf/pncconf/private_data.py:497
 msgid "Y Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "Z Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:484
+#: src/emc/usr_intf/pncconf/private_data.py:498
 msgid "A Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:485
+#: src/emc/usr_intf/pncconf/private_data.py:499
 msgid "Multi Hand Wheel"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "Feed Override"
 msgstr "進給 超速"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 msgid "spindle Override"
 msgstr "主軸 超越"
 
-#: src/emc/usr_intf/pncconf/private_data.py:486
+#: src/emc/usr_intf/pncconf/private_data.py:500
 #, fuzzy
 msgid "Max Vel Override"
 msgstr "最大　進給　超越"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:501
+msgid "Arc Voltage"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Unused Encoder"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:488
+#: src/emc/usr_intf/pncconf/private_data.py:503
 msgid "Axis Encoder"
 msgstr "軸編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Spindle Encoder"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "MPG Jog Controls"
 msgstr "MPG　慢步　操控"
 
-#: src/emc/usr_intf/pncconf/private_data.py:489
+#: src/emc/usr_intf/pncconf/private_data.py:504
 msgid "Override MPG control"
 msgstr "超速 MPG　操控"
 
-#: src/emc/usr_intf/pncconf/private_data.py:493
+#: src/emc/usr_intf/pncconf/private_data.py:505
+#, fuzzy
+msgid "Plasma Encoder"
+msgstr "軸編碼器"
+
+#: src/emc/usr_intf/pncconf/private_data.py:508
 #, fuzzy
 msgid "Unused Unused"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:494
+#: src/emc/usr_intf/pncconf/private_data.py:509
 #, fuzzy
 msgid "Spindle Enable"
 msgstr "主軸 慢些"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 #, fuzzy
 msgid "Machine Is Enabled"
 msgstr "機器 名稱:"
 
-#: src/emc/usr_intf/pncconf/private_data.py:496
+#: src/emc/usr_intf/pncconf/private_data.py:511
 msgid "X Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Y Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "Z Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:497
+#: src/emc/usr_intf/pncconf/private_data.py:512
 msgid "A Amplifier Enable"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:498
+#: src/emc/usr_intf/pncconf/private_data.py:513
 msgid "Force Pin True"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:511
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Ohmic Enable"
+msgstr "啟用"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Scribe Arm"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Scribe On"
+msgstr "機器開"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+#, fuzzy
+msgid "Torch On"
+msgstr "對刀"
+
+#: src/emc/usr_intf/pncconf/private_data.py:525
+msgid "Laser On"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/private_data.py:527
 msgid "Unused Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Coolant"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:512
+#: src/emc/usr_intf/pncconf/private_data.py:528
 msgid "Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:515
+#: src/emc/usr_intf/pncconf/private_data.py:531
 msgid " S BLDC Control"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:518
+#: src/emc/usr_intf/pncconf/private_data.py:534
 msgid "Unused 8I20"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 #, fuzzy
 msgid "Unused Resolver"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:521
+#: src/emc/usr_intf/pncconf/private_data.py:537
 msgid "X Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Y Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:522
+#: src/emc/usr_intf/pncconf/private_data.py:538
 msgid "Z Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "A Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:523
+#: src/emc/usr_intf/pncconf/private_data.py:539
 msgid "S Resolver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 msgid "Unused Analog Output"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:525
+#: src/emc/usr_intf/pncconf/private_data.py:541
 #, fuzzy
 msgid "Spindle Output"
 msgstr "主軸 關"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "Unused TPPWM Gen"
 msgstr "未使用的 TPPWM　產生器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:529
+#: src/emc/usr_intf/pncconf/private_data.py:545
 msgid "X Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Y Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:530
+#: src/emc/usr_intf/pncconf/private_data.py:546
 msgid "Z Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "A Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:531
+#: src/emc/usr_intf/pncconf/private_data.py:547
 msgid "S Axis BL Driver"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:534
+#: src/emc/usr_intf/pncconf/private_data.py:550
 msgid "8i20 Amplifier Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i64 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:535
+#: src/emc/usr_intf/pncconf/private_data.py:551
 msgid "7i69 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i70 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:536
+#: src/emc/usr_intf/pncconf/private_data.py:552
 msgid "7i71 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:537
+#: src/emc/usr_intf/pncconf/private_data.py:553
 msgid "7i76 Mode 2 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 0 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:538
+#: src/emc/usr_intf/pncconf/private_data.py:554
 msgid "7i77 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:539
+#: src/emc/usr_intf/pncconf/private_data.py:555
 msgid "7i73 Mode 1 Pendant Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 1 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:540
+#: src/emc/usr_intf/pncconf/private_data.py:556
 msgid "7i84 Mode 3 I/O Card"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:542
+#: src/emc/usr_intf/pncconf/private_data.py:558
 #, fuzzy
 msgid "Unused Analog In"
 msgstr "未使用的編碼器"
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Input\n"
 "P3 and P4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid ""
 "7i64-Output\n"
 "P2 and P5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:814
+#: src/emc/usr_intf/pncconf/private_data.py:882
 msgid "7i64-Analog In"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:827
+#: src/emc/usr_intf/pncconf/private_data.py:895
 msgid ""
 "7i69\n"
 "P3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:839
+#: src/emc/usr_intf/pncconf/private_data.py:907
 msgid ""
 "7i70-Input\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:851
+#: src/emc/usr_intf/pncconf/private_data.py:919
 msgid ""
 "7i71-Output\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB6"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-I/O\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:863
-#: src/emc/usr_intf/pncconf/private_data.py:875
+#: src/emc/usr_intf/pncconf/private_data.py:931
+#: src/emc/usr_intf/pncconf/private_data.py:943
 msgid ""
 "7i76-Analog Output\n"
 "TB4"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB8"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-I/O\n"
 "TB7"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:887
-#: src/emc/usr_intf/pncconf/private_data.py:899
+#: src/emc/usr_intf/pncconf/private_data.py:955
+#: src/emc/usr_intf/pncconf/private_data.py:967
 msgid ""
 "7i77-Analog Output\n"
 "TB5"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:911
+#: src/emc/usr_intf/pncconf/private_data.py:979
 msgid "7i73-I/O\n"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
+#: src/emc/usr_intf/pncconf/private_data.py:992
 msgid ""
 "7i84-I/O\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:924
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:992
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O\n"
 "TB2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:939
+#: src/emc/usr_intf/pncconf/private_data.py:1007
 msgid ""
 "7i84-I/O-MPG\n"
 "TB3"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1004
+#: src/emc/usr_intf/pncconf/private_data.py:1072
 msgid ""
 "OK to replace existing custom pyvcp panel and custom_postgui.hal file ?\n"
 "Existing custompanel.xml and custom_postgui.hal will be renamed "
@@ -13062,15 +13554,15 @@ msgid ""
 "be lost. "
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1005
+#: src/emc/usr_intf/pncconf/private_data.py:1073
 msgid "Quit PNCconf and discard changes?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1006
+#: src/emc/usr_intf/pncconf/private_data.py:1074
 msgid "Do you want to quit?"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/private_data.py:1012
+#: src/emc/usr_intf/pncconf/private_data.py:1080
 msgid ""
 "Ok to replace AXIS's .axisrc file?\n"
 " If you haven't added custom commands to this hidden file, outside of "
@@ -13085,83 +13577,92 @@ msgid ""
 "machine-named folder.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/tests.py:488
+#: src/emc/usr_intf/pncconf/tests.py:469
+msgid ""
+"± = move on both sides of start position\n"
+"\n"
+"+ = move on positive side of start position\n"
+"\n"
+"- = move on negative side of start position"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/tests.py:492
 #, fuzzy
 msgid "Servo tuning is not tested in PNCconf yet\n"
 msgstr "伺服 調整 還沒有完成 / 在工作\n"
 
-#: src/emc/usr_intf/pncconf/tests.py:497
+#: src/emc/usr_intf/pncconf/tests.py:501
 msgid "degrees"
 msgstr "度"
 
-#: src/emc/usr_intf/pncconf/tests.py:498
+#: src/emc/usr_intf/pncconf/tests.py:502
 msgid "degrees / minute"
 msgstr "度 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/tests.py:499
+#: src/emc/usr_intf/pncconf/tests.py:503
 msgid "degrees / second²"
 msgstr "度 / 秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:502
+#: src/emc/usr_intf/pncconf/tests.py:506
 msgid "revolutions"
 msgstr "轉"
 
-#: src/emc/usr_intf/pncconf/tests.py:503
+#: src/emc/usr_intf/pncconf/tests.py:507
 msgid "rpm"
 msgstr "轉速"
 
-#: src/emc/usr_intf/pncconf/tests.py:504
+#: src/emc/usr_intf/pncconf/tests.py:508
 msgid "revs / second²"
 msgstr "轉速 / 秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:508
-#: src/emc/usr_intf/pncconf/x_axis.glade:287
-#: src/emc/usr_intf/pncconf/x_axis.glade:405
-#: src/emc/usr_intf/pncconf/x_axis.glade:603
-#: src/emc/usr_intf/pncconf/y_axis.glade:287
-#: src/emc/usr_intf/pncconf/y_axis.glade:405
-#: src/emc/usr_intf/pncconf/y_axis.glade:603
-#: src/emc/usr_intf/pncconf/z_axis.glade:287
-#: src/emc/usr_intf/pncconf/z_axis.glade:405
-#: src/emc/usr_intf/pncconf/z_axis.glade:603
-#: src/emc/usr_intf/pncconf/a_axis.glade:287
-#: src/emc/usr_intf/pncconf/a_axis.glade:405
-#: src/emc/usr_intf/pncconf/a_axis.glade:603
+#: src/emc/usr_intf/pncconf/tests.py:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:512
+#: src/emc/usr_intf/pncconf/x_axis.glade:547
+#: src/emc/usr_intf/pncconf/x_axis.glade:563
+#: src/emc/usr_intf/pncconf/y_axis.glade:512
+#: src/emc/usr_intf/pncconf/y_axis.glade:547
+#: src/emc/usr_intf/pncconf/y_axis.glade:563
+#: src/emc/usr_intf/pncconf/z_axis.glade:512
+#: src/emc/usr_intf/pncconf/z_axis.glade:547
+#: src/emc/usr_intf/pncconf/z_axis.glade:563
+#: src/emc/usr_intf/pncconf/a_axis.glade:512
+#: src/emc/usr_intf/pncconf/a_axis.glade:547
+#: src/emc/usr_intf/pncconf/a_axis.glade:563
 msgid "mm / minute"
 msgstr "毫米 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/tests.py:509
+#: src/emc/usr_intf/pncconf/tests.py:513
 msgid "mm / second²"
 msgstr "毫米 / 秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:513
+#: src/emc/usr_intf/pncconf/tests.py:517
 msgid "inches / minute"
 msgstr "英寸 / 分鐘"
 
-#: src/emc/usr_intf/pncconf/tests.py:514
+#: src/emc/usr_intf/pncconf/tests.py:518
 msgid "inches / second²"
 msgstr "英寸 / 秒²"
 
-#: src/emc/usr_intf/pncconf/tests.py:714
+#: src/emc/usr_intf/pncconf/tests.py:720
 #, python-format
 msgid "%s Axis Tune"
 msgstr "%s 軸 調整"
 
-#: src/emc/usr_intf/pncconf/tests.py:908
+#: src/emc/usr_intf/pncconf/tests.py:914
 #, fuzzy
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and an ANALOG SPINDLE signal "
 "for this axis test"
 msgstr "您必須指定  一個 編碼器 信號  和  PWM 信號  給此軸測試"
 
-#: src/emc/usr_intf/pncconf/tests.py:912
+#: src/emc/usr_intf/pncconf/tests.py:918
 #, fuzzy
 msgid ""
 " You must designate a ENCODER / RESOLVER signal and a PWM signal for this "
 "axis test"
 msgstr "您必須指定  一個 編碼器 信號  和  PWM 信號  給此軸測試"
 
-#: src/emc/usr_intf/pncconf/tests.py:1201
+#: src/emc/usr_intf/pncconf/tests.py:1207
 msgid ""
 "Do to technical reasons this test panel can be loaded only once without "
 "reloading pncconf.You also will not be able to do any other testing untill "
@@ -13174,7 +13675,7 @@ msgstr ""
 msgid "my_LinuxCNC_machine"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:855
+#: src/emc/usr_intf/pncconf/data.py:879
 msgid ""
 "This configuration was saved with an earlier version of pncconf which may be "
 "incompatible.\n"
@@ -13184,18 +13685,18 @@ msgid ""
 "version of PNConf - ask on the LinuxCNC forum - it may be possible.."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:861
+#: src/emc/usr_intf/pncconf/data.py:885
 #, python-format
 msgid "File %r was modified since it was written by PNCconf"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:865
+#: src/emc/usr_intf/pncconf/data.py:889
 msgid ""
 "Saving this configuration file will discard configuration changes made "
 "outside PNCconf."
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/data.py:1068
+#: src/emc/usr_intf/pncconf/data.py:1092
 #, fuzzy
 msgid "Desktop Launcher for LinuxCNC config made by PNCconf"
 msgstr "創建一個桌面 啟動器 啟動 LinuxCNC 與 此配置."
@@ -14864,9 +15365,9 @@ msgid "Z"
 msgstr ""
 
 #: src/emc/usr_intf/pncconf/external.glade:1471
-#: src/emc/usr_intf/pncconf/screen.glade:1053
-#: src/emc/usr_intf/pncconf/screen.glade:1404
-#: src/emc/usr_intf/pncconf/screen.glade:1955
+#: src/emc/usr_intf/pncconf/screen.glade:1081
+#: src/emc/usr_intf/pncconf/screen.glade:1498
+#: src/emc/usr_intf/pncconf/screen.glade:2253
 #: src/emc/usr_intf/pncconf/vcp.glade:201
 #: src/emc/usr_intf/pncconf/vcp.glade:644
 #: src/emc/usr_intf/gscreen/gscreen.glade:244
@@ -15021,6 +15522,13 @@ msgstr "用　防抖動"
 #: src/emc/usr_intf/pncconf/external.glade:5401
 msgid "Mux options"
 msgstr "MUX　的選項"
+
+#: src/emc/usr_intf/pncconf/external.glade:2562
+#: src/emc/usr_intf/pncconf/external.glade:3534
+#: src/emc/usr_intf/pncconf/external.glade:4511
+#: src/emc/usr_intf/pncconf/external.glade:5488
+msgid "Sec"
+msgstr "秒"
 
 #: src/emc/usr_intf/pncconf/external.glade:2586
 msgid "increments"
@@ -15209,182 +15717,200 @@ msgstr "停機後　恢復　Joint　的位置"
 msgid "<b>Defaults and Options</b>"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:201
+#: src/emc/usr_intf/pncconf/screen.glade:141
+msgid "QtDragon"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:229
 #, fuzzy
 msgid "<b>GUI Screen list</b>"
 msgstr "<b>GUI前台列表</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:371
+#: src/emc/usr_intf/pncconf/screen.glade:399
 msgid "Position_offset"
 msgstr "位置 偏移量 (_o)"
 
-#: src/emc/usr_intf/pncconf/screen.glade:379
+#: src/emc/usr_intf/pncconf/screen.glade:407
 msgid "Position_feedback"
 msgstr "定 位 反 饋 (_f)"
 
-#: src/emc/usr_intf/pncconf/screen.glade:391
+#: src/emc/usr_intf/pncconf/screen.glade:419
 msgid "Max Spindle Override "
 msgstr "設定 主軸超速"
 
-#: src/emc/usr_intf/pncconf/screen.glade:419
+#: src/emc/usr_intf/pncconf/screen.glade:447
 msgid "Min Spindle Override"
 msgstr "最小　主軸超速"
 
-#: src/emc/usr_intf/pncconf/screen.glade:487
+#: src/emc/usr_intf/pncconf/screen.glade:515
+#: src/emc/usr_intf/pncconf/screen.glade:3082
 msgid "Max Feed Override"
 msgstr "最大　進給　超越"
 
-#: src/emc/usr_intf/pncconf/screen.glade:568
+#: src/emc/usr_intf/pncconf/screen.glade:596
 msgid "xyzabc"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:590
+#: src/emc/usr_intf/pncconf/screen.glade:618
 #, fuzzy
 msgid "Display Geometry"
 msgstr "幾　　何"
 
-#: src/emc/usr_intf/pncconf/screen.glade:603
+#: src/emc/usr_intf/pncconf/screen.glade:631
 msgid "<b>General GUI Defaults</b>"
 msgstr "<b>一　般　GUI　預　設　值</b>"
 
-#: src/emc/usr_intf/pncconf/screen.glade:698
+#: src/emc/usr_intf/pncconf/screen.glade:726
+#: src/emc/usr_intf/pncconf/screen.glade:2895
 msgid "Default linear velocity "
 msgstr " 線 性  速 度  預 置 值   "
 
-#: src/emc/usr_intf/pncconf/screen.glade:706
+#: src/emc/usr_intf/pncconf/screen.glade:734
+#: src/emc/usr_intf/pncconf/screen.glade:2907
 msgid "Min linear velocity"
 msgstr "最　小　線 性  速 度　"
 
-#: src/emc/usr_intf/pncconf/screen.glade:718
+#: src/emc/usr_intf/pncconf/screen.glade:746
+#: src/emc/usr_intf/pncconf/screen.glade:2919
 msgid "Max linear velocity"
 msgstr "最　大　線 性  速 度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:798
+#: src/emc/usr_intf/pncconf/screen.glade:826
 msgid "Default Angular velocity "
 msgstr "　角  速 度  預 置 值 　"
 
-#: src/emc/usr_intf/pncconf/screen.glade:839
+#: src/emc/usr_intf/pncconf/screen.glade:867
 msgid "gedit"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:857
+#: src/emc/usr_intf/pncconf/screen.glade:885
 msgid "Min Angular velocity"
 msgstr "最　小　角  速 度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:890
+#: src/emc/usr_intf/pncconf/screen.glade:918
+#: src/emc/usr_intf/pncconf/screen.glade:2988
 msgid "Increments "
 msgstr "　增　量　"
 
-#: src/emc/usr_intf/pncconf/screen.glade:902
+#: src/emc/usr_intf/pncconf/screen.glade:930
 msgid "5mm 1mm .5mm .1mm .05mm .01mm .005mm"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:920
+#: src/emc/usr_intf/pncconf/screen.glade:948
 msgid "Max Angular velocity"
 msgstr "最　大　角  速 度"
 
-#: src/emc/usr_intf/pncconf/screen.glade:952
-#: src/emc/usr_intf/pncconf/screen.glade:965
-#: src/emc/usr_intf/pncconf/screen.glade:978
+#: src/emc/usr_intf/pncconf/screen.glade:980
+#: src/emc/usr_intf/pncconf/screen.glade:993
+#: src/emc/usr_intf/pncconf/screen.glade:1006
 msgid "Deg / min"
 msgstr "角度　/　分"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1029
-#: src/emc/usr_intf/pncconf/screen.glade:1428
-#: src/emc/usr_intf/pncconf/screen.glade:1979
+#: src/emc/usr_intf/pncconf/screen.glade:1057
+#: src/emc/usr_intf/pncconf/screen.glade:1522
+#: src/emc/usr_intf/pncconf/screen.glade:2277
 #: src/emc/usr_intf/pncconf/vcp.glade:175
 #: src/emc/usr_intf/pncconf/vcp.glade:670
 msgid "size"
 msgstr "大小"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1038
-#: src/emc/usr_intf/pncconf/screen.glade:1415
-#: src/emc/usr_intf/pncconf/screen.glade:1966
+#: src/emc/usr_intf/pncconf/screen.glade:1066
+#: src/emc/usr_intf/pncconf/screen.glade:1509
+#: src/emc/usr_intf/pncconf/screen.glade:2264
 #: src/emc/usr_intf/pncconf/vcp.glade:185
 #: src/emc/usr_intf/pncconf/vcp.glade:655
 msgid "Position"
 msgstr "位置"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1084
-#: src/emc/usr_intf/pncconf/screen.glade:1373
-#: src/emc/usr_intf/pncconf/screen.glade:1924
+#: src/emc/usr_intf/pncconf/screen.glade:1112
+#: src/emc/usr_intf/pncconf/screen.glade:1467
+#: src/emc/usr_intf/pncconf/screen.glade:2222
 #: src/emc/usr_intf/pncconf/vcp.glade:231
 #: src/emc/usr_intf/pncconf/vcp.glade:614
 #: src/emc/usr_intf/gscreen/gscreen.glade:116
 msgid "X"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1097
-#: src/emc/usr_intf/pncconf/screen.glade:1362
-#: src/emc/usr_intf/pncconf/screen.glade:1913
+#: src/emc/usr_intf/pncconf/screen.glade:1125
+#: src/emc/usr_intf/pncconf/screen.glade:1456
+#: src/emc/usr_intf/pncconf/screen.glade:2211
 #: src/emc/usr_intf/pncconf/vcp.glade:244
 #: src/emc/usr_intf/pncconf/vcp.glade:603
 #: src/emc/usr_intf/gscreen/gscreen.glade:1142
 msgid "W"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1142
-#: src/emc/usr_intf/pncconf/screen.glade:1317
-#: src/emc/usr_intf/pncconf/screen.glade:1868
+#: src/emc/usr_intf/pncconf/screen.glade:1170
+#: src/emc/usr_intf/pncconf/screen.glade:1411
+#: src/emc/usr_intf/pncconf/screen.glade:2166
 #: src/emc/usr_intf/pncconf/vcp.glade:287
 #: src/emc/usr_intf/pncconf/vcp.glade:560
 msgid "H"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1167
+#: src/emc/usr_intf/pncconf/screen.glade:1195
 msgid "Force Axis to Maximize"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1192
+#: src/emc/usr_intf/pncconf/screen.glade:1220
 #, fuzzy
 msgid "AXIS Defaults"
 msgstr "AXIS 預 置 值"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1285
+#: src/emc/usr_intf/pncconf/screen.glade:1379
 msgid "Force Touchy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1476
-#: src/emc/usr_intf/pncconf/screen.glade:2027
+#: src/emc/usr_intf/pncconf/screen.glade:1588
+#: src/emc/usr_intf/pncconf/screen.glade:2343
 #: src/emc/usr_intf/pncconf/vcp.glade:767
 msgid "GTK Theme"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1508
+#: src/emc/usr_intf/pncconf/screen.glade:1632
 #: src/emc/usr_intf/gscreen/gscreen.glade:1892
 msgid "Absolute Text Color"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1569
+#: src/emc/usr_intf/pncconf/screen.glade:1699
 #, fuzzy
 msgid "Absolute Textcolor"
 msgstr "絕對反饋"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1582
+#: src/emc/usr_intf/pncconf/screen.glade:1712
 #, fuzzy
 msgid "Relative Textcolor"
 msgstr "相對位置"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1595
+#: src/emc/usr_intf/pncconf/screen.glade:1725
 msgid "DTG Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1608
+#: src/emc/usr_intf/pncconf/screen.glade:1738
 msgid "Error Textcolor"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:1715
+#: src/emc/usr_intf/pncconf/screen.glade:1845
 #, fuzzy
 msgid "Touchy Defaults"
 msgstr "使用預置值"
 
-#: src/emc/usr_intf/pncconf/screen.glade:1836
+#: src/emc/usr_intf/pncconf/screen.glade:2134
 msgid "Force Gmoccapy to Maximize after positioning"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/screen.glade:2174
+#: src/emc/usr_intf/pncconf/screen.glade:2502
 msgid "Gmoccapy Defaults"
 msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3000
+msgid "10 1 .1 .01 .001"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/screen.glade:3126
+#, fuzzy
+msgid "QtPlasmaC Options"
+msgstr "樣辦配置"
 
 #: src/emc/usr_intf/pncconf/vcp.glade:27
 msgid "<b>Virtual Control Panel</b>"
@@ -15482,138 +16008,155 @@ msgstr "GladeVCP　詳情"
 msgid "Include custom GladeVCP GUI panel"
 msgstr "包括自訂 GladeVCP GUI面板"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:16
-#: src/emc/usr_intf/pncconf/y_axis.glade:16
-#: src/emc/usr_intf/pncconf/z_axis.glade:16
-#: src/emc/usr_intf/pncconf/a_axis.glade:16
+#: src/emc/usr_intf/pncconf/thcad.glade:120
+msgid "Full Scale Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:159
+msgid "0V Frequency (kHz)"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/thcad.glade:272
+#, fuzzy
+msgid "Encoder"
+msgstr "軸編碼器"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:15
+#: src/emc/usr_intf/pncconf/y_axis.glade:15
+#: src/emc/usr_intf/pncconf/z_axis.glade:15
+#: src/emc/usr_intf/pncconf/a_axis.glade:15
+msgid "Use Encoder Index For Home:"
+msgstr "使用編碼器指標為零點:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:29
+#: src/emc/usr_intf/pncconf/y_axis.glade:29
+#: src/emc/usr_intf/pncconf/z_axis.glade:29
+#: src/emc/usr_intf/pncconf/a_axis.glade:29
+msgid "Home Final Velocity:"
+msgstr "歸零最終速度"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:42
+#: src/emc/usr_intf/pncconf/y_axis.glade:42
+#: src/emc/usr_intf/pncconf/z_axis.glade:42
+#: src/emc/usr_intf/pncconf/a_axis.glade:42
+msgid "Home Latch Direction:"
+msgstr "歸零閉鎖方向:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:57
+#: src/emc/usr_intf/pncconf/y_axis.glade:57
+#: src/emc/usr_intf/pncconf/z_axis.glade:57
+#: src/emc/usr_intf/pncconf/a_axis.glade:57
+msgid "Home Search Direction:"
+msgstr ""
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:72
+#: src/emc/usr_intf/pncconf/y_axis.glade:72
+#: src/emc/usr_intf/pncconf/z_axis.glade:72
+#: src/emc/usr_intf/pncconf/a_axis.glade:72
+msgid "Home latch Velocity:"
+msgstr "零點鎖定速率:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:104
+#: src/emc/usr_intf/pncconf/y_axis.glade:104
+#: src/emc/usr_intf/pncconf/z_axis.glade:104
+#: src/emc/usr_intf/pncconf/a_axis.glade:104
+#, fuzzy
+msgid "Use Compensation Filename:"
+msgstr "使用補償文件:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:120
+#: src/emc/usr_intf/pncconf/y_axis.glade:120
+#: src/emc/usr_intf/pncconf/z_axis.glade:120
+#: src/emc/usr_intf/pncconf/a_axis.glade:120
+msgid "Use Backlash Compensation:"
+msgstr "使用反向間隙補償:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:140
+#: src/emc/usr_intf/pncconf/y_axis.glade:140
+#: src/emc/usr_intf/pncconf/z_axis.glade:140
+#: src/emc/usr_intf/pncconf/a_axis.glade:140
+#, fuzzy
+msgid "Final Home Position location   (Offset from machine zero Origin):"
+msgstr "零點定位 (從機床零點的偏移):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:156
+#: src/emc/usr_intf/pncconf/y_axis.glade:156
+#: src/emc/usr_intf/pncconf/z_axis.glade:156
+#: src/emc/usr_intf/pncconf/a_axis.glade:156
+msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
+msgstr "負移動距離 (機床 零點到 負 行程尾): "
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:172
+#: src/emc/usr_intf/pncconf/y_axis.glade:172
+#: src/emc/usr_intf/pncconf/z_axis.glade:172
+#: src/emc/usr_intf/pncconf/a_axis.glade:172
+#, fuzzy
+msgid "Tandem Home Switch location   (Offset from machine zero Origin):"
+msgstr "歸零開關的位置 (從機床零點的偏移):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:188
+#: src/emc/usr_intf/pncconf/y_axis.glade:188
+#: src/emc/usr_intf/pncconf/z_axis.glade:188
+#: src/emc/usr_intf/pncconf/a_axis.glade:188
+msgid "Home Search Velocity:"
+msgstr "零點搜索速率:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:203
+#: src/emc/usr_intf/pncconf/y_axis.glade:203
+#: src/emc/usr_intf/pncconf/z_axis.glade:203
+#: src/emc/usr_intf/pncconf/a_axis.glade:203
+msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
+msgstr "正移動距離 (機床 零點到 正 行程尾): "
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:219
+#: src/emc/usr_intf/pncconf/y_axis.glade:219
+#: src/emc/usr_intf/pncconf/z_axis.glade:219
+#: src/emc/usr_intf/pncconf/a_axis.glade:219
+#, fuzzy
+msgid "Home Search Sequence:"
+msgstr "零點搜索速率:"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:234
+#: src/emc/usr_intf/pncconf/y_axis.glade:234
+#: src/emc/usr_intf/pncconf/z_axis.glade:234
+#: src/emc/usr_intf/pncconf/a_axis.glade:234
+#, fuzzy
+msgid "Home Switch location   (offset from machine zero Origin):"
+msgstr "歸零開關的位置 (從機床零點的偏移):"
+
+#: src/emc/usr_intf/pncconf/x_axis.glade:673
+#: src/emc/usr_intf/pncconf/y_axis.glade:673
+#: src/emc/usr_intf/pncconf/z_axis.glade:673
+#: src/emc/usr_intf/pncconf/a_axis.glade:673
 msgid "Type 1"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:19
-#: src/emc/usr_intf/pncconf/y_axis.glade:19
-#: src/emc/usr_intf/pncconf/z_axis.glade:19
-#: src/emc/usr_intf/pncconf/a_axis.glade:19
+#: src/emc/usr_intf/pncconf/x_axis.glade:676
+#: src/emc/usr_intf/pncconf/y_axis.glade:676
+#: src/emc/usr_intf/pncconf/z_axis.glade:676
+#: src/emc/usr_intf/pncconf/a_axis.glade:676
 msgid "Type 2"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:58
-#: src/emc/usr_intf/pncconf/y_axis.glade:58
-#: src/emc/usr_intf/pncconf/z_axis.glade:58
-#: src/emc/usr_intf/pncconf/a_axis.glade:58
+#: src/emc/usr_intf/pncconf/x_axis.glade:715
+#: src/emc/usr_intf/pncconf/y_axis.glade:715
+#: src/emc/usr_intf/pncconf/z_axis.glade:715
+#: src/emc/usr_intf/pncconf/a_axis.glade:715
 #, fuzzy
 msgid "Towards Negative Limit"
 msgstr ""
 "朝向負極限\n"
 "朝向正極限"
 
-#: src/emc/usr_intf/pncconf/x_axis.glade:61
-#: src/emc/usr_intf/pncconf/y_axis.glade:61
-#: src/emc/usr_intf/pncconf/z_axis.glade:61
-#: src/emc/usr_intf/pncconf/a_axis.glade:61
+#: src/emc/usr_intf/pncconf/x_axis.glade:718
+#: src/emc/usr_intf/pncconf/y_axis.glade:718
+#: src/emc/usr_intf/pncconf/z_axis.glade:718
+#: src/emc/usr_intf/pncconf/a_axis.glade:718
 #, fuzzy
 msgid "Towards Positive Limit"
 msgstr ""
 "朝向負極限\n"
 "朝向正極限"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:273
-#: src/emc/usr_intf/pncconf/y_axis.glade:273
-#: src/emc/usr_intf/pncconf/z_axis.glade:273
-#: src/emc/usr_intf/pncconf/a_axis.glade:273
-msgid "Use Encoder Index For Home:"
-msgstr "使用編碼器指標為零點:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:321
-#: src/emc/usr_intf/pncconf/y_axis.glade:321
-#: src/emc/usr_intf/pncconf/z_axis.glade:321
-#: src/emc/usr_intf/pncconf/a_axis.glade:321
-msgid "Home Final Velocity:"
-msgstr "歸零最終速度"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:354
-#: src/emc/usr_intf/pncconf/y_axis.glade:354
-#: src/emc/usr_intf/pncconf/z_axis.glade:354
-#: src/emc/usr_intf/pncconf/a_axis.glade:354
-msgid "Home Latch Direction:"
-msgstr "歸零閉鎖方向:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:390
-#: src/emc/usr_intf/pncconf/y_axis.glade:390
-#: src/emc/usr_intf/pncconf/z_axis.glade:390
-#: src/emc/usr_intf/pncconf/a_axis.glade:390
-msgid "Home Search Direction:"
-msgstr ""
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:439
-#: src/emc/usr_intf/pncconf/y_axis.glade:439
-#: src/emc/usr_intf/pncconf/z_axis.glade:439
-#: src/emc/usr_intf/pncconf/a_axis.glade:439
-msgid "Home latch Velocity:"
-msgstr "零點鎖定速率:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:470
-#: src/emc/usr_intf/pncconf/y_axis.glade:470
-#: src/emc/usr_intf/pncconf/z_axis.glade:470
-#: src/emc/usr_intf/pncconf/a_axis.glade:470
-msgid "filename:"
-msgstr "文件名:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:538
-#: src/emc/usr_intf/pncconf/y_axis.glade:538
-#: src/emc/usr_intf/pncconf/z_axis.glade:538
-#: src/emc/usr_intf/pncconf/a_axis.glade:538
-msgid "Use Compensation File:"
-msgstr "使用補償文件:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:552
-#: src/emc/usr_intf/pncconf/y_axis.glade:552
-#: src/emc/usr_intf/pncconf/z_axis.glade:552
-#: src/emc/usr_intf/pncconf/a_axis.glade:552
-msgid "Use Backlash Compensation:"
-msgstr "使用反向間隙補償:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:569
-#: src/emc/usr_intf/pncconf/y_axis.glade:569
-#: src/emc/usr_intf/pncconf/z_axis.glade:569
-#: src/emc/usr_intf/pncconf/a_axis.glade:569
-msgid "Home Position location   (offset from machine zero Origin):"
-msgstr "零點定位 (從機床零點的偏移):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:586
-#: src/emc/usr_intf/pncconf/y_axis.glade:586
-#: src/emc/usr_intf/pncconf/z_axis.glade:586
-#: src/emc/usr_intf/pncconf/a_axis.glade:586
-msgid "Negative Travel Distance  (Machine zero Origin to end of - travel): "
-msgstr "負移動距離 (機床 零點到 負 行程尾): "
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:637
-#: src/emc/usr_intf/pncconf/y_axis.glade:637
-#: src/emc/usr_intf/pncconf/z_axis.glade:637
-#: src/emc/usr_intf/pncconf/a_axis.glade:637
-msgid "Home Switch location   (Offset from machine zero Origin):"
-msgstr "歸零開關的位置 (從機床零點的偏移):"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:654
-#: src/emc/usr_intf/pncconf/y_axis.glade:654
-#: src/emc/usr_intf/pncconf/z_axis.glade:654
-#: src/emc/usr_intf/pncconf/a_axis.glade:654
-msgid "Home Search Velocity:"
-msgstr "零點搜索速率:"
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:670
-#: src/emc/usr_intf/pncconf/y_axis.glade:670
-#: src/emc/usr_intf/pncconf/z_axis.glade:670
-#: src/emc/usr_intf/pncconf/a_axis.glade:670
-msgid "Positive Travel Distance  (Machine zero Origin to end of + travel): "
-msgstr "正移動距離 (機床 零點到 正 行程尾): "
-
-#: src/emc/usr_intf/pncconf/x_axis.glade:978
-#: src/emc/usr_intf/pncconf/y_axis.glade:978
-#: src/emc/usr_intf/pncconf/z_axis.glade:978
-#: src/emc/usr_intf/pncconf/a_axis.glade:978
-#, fuzzy
-msgid "Home Search Sequence:"
-msgstr "零點搜索速率:"
 
 #: src/emc/usr_intf/pncconf/x_motor.glade:48
 #: src/emc/usr_intf/pncconf/y_motor.glade:48
@@ -16557,10 +17100,6 @@ msgstr ""
 msgid "24"
 msgstr ""
 
-#: src/emc/usr_intf/pncconf/dialogs.glade:374
-msgid "17"
-msgstr ""
-
 #: src/emc/usr_intf/pncconf/dialogs.glade:451
 #, fuzzy
 msgid "Number of connectors:"
@@ -16651,10 +17190,6 @@ msgstr "微步乘係數:"
 #: src/emc/usr_intf/pncconf/dialogs.glade:2260
 msgid "Motor steps per revolution:"
 msgstr "電機步每轉:"
-
-#: src/emc/usr_intf/pncconf/dialogs.glade:1443
-msgid "10"
-msgstr ""
 
 #: src/emc/usr_intf/pncconf/dialogs.glade:1485
 msgid "      Voltage for Max RPM:"
@@ -17107,7 +17642,6 @@ msgstr ""
 #: src/emc/usr_intf/gscreen/gscreen.py:4264
 #: src/emc/usr_intf/gscreen/gscreen.py:4270
 #: src/emc/usr_intf/gscreen/gscreen.py:4273
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3676
 msgid "INFO:"
 msgstr ""
 
@@ -17275,32 +17809,24 @@ msgid "Manual Toolchange"
 msgstr "AXIS 手動 換刀"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3743
-#: src/emc/usr_intf/gmoccapy/dialogs.py:111
-#: src/emc/usr_intf/gmoccapy/dialogs.py:126
-#: src/emc/usr_intf/gmoccapy/dialogs.py:140
 msgid "Operator Message"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3777
 #: src/emc/usr_intf/gscreen/gscreen.py:3781
-#: src/emc/usr_intf/gmoccapy/dialogs.py:178
-#: src/emc/usr_intf/gmoccapy/dialogs.py:182
 #, fuzzy
 msgid "Restart Entry"
 msgstr "重新 起動"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3790
-#: src/emc/usr_intf/gmoccapy/dialogs.py:194
 msgid "Up"
 msgstr "向上"
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3792
-#: src/emc/usr_intf/gmoccapy/dialogs.py:196
 msgid "Enter"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.py:3794
-#: src/emc/usr_intf/gmoccapy/dialogs.py:198
 msgid "Down"
 msgstr "向下"
 
@@ -17380,33 +17906,33 @@ msgstr ""
 msgid "%d RPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4567
+#: src/emc/usr_intf/gscreen/gscreen.py:4566
 #, python-format
 msgid "Tool %(t)s     %(l)s"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4599
+#: src/emc/usr_intf/gscreen/gscreen.py:4598
 #, fuzzy, python-format
 msgid "%4.2f mm/min"
 msgstr "mm/分"
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4601
+#: src/emc/usr_intf/gscreen/gscreen.py:4600
 #, python-format
 msgid "%3.2f IPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4604
+#: src/emc/usr_intf/gscreen/gscreen.py:4603
 #, python-format
 msgid "%4.2f DPM"
 msgstr ""
 
-#: src/emc/usr_intf/gscreen/gscreen.py:4613
+#: src/emc/usr_intf/gscreen/gscreen.py:4612
 #, python-format
 msgid "%(n)s   View -%(v)s               %(t)s"
 msgstr ""
 
+#: src/emc/usr_intf/gscreen/gscreen.py:4621
 #: src/emc/usr_intf/gscreen/gscreen.py:4622
-#: src/emc/usr_intf/gscreen/gscreen.py:4623
 msgid " mm "
 msgstr ""
 
@@ -17528,14 +18054,12 @@ msgid "<b>Status</b>"
 msgstr "<b>冷卻液</b>"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1715
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2789
 msgid ""
 "Search\n"
 "  Text:"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1743
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2719
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17543,7 +18067,6 @@ msgid ""
 msgstr "替換："
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1762
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2729
 #, fuzzy
 msgid ""
 "Replace\n"
@@ -17551,7 +18074,6 @@ msgid ""
 msgstr "全部替換"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2744
 msgid ""
 "Ignore\n"
 " Case"
@@ -17568,7 +18090,6 @@ msgid "Main Level"
 msgstr "等級"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1858
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4061
 msgid "Themes"
 msgstr ""
 
@@ -17582,13 +18103,11 @@ msgid "DTG Text Color"
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1951
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4095
 #, fuzzy
 msgid "Warning Audio"
 msgstr "警告"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:1961
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4109
 msgid "Alert Audio"
 msgstr ""
 
@@ -17598,7 +18117,6 @@ msgid "Grid Size"
 msgstr "大小"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2021
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4546
 #, fuzzy
 msgid "Starting RPM"
 msgstr "設定"
@@ -17680,7 +18198,6 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:2328
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6665
 #, fuzzy
 msgid "Calibration"
 msgstr "校準(_C)"
@@ -17958,12 +18475,10 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3550
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2629
 msgid "Undo"
 msgstr "復原"
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3561
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2680
 msgid "Redo"
 msgstr "重做"
 
@@ -17988,6 +18503,8 @@ msgid ""
 msgstr ""
 
 #: src/emc/usr_intf/gscreen/gscreen.glade:3678
+#: lib/python/gladevcp/offsetpage.glade:108
+#: lib/python/gladevcp/offsetpage.glade:122
 msgid "G54"
 msgstr ""
 
@@ -18052,1664 +18569,718 @@ msgstr ""
 msgid "screen 2"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:246
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:251
-msgid "**** GMOCCAPY INI Entry **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:247
-#, fuzzy
-msgid "user mode selected"
-msgstr "選擇歸零"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:252
-#, python-brace-format
-msgid "logo entry found = {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:257
-msgid "**** GMOCCAPY INI Entry Error **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:258
-msgid "Logofile entry found, but could not be converted to path.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:259
-msgid "The file path should not contain any spaces"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:640
-#, python-brace-format
-msgid "Press to home all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:649
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:899
-msgid "Press to display previous homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:667
-#, python-brace-format
-msgid "Press to home {0} {1}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:680
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:923
-msgid "Press to display next homing button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:695
-#, python-brace-format
-msgid "Press to unhome all {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:701
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:959
-msgid "Press to return to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:731
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1795
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2026
-msgid "**** GMOCCAPY ERROR ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:732
-#, python-brace-format
-msgid ""
-"**** could not resolv the image path '{0}' given for macro button '{1}' ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:888
-msgid ""
-"  edit\n"
-"offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:890
-msgid "Press to edit the offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:910
-#, python-brace-format
-msgid "Press to set touch off value for axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:936
-msgid ""
-"zero\n"
-" G92"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:938
-msgid "Press to reset all G92 offsets"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:944
-msgid ""
-" Block\n"
-"Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:946
-msgid "Press to enter new value for block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:951
-msgid ""
-"    set\n"
-"selected"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:953
-msgid "Press to set the selected coordinate system to be the active one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:974
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:990
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1127
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1699
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1857
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1870
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1880
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1941
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1948
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1951
-msgid "**** GMOCCAPY INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:975
-msgid "**** no valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:976
-msgid "**** disabled tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:991
-msgid "**** found valid probe config in INI File ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:992
-msgid "**** will use auto tool measurement ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1007
-msgid "**** GMOCCAPY build_GUI INFO ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1008
-msgid "**** To many increments given in INI File for this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1009
-msgid "**** Only the first 10 will be reachable through this screen ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1128
-#, fuzzy, python-brace-format
-msgid "unknown jog command {0}"
-msgstr "未知的G代碼在使用"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1155
-#, python-brace-format
-msgid "Press to jog axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1174
-#, python-brace-format
-msgid "Press to jog joint {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1197
-msgid "**** GMOCCAPY INFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1198
-msgid "**** found more than 16 macros, will use only the first 16 ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1205
-msgid "Press to display previous macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1224
-#, python-brace-format
-msgid "Press to run macro {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1231
-msgid "Press to display next macro button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1251
-msgid "Press to display the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1355
-msgid "*****  GMOCCAPY ERROR  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1356
-msgid "this is not a lathe, as a lathe must have at least\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1357
-msgid "an X and an Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1358
-msgid "Wrong lathe configuration, we will leave here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1359
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1798
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2029
-msgid "Very critical situation"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1509
-msgid "*****  GMOCCAPY INFO  *****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1510
-msgid "this is not a usual config\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1511
-msgid "we miss one of X , Y or Z axis\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1512
-msgid "We will use by axisletter ordered jog button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1676
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2688
-#, fuzzy
-msgid "mm/min"
-msgstr "mm/分"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1679
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2691
-#, fuzzy
-msgid "inch/min"
-msgstr "英寸 / 分鐘"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1700
-msgid "**** Invalid embedded tab configuration ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1701
-msgid "**** No tabs will be added! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1714
-msgid "ERROR, trying to initialize the user tabs or panels, check for typos"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1796
-msgid "**** Did not find a toolfile file in [EMCIO] TOOL_TABLE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1858
-msgid "**** audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1871
-msgid "**** no audio available! ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1872
-msgid "**** PYGST libray not installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1873
-msgid "**** is python-gstX.XX installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1881
-msgid "**** Entering init gremlin ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1901
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4752
-#, fuzzy
-msgid ""
-" Joint\n"
-"mode"
-msgstr "Joint 模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1942
-msgid "**** virtual keyboard program found : <onboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1949
-msgid "**** virtual keyboard program found : <matchbox-keyboard>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1952
-msgid ""
-"**** No virtual keyboard installed, we checked for <onboard> and <matchbox-"
-"keyboard>."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1963
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3132
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3142
-msgid "**** GMOCCAPY ERROR ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1964
-msgid "**** Error with launching virtual keyboard,"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1965
-msgid "**** is onboard or matchbox-keyboard installed? ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:1997
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2812
-msgid "interrupt running macro"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2027
-msgid "**** Did not find a parameter file in [RS274NGC] PARAMETER_FILE ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2097
-msgid "Select the file you want to be loaded at program start"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2131
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2155
-#, python-brace-format
-msgid "**** GMOCCAPY ERROR **** /n Message type {0} not supported"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2268
-msgid "Unknown error type and no error text given"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2282
-msgid "Important Warning"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2302
-msgid "ERROR : External ESTOP is set, could not change state!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2315
-msgid "ERROR : Could not switch the machine on, is limit switch activated?"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2578
-msgid "It is not possible to change to MDI Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2610
-msgid "It is not possible to change to Auto Mode at the moment"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2771
-msgid "Enter value:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2772
-#, fuzzy, python-brace-format
-msgid "Set parameter {0} to:"
-msgstr " 參數(_m) "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2774
-msgid "conversion error"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2775
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4455
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4478
-msgid "Conversion error !"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2810
-msgid "This button will show or hide the keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:2918
-#, fuzzy
-msgid "Mode change is only allowed if the interpreter is idle!"
-msgstr "不能做到這一點（%s）在自動模式與翻譯空閒"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3133
-#, python-brace-format
-msgid "**** {0} ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3143
-#, python-brace-format
-msgid "**** No widget named: {0} to sensitize ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3305
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1671
-msgid "No tool description available"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3426
-#, python-brace-format
-msgid "Halo, welcome to the test message {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3522
-msgid "Hal Pin is low, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3524
-msgid "wrong code entered, Access denied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3525
-msgid "Just to warn you"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3628
-msgid "ERROR : No limit switch is active, ignore limits will not be set."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3677
-#, fuzzy
-msgid "Classicladder real-time component not detected"
-msgstr "實時元件沒有加載"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3792
-#, python-brace-format
-msgid "Something went wrong, we have an unknown spindle widget {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3903
-msgid "Do you really want to delete the MDI history?\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3904
-msgid "this will not delete the MDI History file, but will\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3905
-msgid "delete the listbox entries for this session"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:3906
-msgid "Attention!!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4024
-#, fuzzy
-msgid "Enter value for diameter"
-msgstr "非整數值對整數"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4025
-#, fuzzy
-msgid "Set diameter to:"
-msgstr "  直徑"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4028
-#, fuzzy
-msgid "Enter value for radius"
-msgstr "非整數值對整數"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4029
-#, fuzzy
-msgid "Set radius to:"
-msgstr "  半徑"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4032
-#, fuzzy, python-brace-format
-msgid "Enter value for axis {0}"
-msgstr "非整數值對整數"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4033
-#, fuzzy, python-brace-format
-msgid "Set axis {0} to:"
-msgstr "設定軸 偏移量:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4037
-msgid "Conversion error in btn_set_value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4038
-msgid "Conversion error in btn_set_value!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4039
-msgid "Please enter only numerical values. Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4053
-msgid ""
-"you did not selected a system to be changed to, so nothing will be changed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4054
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4484
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4498
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4502
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4517
-msgid "Important Warning!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4104
-msgid "Enter the block height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4105
-msgid "Block height measured from base table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4117
-msgid "Conversion error in btn_block_height!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4118
-msgid ""
-"Please enter only numerical values\n"
-"Values have not been applied"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4377
-msgid "Please remove the mounted tool and press OK when done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4380
-#, python-brace-format
-msgid ""
-"Please change to tool\n"
-"\n"
-"# {0:d}     {1}\n"
-"\n"
-" then click OK."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4381
-#, fuzzy
-msgid "Manual Tool change"
-msgstr "AXIS 手動 換刀"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4390
-msgid "Tool Change has been aborted!\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4391
-msgid "The old tool will remain set!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4399
-msgid "You are trying to delete the tool mounted in the spindle\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4400
-msgid "This is not allowed, please change tool prior to delete it"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4401
-msgid "Warning Tool can not be deleted!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4420
-msgid "No or more than one tool selected in tool table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4421
-msgid "Please select only one tool in the table"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4422
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4428
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4436
-msgid "Warning Tool Touch off not possible!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4426
-msgid "you can not touch of a tool, witch is not mounted in the spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4427
-msgid "your selection has been reseted to the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4434
-#, fuzzy
-msgid ""
-"Tool touch off is not possible with cutter radius compensation switched on!\n"
-msgstr "不能改變刀具補償當刀具半徑補償在使用"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4435
-msgid "Please emit an G40 before tool touch off"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4444
-msgid "Real big error!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4445
-msgid ""
-"You managed to come to a place that is not possible in on_btn_tool_touchoff"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4449
-#, python-brace-format
-msgid "Enter value for axis {0} to set:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4450
-#, python-brace-format
-msgid "Set parameter of tool {0:d} and axis {1} to:"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4454
-#, python-brace-format
-msgid "Conversion error because of wrong entry for touch off axis {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4473
-msgid "Enter the tool number as integer "
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4474
-#, fuzzy
-msgid "Select the tool to change"
-msgstr "選擇項目 以探測"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4476
-msgid "Conversion error because of wrong entry for tool number\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4477
-msgid "enter only integer numbers"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4483
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4501
-msgid "Selected tool is already in spindle, no change needed."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4497
-msgid ""
-"you selected no or more than one tool, the tool selection must be unique"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4516
-msgid "Could not understand the entered tool number. Will not change anything"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4757
-#, fuzzy
-msgid ""
-"World\n"
-"mode"
-msgstr "World 模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4943
-msgid "Axis jogging is only allowed in world mode, but you are in joint mode!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4979
-#, python-brace-format
-msgid "Recieved a not clasified signal from pin {0}"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4984
-#, python-brace-format
-msgid "Could not translate {0} to number"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4989
-msgid "no button here"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4992
-msgid "the button is not sensitive"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:4997
-#, python-brace-format
-msgid "Button {0} has been toggled"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5001
-#, python-brace-format
-msgid "Button {0} has been pressed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5004
-#, python-brace-format
-msgid "Button {0} has been clicked"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.py:5017
-msgid "got wrong location to locate the childs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:46
-#: src/emc/usr_intf/gmoccapy/dialogs.py:51
-msgid "Enter System Unlock Code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter value"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/dialogs.py:72
-msgid "Enter the value to set"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:100
-msgid "**** GMOCCAPY GETINIINFO : ****"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:101
-#, python-brace-format
-msgid ""
-"**** gmoccapy can only handle 9 axis, ****\n"
-"**** but you have given {0} through your INI file ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:102
-msgid ""
-"**** gmoccapy will not start ****\n"
-"\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:402
-msgid "**** GMOCCAPY GETINIINFO ****\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/getiniinfo.py:403
-msgid ""
-"**** No subroutine folder or program prefix is given in the ini file **** \n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/notification.py:205
-#, python-format
-msgid "Error trying to delet the message with number %s"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:426
-msgid "left rotate,  middle move,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:430
-msgid "left zoom,  middle move,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:434
-msgid "left move,  middle rotate,  right zoom"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:438
-msgid "left zoom,  middle rotate,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:442
-msgid "left move,  middle zoom,  right rotate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:446
-msgid "left rotate,  middle zoom,  right move"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:535
-#, fuzzy
-msgid "No Program loaded"
-msgstr "程序檔案"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:579
-msgid "blockheight = 0.0"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:613
-#, fuzzy
-msgid "clear plot"
-msgstr "清除 現場 繪圖"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:676
-#, fuzzy
-msgid "view perspective"
-msgstr "透視 視圖"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:701
-msgid "view along the X axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:728
-msgid "view along the Y axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:755
-msgid "view along the Z axis from positive to negative"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:784
-msgid "Show or hide tool path"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:809
-msgid "Show or hide dimensions"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:834
-msgid ""
-"view along the Y axis from positive to negative as viewn for a back tool "
-"lathe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:902
-#, fuzzy
-msgid "Offset Page"
-msgstr "偏移 值 "
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:922
-#, fuzzy
-msgid "Tooledit"
-msgstr "刀具"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:946
-msgid "File Selection"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1208
-msgid "jog axes"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1294
-#, fuzzy
-msgid "jog joints"
-msgstr "輸入輸出點"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1315
-msgid "Logo"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1331
-#, fuzzy
-msgid "Ignore limits"
-msgstr "超速 極限"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1399
-#, fuzzy
-msgid "<b>Jogging</b>"
-msgstr "<b>歸零</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1529
-msgid "Information over the tool in spindle"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1550
-#, fuzzy
-msgid "Tool no."
-msgstr "刀具訊息"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1578
-#, fuzzy
-msgid "Diameter"
-msgstr "  直徑"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1609
-#, fuzzy
-msgid "offset z"
-msgstr "偏移"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1640
-#, fuzzy
-msgid "offset x"
-msgstr "偏移"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1688
-msgid "Vc= 0.00"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1705
-#, fuzzy
-msgid "<b>Tool information</b>"
-msgstr "<b>配置</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1720
-msgid "G and M code information as well as speed and feed"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1743
-#, fuzzy
-msgid "active_mcodes_label"
-msgstr "代碼中使用負值m"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1806
-#, fuzzy
-msgid "active_gcodes_label"
-msgstr "代碼中使用負值g"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1870
-#, fuzzy
-msgid "<b>G-Code</b>"
-msgstr "<b>電源</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:1972
-#, fuzzy
-msgid "<b>Cooling</b>"
-msgstr "<b>冷卻液</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2283
-#, fuzzy
-msgid "<b>Spindle [rpm]</b>"
-msgstr "<b>主軸</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2370
-msgid "Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2389
-msgid "Displays the current velocity"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2438
-#, fuzzy
-msgid "<b>Rapid Override</b>"
-msgstr "<b>外部 主軸 超速</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2477
-msgid "Displayes the programmed feed rate"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2500
-#, fuzzy
-msgid "reset feed override to 100 %"
-msgstr "進給 超速設為從　0% 至　100%"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2542
-#, fuzzy
-msgid "<b>Feed Override</b>"
-msgstr "<b>外部　進給 超速</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2644
-msgid ""
-"Search\n"
-" back"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2662
-msgid ""
-"Search\n"
-"  fwd"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2770
-msgid "Replace"
-msgstr "替換"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2909
-msgid "Start as fullscreen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2926
-msgid "Start maximized"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2943
-msgid "Start as window"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2971
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4894
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5549
-#, fuzzy
-msgid "X Pos."
-msgstr "位置"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:2985
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4906
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5533
-#, fuzzy
-msgid "Y Pos."
-msgstr "位置"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3001
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5451
-msgid "Width"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3017
-msgid "Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3125
-msgid "hide cursor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3148
-#, fuzzy
-msgid "<b>Main Window</b>"
-msgstr "<b>機器 基本</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3178
-#, fuzzy
-msgid "Show keyboard on offset"
-msgstr "顯示 偏移量(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3195
-msgid "Show keyboard on tooledit"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3212
-msgid "Show keyboard on MDI"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3229
-msgid "Show keyboard on EDIT"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3246
-msgid "Show keyboard on load file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3268
-#, fuzzy
-msgid "<b>Keyboard</b>"
-msgstr "<b>電源</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3299
-#, fuzzy
-msgid "show preview"
-msgstr "預演"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3316
-#, fuzzy
-msgid "show offsets"
-msgstr "顯示 偏移量(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3338
-msgid "<b>On Touch off</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3387
-#, fuzzy
-msgid "Relative Color"
-msgstr "相對位置"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3416
-#, fuzzy
-msgid "Absolute Color"
-msgstr "絕對反饋"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3449
-msgid "DTG Color"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3493
-#, fuzzy
-msgid "Homed color"
-msgstr "全部 歸零"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3508
-#, fuzzy
-msgid "Unhomed color"
-msgstr "離零"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3613
-msgid "Digits"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3663
-msgid ""
-"toggle DRO mode \n"
-"clicking on the DRO"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3702
-#, fuzzy
-msgid "<b>DRO</b>"
-msgstr "<b>電源</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3739
-#, fuzzy
-msgid "Grid size"
-msgstr "大小"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3776
-#, fuzzy
-msgid "Show DRO"
-msgstr "展示"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3792
-#, fuzzy
-msgid "Show offsets"
-msgstr "顯示 偏移量(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3808
-#, fuzzy
-msgid "Show DTG"
-msgstr "展示"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3838
-#, fuzzy
-msgid "<b>Mouse Button mode</b>"
-msgstr "<b>外部　按鈕　慢步</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3878
-#, fuzzy
-msgid "<b>Preview</b>"
-msgstr "<b>電源</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3937
-#, fuzzy
-msgid ""
-"current\n"
-"   file"
-msgstr "重新打開 當前 文件 [Control-R]"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:3986
-msgid "<b>File to load on start</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4016
-#, fuzzy
-msgid "Select user dir"
-msgstr "選擇 慢步 速度"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4026
-#, fuzzy
-msgid "<b>Select jump to dir</b>"
-msgstr "選擇項目 以探測"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4156
-msgid "<b>Themes and sound</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4193
-msgid "Appearance"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4233
-#, fuzzy
-msgid "Scale rapid override"
-msgstr "設定 主軸超速"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4249
-#, fuzzy
-msgid "Scale jog velocity"
-msgstr "顯示 速率(_e)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4263
-#, fuzzy
-msgid "Scale feed override"
-msgstr "設定 超速調整:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4279
-#, fuzzy
-msgid "Scale spindle override"
-msgstr "設定 主軸超速"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4382
-#, fuzzy
-msgid "<b>Hardware MPG Scale</b>"
-msgstr "<b>步進馬達比例</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4408
-msgid "Use keyboard shortcuts"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4423
-msgid "<b>Keyboard shortcuts</b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4453
-#, fuzzy
-msgid "Use unlock code"
-msgstr "未使用的編碼器"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4470
-msgid "Do not use unlock code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4487
-msgid "Use hal pin to unlock"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4510
-#, fuzzy
-msgid "<b>Unlock settings</b>"
-msgstr "<b>歸零</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4631
-#, fuzzy
-msgid "Spindle bar min"
-msgstr "主軸 剎車 開"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4645
-#, fuzzy
-msgid "Spindle bar max"
-msgstr "主軸 剎車 開"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4692
-msgid "Hide turtle Jog Button"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4729
-msgid "Turtle jog Factor"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4770
-#, fuzzy
-msgid "<b>Turtle Jog</b>"
-msgstr "<b>　前　台　</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4817
-msgid "Hardware"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4855
-msgid "Use auto tool measurement"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4920
-msgid "Probe Height"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4958
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4972
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5003
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5034
-msgid "0.000"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:4989
-#, fuzzy
-msgid "Z Pos."
-msgstr "位置"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5020
-msgid "Max. Probe"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5054
-#, fuzzy
-msgid "<b>Probe Informations</b>"
-msgstr "<b>配置</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5090
-#, fuzzy
-msgid "Search Vel."
-msgstr "零點搜索速率:"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5102
-msgid "Probe Vel."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5163
-#, fuzzy
-msgid "<b>Probe velocitys</b>"
-msgstr "<b>GUI前台列表</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5178
-msgid ""
-"No valid configuration\n"
-"found in your INI file,\n"
-"please take a look at \n"
-"the WIKI to check how\n"
-"to configure the settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5199
-#, fuzzy
-msgid "<b>Tool Measurement</b>"
-msgstr "<b>冷卻液</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5229
-#, fuzzy
-msgid "Reload Tool on Start"
-msgstr "重新 載入 刀具表"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5233
-msgid ""
-"If checked, the tool in spindle\n"
-"will be saved on each change\n"
-"and the last tool will be reloaded\n"
-"at start of the GUI. Also it's \n"
-"length offset will be reloaded.\n"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5254
-msgid ""
-"You use NO_FORCE_HOMING,\n"
-"so the reload of a tool at start\n"
-"is not possible."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5272
-#, fuzzy
-msgid "<b>Reload Tool</b>"
-msgstr "重新 載入 刀具表"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5314
-msgid "Do not use run from line"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5331
-#, fuzzy
-msgid "Use run from line"
-msgstr "運行選定的行(_n)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5354
-#, fuzzy
-msgid "<b>Run from line</b>"
-msgstr "<b>歸零</b>"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5398
-msgid "Use frames"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5402
-msgid ""
-"If checked, the messages\n"
-"will be in a frame."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5435
-msgid "max."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5465
-msgid "The font to use"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5481
-msgid "The maximum messages you want to be shown\t"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5505
-msgid "The width of the messages"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5560
-msgid "X-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5582
-msgid "Y-position in pixel from top left corner of the screen"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5604
-#, fuzzy
-msgid "Launch test message"
-msgstr "啟動測試面板"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5608
-msgid ""
-"Push here to launch a test message\n"
-"to test your settings."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5627
-msgid ""
-"<b>      gmoccapy message\n"
-" behavior and appearance </b>"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5664
-#, fuzzy
-msgid ""
-"Advanced\n"
-" Settings"
-msgstr "進階選項"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5705
-msgid "User tab 1"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5720
-msgid "User tabs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5761
-msgid ""
-"Estop the machine\n"
-"[F1]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5786
-#, fuzzy
-msgid ""
-"Turn the machine on/off\n"
-"[F2]"
-msgstr "開動 機器"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5811
-msgid ""
-"enter manual mode to jog axis by hand or touch off\n"
-"[F3]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5833
-msgid ""
-"enter MDI mode to launch g-code commands\n"
-"[F5]"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5854
-msgid "enter auto mode to run programs"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5873
-msgid "Enter the settings page, the default code is \"123\""
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5897
-#, fuzzy
-msgid "show user tabs"
-msgstr "顯示重開"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5955
-msgid "open homing button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:5973
-#, fuzzy
-msgid "open touch off button list"
-msgstr "刀具 對 夾具 對刀(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6004
-msgid "Open the tooleditor page"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6050
-#, fuzzy
-msgid ""
-"World\n"
-"Mode"
-msgstr "World 模式"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6057
-msgid ""
-"Switch motion mode between Joint and World mode\n"
-"F12 or $ key does the same"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6101
-msgid "make the preview as large as possible"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6119
-msgid "Close gmoccapy / leave the program"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6208
-#, fuzzy
-msgid "Load a new program"
-msgstr "重裝 程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6247
-#, fuzzy
-msgid "Run the loaded program"
-msgstr "重裝 程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6265
-#, fuzzy
-msgid "Stop the running program"
-msgstr "停止 正在 運行 的程序, 或"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6283
-#, fuzzy
-msgid "Pause the running program"
-msgstr "停止 正在 運行 的程序, 或"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6292
-#, fuzzy
-msgid "pause the running program"
-msgstr "停止 正在 運行 的程序, 或"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6310
-msgid "Run the  loaded program step by step"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6327
-msgid ""
-"run the program from a certain line, attention, that is dangerous, because "
-"the previous lines will not checed!"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6345
-msgid ""
-"Machine or not the optional blocks of the program. If the button is pressed, "
-"the optional blocks will not be machined. The button will indicate this by a "
-"yellow background."
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6388
-#, fuzzy
-msgid "Edit the loaded program"
-msgstr "重裝 程序"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6532
-#, fuzzy
-msgid "delete MDI"
-msgstr "刪除"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6538
-#, fuzzy
-msgid "delete MDI history"
-msgstr "清除 MDI 歷史"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6592
-msgid "Cl.-ladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6598
-msgid "Open classicladder"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6610
-#, fuzzy
-msgid "Hal-Scope"
-msgstr "HAL 顯示器"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6616
-msgid "launch hal scope"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6634
-msgid "launch linuxcnc status"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6652
-msgid "launch hal meter"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6671
-#, fuzzy
-msgid "launch calibration"
-msgstr "校準(_C)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6683
-msgid "Halshow"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6689
-msgid "opens the show hal tool"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6759
-msgid "save the file using the original name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6782
-msgid "save the file with a new name"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6831
-msgid "clear the edit field and make a new file"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6870
-msgid "Show or hide the virtual keyboard"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6896
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7125
-msgid "Go back to main button list"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6935
-msgid "delete selected tool or tools"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6953
-#, fuzzy
-msgid "add a new tool to tool table"
-msgstr "重新載入刀具表(_b)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6965
-#, fuzzy
-msgid "Reload"
-msgstr "重新載入(_R)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6971
-#, fuzzy
-msgid "reload tool table from file"
-msgstr "重新載入刀具表(_b)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:6989
-msgid ""
-"apply the changes you made, G43 will be excecuted only if it is active g-code"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7006
-#, fuzzy
-msgid "Select a tool by number"
-msgstr "選擇項目 以探測"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7030
-msgid "change tool with the command M61 Q?, no machine move will be done"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7054
-msgid "change tool to the selected one"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7067
-#, fuzzy
-msgid ""
-"touchoff\n"
-"  tool x"
-msgstr "刀具 對 夾具 對刀(_f)"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7075
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7108
-#, fuzzy
-msgid "touch off the tool and set the value to the tool table"
-msgstr "請求工具 %d 刀具表找不到"
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7100
-msgid ""
-"touchoff\n"
-"  tool z"
-msgstr ""
-
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7164
+#: lib/python/gladevcp/iconview.py:112
 msgid "Move to your home directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7182
-msgid "Move to parrent directory"
+#: lib/python/gladevcp/iconview.py:120
+msgid "Move to parent directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7213
+#: lib/python/gladevcp/iconview.py:128
 #, fuzzy
-msgid "Select the previos file"
+msgid "Select the previous file"
 msgstr "選擇項目 以探測"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7232
+#: lib/python/gladevcp/iconview.py:136
 #, fuzzy
 msgid "Select the next file"
 msgstr "選擇項目 以探測"
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7251
+#: lib/python/gladevcp/iconview.py:160
 msgid "Jump to user defined directory"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7283
+#: lib/python/gladevcp/iconview.py:168
 msgid "select the highlighted file and return the path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7315
+#: lib/python/gladevcp/iconview.py:176
 msgid "Close without returning a file path"
 msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7335
-#, fuzzy
-msgid "Load File"
-msgstr "程序檔案"
+#: lib/python/gladevcp/offsetpage_widget.py:142
+msgid ""
+"**** Offsetpage widget ERROR: LINEAR_UNITS not found in INI's TRAJ section"
+msgstr ""
 
-#: src/emc/usr_intf/gmoccapy/gmoccapy.glade:7395
+#: lib/python/gladevcp/offsetpage_widget.py:342
+msgid "offsetpage widget error: unrecognized float input"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:379
+msgid "offsetpage widget error: MDI call error"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:398
+msgid "MDI error in offsetpage widget -zero G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:415
+msgid "MDI error in offsetpage widget-zero rotational offset"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage_widget.py:486
+msgid "offsetpage_widget error: cannot select coordinate system"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:225
+msgid "tooledit_widget error: cannot select tool number"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:244
 #, fuzzy
-msgid "home joints"
-msgstr "輸入輸出點"
+msgid "Toolfile does not exist"
+msgstr "刀具文件是　%s"
+
+#: lib/python/gladevcp/tooledit_widget.py:278
+msgid "Tooledit widget int error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:283
+msgid "Tooledit_widget float error"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_widget.py:320
+#, fuzzy
+msgid "Reloading tooltable into linuxcnc failed"
+msgstr "重新載入刀具表(_b)"
+
+#: lib/python/gladevcp/tooledit_widget.py:480
+msgid "Tool file was modified since it was last read"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:103
+#: lib/python/gladevcp/gladevcp-test.glade:119
+msgid "radiobutton"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:159
+#, fuzzy
+msgid "checkbutton"
+msgstr "滾輪 按鍵"
+
+#: lib/python/gladevcp/gladevcp-test.glade:183
+msgid "button"
+msgstr ""
+
+#: lib/python/gladevcp/gladevcp-test.glade:194
+#, fuzzy
+msgid "togglebutton"
+msgstr "切換 淹浸"
+
+#: lib/python/gladevcp/offsetpage.glade:40
+#: lib/python/gladevcp/offsetpage.glade:54
+#, fuzzy
+msgid "Tool"
+msgstr "刀具:"
+
+#: lib/python/gladevcp/offsetpage.glade:53
+#: lib/python/gladevcp/offsetpage.glade:70
+#: lib/python/gladevcp/offsetpage.glade:87
+#: lib/python/gladevcp/offsetpage.glade:104
+#: lib/python/gladevcp/offsetpage.glade:121
+#: lib/python/gladevcp/offsetpage.glade:138
+#: lib/python/gladevcp/offsetpage.glade:155
+#: lib/python/gladevcp/offsetpage.glade:172
+#: lib/python/gladevcp/offsetpage.glade:189
+#: lib/python/gladevcp/offsetpage.glade:206
+#: lib/python/gladevcp/offsetpage.glade:223
+#: lib/python/gladevcp/offsetpage.glade:240
+#: lib/python/gladevcp/offsetpage.glade:257
+#, fuzzy
+msgid "black"
+msgstr "黑"
+
+#: lib/python/gladevcp/offsetpage.glade:57
+#: lib/python/gladevcp/offsetpage.glade:71
+msgid "G5x"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:74
+msgid "Rot"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:88
+#, fuzzy
+msgid "Rotation of Z"
+msgstr "旋轉 或 平移"
+
+#: lib/python/gladevcp/offsetpage.glade:91
+#: lib/python/gladevcp/offsetpage.glade:105
+msgid "G92"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:125
+#: lib/python/gladevcp/offsetpage.glade:139
+msgid "G55"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:142
+#: lib/python/gladevcp/offsetpage.glade:156
+msgid "G56"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:159
+#: lib/python/gladevcp/offsetpage.glade:173
+msgid "G57"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:176
+#: lib/python/gladevcp/offsetpage.glade:190
+msgid "G58"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:193
+#: lib/python/gladevcp/offsetpage.glade:207
+msgid "G59"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:210
+#: lib/python/gladevcp/offsetpage.glade:224
+msgid "G59.1"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:227
+#: lib/python/gladevcp/offsetpage.glade:241
+msgid "G59.2"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:244
+#: lib/python/gladevcp/offsetpage.glade:258
+msgid "G59.3"
+msgstr ""
+
+#: lib/python/gladevcp/offsetpage.glade:285
+#, fuzzy
+msgid "Offset"
+msgstr "位移:"
+
+#: lib/python/gladevcp/offsetpage.glade:416
+#, fuzzy
+msgid "Offset Name"
+msgstr "偏移 值 "
+
+#: lib/python/gladevcp/offsetpage.glade:442
+#, fuzzy
+msgid ""
+"Zero\n"
+"G92"
+msgstr "置零 于 所有G5"
+
+#: lib/python/gladevcp/offsetpage.glade:456
+#, fuzzy
+msgid ""
+"    Zero\n"
+"Rotational"
+msgstr "水平"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:80
+#: lib/python/gladevcp/tooledit_gtk.glade:391
+#: lib/python/gladevcp/tooledit_gtk.glade:613
+#, fuzzy
+msgid "Select"
+msgstr "選擇(_S)"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:93
+#: lib/python/gladevcp/tooledit_gtk.glade:402
+#: lib/python/gladevcp/tooledit_gtk.glade:624
+#, fuzzy
+msgid "Tool#"
+msgstr "刀具 #:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:109
+#: lib/python/gladevcp/tooledit_gtk.glade:413
+#: lib/python/gladevcp/tooledit_gtk.glade:635
+msgid "Pocket"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:222
+#, fuzzy
+msgid "Diameter"
+msgstr "  直徑"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:237
+#: lib/python/gladevcp/tooledit_gtk.glade:538
+#: lib/python/gladevcp/tooledit_gtk.glade:760
+#, fuzzy
+msgid "Front"
+msgstr "正面 視圖"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:259
+#: lib/python/gladevcp/tooledit_gtk.glade:560
+#: lib/python/gladevcp/tooledit_gtk.glade:782
+msgid "Orientation"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:270
+#: lib/python/gladevcp/tooledit_gtk.glade:571
+#: lib/python/gladevcp/tooledit_gtk.glade:793
+#, fuzzy
+msgid "Comments"
+msgstr "指令："
+
+#: lib/python/gladevcp/tooledit_gtk.glade:325
+#, fuzzy
+msgid "Reload"
+msgstr "重新載入(_R)"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:369
+#, fuzzy
+msgid "All Offsets"
+msgstr "軸向的 偏置"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:424
+msgid "X Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:446
+msgid "Z Wear"
+msgstr ""
+
+#: lib/python/gladevcp/tooledit_gtk.glade:523
+#: lib/python/gladevcp/tooledit_gtk.glade:745
+#, fuzzy
+msgid "DIameter"
+msgstr "  直徑"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:590
+#, fuzzy
+msgid "Lathe Wear Offsets"
+msgstr "工件 位移:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:646
+#, fuzzy
+msgid "X Tool"
+msgstr "刀具:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:668
+#, fuzzy
+msgid "Z Tool"
+msgstr "刀具:"
+
+#: lib/python/gladevcp/tooledit_gtk.glade:812
+#, fuzzy
+msgid "Lathe Tool Offsets"
+msgstr "設置 刀具 偏移量"
+
+#~ msgid "filename:"
+#~ msgstr "文件名:"
+
+#, fuzzy
+#~ msgid "user mode selected"
+#~ msgstr "選擇歸零"
+
+#, fuzzy
+#~ msgid "unknown jog command {0}"
+#~ msgstr "未知的G代碼在使用"
+
+#, fuzzy
+#~ msgid "mm/min"
+#~ msgstr "mm/分"
+
+#, fuzzy
+#~ msgid "inch/min"
+#~ msgstr "英寸 / 分鐘"
+
+#, fuzzy
+#~ msgid ""
+#~ " Joint\n"
+#~ "mode"
+#~ msgstr "Joint 模式"
+
+#, fuzzy
+#~ msgid "Set parameter {0} to:"
+#~ msgstr " 參數(_m) "
+
+#, fuzzy
+#~ msgid "Mode change is only allowed if the interpreter is idle!"
+#~ msgstr "不能做到這一點（%s）在自動模式與翻譯空閒"
+
+#, fuzzy
+#~ msgid "Classicladder real-time component not detected"
+#~ msgstr "實時元件沒有加載"
+
+#, fuzzy
+#~ msgid "Enter value for diameter"
+#~ msgstr "非整數值對整數"
+
+#, fuzzy
+#~ msgid "Set diameter to:"
+#~ msgstr "  直徑"
+
+#, fuzzy
+#~ msgid "Enter value for radius"
+#~ msgstr "非整數值對整數"
+
+#, fuzzy
+#~ msgid "Set radius to:"
+#~ msgstr "  半徑"
+
+#, fuzzy
+#~ msgid "Enter value for axis {0}"
+#~ msgstr "非整數值對整數"
+
+#, fuzzy
+#~ msgid "Set axis {0} to:"
+#~ msgstr "設定軸 偏移量:"
+
+#, fuzzy
+#~ msgid "Manual Tool change"
+#~ msgstr "AXIS 手動 換刀"
+
+#, fuzzy
+#~ msgid ""
+#~ "Tool touch off is not possible with cutter radius compensation switched "
+#~ "on!\n"
+#~ msgstr "不能改變刀具補償當刀具半徑補償在使用"
+
+#, fuzzy
+#~ msgid "Select the tool to change"
+#~ msgstr "選擇項目 以探測"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "mode"
+#~ msgstr "World 模式"
+
+#, fuzzy
+#~ msgid "No Program loaded"
+#~ msgstr "程序檔案"
+
+#, fuzzy
+#~ msgid "clear plot"
+#~ msgstr "清除 現場 繪圖"
+
+#, fuzzy
+#~ msgid "view perspective"
+#~ msgstr "透視 視圖"
+
+#, fuzzy
+#~ msgid "Tooledit"
+#~ msgstr "刀具"
+
+#, fuzzy
+#~ msgid "jog joints"
+#~ msgstr "輸入輸出點"
+
+#, fuzzy
+#~ msgid "Ignore limits"
+#~ msgstr "超速 極限"
+
+#, fuzzy
+#~ msgid "<b>Jogging</b>"
+#~ msgstr "<b>歸零</b>"
+
+#, fuzzy
+#~ msgid "Tool no."
+#~ msgstr "刀具訊息"
+
+#, fuzzy
+#~ msgid "offset z"
+#~ msgstr "偏移"
+
+#, fuzzy
+#~ msgid "offset x"
+#~ msgstr "偏移"
+
+#, fuzzy
+#~ msgid "<b>Tool information</b>"
+#~ msgstr "<b>配置</b>"
+
+#, fuzzy
+#~ msgid "active_mcodes_label"
+#~ msgstr "代碼中使用負值m"
+
+#, fuzzy
+#~ msgid "active_gcodes_label"
+#~ msgstr "代碼中使用負值g"
+
+#, fuzzy
+#~ msgid "<b>G-Code</b>"
+#~ msgstr "<b>電源</b>"
+
+#, fuzzy
+#~ msgid "<b>Cooling</b>"
+#~ msgstr "<b>冷卻液</b>"
+
+#, fuzzy
+#~ msgid "<b>Spindle [rpm]</b>"
+#~ msgstr "<b>主軸</b>"
+
+#, fuzzy
+#~ msgid "<b>Rapid Override</b>"
+#~ msgstr "<b>外部 主軸 超速</b>"
+
+#, fuzzy
+#~ msgid "reset feed override to 100 %"
+#~ msgstr "進給 超速設為從　0% 至　100%"
+
+#, fuzzy
+#~ msgid "<b>Feed Override</b>"
+#~ msgstr "<b>外部　進給 超速</b>"
+
+#~ msgid "Replace"
+#~ msgstr "替換"
+
+#, fuzzy
+#~ msgid "X Pos."
+#~ msgstr "位置"
+
+#, fuzzy
+#~ msgid "Y Pos."
+#~ msgstr "位置"
+
+#, fuzzy
+#~ msgid "<b>Main Window</b>"
+#~ msgstr "<b>機器 基本</b>"
+
+#, fuzzy
+#~ msgid "Show keyboard on offset"
+#~ msgstr "顯示 偏移量(_f)"
+
+#, fuzzy
+#~ msgid "<b>Keyboard</b>"
+#~ msgstr "<b>電源</b>"
+
+#, fuzzy
+#~ msgid "show preview"
+#~ msgstr "預演"
+
+#, fuzzy
+#~ msgid "show offsets"
+#~ msgstr "顯示 偏移量(_f)"
+
+#, fuzzy
+#~ msgid "Relative Color"
+#~ msgstr "相對位置"
+
+#, fuzzy
+#~ msgid "Absolute Color"
+#~ msgstr "絕對反饋"
+
+#, fuzzy
+#~ msgid "Homed color"
+#~ msgstr "全部 歸零"
+
+#, fuzzy
+#~ msgid "Unhomed color"
+#~ msgstr "離零"
+
+#, fuzzy
+#~ msgid "<b>DRO</b>"
+#~ msgstr "<b>電源</b>"
+
+#, fuzzy
+#~ msgid "Grid size"
+#~ msgstr "大小"
+
+#, fuzzy
+#~ msgid "Show DRO"
+#~ msgstr "展示"
+
+#, fuzzy
+#~ msgid "Show offsets"
+#~ msgstr "顯示 偏移量(_f)"
+
+#, fuzzy
+#~ msgid "Show DTG"
+#~ msgstr "展示"
+
+#, fuzzy
+#~ msgid "<b>Mouse Button mode</b>"
+#~ msgstr "<b>外部　按鈕　慢步</b>"
+
+#, fuzzy
+#~ msgid "<b>Preview</b>"
+#~ msgstr "<b>電源</b>"
+
+#, fuzzy
+#~ msgid ""
+#~ "current\n"
+#~ "   file"
+#~ msgstr "重新打開 當前 文件 [Control-R]"
+
+#, fuzzy
+#~ msgid "Select user dir"
+#~ msgstr "選擇 慢步 速度"
+
+#, fuzzy
+#~ msgid "<b>Select jump to dir</b>"
+#~ msgstr "選擇項目 以探測"
+
+#, fuzzy
+#~ msgid "Scale rapid override"
+#~ msgstr "設定 主軸超速"
+
+#, fuzzy
+#~ msgid "Scale jog velocity"
+#~ msgstr "顯示 速率(_e)"
+
+#, fuzzy
+#~ msgid "Scale feed override"
+#~ msgstr "設定 超速調整:"
+
+#, fuzzy
+#~ msgid "Scale spindle override"
+#~ msgstr "設定 主軸超速"
+
+#, fuzzy
+#~ msgid "<b>Hardware MPG Scale</b>"
+#~ msgstr "<b>步進馬達比例</b>"
+
+#, fuzzy
+#~ msgid "Use unlock code"
+#~ msgstr "未使用的編碼器"
+
+#, fuzzy
+#~ msgid "<b>Unlock settings</b>"
+#~ msgstr "<b>歸零</b>"
+
+#, fuzzy
+#~ msgid "Spindle bar min"
+#~ msgstr "主軸 剎車 開"
+
+#, fuzzy
+#~ msgid "Spindle bar max"
+#~ msgstr "主軸 剎車 開"
+
+#, fuzzy
+#~ msgid "<b>Turtle Jog</b>"
+#~ msgstr "<b>　前　台　</b>"
+
+#, fuzzy
+#~ msgid "Z Pos."
+#~ msgstr "位置"
+
+#, fuzzy
+#~ msgid "<b>Probe Informations</b>"
+#~ msgstr "<b>配置</b>"
+
+#, fuzzy
+#~ msgid "Search Vel."
+#~ msgstr "零點搜索速率:"
+
+#, fuzzy
+#~ msgid "<b>Probe velocitys</b>"
+#~ msgstr "<b>GUI前台列表</b>"
+
+#, fuzzy
+#~ msgid "<b>Tool Measurement</b>"
+#~ msgstr "<b>冷卻液</b>"
+
+#, fuzzy
+#~ msgid "Reload Tool on Start"
+#~ msgstr "重新 載入 刀具表"
+
+#, fuzzy
+#~ msgid "<b>Reload Tool</b>"
+#~ msgstr "重新 載入 刀具表"
+
+#, fuzzy
+#~ msgid "Use run from line"
+#~ msgstr "運行選定的行(_n)"
+
+#, fuzzy
+#~ msgid "<b>Run from line</b>"
+#~ msgstr "<b>歸零</b>"
+
+#, fuzzy
+#~ msgid "Launch test message"
+#~ msgstr "啟動測試面板"
+
+#, fuzzy
+#~ msgid ""
+#~ "Advanced\n"
+#~ " Settings"
+#~ msgstr "進階選項"
+
+#, fuzzy
+#~ msgid ""
+#~ "Turn the machine on/off\n"
+#~ "[F2]"
+#~ msgstr "開動 機器"
+
+#, fuzzy
+#~ msgid "show user tabs"
+#~ msgstr "顯示重開"
+
+#, fuzzy
+#~ msgid "open touch off button list"
+#~ msgstr "刀具 對 夾具 對刀(_f)"
+
+#, fuzzy
+#~ msgid ""
+#~ "World\n"
+#~ "Mode"
+#~ msgstr "World 模式"
+
+#, fuzzy
+#~ msgid "Load a new program"
+#~ msgstr "重裝 程序"
+
+#, fuzzy
+#~ msgid "Run the loaded program"
+#~ msgstr "重裝 程序"
+
+#, fuzzy
+#~ msgid "Stop the running program"
+#~ msgstr "停止 正在 運行 的程序, 或"
+
+#, fuzzy
+#~ msgid "Pause the running program"
+#~ msgstr "停止 正在 運行 的程序, 或"
+
+#, fuzzy
+#~ msgid "pause the running program"
+#~ msgstr "停止 正在 運行 的程序, 或"
+
+#, fuzzy
+#~ msgid "Edit the loaded program"
+#~ msgstr "重裝 程序"
+
+#, fuzzy
+#~ msgid "delete MDI"
+#~ msgstr "刪除"
+
+#, fuzzy
+#~ msgid "delete MDI history"
+#~ msgstr "清除 MDI 歷史"
+
+#, fuzzy
+#~ msgid "Hal-Scope"
+#~ msgstr "HAL 顯示器"
+
+#, fuzzy
+#~ msgid "launch calibration"
+#~ msgstr "校準(_C)"
+
+#, fuzzy
+#~ msgid "add a new tool to tool table"
+#~ msgstr "重新載入刀具表(_b)"
+
+#, fuzzy
+#~ msgid "Select a tool by number"
+#~ msgstr "選擇項目 以探測"
+
+#, fuzzy
+#~ msgid ""
+#~ "touchoff\n"
+#~ "  tool x"
+#~ msgstr "刀具 對 夾具 對刀(_f)"
+
+#, fuzzy
+#~ msgid "touch off the tool and set the value to the tool table"
+#~ msgstr "請求工具 %d 刀具表找不到"
+
+#, fuzzy
+#~ msgid "Load File"
+#~ msgstr "程序檔案"
+
+#, fuzzy
+#~ msgid "home joints"
+#~ msgstr "輸入輸出點"
 
 #, fuzzy
 #~ msgid "Substituting"
@@ -19788,9 +19359,6 @@ msgstr "輸入輸出點"
 #~ msgid "Tool File"
 #~ msgstr "刀具文件"
 
-#~ msgid "Tool file is %s"
-#~ msgstr "刀具文件是　%s"
-
 #~ msgid "Active G Codes"
 #~ msgstr "激活 G Codes"
 
@@ -19803,9 +19371,6 @@ msgstr "輸入輸出點"
 
 #~ msgid "CONTINUE"
 #~ msgstr "繼續"
-
-#~ msgid "Tool #:"
-#~ msgstr "刀具 #:"
 
 #~ msgid "Length :"
 #~ msgstr "長度 :"
@@ -19945,9 +19510,6 @@ msgstr "輸入輸出點"
 #~ msgid "Zero All G59.1"
 #~ msgstr "置零 于 所有G59.1"
 
-#~ msgid "Zero All G59.2"
-#~ msgstr "置零 于 所有G5"
-
 #~ msgid "Zero All G59.3"
 #~ msgstr "置零 于 所有G59.3"
 
@@ -19998,9 +19560,6 @@ msgstr "輸入輸出點"
 
 #~ msgid "Show Setup"
 #~ msgstr "顯示 設定"
-
-#~ msgid "Axis Offset"
-#~ msgstr "軸向的 偏置"
 
 #~ msgid "Home All Axes"
 #~ msgstr "所有軸 歸零"


### PR DESCRIPTION
Fixes:

"kelvin-hertz" (KHz) -> kilohertz (kHz)
"mSec" -> ms
"uSec", "uS" -> us
"nSec" -> ns
"Mhz" -> "MHz".