### PR TITLE
update shuttle docs & driver

### DIFF
--- a/debian/extras/lib/udev/rules.d/99-shuttle.rules
+++ b/debian/extras/lib/udev/rules.d/99-shuttle.rules
@@ -1,5 +1,11 @@
 # ShuttleXpress USB jog pendant
+# model "S-XPRS"
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", MODE="0444"
 
 # ShuttlePRO USB jog pendant
+# model "SP-JNS"
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="05f3", ATTRS{idProduct}=="0240", MODE="0444"
+
+# ShuttlePROv2 USB jog pendant
+# model "S-PROV2"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0030", MODE="0444"

--- a/docs/man/man1/shuttle.1
+++ b/docs/man/man1/shuttle.1
@@ -5,12 +5,12 @@
 .TP \\$1
 ..
 .SH NAME
-shuttle \- control HAL pins with the ShuttleXpress or ShuttlePRO device made by Contour Design
+shuttle \- control HAL pins with the ShuttleXpress, ShuttlePRO, and ShuttlePRO2 device made by Contour Design
 .SH SYNOPSIS
 \fIloadusr\fR \fBshuttle\fR \fI[DEVICE ...]\fR
 .SH DESCRIPTION
 shuttle is a non-realtime HAL component that interfaces Contour
-Design's ShuttleXpress and ShuttlePRO devices with LinuxCNC's HAL.
+Design's ShuttleXpress, ShuttlePRO, and ShuttlePRO2 devices with LinuxCNC's HAL.
 
 .PP
 If the driver is started without command-line arguments, it will probe all
@@ -28,6 +28,11 @@ The ShuttlePRO has 13 momentary buttons, a 10 counts/revolution
 jog wheel with detents, and a 15-position spring-loaded outer wheel that
 returns to center when released.
 
+.PP
+The ShuttlePRO2 has 15 momentary buttons, a 10 counts/revolution
+jog wheel with detents, and a 15-position spring-loaded outer wheel that
+returns to center when released.
+
 .SH UDEV
 The shuttle driver needs read permission to the Shuttle devices'
 /dev/hidraw* device files.  This can be accomplished by adding a file
@@ -36,6 +41,8 @@ The shuttle driver needs read permission to the Shuttle devices'
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", MODE="0444"
 
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="05f3", ATTRS{idProduct}=="0240", MODE="0444"
+
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0030", MODE="0444"
 
 The LinuxCNC Debian package installs an appropriate udev file
 automatically, but if you are building LinuxCNC from source and are not

--- a/docs/man/man1/shuttle.1
+++ b/docs/man/man1/shuttle.1
@@ -60,9 +60,9 @@ notice the first click.
 
 .SH Pins
 
-All HAL pin names are prefixed with the type of device followed by
-the index of the device (the order in which the driver found them),
-for example "shuttlexpress.0" or "shuttlepro.2".
+All HAL pin names are prefixed with `shuttle` followed by the index
+of the device (the order in which the driver found them), for example
+"shuttle.0" or "shuttle.2".
 
 .TP
 (bit out) \fI(prefix).button-(number)\fR

--- a/docs/man/man1/shuttle.1
+++ b/docs/man/man1/shuttle.1
@@ -40,6 +40,8 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="05f3", ATTRS{idProduct}=="0240", MODE="04
 The LinuxCNC Debian package installs an appropriate udev file
 automatically, but if you are building LinuxCNC from source and are not
 using the Debian packaging, you'll need to install this file by hand.
+If you install the file by hand you'll need to tell udev to reload its
+rules files by running `udevadm control --reload-rules`.
 
 .SH A warning about the Jog Wheel
 The Shuttle devices have an internal 8-bit counter for the current

--- a/docs/src/drivers/shuttle.txt
+++ b/docs/src/drivers/shuttle.txt
@@ -58,9 +58,9 @@ rules files by running `udevadm control --reload-rules`.
 
 == Pins
 
-All HAL pin names are prefixed with the type of device followed by
-the index of the device (the order in which the driver found them),
-for example "shuttlexpress.0" or "shuttlepro.2".
+All HAL pin names are prefixed with `shuttle` followed by the index
+of the device (the order in which the driver found them), for example
+"shuttle.0" or "shuttle.2".
 
 '<Prefix>.button-<ButtonNumber>' (bit out)::
 

--- a/docs/src/drivers/shuttle.txt
+++ b/docs/src/drivers/shuttle.txt
@@ -52,6 +52,8 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="05f3", ATTRS{idProduct}=="0240", MODE="04
 The LinuxCNC Debian package installs an appropriate udev file
 automatically, but if you are building LinuxCNC from source and are not
 using the Debian packaging you'll need to install this file by hand.
+If you install the file by hand you'll need to tell udev to reload its
+rules files by running `udevadm control --reload-rules`.
 
 
 == Pins

--- a/docs/src/drivers/shuttle.txt
+++ b/docs/src/drivers/shuttle.txt
@@ -5,7 +5,7 @@
 == Description
 
 Shuttle is a non-realtime HAL component that interfaces Contour Design’s
-ShuttleXpress and ShuttlePRO devices with LinuxCNC’s HAL.
+ShuttleXpress, ShuttlePRO, and ShuttlePRO2 devices with LinuxCNC’s HAL.
 
 If the driver is started without command-line arguments, it will probe
 all /dev/hidraw* device files for Shuttle devices, and use all devices
@@ -17,6 +17,10 @@ jog wheel with detents, and a 15-position spring-loaded outer wheel that
 returns to center when released.
 
 The ShuttlePRO has 13 momentary buttons, a 10 counts/revolution jog
+wheel with detents, and a 15-position spring-loaded outer wheel that
+returns to center when released.
+
+The ShuttlePRO2 has 15 momentary buttons, a 10 counts/revolution jog
 wheel with detents, and a 15-position spring-loaded outer wheel that
 returns to center when released.
 
@@ -47,6 +51,7 @@ device files. This can be accomplished by adding a file
 ----
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0020", MODE="0444"
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="05f3", ATTRS{idProduct}=="0240", MODE="0444"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0b33", ATTRS{idProduct}=="0030", MODE="0444"
 ----
 
 The LinuxCNC Debian package installs an appropriate udev file

--- a/src/hal/user_comps/shuttle.c
+++ b/src/hal/user_comps/shuttle.c
@@ -3,7 +3,7 @@
 // This is a userspace HAL driver for the ShuttleXpress and ShuttlePRO
 // devices by Contour Design.
 //
-// Copyright 2011, 2016 Sebastian Kuzminsky <seb@highlab.com>
+// Copyright 2011, 2016, 2021 Sebastian Kuzminsky <seb@highlab.com>
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -48,7 +48,7 @@
 
 #define Max(a, b)  ((a) > (b) ? (a) : (b))
 
-#define MAX_BUTTONS 13
+#define MAX_BUTTONS 15
 
 
 typedef struct {
@@ -80,8 +80,8 @@ contour_dev_t contour_dev[] = {
         .name = "shuttleproV2",
         .vendor_id = 0x0b33,
         .product_id = 0x0030,
-        .num_buttons = 13,
-        .button_mask = { 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100, 0x0200, 0x0400, 0x0800, 0x1000 }
+        .num_buttons = 15,
+        .button_mask = { 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080, 0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000 }
     }
 };
 


### PR DESCRIPTION
This fixes some little problems with the `shuttle.1` manpage and the (nearly identical) HTML docs, adds a udev rule for the ShuttlePRO2, and adds support for the extra two buttons on the ShuttlePRO2.

All of ShuttleXpress, ShuttlePRO, and ShuttlePRO2 work fine in LinuxCNC on Buster (rt-preempt) for me with this branch.  