### PR TITLE
Fix changelog when running GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
         set -x
         git fetch --recurse-submodules=no https://github.com/linuxcnc/linuxcnc refs/tags/*:refs/tags/*
         ./scripts/travis-install-build-deps.sh
+        codename=$(grep VERSION_CODENAME /etc/os-release | cut -d = -f 2)
+        dch --maintmaint --distribution $codename "GitHub test package."
         debuild -uc -us -I -i -j$(nproc)
         sudo apt-get install ../*.deb
         ./scripts/runtests -p tests/

--- a/debian/changelog
+++ b/debian/changelog
@@ -79,7 +79,7 @@ linuxcnc (1:2.8.1) buster; urgency=low
   * docs: plasmac user guide update
 
  -- andypugh <andy@bodgesoc.org>  Sun, 29 Nov 2020 14:43:33 +0000
- 
+
 linuxcnc (1:2.8.0) buster; urgency=low
 
   * Finally merge "Joints Axes". Joints and cartesian axes are no longer
@@ -197,7 +197,6 @@ linuxcnc (1:2.8.0) buster; urgency=low
   * add a sample config for the scorbot-er-3 robot arm
   * docs: document AXIS's foam mode
 
-
  -- andypugh <andy@bodgesoc.org>  Sun, 12 Jul 2020 20:29:54 +0100
 
 linuxcnc (1:2.8.0~pre1) rosa; urgency=low
@@ -210,7 +209,6 @@ linuxcnc (1:2.8.0~pre1) rosa; urgency=low
   * Back tool lathe support in axis and gmoccapy
   * Seperate joint and axis limits for non trivial kins machines
   * bldc_hall removed: use bldc
-
 
  -- Sebastian Kuzminsky <seb@highlab.com>  Sun, 26 Oct 2014 23:18:24 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ linuxcnc (1:2.9.0~pre0) stretch; urgency=medium
 
   * Master branch open for new features.
 
- -- Sebastian Kuzminsky <seb@highlab.com>  Sun, 29 Nov 2020 15:00:00 +0000
+ -- Sebastian Kuzminsky <seb@highlab.com>  Sun, 02 Jun 2019 16:52:46 -0600
 
 linuxcnc (1:2.8.2) buster; urgency=low
 


### PR DESCRIPTION
lintian throws errors when the distribution in the changelog is wrong and when the timestamp for the last release is older then the previous. This PR resolves this by creating a new changelog entry during the workflow. This will always use the current time as timestamp. The distribution is parsed from `/etc/os-release`.

It also reverts a previous commit that changed the timestamp for the 1.2.9.0~pre0 release.