### PR TITLE
qtplasmac: various enhancements

### DIFF
--- a/docs/src/plasma/qtplasmac.txt
+++ b/docs/src/plasma/qtplasmac.txt
@@ -2995,6 +2995,9 @@ The following HAL bit pins are always created. The HAL pin has the identical beh
 |Abort the loaded gcode program|qtplasmac.ext_abort|CYCLE STOP
 |Touchoff X & Y axes to zero|qtplasmac.ext_touchoff|X0Y0
 |Run/Pause/Resume the loaded gcode program|qtplasmac.ext_run_pause|CYCLE START, CYCLE PAUSE, CYCLE RESUME in sequence
+|Torch height override plus|qtplasmac.ext_height_ovr_plus|OVERRIDE +
+|Torch height override minus|qtplasmac.ext_height_ovr_minus|OVERRIDE -
+|Torch height override reset|qtplasmac.ext_height_ovr_reset|OVERRIDE RESET TO 0.00
 |===
 
 The following HAL bit pins are only created if the function is specified in a <<qt_custom-user-buttons, custom user button>>. The HAL pin has the identical behaviour of the related custom user button.

--- a/share/qtvcp/screens/qtplasmac/qtplasmac_handler.py
+++ b/share/qtvcp/screens/qtplasmac/qtplasmac_handler.py
@@ -1,4 +1,4 @@
-VERSION = '1.0.53'
+VERSION = '1.0.54'
 
 import os, sys
 from shutil import copy as COPY
@@ -668,6 +668,7 @@ class HandlerClass:
         self.runButtonTimer.setSingleShot(True)
         self.runButtonTimer.timeout.connect(self.run_button_timeout)
         self.manualCut = False
+        self.probeTest = False
 
     def get_overlay_text(self, kerf):
         if '.' in self.w.cut_feed_rate.text() and len(self.w.cut_feed_rate.text().split('.')[0]) > 3:
@@ -1215,7 +1216,14 @@ class HandlerClass:
     def abort_pressed(self):
         if self.manualCut:
             ACTION.SET_SPINDLE_STOP(0)
+            if self.mcButton:
+                self.button_normal(self.mcButton)
+                self.w[self.mcButton].setEnabled(False)
             self.w.abort.setEnabled(False)
+            return
+        elif self.probeTest:
+            self.probe_test_stop()
+            return
         else:
             ACTION.ABORT()
         hal.set_p('plasmac.cut-recovery', '0')
@@ -2856,10 +2864,12 @@ class HandlerClass:
             if self.probeTimer.remainingTime() <= 0 and not self.offsetsActivePin.get():
                 self.probeTime = self.ptTime
                 self.probeTimer.start(1000)
+                self.probeTest = True
                 hal.set_p('plasmac.probe-test','1')
                 self.w[self.ptButton].setText('{}'.format(self.probeTime))
                 self.button_active(self.ptButton)
                 self.w.run.setEnabled(False)
+                self.w.abort.setEnabled(True)
                 self.set_buttons_state([self.idleList, self.idleOnList, self.idleHomedList], False)
                 self.w[self.ptButton].setEnabled(True)
             else:
@@ -2870,9 +2880,12 @@ class HandlerClass:
     def probe_test_stop(self):
         self.probeTimer.stop()
         self.probeTime = 0
+        self.probeTest = False
+        self.w.abort.setEnabled(False)
         hal.set_p('plasmac.probe-test','0')
         self.w[self.ptButton].setText(self.probeText)
         self.button_normal(self.ptButton)
+        self.w[self.ptButton].setEnabled(False)
 
     def probe_test_error(self, state):
         if state:
@@ -3037,10 +3050,12 @@ class HandlerClass:
             self.w.abort.setEnabled(False)
             if self.mcButton:
                 self.w[self.mcButton].setEnabled(False)
+                self.button_normal(self.mcButton)
         elif STATUS.machine_is_on() and STATUS.is_all_homed() and STATUS.is_interp_idle():
             ACTION.SET_SPINDLE_ROTATION(1 ,1 , 0)
             self.manualCut = True
             self.w.abort.setEnabled(True)
+            self.button_active(self.mcButton)
             self.set_buttons_state([self.idleList, self.idleOnList, self.idleHomedList], False)
             if self.mcButton:
                 self.w[self.mcButton].setEnabled(True)
@@ -4833,7 +4848,10 @@ class HandlerClass:
         if self.manualCut:
             self.w.abort.setEnabled(False)
             if self.mcButton:
+                self.button_normal(self.mcButton)
                 self.w[self.mcButton].setEnabled(False)
+        if self.probeTest:
+            self.probe_test_stop()
 
     def on_keycall_HOME(self, event, state, shift, cntrl):
         if state and not shift and STATUS.is_on_and_idle() and self.keyboard_shortcuts():

--- a/share/qtvcp/screens/qtplasmac/versions.html
+++ b/share/qtvcp/screens/qtplasmac/versions.html
@@ -19,6 +19,17 @@ table th {
 </head>
 <body>
 
+<br><b><u>v1.0.54 2021 Jul 19</u></b>
+  <ul style="margin:0;">
+  <li>add external pins ext_height_ovr_plus, ext_height_ovr_minus, ext_height_ovr_reset</li>
+</ul>
+Changes submitted by fupeama (Martin Kaplan)<br>
+  <ul style="margin:0;">
+  <li>probe test can be canceled via cycle stop or esc key</li>
+  <li>make manual cut button activate during manual cut</li>
+</ul>
+Changes submitted by snowgoer540 (Greg Carl)<br>
+
 <br><b><u>v1.0.53 2021 Jul 18</u></b>
   <ul style="margin:0;">
   <li>add manual cut user button</li>


### PR DESCRIPTION
add external pins ext_height_ovr_plus, ext_height_ovr_minus, ext_height_ovr_reset to docs
probe test can be canceled via cycle stop or esc key
make manual cut button activate during manual cut