### PR TITLE
qtvcp - DetachTabs backwards equality

### DIFF
--- a/lib/python/qtvcp/widgets/detach_tabs.py
+++ b/lib/python/qtvcp/widgets/detach_tabs.py
@@ -254,7 +254,7 @@ class DetachTabWidget(QTabWidget):
         def mouseMoveEvent(self, event):
 
             # Determine if the current movement is detected as a drag
-            if not self.dragStartPos.isNull() and ((event.pos() - self.dragStartPos).manhattanLength() < QApplication.startDragDistance()):
+            if not self.dragStartPos.isNull() and ((event.pos() - self.dragStartPos).manhattanLength() > QApplication.startDragDistance()):
                 self.dragInitiated = True
 
             # If the current movement is a drag initiated by the left button


### PR DESCRIPTION
Caution should be taken when copying from stack overflow ;) https://stackoverflow.com/questions/47267195/in-pyqt-is-it-possible-to-detach-tabs-from-a-qtabwidget

The drag event should not happen until after the length of setStartDragDistance is met. Default from system is 10 pixels. on a touch screen typically is about 50-150px.