### PR TITLE
Update man-pages for latency-* scripts.

### DIFF
--- a/docs/man/man1/latency-histogram.1
+++ b/docs/man/man1/latency-histogram.1
@@ -22,36 +22,99 @@
 .\"
 .\"
 .\"
-.TH LATENCY-HISTOGRAM "1"  "2020-08-26" "LinuxCNC Documentation" "The Enhanced Machine Controller"
+.TH LATENCY-HISTOGRAM "1"  "2021-08-14" "LinuxCNC Documentation" "The Enhanced Machine Controller"
 .SH NAME
 latency-histogram \- plot a histogram of machine latency
 .SH SYNOPSIS
 .B latency-histogram
-
+.RB [ \-?|\-\-help ]
+.RB [ \-\-base " " \fInS\fP ]
+.RB [ \-\-servo " " \fInS\fP ]
+.RB [ \-\-bbinsize " " \fInS\fP ]
+.RB [ \-\-sbinsize " " \fInS\fP ]
+.RB [ \-\-bbins " " \fInS\fP ]
+.RB [ \-\-sbins " " \fInS\fP ]
+.RB [ \-\-logscale " " \fI0|1\fP ]
+.RB [ \-\-text " " \fInote\fP ]
+.RB [ \-\-show ]
+.RB [ \-\-nobase ]
+.RB [ \-\-verbose ]
+.RB [ \-\-nox ]
 .SH DESCRIPTION
-The latency test is important when configuring a LinuxCNC system. 
+The latency test is important when configuring a LinuxCNC system.
 An adjunct to the standard latency-test latency-histogram plots the
 distribution of latency. This can be useful to get a feel for how frequent
-the high latency excursions are. 
-
-More details:
-.nf http://linuxcnc.org/docs/html/install/latency-test.html
-
-.SH "SEE ALSO"
-\fBLinuxCNC(1)\fR
-
-Much more information about LinuxCNC and HAL is available in the LinuxCNC
-and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
-
-.SH HISTORY
-
-.SH BUGS
-None known at this time. 
+the high latency excursions are.
 .PP
+LinuxCNC and Hal should not be running, stop with
+.IR "halrun \-U" .
+Large number of bins and/or small binsizes will slow updates.
+For single thread, specify
+.B \-\-nobase
+(and options for servo thread).
+Measured latencies outside of the +/\- bin range are reported
+with special end bars.  Use
+.B \-\-show
+to show count for
+the off-chart [pos|neg] bin
+.PP
+More details:
+\%https://linuxcnc.org/docs/html/install/latency-test.html
+.SH OPTIONS
+.TP
+.BR \-? ", " \-\-help
+Show options and exit.
+.TP
+.BI \-\-base " nS"
+base thread interval, default: 25000, min: 5000
+.TP
+.BI \-\-servo " nS"
+servo thread interval, default: 1000000, min: 25000
+.TP
+.BI \-\-bbinsize " nS"
+base bin size, default: 100
+.TP
+.BI \-\-sbinsize " nS"
+servo bin size, default: 100
+.TP
+.BI \-\-bbins " nS"
+base bins, default: 200
+.TP
+.BI \-\-sbins " nS"
+servo bins, default: 200
+.TP
+.BI \-\-logscale " 0|1"
+y axis log scale, default: 1
+.TP
+.BI \-\-text " note"
+additional note, default: ""
+.TP
+.BI \-\-show
+show count of undisplayed bins
+.TP
+.BI \-\-nobase
+servo thread only
+.TP
+.BI \-\-verbose
+progress and debug
+.TP
+.BI \-\-nox
+no gui, display elapsed,min,max,sdev for each thread
+.SH "SEE ALSO"
+.BR latency-plot (1),
+.BR latency-test (1),
+.BR linuxcnc (1)
+.PP
+Much more information about LinuxCNC and HAL is available in the LinuxCNC
+and HAL User Manuals, found at
+.IR /usr/share/doc/linuxcnc/ .
+.SH BUGS
+None known at this time.
 .SH AUTHOR
 This man page written by andypugh, as part of the LinuxCNC project.
 .SH REPORTING BUGS
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at
+\%https://github.com/LinuxCNC/linuxcnc/issues
 .SH COPYRIGHT
 Copyright \(co 2020 andypugh.
 .br

--- a/docs/man/man1/latency-plot.1
+++ b/docs/man/man1/latency-plot.1
@@ -22,34 +22,65 @@
 .\"
 .\"
 .\"
-.TH LATENCY-PLOT "1"  "2020-08-26" "LinuxCNC Documentation" "The Enhanced Machine Controller"
+.TH LATENCY-PLOT "1"  "2021-08-14" "LinuxCNC Documentation" "The Enhanced Machine Controller"
 .SH NAME
 latency-plot \- another way to view latency numbers
 .SH SYNOPSIS
 .B latency-plot
-
+.RB [ \-?|\-\-help ]
+.RB [ \-H|\-\-hal ]
+.RB [ \-b|\-\-base " " \fInS\fP ]
+.RB [ \-s|\-\-servo " " \fInS\fP ]
+.RB [ \-t|\-\-time " " \fImS\fP ]
+.RB [ \-\-relative ]
+.RB [ \-\-actual ]
 .SH DESCRIPTION
-\fBlatency-plot\fR plots realtime system latency.
-Mainly superseded by latency-histogram
-
-http://linuxcnc.org/docs/html/install/latency-test.html
-
-.SH "SEE ALSO"
-\fBlatency-histogram(1)\fR
-\fBLinuxCNC(1)\fR
-
-Much more information about LinuxCNC and HAL is available in the LinuxCNC
-and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
-
-.SH HISTORY
-
-.SH BUGS
-None known at this time. 
+.B latency-plot
+makes a strip chart recording for a base and a servo thread. It may be useful
+to see spikes in latency when other applications are started or used.
+Mainly superseded by latency-histogram.
 .PP
+LinuxCNC and Hal should not be running, stop with
+.IR "halrun \-U" .
+.PP
+More details:
+\%https://linuxcnc.org/docs/html/install/latency-test.html
+.SH OPTIONS
+.TP
+.BR \-? ", " \-\-help
+Show options and exit.
+.TP
+.BR \-H ", " \-\-hal
+.TP
+.BR \-b ", " \-\-base " " \fInS\fP
+base thread interval, default: 25000
+.TP
+.BR \-s ", " \-\-servo " " \fInS\fP
+servo thread interval, default: 1000000
+.TP
+.BR \-t ", " \-\-time " " \fImS\fP
+report interval, default: 1000, min: 100, max: 10000
+.TP
+.B \-\-relative
+relative clock time (default)
+.TP
+.B \-\-actual
+actual clock time
+.SH "SEE ALSO"
+.BR latency-histogram (1),
+.BR latency-test (1),
+.BR linuxcnc (1)
+.PP
+Much more information about LinuxCNC and HAL is available in the LinuxCNC
+and HAL User Manuals, found at
+.IR /usr/share/doc/linuxcnc/ .
+.SH BUGS
+None known at this time.
 .SH AUTHOR
 This man page written by andypugh, as part of the LinuxCNC project.
 .SH REPORTING BUGS
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at
+\%https://github.com/LinuxCNC/linuxcnc/issues
 .SH COPYRIGHT
 Copyright \(co 2020 andypugh.
 .br


### PR DESCRIPTION
Create content for man-page latency-histogram and latency-plot. The
man-pages consist of information found in '--help' option in the
actual script, and documentation found in 'docs/' path in LinuxCNC
repository.