### PR TITLE
qtplasmac:

### DIFF
--- a/docs/src/plasma/qtplasmac.txt
+++ b/docs/src/plasma/qtplasmac.txt
@@ -715,7 +715,7 @@ OFFSET_AV_RATIO  = 0.5
 These variables are mandatory.
 
 ----
-MIN_LIMIT        = the top of your slats or just below
+MIN_LIMIT        = the top of the table's slats or just below
 MAX_VELOCITY     = double the value in the corresponding joint
 MAX_ACCELERATION = double the value in the corresponding joint
 OFFSET_AV_RATIO  = 0.5
@@ -2648,7 +2648,7 @@ For example the user may want the arc voltage display in red, a green Torch On L
 Custom stylesheets are enable by a setting in the [QTPLASMAC] section of the INI file with the filename of the stylesheet.
 
 ----
-CUSTOM_STYLE = my_cool_style.qss
+CUSTOM_STYLE = the_cool_style.qss
 ----
 
 The filename may be any valid filename. The standard extension name is .qss but this is not mandatory.
@@ -2805,7 +2805,7 @@ BUTTON_n_CODE = G0 X100
 To run an existing subroutine.
 
 ----
-BUTTON_n_CODE = o<my_subroutine> call
+BUTTON_n_CODE = o<the_subroutine> call
 ----
 
 <machine_name>.ini file variables can be entered by using {} (a space must be placed after the })
@@ -2834,16 +2834,22 @@ BUTTON_n_CODE = %halshow \ g0x.5y.5 \ %halmeter
 The following code will allow the user to use a button to invert the current state of a HAL bit pin:
 
 ----
-BUTTON_n_CODE = toggle-halpin my-hal-pin-name
+BUTTON_n_CODE = toggle-halpin the-hal-pin-name
 ----
 
 This code is required to be used as a single command and may only control one HAL bit pin per button.
 
-The button colors will follow the state of the halpin.
+The button colors will follow the state of the hal pin.
 
-After setting the code, upon clicking, the button will invert colors and the HAL pin will invert pin state. They will stay "latched" until the button is clicked again, which will return the button to the original colors and the HAL pin to the original pin state.
+After setting the code, upon clicking, the button will invert colors and the HAL pin will invert pin state. The button will stay "latched" until the button is clicked again, which will return the button to the original colors and the HAL pin to the original pin state.
 
 There are three <<qt_ext-hal-pin, External HAL Pins>> that are available to toggle as an output, the pin names are qtplasmac.ext_out_0, qtplasmac.ext_out_1, and qtplasmac.ext_out_2.
+
+It is possible for the user to mark a toggle-halpin button's associated hal pin as being required to be turned "ON" before *CYCLE START* can be pressed by adding "runcritical" after the hal pin in the button code.
+
+----
+BUTTON_n_CODE = toggle-halpin the-hal-pin-name runcritical
+----
 
 [[qt_button-pulse]]
 
@@ -2852,14 +2858,14 @@ There are three <<qt_ext-hal-pin, External HAL Pins>> that are available to togg
 The following code will allow the user to use a button to pulse a HAL bit pin for a duration of 0.5 seconds:
 
 ----
-BUTTON_n_CODE = pulse-halpin my-hal-pin-name 0.5
+BUTTON_n_CODE = pulse-halpin the-hal-pin-name 0.5
 ----
 
 This code is required to be used as a single command and may only control one HAL bit pin per button.
 
 The delay is specified in seconds, if the delay is not specified then it will default to one second.
 
-The button colors will follow the state of the halpin.
+The button colors will follow the state of the hal pin.
 
 After setting the code, upon clicking the button, the button will invert colors, the HAL pin will invert pin state, and the time remaining will be displayed on the button. The button color and the pin state will stay inverted until the delay timer has completed, which will return the button to the original colors, the HAL pin to the original pin state, and the original button name.
 
@@ -2986,10 +2992,10 @@ NOTE: IF THE FEED RATE IS CHANGED FOR THE FRAMING MOTION, IT WILL BE NECESSARY T
 BUTTON_n_CODE = framing
 ----
 
-It is possible for the user to omit the initial default Z movement and run the framing sequence at the current Z height by adding "usecurrentZheight" after "framing".
+It is possible for the user to omit the initial default Z movement and run the framing sequence at the current Z height by adding "usecurrentzheight" after "framing".
 
 ----
-BUTTON_n_CODE = framing usecurrentZheight
+BUTTON_n_CODE = framing usecurrentzheight
 ----
 
 Enabling a user button as a Framing button will add a <<qt_ext-hal-pin, external HAL pin>> that may be connected from a pendant etc.

--- a/share/qtvcp/screens/qtplasmac/versions.html
+++ b/share/qtvcp/screens/qtplasmac/versions.html
@@ -19,6 +19,14 @@ table th {
 </head>
 <body>
 
+<br><b><u>v1.0.68 2021 Aug 22</u></b>
+<ul style="margin:0;">
+  <li>allow toggle-halpin buttons to be marked "runcritical"</li>
+  <li>check for spelling errors in a framing button using "usecurrentzheight"</li>
+  <li>docs updates</li>
+</ul>
+Changes submitted by snowgoer540 (Greg Carl)<br>
+
 <br><b><u>v1.0.67 2021 Aug 21</u></b>
 <ul style="margin:0;">
   <li>save machine log files</li>


### PR DESCRIPTION
allow toggle-halpin buttons to be marked "runcritical"
check for spelling errors in a framing button using "usecurrentzheight"
docs updates