### PR TITLE
qtvcp: add number pad jog keys to default autorepeat dictionaries

### DIFF
--- a/lib/python/qtvcp/qt_action.py
+++ b/lib/python/qtvcp/qt_action.py
@@ -666,11 +666,11 @@ class _Lcnc_Action(object):
         self.RELOAD_DISPLAY()
 
     # Some systems need repeat disabled for keyboard jogging because repeat rate is uneven
-    def DISABLE_AUTOREPEAT_KEYS(self, keys={'34','35','111','112','113','114','116','117'}):
+    def DISABLE_AUTOREPEAT_KEYS(self, keys={'34','35','80','81','83','85','88','89','111','112','113','114','116','117'}):
         for k in keys:
             subprocess.Popen('xset -r {}'.format(k), stdout = subprocess.PIPE, shell = True)
 
-    def ENABLE_AUTOREPEAT_KEYS(self, keys={'34','35','111','112','113','114','116','117'}):
+    def ENABLE_AUTOREPEAT_KEYS(self, keys={'34','35','80','81','83','85','88','89','111','112','113','114','116','117'}):
         for k in keys:
             subprocess.Popen('xset r {}'.format(k), stdout = subprocess.PIPE, shell = True)
 


### PR DESCRIPTION
83 and 85 for X
80 and 88 for Y
81 and 89 for Z