### PR TITLE
Fix "object has no attribute 'tolist'"

### DIFF
--- a/lib/python/glnav.py
+++ b/lib/python/glnav.py
@@ -93,7 +93,6 @@ def pango_font_post():
 def glTranslateScene(w, s, x, y, mousex, mousey):
     glMatrixMode(GL_MODELVIEW)
     mat = glGetDoublev(GL_MODELVIEW_MATRIX)
-    mat = [i for i in itertools.chain(*mat.tolist())]
     glLoadIdentity()
     glTranslatef(s * (x - mousex), s * (mousey - y), 0.0)
     glMultMatrixd(mat)
@@ -116,10 +115,9 @@ def glRotateScene(w, s, xcenter, ycenter, zcenter, x, y, mousex, mousey):
 
     glTranslatef(xcenter, ycenter, zcenter)
     mat = glGetDoublev(GL_MODELVIEW_MATRIX)
-    mat = [i for i in itertools.chain(*mat.tolist())]
 
     glLoadIdentity()
-    tx, ty, tz = mat[12:15]
+    tx, ty, tz = mat[3][:3]
     glTranslatef(tx, ty, tz)
     glRotatef(snap(lat), *w.rotation_vectors[0])
     glRotatef(snap(lon), *w.rotation_vectors[1])

--- a/lib/python/hershey.py
+++ b/lib/python/hershey.py
@@ -126,15 +126,13 @@ class Hershey:
     def plot_string(self, s, frac=0, bbox=0):
         glPushMatrix()
         mat = glGetDoublev(GL_MODELVIEW_MATRIX)
-        mat = [i for i in itertools.chain(*mat.tolist())]
-        if mat[10] < -.001:
+        if mat[2][2] < -.001:
             glTranslatef(0, .5, 0)
             glRotatef(180, 0, 1, 0)
             glTranslatef(0, -.5, 0)
             frac = 1 - frac
             mat = glGetDoublev(GL_MODELVIEW_MATRIX)
-            mat = [i for i in itertools.chain(*mat.tolist())]
-        if mat[5] < -.001:
+        if mat[1][1] < -.001:
             glTranslatef(0, .5, 0)
             glRotatef(180, 0, 0, 1)
             glTranslatef(0, -.5, 0)

--- a/lib/python/qtvcp/lib/qt_vismach/primitives.py
+++ b/lib/python/qtvcp/lib/qt_vismach/primitives.py
@@ -1,4 +1,4 @@
-import itertools
+import copy
 import OpenGL.GL as GL
 from OpenGL import GLU
 import hal
@@ -164,9 +164,9 @@ class Track(Collection):
 
         view2world = invert(self.world2view.t)
 
-        px, py, pz = self.position.t[12:15]
+        px, py, pz = self.position.t[3][:3]
         px, py, pz = self.map_coords(px, py, pz, view2world)
-        tx, ty, tz = self.target.t[12:15]
+        tx, ty, tz = self.target.t[3][:3]
         tx, ty, tz = self.map_coords(tx, ty, tz, view2world)
         dx = tx - px;
         dy = ty - py;
@@ -654,8 +654,7 @@ class Capture(object):
         # give a list of lists.
         # It would be better to change all the functions so a flat list could be used 
         # directly - i don't understand the code well enough
-        # self.t = GL.glGetDoublev(GL.GL_MODELVIEW_MATRIX)
-        self.t = list(itertools.chain.from_iterable(GL.glGetDoublev(GL.GL_MODELVIEW_MATRIX)))
+        self.t = glGetDoublev(GL_MODELVIEW_MATRIX))
 
     def volume(self):
         return 0.0
@@ -672,17 +671,17 @@ class Capture(object):
 
 def invert(src):
     # make a copy
-    inv = src[:]
+    inv = copy.deepcopy(src[:])
     # The inverse of the upper 3x3 is the transpose (since the basis
     # vectors are orthogonal to each other.
-    inv[1], inv[4] = inv[4], inv[1]
-    inv[2], inv[8] = inv[8], inv[2]
-    inv[6], inv[9] = inv[9], inv[6]
+    inv[0][1], inv[1][0] = inv[1][0], inv[0][1]
+    inv[0][2], inv[2][0] = inv[2][0], inv[0][2]
+    inv[1][2], inv[2][1] = inv[2][1], inv[1][2]
     # The inverse of the translation component is just the negation
     # of the translation after dotting with the new upper3x3 rows. */
-    inv[12] = -(src[12] * inv[0] + src[13] * inv[4] + src[14] * inv[8])
-    inv[13] = -(src[12] * inv[1] + src[13] * inv[5] + src[14] * inv[9])
-    inv[14] = -(src[12] * inv[2] + src[13] * inv[6] + src[14] * inv[10])
+    inv[3][0] = -(src[3][0] * inv[0][0] + src[3][1] * inv[1][0] + src[3][2] * inv[2][0])
+    inv[3][1] = -(src[3][0] * inv[0][1] + src[3][1] * inv[1][1] + src[3][2] * inv[2][1])
+    inv[3][2] = -(src[3][0] * inv[0][2] + src[3][1] * inv[1][2] + src[3][2] * inv[2][2])
     return inv
 
 

--- a/lib/python/qtvcp/lib/qt_vismach/primitives.py
+++ b/lib/python/qtvcp/lib/qt_vismach/primitives.py
@@ -654,7 +654,7 @@ class Capture(object):
         # give a list of lists.
         # It would be better to change all the functions so a flat list could be used 
         # directly - i don't understand the code well enough
-        self.t = glGetDoublev(GL_MODELVIEW_MATRIX))
+        self.t = glGetDoublev(GL_MODELVIEW_MATRIX)
 
     def volume(self):
         return 0.0

--- a/lib/python/qtvcp/lib/qt_vismach/qt_vismach.py
+++ b/lib/python/qtvcp/lib/qt_vismach/qt_vismach.py
@@ -273,9 +273,9 @@ class GLWidget(QOpenGLWidget):
         # is easy
         tx, ty, tz = self.tool2view.t[12:15]
         # now we have to transform them to the work frame
-        wx = tx * view2work[0] + ty * view2work[4] + tz * view2work[8] + view2work[12]
-        wy = tx * view2work[1] + ty * view2work[5] + tz * view2work[9] + view2work[13]
-        wz = tx * view2work[2] + ty * view2work[6] + tz * view2work[10] + view2work[14]
+        wx = tx * view2work[0][0] + ty * view2work[1][0] + tz * view2work[2][0] + view2work[3][0]
+        wy = tx * view2work[0][1] + ty * view2work[1][1] + tz * view2work[2][1] + view2work[3][1]
+        wz = tx * view2work[0][2] + ty * view2work[1][2] + tz * view2work[2][2] + view2work[3][2]
         # wx, wy, wz are the values to use for backplot
         # so we save them in a buffer
         if len(self.plotdata) == self.plotlen:

--- a/lib/python/rs274/OpenGLTk.py
+++ b/lib/python/rs274/OpenGLTk.py
@@ -123,8 +123,7 @@ class RawOpengl(Togl, Misc):
         # will call redraw recursively. 
         self.update_idletasks()
         self.tk.call(self._w, 'makecurrent')
-        _mode = glGetDoublev(GL_MATRIX_MODE)
-        _mode = [i for i in itertools.chain(*_mode.tolist())]
+        _mode = glGetInteger(GL_MATRIX_MODE)
         try:
             glMatrixMode(GL_PROJECTION)
             glPushMatrix()
@@ -339,7 +338,6 @@ http://www.yorvic.york.ac.uk/~mjh/
             # Now translate the scene origin away from the world origin
             glMatrixMode(GL_MODELVIEW)
             mat = glGetDoublev(GL_MODELVIEW_MATRIX)
-            mat = [i for i in itertools.chain(*mat.tolist())]
             glLoadIdentity()
             glTranslatef(-self.xcenter, -self.ycenter, -(self.zcenter+self.distance))
             glMultMatrixd(mat)

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -508,7 +508,6 @@ class GlCanonDraw:
     def select(self, x, y):
         if self.canon is None: return
         pmatrix = glGetDoublev(GL_PROJECTION_MATRIX)
-        pmatrix = [i for i in itertools.chain(*pmatrix.tolist())]
         glMatrixMode(GL_PROJECTION)
         glPushMatrix()
         glLoadIdentity()


### PR DESCRIPTION
This occurs since the switch to pyopengl (yay!) but only if python3-numpy is not also installed.

I was able to eliminate the conversion of the matrix to its 1D / list form entirely.

I think I got pretty good manual testing coverage of everything _except_ qt vismach in my testing, both with and without python3-numpy installed.  qt vismach should be the same as tk vismach, as I made edits with the same intended effect.