### PR TITLE
switch deb Maintainer to "LinuxCNC Developers"

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -1,7 +1,7 @@
 Source: linuxcnc
 Section: misc
 Priority: optional
-Maintainer: Sebastian Kuzminsky <seb@highlab.com>
+Maintainer: LinuxCNC Developers <emc-developers@lists.sourceforge.net>
 Uploaders: Steffen Moeller <moeller@debian.org>, Jeff Epler <jepler@gmail.com>, Sebastian Kuzminsky <seb@highlab.com>
 Build-Depends: debhelper (>= 9),
     @PYTHON_PACKAGING_DEPENDS@,


### PR DESCRIPTION
It's a group effort after all...

This is per @smoe's suggestion, to help get LinuxCNC into Debian.