### PR TITLE
github workflow: bump ci runner from 16.04 to 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
     - name: Dump GitHub context
       env:
@@ -23,5 +23,3 @@ jobs:
     - run: git fetch --recurse-submodules=no https://github.com/linuxcnc/linuxcnc refs/tags/*:refs/tags/*
     - run: ./scripts/travis-install-build-deps.sh
     - run: ./scripts/travis-build-test.sh
-    
-


### PR DESCRIPTION
This fixes #1276.