### PR TITLE
The patch is no longer needed

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,0 @@
-No_root_install.patch


### PR DESCRIPTION
The patch itself is missing, so it does not build. And it does not seem to be required anyway.
This also eliminates the quilt lintian warning in PR #1291 .