### PR TITLE
Do not create new files while cleaning

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -48,18 +48,11 @@ clean: debian/control
 	dh_testdir
 	dh_testroot
 	rm -f build-stamp
-	py3clean .
-	cd src && ./autogen.sh
-	cd src && ./configure \
-	    --prefix=/usr --sysconfdir=/etc \
-	    --mandir=/usr/share/man \
-	    $(configure_realtime_arg) \
-            $(enable_build_documentation) \
-	    --disable-check-runtime-deps
-	cd src && $(MAKE) clean -s
+	#py3clean .
+	if [ -r src/Makefile ]; then cd src && $(MAKE) clean -s; fi
 	rm -f Makefile.inc
 	rm -f src/config.log src/config.status
-
+	rm -f $(for i in $(find . -name "*.in"); do basename $i .in; done)
 	dh_clean
 
 install: build


### PR DESCRIPTION
This is a surprisingly important change to transition to quilt :) dpkg-buildpackage first invokes a clean and then compares with the orig tarball. Only changes in the debian directory are tolerated, everything else should be a patch. In my reading this eliminates the technical convenience for LinuxCNC to be a native package.