### PR TITLE
Added mesaflash as a suggestion to d/control

### DIFF
--- a/debian/control.main-pkg.in
+++ b/debian/control.main-pkg.in
@@ -25,6 +25,7 @@ Depends: ${shlibs:Depends}, @KERNEL_DEPENDS@,
     python3-cairo, python3-gi-cairo, python3-opengl, python3-configobj,
     tclreadline, procps, psmisc, tclx, @MODUTILS_DEPENDS@,
     mesa-utils, blt, udev
+Suggests: mesaflash
 Description: motion controller for CNC machines and robots
  LinuxCNC is the next-generation Enhanced Machine Controller which
  provides motion control for CNC machine tools and robotic


### PR DESCRIPTION
Not a very impressive patch, but it may be helpful to distinguish mesaflash from the dependency mesa-utils. 
On a sidenote, maybe you could directly change without going through a difficult-to-interpret PR the order ot attributes in the control?  It should be Depends: -> Recommends: -> Suggests.