### PR TITLE
Remove use of unknown .HTML macro.

### DIFF
--- a/docs/man/man1/iov2.1
+++ b/docs/man/man1/iov2.1
@@ -185,7 +185,6 @@ mechanism) of the tool requested by the most recent T-word.
 \fBiocontrol.0.state
 (S32,OUT) Debugging pin reflecting internal state
 
-.HTML <br>
 .PP
 See 
 .UR http://wiki.linuxcnc.org/cgi-bin/wiki.pl?ToolchangerProtocolProposal 


### PR DESCRIPTION
As far as I can tell this &lt;br> do not make it into HTML pages, and
it is useless in the 'man' rendering of the text.