### PR TITLE
Adjusted udev rules to flag xhc units as user accessable.

### DIFF
--- a/debian/extras/lib/udev/rules.d/99-xhc-whb04b-6.rules
+++ b/debian/extras/lib/udev/rules.d/99-xhc-whb04b-6.rules
@@ -1,3 +1,3 @@
 # xhc-whb04b-6 mpg pendant
-SUBSYSTEM=="usb", ATTR{idProduct}=="eb93", ATTR{idVendor}=="10ce", MODE="666", OWNER="root", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idProduct}=="eb93", ATTR{idVendor}=="10ce", MODE="666", OWNER="root", GROUP="plugdev", TAG+="uaccess"
 

--- a/debian/extras/lib/udev/rules.d/99-xhc.rules
+++ b/debian/extras/lib/udev/rules.d/99-xhc.rules
@@ -1,2 +1,2 @@
 # xhc-hb04 mpg pendant
-SUBSYSTEM=="usb", ATTR{idProduct}=="eb70", ATTR{idVendor}=="10ce", MODE="0666", OWNER="root", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idProduct}=="eb70", ATTR{idVendor}=="10ce", MODE="0666", OWNER="root", GROUP="plugdev", TAG+="uaccess"


### PR DESCRIPTION
This is an alternative to using the plugdev group, which provide access
to the user logged in on the console without having to statically grant
plugdev membership.