### PR TITLE
Added Appstream metadata announcing supported USB IDs

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -30,6 +30,10 @@ Files: src/rtapi/*
 Copyright: the LinuxCNC developers
 License: LGPL-2.1+
 
+Files: debian/linuxcnc-uspace.metainfo.xml
+Copyright: 2021 Petter Reinholdtsen <pere@debian.org>
+License: MIT
+
 License: GPL-2
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -95,3 +99,22 @@ License: LGPL-2.1+
  .
  On Debian systems, the complete text of the GNU Lesser General Public
  License version 2.1 can be found in ‘/usr/share/common-licenses/LGPL-2.1’.
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/debian/linuxcnc-uspace.install
+++ b/debian/linuxcnc-uspace.install
@@ -1,0 +1,1 @@
+debian/linuxcnc-uspace.metainfo.xml usr/share/metainfo

--- a/debian/linuxcnc-uspace.metainfo.xml
+++ b/debian/linuxcnc-uspace.metainfo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component>
+  <id>linuxcnc</id>
+  <metadata_license>MIT</metadata_license>
+  <name>LinuxCNC</name>
+  <summary>LinuxCNC Machine Controller</summary>
+  <description>
+    <p>LinuxCNC controls CNC machines. It can drive milling machines,
+      lathes, 3D printers, laser cutters, plasma cutters, robot arms,
+      hexapods, and more.</p>
+  </description>
+  <provides>
+    <modalias>usb:v05F3p0240d**</modalias>
+    <modalias>usb:v10CEpEB70d*</modalias>
+    <modalias>usb:v10CEpEB93d*</modalias>
+    <modalias>usb:v1B33p0020d**</modalias>
+    <modalias>usb:v1B33p0030d**</modalias>
+  </provides>
+</component>

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -112,6 +112,7 @@ binary-arch: build install
 	dh_installexamples
 	dh_installman
 	dh_installmime
+	dh_install
 	dh_link
 	dh_strip
 	dh_compress -X.pdf -X.txt -X.hal -X.ini -X.clp -X.var -X.nml -X.tbl -X.xml -Xsample-configs


### PR DESCRIPTION
See https://wiki.debian.org/AppStream/Guidelines for information about
the format and setup.