### PR TITLE
halmodule - adding getpins function

### DIFF
--- a/docs/src/hal/halmodule.txt
+++ b/docs/src/hal/halmodule.txt
@@ -128,6 +128,14 @@ the value may be accessed or set using the subscript syntax:
 h['out'] = h['in']
 ----
 
+To see all pins with their values, getpins returns all values in a dictionary
+of that component.
+
+----
+h.getpins()
+>>>{'in': 0.0, 'out': 0.0}
+----
+
 === Driving output (HAL_OUT) pins
 
 Periodically, usually in response to a timer, all HAL_OUT pins should

--- a/lib/python/hal.py
+++ b/lib/python/hal.py
@@ -69,3 +69,4 @@ class component(_hal.component):
 
     def getpin(self, *a, **kw): return Pin(_hal.component.getpin(self, *a, **kw))
     def getparam(self, *a, **kw): return Param(_hal.component.getparam(self, *a, **kw))
+    def getpins(self, *a, **kw): return _hal.component.getpins(self, *a, **kw)

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -438,6 +438,23 @@ static PyObject *pyhal_get_pin(PyObject *_self, PyObject *o) {
     return pyhal_pin_new(pin, name);
 }
 
+
+static PyObject *pyhal_get_pins(PyObject *_self, PyObject *o) {
+  char *name;
+  halobject *self = (halobject *)_self;
+
+  EXCEPTION_IF_NOT_LIVE(NULL);
+
+  PyObject *d = PyDict_New();
+  for(itemmap::iterator i = self->items->begin(); i != self->items->end(); i++) {
+    halitem * pin = &(i->second);
+    name = strdup(i->first.c_str());
+    PyDict_SetItemString(d, name, pyhal_read_common(pin));
+  }
+  return d;
+}
+
+
 static PyObject *pyhal_ready(PyObject *_self, PyObject *o) {
     // hal_ready did not exist in EMC 2.0.x, make it a no-op
     halobject *self = (halobject *)_self;
@@ -524,6 +541,8 @@ static PyMethodDef hal_methods[] = {
         "Create a new pin"},
     {"getitem", pyhal_get_pin, METH_VARARGS,
         "Get existing pin object"},
+    {"getpins", pyhal_get_pins, METH_VARARGS,
+            "Get all pins and values of component"},
     {"exit", pyhal_exit, METH_NOARGS,
         "Call hal_exit"},
     {"ready", pyhal_ready, METH_NOARGS,


### PR DESCRIPTION
Adds a getpins option to hal components in python:
```python
>>> import hal
>>> h = hal.component("passthrough")
>>> h.newpin("in", hal.HAL_FLOAT, hal.HAL_IN)
<hal.Pin object at 0x7f7a21216d60>
>>> h.newpin("out", hal.HAL_FLOAT, hal.HAL_OUT)
<hal.Pin object at 0x7f7a22c05c40>
>>> h.ready()
>>> h.getpins()
{'in': 0.0, 'out': 0.0}
>>> dir(h)
['__class__', '__delattr__', '__delitem__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getitem__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__len__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__setitem__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', 'exit', 'getitem', 'getparam', 'getpin', 'getpins', 'getprefix', 'newparam', 'newpin', 'ready', 'setprefix']


```


Motivation, found this really annoying. There is currently not an easy way of seeing the pins of a component in python.

```python
>>> import hal
>>> h = hal.component("test")
>>> h.newpin("in", hal.HAL_FLOAT, hal.HAL_IN);
<hal.Pin object at 0x7f00c2aa4c40>
>>> h.newpin("out", hal.HAL_FLOAT, hal.HAL_OUT);
<hal.Pin object at 0x7f00c285b9a0>
>>> h.ready()
>>> h["out"]
0.0
>>> h["nope"]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: Pin 'nope' does not exist
```
My work around has been
```python
try:
    h["nope"] = value
except:
    pass
```
except pass feels extremely hacky in a testing suite. The new method allows for:

```python
if "nope" in hal.getpins():
   hal["nope"] = value
```

Which appeases the no exceptions generated test suite.