### PR TITLE
Import LSB shell methods into realtime init.d script

### DIFF
--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -17,6 +17,11 @@
 # on @DATE@
 #
 
+# Get lsb functions and provide systemd hook into script, when it exist
+if [ -e /lib/lsb/init-functions ]; then
+    . /lib/lsb/init-functions
+fi
+
 export LANG=C
 
 GREP=@GREP@


### PR DESCRIPTION
This allow systemd to hook into the script.  This also get rid of
a lintian warning on Debian.