### PR TITLE
Rough first shot at a d/u/metadata file

### DIFF
--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,15 @@
+---
+Bug-Database: https://github.com/LinuxCNC/linuxcnc/issues
+Bug-Submit: https://github.com/LinuxCNC/linuxcnc/issues/new
+Documentation: http://linuxcnc.org/docs/2.8/html/
+Repository-Browse: https://github.com/LinuxCNC/linuxcnc
+References:
+ - Author: William P. Shackleford and Frederick M. Proctor
+   Title: Use of Open Source Distribution for a Machine Tool Controller
+   ePrint: http://www.isd.mel.nist.gov/documents/shackleford/4191_05.pdf
+Registry:
+ - Name: conda:conda-forge
+   Entry: NA
+ - Name: SciCrunch
+   Entry: NA
+   Comment: Request sent to be added.


### PR DESCRIPTION
Well, these metadata files are something that the Science and Med packages fell into to link software to publications, such that you also find the package when googling for the DOI. And there are also multiple software registries that help identifying a tool in the context of a workflow that these are involved in.

Are there publications for LinuxCNC that are from within the community and not someone else writing about it? These should then be listed in this d/u/metadata file. If there is no such book or "new features of LinuxCNC in 2017"-kind-of-paper for LinuxCNC then maybe that would be a plan for version 3.0?

Technical details on https://wiki.debian.org/UpstreamMetadata .