### PR TITLE
Clean src/emc/usr_intf/gremlin/__pycache__

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -490,6 +490,7 @@ userspace: $(TARGETS)
 pythonclean:
 	rm -f $(PYTARGETS)
 	find ../lib/python -name '*.so' -exec rm {} +
+	find . -name __pycache__ | xargs -r rm -r
 python: $(PYTARGETS)
 userspace: python
 clean: docclean pythonclean cscopeclean


### PR DESCRIPTION
The file src/emc/usr_intf/gremlin/__pycache__/gremlin-runcpython-39.pyc is created but does not disappear upon clean. This triggered a lintian warning when building a native Debian package or when quilt-formatted would stop already early once dpkg-buildpackage finds it.