### PR TITLE
LinuxCNC was assigned RRID:SCR_021787

### DIFF
--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -11,5 +11,4 @@ Registry:
  - Name: conda:conda-forge
    Entry: NA
  - Name: SciCrunch
-   Entry: NA
-   Comment: Request sent to be added.
+   Entry: SCR_021787


### PR DESCRIPTION
RRID stands for "Research Resource Identifier" and help referencing work when a URL is to long.