### PR TITLE
Fix qtvcp related typos

### DIFF
--- a/docs/src/gui/qtvcp_custom_widgets.txt
+++ b/docs/src/gui/qtvcp_custom_widgets.txt
@@ -438,7 +438,7 @@ class HomeLabel(QLabel, _HalWidgetBase):
 
     # update ishomed property
     # polish widget so stylesheet sees the property change
-    # some stylessheets color the text on home/unhome
+    # some stylesheets color the text on home/unhome
     def _home_status_polish(self, d, state):
         if self.joint_number = d:
             self.setProperty('isHomed', state)

--- a/docs/src/gui/qtvcp_widgets_es.txt
+++ b/docs/src/gui/qtvcp_widgets_es.txt
@@ -230,7 +230,7 @@ Then add as many pages as there are views to switch to. +
 on each page add a layout widget. +
 After adding the layout you must right click the widget switcher again +
 and set the layout option. +
-click on the widgetswitcher widget and then scroll to the botton of the property editor. +
+click on the widgetswitcher widget and then scroll to the bottom of the property editor. +
 you are looking for the dynamic property 'widget_list'. +
 double click the to the right of the widget_list property. +
 A dialog will pop up allowing you to add the names of the widgets to move to the pages you added to the widgetswitcher. +
@@ -657,7 +657,7 @@ sets up the standard close screen prompt dialog
 sets up the numerical entry dialog
 
 * 'toolDialog_option':
-sets up the manual tool change dialog, incuding HAL pin.
+sets up the manual tool change dialog, including HAL pin.
 
 * 'fileDialog_option':
 sets up the file choosing dialog.
@@ -783,7 +783,7 @@ SUBROUTINE_PATH =
 ----
 The macros are Oword subroutine with special comments to work with the launcher. +
 The first three lines must have the keywords: (The forth is optional) +
-Here is a sample fr the forst four lines in an Oword file: +
+Here is a sample for the first four lines in an Oword file: +
 ----
 ; MACROCOMMAND=Entry1,Entry2
 ; MACRODEFAULTS=0,true
@@ -991,7 +991,7 @@ It has a the ability to scroll the names with hardware such as a MPG. +
 
 one can class patch the function 'load(self,fname):' to customize file loading. +
 
-the function 'getCurrentSelected()' will return a python touple, containing +
+the function 'getCurrentSelected()' will return a python tuple, containing +
 the file path and whether it's a file. +
 
 [source,python]

--- a/lib/python/qtvcp/designer/README.txt
+++ b/lib/python/qtvcp/designer/README.txt
@@ -35,7 +35,7 @@ pyqt5-dev-tools
 Create the plugin directory for designer to search:
 mkdir -p ~/.designer/plugins/python
 
-The <pluginfile> is dependant on the type of LinuxCNC installation.
+The <pluginfile> is dependent on the type of LinuxCNC installation.
 For a package installation:
 /usr/lib/python3/dist-packages/qtvcp/plugins/qtvcp_pluin.py
 

--- a/lib/python/qtvcp/designer/install_script
+++ b/lib/python/qtvcp/designer/install_script
@@ -89,7 +89,7 @@ if [ ! -f $sopath/$p3sofile ]; then
     if [ -f $sopath/$p3sofile.old ]; then
         echo -e '\nrename libpyqt5.so.old file to libpyqt5.so'
         sudo mv $sopath/$p3sofile.old $sopath/$p3sofile
-    # othewise report an error
+    # otherwise report an error
     else
         echo -e '\nlibpyqt5.so is missing from:'
         echo -e '/usr/lib/x86_64-linux-gnu/qt5/plugins/designer/'

--- a/lib/python/qtvcp/lib/qt_vismach/mill_xyz.py
+++ b/lib/python/qtvcp/lib/qt_vismach/mill_xyz.py
@@ -31,7 +31,7 @@ MODEL_SCALING = IMPERIAL
 # tells loadusr pins is ready
 # c.ready()
 
-# we are not using a component but the original code requires a varible
+# we are not using a component but the original code requires a variable
 c = None
 
 # Used for tool cylinder

--- a/lib/python/qtvcp/lib/qt_vismach/primitives.py
+++ b/lib/python/qtvcp/lib/qt_vismach/primitives.py
@@ -643,7 +643,7 @@ class BoxCenteredXY(Box):
 
 
 # capture current transformation matrix
-# note that this tranforms from the current coordinate system
+# note that this transforms from the current coordinate system
 # to the viewport system, NOT to the world system
 class Capture(object):
     def __init__(self):

--- a/lib/python/qtvcp/lib/qt_vismach/qt_vismach.py
+++ b/lib/python/qtvcp/lib/qt_vismach/qt_vismach.py
@@ -268,7 +268,7 @@ class GLWidget(QOpenGLWidget):
         # so lets also invert the work2view matrix
         view2work = invert(self.work2view.t)
 
-        # since backplot lines only need vertexes, not orientation,
+        # since backplot lines only need vertices, not orientation,
         # and the tooltip is at the origin, getting the tool coords
         # is easy
         tx, ty, tz = self.tool2view.t[3][:3]

--- a/lib/python/qtvcp/lib/qtplasmac/conv_block.py
+++ b/lib/python/qtvcp/lib/qtplasmac/conv_block.py
@@ -391,7 +391,7 @@ def get_parameters(P, W):
     P.convFlipToggle = False
     for line in inCode:
         line = line.strip().lower()
-        # maybe check here fo old style rotate, scale, and array
+        # maybe check here for old style rotate, scale, and array
         if line.startswith(';conversational block'):
             P.convBlock = [True, True]
         elif 'G21' in line.upper().replace(' ', '') and P.unitsPerMm != 1:

--- a/lib/python/qtvcp/qt_action.py
+++ b/lib/python/qtvcp/qt_action.py
@@ -129,7 +129,7 @@ class _Lcnc_Action(object):
         self.ensure_mode(linuxcnc.MODE_MANUAL)
 
     # sets up a python generator that goes through the MDI list of lists.
-    # if it's a command that we have to wait indefinately
+    # if it's a command that we have to wait indefinitely
     # ie like a manual tool change.
     # then we wait for STATUS to return 'command-stopped'
     # and then continue where we left off.
@@ -185,7 +185,7 @@ class _Lcnc_Action(object):
         mdi_list = mdi.split(';')
         self.ensure_mode(linuxcnc.MODE_MDI)
         for code in (mdi_list):
-            LOG.debug('CALL_INI_MDI comand:{}'.format(code))
+            LOG.debug('CALL_INI_MDI command:{}'.format(code))
             self.cmd.mdi('%s' % code)
 
     def CALL_OWORD(self, code, time=5):
@@ -780,7 +780,7 @@ class _Lcnc_Action(object):
             STATUS.handler_disconnect(self._a)
 
     # python generator that goes through the MDI list.
-    # if it's a command that we have to wait indefinately
+    # if it's a command that we have to wait indefinitely
     # ie like a manual tool change.
     # then we wait for STATUS to return 'command-stopped'
     # and then continue where we left off.
@@ -818,9 +818,9 @@ class _Lcnc_Action(object):
             self.SET_DISPLAY_MESSAGE("Touchplate touchoff routine returned successfully")
         elif "DEBUG" in line: # must set DEBUG level on LOG in top of this file
             LOG.debug(line[line.find('DEBUG')+6:])
-        # This also gets error text sent from logging of ACTION libray in the subprogram
+        # This also gets error text sent from logging of ACTION library in the subprogram
         elif "ERROR" in line:
-            # remove preceeding text
+            # remove preceding text
             s = line[line.find('ERROR')+6:]
             s = s[s.find(']')+1:]
             # remove (possible)trailing debug info

--- a/lib/python/qtvcp/widgets/camview_widget.py
+++ b/lib/python/qtvcp/widgets/camview_widget.py
@@ -184,7 +184,7 @@ class CamView(QtWidgets.QWidget, _HalWidgetBase):
         return CV.resize(frame, dims, interpolation=CV.INTER_CUBIC)
 
     def zoom(self, frame, scale):
-        # get orignal size of image
+        # get original size of image
         (oh, ow) = frame.shape[:2]
         #############################
         # scale image

--- a/lib/python/qtvcp/widgets/dro_widget.py
+++ b/lib/python/qtvcp/widgets/dro_widget.py
@@ -91,7 +91,7 @@ class DROLabel(ScaledLabel, _HalWidgetBase):
 
     # update ishomed property
     # polish widget so stylesheet sees the property change
-    # some stylessheets color the text on home/unhome
+    # some stylesheets color the text on home/unhome
     def _home_status_polish(self, d, state):
         if d == self.joint_number or (self.joint_number==10 and d==1):
             self.setProperty('isHomed', state)

--- a/lib/python/qtvcp/widgets/gcode_editor.py
+++ b/lib/python/qtvcp/widgets/gcode_editor.py
@@ -265,7 +265,7 @@ class EditorBase(QsciScintilla):
         self.setMarkerBackgroundColor(QColor("yellow"),
                                       self.CURRENT_MARKER_NUM)
 
-        # user Hightlight line
+        # user Highlight line
         self.userHandle = self.markerDefine(QsciScintilla.Background,
                           self.USER_MARKER_NUM)
         self.setMarkerBackgroundColor(QColor("red"),
@@ -646,7 +646,7 @@ class GcodeDisplay(EditorBase, _HalWidgetBase):
         if STATUS.is_auto_running():
             self.highlight_line(None, line-1)
             return
-        LOG.debug('editor: got external hilight {}'.format(line))
+        LOG.debug('editor: got external highlight {}'.format(line))
         #self.highlight_line(None, line-1)
         self.ensureLineVisible(line-1)
         #self.setSelection(line-1,0,line-1,self.lineLength(line-1)-1)

--- a/lib/python/qtvcp/widgets/gcode_graphics.py
+++ b/lib/python/qtvcp/widgets/gcode_graphics.py
@@ -94,7 +94,7 @@ class  GCodeGraphics(Lcnc_3dGraphics, _HalWidgetBase):
             lon = self.PREFS_.getpref(self.HAL_NAME_+'-user-lon', lon, float, 'SCREEN_CONTROL_LAST_SETTING')
             self.presetViewSettings(v,z,x,y,lat,lon)
 
-    # external source asked for hightlight,
+    # external source asked for highlight,
     # make sure we block the propagation
     def highlight_graphics(self, line):
         if self._current_file is None: return

--- a/lib/python/qtvcp/widgets/status_slider.py
+++ b/lib/python/qtvcp/widgets/status_slider.py
@@ -131,7 +131,7 @@ class StatusSlider(QtWidgets.QSlider, _HalWidgetBase):
             return'normal'
 
     # polish widget so stylesheet sees the property change
-    # some stylessheets color the widget based on the abritrary hi/lo range
+    # some stylesheets color the widget based on the arbitrary hi/lo range
     def _style_polish(self, prop = 'alertState',state = 'normal'):
         if self._alertState != state:
             self.setProperty(prop, state)

--- a/share/qtvcp/panels/copy_dialog/copy_dialog_handler.py
+++ b/share/qtvcp/panels/copy_dialog/copy_dialog_handler.py
@@ -96,7 +96,7 @@ class HandlerClass:
             else:
                 self.makedirs(dest)
 
-            # walk the folder and copy everthing
+            # walk the folder and copy everything
             for path, dirs, filenames in os.walk(src):
                 for directory in dirs:
                     destDir = path.replace(src,dest)

--- a/share/qtvcp/screens/blender/blender.ui
+++ b/share/qtvcp/screens/blender/blender.ui
@@ -1020,7 +1020,7 @@
            <item>
             <widget class="QGroupBox" name="groupBox_2">
              <property name="title">
-              <string>Offsets Managment</string>
+              <string>Offsets Management</string>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_8">
               <item>
@@ -1210,7 +1210,7 @@
              <item>
               <widget class="QGroupBox" name="groupBox">
                <property name="title">
-                <string>Tool File Managment</string>
+                <string>Tool File Management</string>
                </property>
                <layout class="QHBoxLayout" name="horizontalLayout_7">
                 <item>

--- a/share/qtvcp/screens/qt_cnc_9_axis/qt_cnc_9_axis.ui
+++ b/share/qtvcp/screens/qt_cnc_9_axis/qt_cnc_9_axis.ui
@@ -1745,7 +1745,7 @@ font: 75 12pt &quot;Noto Sans&quot;;</string>
        </property>
        <property name="text">
         <string>Go to
-Origion Zero</string>
+Origin Zero</string>
        </property>
        <property name="mdi_command_action" stdset="0">
         <bool>true</bool>

--- a/share/qtvcp/screens/qtdragon/qtdragon.ui
+++ b/share/qtvcp/screens/qtdragon/qtdragon.ui
@@ -5078,7 +5078,7 @@ TO FILE</string>
                            </sizepolicy>
                           </property>
                           <property name="toolTip">
-                           <string>Eanable Webcam for work offset location</string>
+                           <string>Enable Webcam for work offset location</string>
                           </property>
                           <property name="text">
                            <string>USE CAMERA</string>

--- a/share/qtvcp/screens/qtlathe/qtlathe.ui
+++ b/share/qtvcp/screens/qtlathe/qtlathe.ui
@@ -6525,7 +6525,7 @@ ALARMS</string>
                           </size>
                          </property>
                          <property name="text">
-                          <string>Coodinate
+                          <string>Coordinate
 System</string>
                          </property>
                         </widget>

--- a/share/qtvcp/screens/qtplasmac/qtplasmac_gcode_src.py
+++ b/share/qtvcp/screens/qtplasmac/qtplasmac_gcode_src.py
@@ -598,7 +598,7 @@ with open(inCode, 'r') as fRead:
         # check for a material edit
         if line.startswith('(o='):
             check_material_edit()
-            # add material change for temporay material
+            # add material change for temporary material
             if line.startswith('(o=0'):
                 gcodeList.append('m190 p{} ({})'.format(tmpMatNum, tmpMatNam))
                 gcodeList.append('m66 p3 l3 q1')
@@ -772,7 +772,7 @@ with open(inCode, 'r') as fRead:
         if 'm66' in line:
             if offsetG4x:
                 codeError = True
-                dlg  = '\nCannot validate a material change with cutter compensation acive\n'
+                dlg  = '\nCannot validate a material change with cutter compensation active\n'
                 dlg += '\nError near line #{}.\n'.format(lineNum)
                 dlg += '\nEdit G-Code file to suit.\n'
                 dialog_box('ERROR', dlg)

--- a/share/qtvcp/screens/qtplasmac/qtplasmac_handler.py
+++ b/share/qtvcp/screens/qtplasmac/qtplasmac_handler.py
@@ -5365,7 +5365,7 @@ class HandlerClass:
             self.w[button].setStyleSheet(\
                     'QPushButton {{ background: {0} }} \
                      QPushButton:pressed {{ background: {0} }}'.format(self.backColor))
-        # the error messge label on the status bar
+        # the error message label on the status bar
         self.w.error_label.setStyleSheet('QLabel {{ color: {} }}'.format(self.estopColor))
         # some gcode display/editor colors cannot use .qss file
         # gcode display current gcode line

--- a/share/qtvcp/screens/qttouchy/qttouchy.ui
+++ b/share/qtvcp/screens/qttouchy/qttouchy.ui
@@ -2295,7 +2295,7 @@ p, li { white-space: pre-wrap; }
                   <item>
                    <widget class="QGroupBox" name="groupBox_9">
                     <property name="title">
-                     <string>Scoll Controls</string>
+                     <string>Scroll Controls</string>
                     </property>
                     <layout class="QVBoxLayout" name="verticalLayout_32">
                      <property name="leftMargin">

--- a/share/qtvcp/screens/woodpecker/images/QTvcp Widgets.html
+++ b/share/qtvcp/screens/woodpecker/images/QTvcp Widgets.html
@@ -485,7 +485,7 @@ Then add as many pages as there are views to switch to.<br>
 on each page add a layout widget.<br>
 After adding the layout you must right click the widget switcher again<br>
 and set the layout option.<br>
-click on the widgetswitcher widget and then scroll to the botton of the property editor.<br>
+click on the widgetswitcher widget and then scroll to the bottom of the property editor.<br>
 you are looking for the dynamic property <em>widget_list</em>.<br>
 double click the to the right of the widget_list property.<br>
 A dialog will pop up allowing you to add the names of the widgets to move to the pages you added to the widgetswitcher.<br>
@@ -983,7 +983,7 @@ sets up the numerical entry dialog
 <li>
 <p>
 <em>toolDialog_option</em>:
-sets up the manual tool change dialog, incuding HAL pin.
+sets up the manual tool change dialog, including HAL pin.
 </p>
 </li>
 <li>
@@ -1285,7 +1285,7 @@ http://www.gnu.org/software/src-highlite -->
 <span style="font-weight: bold"><span style="color: #0000FF">SUBROUTINE_PATH </span></span><span style="font-weight: bold"><span style="color: #000000">=</span></span></tt></pre></div></div>
 <div class="paragraph"><p>The macros are Oword subroutine with special comments to work with the launcher.<br>
 The first three lines must have the keywords: (The forth is optional)<br>
-Here is a sample fr the forst four lines in an Oword file:<br></p></div>
+Here is a sample fr the first four lines in an Oword file:<br></p></div>
 <div class="listingblock">
 <div class="content">
 <pre><tt>; MACROCOMMAND=Entry1,Entry2
@@ -1592,7 +1592,7 @@ the state of hard limits
 <div class="paragraph"><p>This widget is used to select files to load.<br>
 It has a the ability to scroll the names with hardware such as a MPG.<br></p></div>
 <div class="paragraph"><p>one can class patch the function <em>load(self,fname):</em> to customize file loading.<br></p></div>
-<div class="paragraph"><p>the function <em>getCurrentSelected()</em> will return a python touple, containing<br>
+<div class="paragraph"><p>the function <em>getCurrentSelected()</em> will return a python tuple, containing<br>
 the file path and whether it’s a file.<br></p></div>
 <div class="listingblock">
 <div class="content"><!-- Generator: GNU source-highlight 3.1.6
@@ -1600,7 +1600,7 @@ by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite -->
 <pre><tt>temp <span style="color: #990000">=</span> FILEMANAGER<span style="color: #990000">.</span><span style="font-weight: bold"><span style="color: #000000">getCurrentSelected</span></span><span style="color: #990000">()</span>
-<span style="font-weight: bold"><span style="color: #0000FF">print</span></span> <span style="color: #FF0000">'filepath={}'</span><span style="color: #990000">.</span><span style="font-weight: bold"><span style="color: #000000">fomat</span></span><span style="color: #990000">(</span>temp<span style="color: #990000">[</span><span style="color: #993399">0</span><span style="color: #990000">])</span>
+<span style="font-weight: bold"><span style="color: #0000FF">print</span></span> <span style="color: #FF0000">'filepath={}'</span><span style="color: #990000">.</span><span style="font-weight: bold"><span style="color: #000000">format</span></span><span style="color: #990000">(</span>temp<span style="color: #990000">[</span><span style="color: #993399">0</span><span style="color: #990000">])</span>
 <span style="font-weight: bold"><span style="color: #0000FF">if</span></span> temp<span style="color: #990000">[</span><span style="color: #993399">1</span><span style="color: #990000">]:</span>
     <span style="font-weight: bold"><span style="color: #0000FF">print</span></span> <span style="color: #FF0000">'Is a file'</span></tt></pre></div></div>
 <div class="paragraph"><p>It is based on pyQT’s</p></div>

--- a/share/qtvcp/screens/woodpecker/images/QTvcp Widgets.html
+++ b/share/qtvcp/screens/woodpecker/images/QTvcp Widgets.html
@@ -485,7 +485,7 @@ Then add as many pages as there are views to switch to.<br>
 on each page add a layout widget.<br>
 After adding the layout you must right click the widget switcher again<br>
 and set the layout option.<br>
-click on the widgetswitcher widget and then scroll to the bottom of the property editor.<br>
+click on the widgetswitcher widget and then scroll to the botton of the property editor.<br>
 you are looking for the dynamic property <em>widget_list</em>.<br>
 double click the to the right of the widget_list property.<br>
 A dialog will pop up allowing you to add the names of the widgets to move to the pages you added to the widgetswitcher.<br>
@@ -983,7 +983,7 @@ sets up the numerical entry dialog
 <li>
 <p>
 <em>toolDialog_option</em>:
-sets up the manual tool change dialog, including HAL pin.
+sets up the manual tool change dialog, incuding HAL pin.
 </p>
 </li>
 <li>
@@ -1285,7 +1285,7 @@ http://www.gnu.org/software/src-highlite -->
 <span style="font-weight: bold"><span style="color: #0000FF">SUBROUTINE_PATH </span></span><span style="font-weight: bold"><span style="color: #000000">=</span></span></tt></pre></div></div>
 <div class="paragraph"><p>The macros are Oword subroutine with special comments to work with the launcher.<br>
 The first three lines must have the keywords: (The forth is optional)<br>
-Here is a sample fr the first four lines in an Oword file:<br></p></div>
+Here is a sample fr the forst four lines in an Oword file:<br></p></div>
 <div class="listingblock">
 <div class="content">
 <pre><tt>; MACROCOMMAND=Entry1,Entry2
@@ -1592,7 +1592,7 @@ the state of hard limits
 <div class="paragraph"><p>This widget is used to select files to load.<br>
 It has a the ability to scroll the names with hardware such as a MPG.<br></p></div>
 <div class="paragraph"><p>one can class patch the function <em>load(self,fname):</em> to customize file loading.<br></p></div>
-<div class="paragraph"><p>the function <em>getCurrentSelected()</em> will return a python tuple, containing<br>
+<div class="paragraph"><p>the function <em>getCurrentSelected()</em> will return a python touple, containing<br>
 the file path and whether it’s a file.<br></p></div>
 <div class="listingblock">
 <div class="content"><!-- Generator: GNU source-highlight 3.1.6
@@ -1600,7 +1600,7 @@ by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite -->
 <pre><tt>temp <span style="color: #990000">=</span> FILEMANAGER<span style="color: #990000">.</span><span style="font-weight: bold"><span style="color: #000000">getCurrentSelected</span></span><span style="color: #990000">()</span>
-<span style="font-weight: bold"><span style="color: #0000FF">print</span></span> <span style="color: #FF0000">'filepath={}'</span><span style="color: #990000">.</span><span style="font-weight: bold"><span style="color: #000000">format</span></span><span style="color: #990000">(</span>temp<span style="color: #990000">[</span><span style="color: #993399">0</span><span style="color: #990000">])</span>
+<span style="font-weight: bold"><span style="color: #0000FF">print</span></span> <span style="color: #FF0000">'filepath={}'</span><span style="color: #990000">.</span><span style="font-weight: bold"><span style="color: #000000">fomat</span></span><span style="color: #990000">(</span>temp<span style="color: #990000">[</span><span style="color: #993399">0</span><span style="color: #990000">])</span>
 <span style="font-weight: bold"><span style="color: #0000FF">if</span></span> temp<span style="color: #990000">[</span><span style="color: #993399">1</span><span style="color: #990000">]:</span>
     <span style="font-weight: bold"><span style="color: #0000FF">print</span></span> <span style="color: #FF0000">'Is a file'</span></tt></pre></div></div>
 <div class="paragraph"><p>It is based on pyQT’s</p></div>

--- a/share/qtvcp/screens/woodpecker/images/QTvcp Widgets_files/asciidoc.css
+++ b/share/qtvcp/screens/woodpecker/images/QTvcp Widgets_files/asciidoc.css
@@ -427,7 +427,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/share/qtvcp/screens/woodpecker/images/QTvcp Widgets_files/asciidoc.css
+++ b/share/qtvcp/screens/woodpecker/images/QTvcp Widgets_files/asciidoc.css
@@ -427,7 +427,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overridden by CSS in most browsers. */
+/* Because the table frame attribute is overriden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/share/qtvcp/screens/woodpecker/woodpecker.ui
+++ b/share/qtvcp/screens/woodpecker/woodpecker.ui
@@ -13214,7 +13214,7 @@ TO FILE</string>
                          </sizepolicy>
                         </property>
                         <property name="toolTip">
-                         <string>Eanable Webcam for work offset location</string>
+                         <string>Enable Webcam for work offset location</string>
                         </property>
                         <property name="styleSheet">
                          <string notr="true">font: 75 12pt &quot;Bebas Kai&quot;;</string>

--- a/share/qtvcp/screens/x1mill/x1mill.ui
+++ b/share/qtvcp/screens/x1mill/x1mill.ui
@@ -849,7 +849,7 @@ VIEW</string>
        </rect>
       </property>
       <property name="text">
-       <string>ORGIN
+       <string>ORIGIN
 OFFSETS</string>
       </property>
       <property name="checkable">

--- a/share/qtvcp/widgets_ui/basic_probe.ui
+++ b/share/qtvcp/widgets_ui/basic_probe.ui
@@ -662,7 +662,7 @@ HELP</string>
                  </size>
                 </property>
                 <property name="toolTip">
-                 <string>Inital probe velocity</string>
+                 <string>Initial probe velocity</string>
                 </property>
                 <property name="maxLength">
                  <number>10</number>

--- a/share/qtvcp/widgets_ui/versa_probe.ui
+++ b/share/qtvcp/widgets_ui/versa_probe.ui
@@ -262,7 +262,7 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Probe Outside Y Edge, Positive Direction, Finsh At Edge</string>
+                  <string>Probe Outside Y Edge, Positive Direction, Finish At Edge</string>
                  </property>
                  <property name="text">
                   <string/>
@@ -368,7 +368,7 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Probe Outside X Edge, Negative Direction, Finsh At Edge</string>
+                  <string>Probe Outside X Edge, Negative Direction, Finish At Edge</string>
                  </property>
                  <property name="text">
                   <string/>
@@ -474,7 +474,7 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Probe Outside X Edge, Positive Direction, Finsh At Edge</string>
+                  <string>Probe Outside X Edge, Positive Direction, Finish At Edge</string>
                  </property>
                  <property name="text">
                   <string/>
@@ -527,7 +527,7 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Probe Outside Y Edge, Negative Direction, Finsh At Edge</string>
+                  <string>Probe Outside Y Edge, Negative Direction, Finish At Edge</string>
                  </property>
                  <property name="text">
                   <string/>
@@ -1404,7 +1404,7 @@ Z</string>
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Probe Inside Y Edge, Positive Direction, Finsh At Edge</string>
+                  <string>Probe Inside Y Edge, Positive Direction, Finish At Edge</string>
                  </property>
                  <property name="text">
                   <string/>
@@ -1510,7 +1510,7 @@ Z</string>
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Probe Inside X Edge, Negative Direction, Finsh At Edge</string>
+                  <string>Probe Inside X Edge, Negative Direction, Finish At Edge</string>
                  </property>
                  <property name="text">
                   <string/>
@@ -1727,7 +1727,7 @@ Z</string>
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Probe Inside Y Edge, Negative Direction, Finsh At Edge</string>
+                  <string>Probe Inside Y Edge, Negative Direction, Finish At Edge</string>
                  </property>
                  <property name="text">
                   <string/>
@@ -1780,7 +1780,7 @@ Z</string>
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>Probe Inside Y Edge, Negative Direction, Finsh At Edge</string>
+                  <string>Probe Inside Y Edge, Negative Direction, Finish At Edge</string>
                  </property>
                  <property name="text">
                   <string/>

--- a/src/emc/usr_intf/qtvcp/qtvcp.py
+++ b/src/emc/usr_intf/qtvcp/qtvcp.py
@@ -317,7 +317,7 @@ Pressing cancel will close linuxcnc.""" % target)
         # theme (styles in QT speak) specify a qss file
         if opts.theme:
             window.apply_styles(opts.theme)
-        # appy qss file or default theme
+        # apply qss file or default theme
         else:
             window.apply_styles()
 
@@ -384,7 +384,7 @@ Pressing cancel will close linuxcnc.""" % target)
         global ERROR_COUNT
         ERROR_COUNT +=1
 
-        # we count errors because often there are mutiple and the first is the
+        # we count errors because often there are multiple and the first is the
         # only important one.
         if ERROR_COUNT == 1:
             lines = traceback.format_exception(exc_type, exc_obj, exc_tb)


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.ts,./share,./docs/man/es,./configs/attic -L ans,doubleclick,dout,halp,parms`