### PR TITLE
Towards package reproducibility: system date to d/changelog date

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -19,6 +19,10 @@
 kernel_version = @KERNEL_VERSION@
 enable_build_documentation = @ENABLE_BUILD_DOCUMENTATION@
 configure_realtime_arg = @CONFIGURE_REALTIME_ARG@
+export DATE=`grep -- -- debian/changelog | head -n 1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '`
+export TIME=`grep -- -- debian/changelog | head -n 1 | sed -e 's/^.*  //' | cut -f5 -d' '`
+
+CPPFLAGS += -u__DATE__ -D__DATE__="$(DATE)" -u__TIME -D__TIME__="$(TIME)"
 
 ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
     NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))

--- a/docs/src/Master_Developer.txt
+++ b/docs/src/Master_Developer.txt
@@ -1,9 +1,11 @@
 :lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 Developer Manual V{lversion}, {localdate}
 =========================================
 
 :lang: en
 :masterdir: {indir}
+:revdate: 2021-10-28
 
 
 == Introduction

--- a/docs/src/Master_Developer_es.txt
+++ b/docs/src/Master_Developer_es.txt
@@ -1,10 +1,12 @@
 ﻿:lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 Manual del Desarrollador V{lversion}, {localdate}
 =================================================
 
 :ascii-ids:
 :lang: es
 :masterdir: {indir}
+:revdate: 2021-10-28
 
 
 == Introducción

--- a/docs/src/Master_Documentation.txt
+++ b/docs/src/Master_Documentation.txt
@@ -1,7 +1,9 @@
 :lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 LinuxCNC V{lversion}, {localdate}
 =================================
 :lang: en
+:revdate: 2021-10-28
 
 = Contents
 

--- a/docs/src/Master_Documentation_es.txt
+++ b/docs/src/Master_Documentation_es.txt
@@ -1,8 +1,10 @@
 :lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 LinuxCNC V{lversion}, {localdate}
 =================================
 :ascii-ids:
 :lang: es
+:revdate: 2021-10-28
 
 = Contenido
 

--- a/docs/src/Master_Getting_Started.txt
+++ b/docs/src/Master_Getting_Started.txt
@@ -1,8 +1,10 @@
 :lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 Getting Started V{lversion}, {localdate}
 ========================================
 :lang: en
 :masterdir: {indir}
+:revdate: 2021-10-28
 
 The LinuxCNC Team
 

--- a/docs/src/Master_Getting_Started_cn.txt
+++ b/docs/src/Master_Getting_Started_cn.txt
@@ -1,8 +1,10 @@
 :lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 Getting Started V{lversion}, {localdate}
 ========================================
 :lang: zh_CN
 :masterdir: {indir}
+:revdate: 2021-10-28
 
 The LinuxCNC Team
 

--- a/docs/src/Master_Getting_Started_es.txt
+++ b/docs/src/Master_Getting_Started_es.txt
@@ -1,8 +1,10 @@
 :lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 Primeros Pasos V{lversion}, {localdate}
 ========================================
 :lang: es
 :masterdir: {indir}
+:revdate: 2021-10-28
 
 [NOTE]
 Esta documentación no se ha actualizado desde LinuxCNC versión 2.5,

--- a/docs/src/Master_Getting_Started_fr.txt
+++ b/docs/src/Master_Getting_Started_fr.txt
@@ -1,8 +1,9 @@
 :lang: fr
 :ascii-ids:
 :toc:
-:localdate: {sys: date +%d/%m/%Y}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 :lversion: {sys: cat ../VERSION}
+:revdate: 2021-10-28
 Guide de démarrage V{lversion}, {localdate}
 ===========================================
 

--- a/docs/src/Master_HAL_fr.txt
+++ b/docs/src/Master_HAL_fr.txt
@@ -3,6 +3,8 @@
 :localdate: {sys: date +%d/%m/%Y}
 :ascii-ids:
 :lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
+:revdate: 2021-10-28
 Manuel de HAL V{lversion}; {localdate}
 ======================================
 :masterdir: {indir}

--- a/docs/src/Master_Integrator.txt
+++ b/docs/src/Master_Integrator.txt
@@ -1,8 +1,10 @@
 :lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 Integrator Information V{lversion}, {localdate}
 ===============================================
 :lang: en
 :masterdir: {indir}
+:revdate: 2021-10-28
 
 :leveloffset: 1
 

--- a/docs/src/Master_Integrator_es.txt
+++ b/docs/src/Master_Integrator_es.txt
@@ -1,8 +1,10 @@
 :lversion: {sys: cat ../VERSION}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 Manuel de l'intégrateur V{lversion}, {localdate}
 ================================================
 :lang: fr
 :masterdir: {indir}
+:revdate: 2021-10-28
 
 :leveloffset: 1
 

--- a/docs/src/Master_Integrator_fr.txt
+++ b/docs/src/Master_Integrator_fr.txt
@@ -1,8 +1,9 @@
 :lang: fr
 :toc:
-:localdate: {sys: date +%d/%m/%Y}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 :ascii-ids:
 :lversion: {sys: cat ../VERSION}
+:revdate: 2021-10-28
 Manuel de l'intégrateur V{lversion}, {localdate}
 ================================================
 :masterdir: {indir}

--- a/docs/src/Master_User_fr.txt
+++ b/docs/src/Master_User_fr.txt
@@ -1,8 +1,9 @@
 :lang: fr
 :toc:
-:localdate: {sys: date +%d/%m/%Y}
+:localdate: {sys: egrep "^ *--" debian/changelog | head -n1 | sed -e 's/^.*  //' | cut -f2,3,4 -d' '}
 :ascii-ids:
 :lversion: {sys: cat ../VERSION}
+:revdate: 2021-10-28
 Manuel de l'utilisateur V{lversion}, {localdate}
 ================================================
 


### PR DESCRIPTION
A software is packaged reproducibly if the same code yields the exact same binary. This also includes the documentation. And if some timestamp is directly derived from the system clock that is integrated in PDFs or the executables, then any diff will be too large to spot the interesting differences.

This PR follows advice from https://wiki.debian.org/ReproducibleBuilds/Howto . The first beneficiary of this patch I hope to be PR #1327 that introduces what basically is a rewrite of the d/rules file. 