### PR TITLE
Moved use of compile time detected values (config.h) out of installed header files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -155,6 +155,7 @@ SUBDIRS := \
     emc/motion emc/ini emc/rs274ngc emc/sai emc emc/pythonplugin \
     emc/motion-logger \
     emc/tooldata \
+    emc \
     \
     module_helper \
     \
@@ -310,7 +311,7 @@ default: $(INFILES)
 # files in the source tree are the ones used when building linuxcnc.  The copy
 # in ../include is used when building external components of linuxcnc.
 HEADERS := \
-    config.h \
+    emc/linuxcnc.h \
     emc/ini/emcIniFile.hh \
     emc/ini/iniaxis.hh \
     emc/ini/inijoint.hh \

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1195,15 +1195,6 @@ AH_TOP([/********************************************************************
 ********************************************************************/
 #ifndef EMC2_CONFIG_H
 #define EMC2_CONFIG_H
-
-/* LINELEN is used throughout for buffer sizes, length of file name strings,
-   etc. Let's just have one instead of a multitude of defines all the same. */
-#define LINELEN 255
-/* Used in a number of places for sprintf() buffers. */
-#define BUFFERLEN 80
-
-#define MM_PER_INCH 25.4
-#define INCH_PER_MM (1.0/25.4)
 ])
 
 AC_CHECK_HEADERS([sys/io.h])

--- a/src/emc/Submakefile
+++ b/src/emc/Submakefile
@@ -1,0 +1,7 @@
+INCLUDES += emc
+
+$(patsubst ./emc/%,../include/%,$(wildcard ./emc/*.h)): ../include/%.h: ./emc/%.h
+	cp $^ $@
+
+$(patsubst ./emc/%,../include/%,$(wildcard ./emc/*.hh)): ../include/%.hh: ./emc/%.hh
+	cp $^ $@

--- a/src/emc/canterp/canterp.cc
+++ b/src/emc/canterp/canterp.cc
@@ -55,6 +55,7 @@
 #include <limits.h>
 #include <algorithm>
 #include "config.h"
+#include "emc/linuxcnc.h"
 #include "emc/nml_intf/interp_return.hh"
 #include "emc/nml_intf/canon.hh"
 #include "emc/rs274ngc/interp_base.hh"

--- a/src/emc/linuxcnc.h
+++ b/src/emc/linuxcnc.h
@@ -1,0 +1,27 @@
+/********************************************************************
+* Description: linuxcnc.hh
+*	Common defines used in many emc2 source files.
+*
+*
+* Author: Petter Reinholdtsen
+* License: LGPL Version 2
+* System: Any
+*
+* Copyright (c) 2021 All rights reserved.
+********************************************************************/
+
+#ifndef LINUXCNC_H
+#define LINUXCNC_H
+
+/* LINELEN is used throughout for buffer sizes, length of file name strings,
+   etc. Let's just have one instead of a multitude of defines all the same. */
+#define LINELEN 255
+
+/* Used in a number of places for sprintf() buffers. */
+#define BUFFERLEN 80
+
+/* Imperial/Metric conversion */
+#define MM_PER_INCH 25.4
+#define INCH_PER_MM (1.0/MM_PER_INCH)
+
+#endif /* LINUXCNC_H */

--- a/src/emc/motion/usrmotintf.cc
+++ b/src/emc/motion/usrmotintf.cc
@@ -13,7 +13,7 @@
 * Copyright (c) 2004 All rights reserved.
 ********************************************************************/
 
-#include "config.h"     	/* LINELEN definition */
+#include "emc/linuxcnc.h"     	/* LINELEN definition */
 #include <stdlib.h>		/* exit() */
 #include <sys/stat.h>
 #include <string.h>		/* memcpy() */

--- a/src/emc/nml_intf/Submakefile
+++ b/src/emc/nml_intf/Submakefile
@@ -1,4 +1,4 @@
-INCLUDES += emc/nml_intf
+INCLUDES += emc emc/nml_intf
 
 LIBEMCSRCS := \
     emc/nml_intf/emcglb.c \

--- a/src/emc/nml_intf/emc.hh
+++ b/src/emc/nml_intf/emc.hh
@@ -15,7 +15,6 @@
 #ifndef EMC_HH
 #define EMC_HH
 
-#include "config.h"
 #include "emcmotcfg.h"		// EMC_JOINT_MAX, EMC_AXIS_MAX
 #include "nml_type.hh"
 #include "motion_types.h"

--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -14,6 +14,7 @@
 ********************************************************************/
 #ifndef EMC_NML_HH
 #define EMC_NML_HH
+#include "linuxcnc.h"
 #include "emc.hh"
 #include "rcs.hh"
 #include "cmd_msg.hh"

--- a/src/emc/nml_intf/emccfg.h
+++ b/src/emc/nml_intf/emccfg.h
@@ -25,7 +25,7 @@ extern "C" {
 #define DEFAULT_EMC_INIFILE "emc.ini"
 
 /* default name of EMC NML file */
-#define DEFAULT_EMC_NMLFILE EMC2_DEFAULT_NMLFILE
+extern const char * DEFAULT_EMC_NMLFILE;
 
 /* cycle time for emctask, in seconds */
 #define DEFAULT_EMC_TASK_CYCLE_TIME 0.100

--- a/src/emc/nml_intf/emcglb.c
+++ b/src/emc/nml_intf/emcglb.c
@@ -13,13 +13,15 @@
 * Last change:
 ********************************************************************/
 
+#include "config.h"
 #include "emcglb.h"		/* these decls */
 #include "emccfg.h"		/* their initial values */
 #include "emcpos.h"		/* EmcPose */
 
 char emc_inifile[LINELEN] = DEFAULT_EMC_INIFILE;
 
-char emc_nmlfile[LINELEN] = DEFAULT_EMC_NMLFILE;
+const char * DEFAULT_EMC_NMLFILE = EMC2_DEFAULT_NMLFILE;
+char emc_nmlfile[LINELEN] = EMC2_DEFAULT_NMLFILE;
 
 char rs274ngc_startup_code[LINELEN] =
     DEFAULT_RS274NGC_STARTUP_CODE;

--- a/src/emc/nml_intf/emcglb.h
+++ b/src/emc/nml_intf/emcglb.h
@@ -15,7 +15,7 @@
 #ifndef EMCGLB_H
 #define EMCGLB_H
 
-#include "config.h"             /* LINELEN */
+#include "linuxcnc.h"           /* LINELEN */
 #include "math.h"		/* M_PI */
 #include "emcmotcfg.h"          /* EMCMOT_MAX_DIO */
 #include "debugflags.h"

--- a/src/emc/rs274ngc/Submakefile
+++ b/src/emc/rs274ngc/Submakefile
@@ -1,7 +1,7 @@
 #BOOST_DEBUG_FLAGS= -DBOOST_DEBUG_PYTHON -g -O0
 BOOST_DEBUG_FLAGS=
 
-INCLUDES += emc/rs274ngc
+INCLUDES += emc emc/rs274ngc
 
 LIBRS274SRCS := $(addprefix emc/rs274ngc/, \
 	interp_arc.cc \

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -15,7 +15,7 @@
 
 #include <locale.h>
 #include <algorithm>
-#include "config.h"
+#include "linuxcnc.h"
 #include <limits.h>
 #include <stdio.h>
 #include <set>
@@ -58,10 +58,6 @@ inline int round_to_int(T x) {
  * example: a user G code command executes a tool change
  */
 #define MAX_NESTED_REMAPS 10
-
-// English - Metric conversion (long number keeps error buildup down)
-#define MM_PER_INCH 25.4
-//#define INCH_PER_MM 0.039370078740157477
 
 /* numerical constants */
 

--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -17,6 +17,9 @@
 *
 * Last change: Juli 2011
 ********************************************************************/
+
+#include "config.h"
+
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -68,6 +68,7 @@
 fpu_control_t __fpu_control = _FPU_IEEE & ~(_FPU_MASK_IM | _FPU_MASK_ZM | _FPU_MASK_OM);
 #endif
 
+#include "config.h"
 #include "rcs.hh"		// NML classes, nmlErrorFormat()
 #include "emc.hh"		// EMC NML
 #include "emc_nml.hh"

--- a/src/emc/usr_intf/axis/extensions/togl.c
+++ b/src/emc/usr_intf/axis/extensions/togl.c
@@ -14,6 +14,7 @@
 #define X11
 #endif
 
+#include "config.h"
 
 /*** Windows headers ***/
 #if defined(WIN32) && !defined(X11) && !defined(macintosh)

--- a/src/emc/usr_intf/emclcd.cc
+++ b/src/emc/usr_intf/emclcd.cc
@@ -43,6 +43,7 @@
 #include <getopt.h>
 #include <string.h>
 
+#include "emc/linuxcnc.h"
 #include "rcs.hh"
 #include "posemath.h"		// PM_POSE, TO_RAD
 #include "emc.hh"		// EMC NML

--- a/src/emc/usr_intf/emcsh.cc
+++ b/src/emc/usr_intf/emcsh.cc
@@ -22,6 +22,7 @@
 #include <tcl.h>
 #include <tk.h>
 
+#include "emc/linuxcnc.h"
 #include "rcs.hh"
 #include "posemath.h"		// PM_POSE, TO_RAD
 #include "emc.hh"		// EMC NML

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <inttypes.h>
 
+#include "emc/linuxcnc.h"
 #include "rcs.hh"
 #include "posemath.h"		// PM_POSE, TO_RAD
 #include "emc.hh"		// EMC NML

--- a/src/emc/usr_intf/shcom.hh
+++ b/src/emc/usr_intf/shcom.hh
@@ -17,13 +17,13 @@
 #ifndef SHCOM_HH
 #define SHCOM_HH
 
+#include "linuxcnc.h"           // INCH_PER_MM
 #include "emc_nml.hh"
 #include "nml_oi.hh"            // NML_ERROR_LEN
 
 #define CLOSE(a,b,eps) ((a)-(b) < +(eps) && (a)-(b) > -(eps))
 #define LINEAR_CLOSENESS 0.0001
 #define ANGULAR_CLOSENESS 0.0001
-#define INCH_PER_MM (1.0/25.4)
 #define CM_PER_MM 0.1
 #define GRAD_PER_DEG (100.0/90.0)
 #define RAD_PER_DEG TO_RAD	// from posemath.h

--- a/src/emc/usr_intf/sockets.h
+++ b/src/emc/usr_intf/sockets.h
@@ -22,10 +22,6 @@
 
 #include <stdlib.h>
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
-
 #ifndef LCDPORT
 # define LCDPORT 13666
 #endif

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -43,6 +43,7 @@
 */
 
 #include "config.h"
+#include "emc/linuxcnc.h"
 
 #ifndef NO_INI
 #include "inifile.h"		/* iniFind() from libnml */

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -38,6 +38,7 @@
  */
 
 #include "config.h"
+#include "emc/linuxcnc.h"
 #include "rtapi.h"
 #include "hal.h"
 #include "../hal_priv.h"

--- a/src/libnml/cms/Submakefile
+++ b/src/libnml/cms/Submakefile
@@ -1,4 +1,4 @@
-INCLUDES += libnml/cms
+INCLUDES += emc libnml/cms
 
 $(patsubst ./libnml/cms/%,../include/%,$(wildcard ./libnml/cms/*.h)): ../include/%.h: ./libnml/cms/%.h
 	cp $^ $@

--- a/src/libnml/cms/cms.cc
+++ b/src/libnml/cms/cms.cc
@@ -33,6 +33,7 @@ extern "C" {
 }
 #endif
 #include <rtapi_string.h>
+#include "cms_cfg.hh"
 #include "cms.hh"		/* class CMS */
 #include "cms_up.hh"		/* class CMS_UPDATER */
 #include "cms_xup.hh"		/* class CMS_XDR_UPDATER */
@@ -120,15 +121,15 @@ CMS::CMS(long s)
     rcs_print_debug(PRINT_CMS_CONSTRUCTORS, "new CMS (%lu)", s);
 
     /* Init string buffers */
-    memset(BufferName, 0, CMS_CONFIG_LINELEN);
-    memset(BufferHost, 0, CMS_CONFIG_LINELEN);
-    memset(ProcessName, 0, CMS_CONFIG_LINELEN);
-    memset(BufferLine, 0, CMS_CONFIG_LINELEN);
-    memset(ProcessLine, 0, CMS_CONFIG_LINELEN);
-    memset(ProcessHost, 0, CMS_CONFIG_LINELEN);
-    memset(buflineupper, 0, CMS_CONFIG_LINELEN);
-    memset(proclineupper, 0, CMS_CONFIG_LINELEN);
-    memset(PermissionString, 0, CMS_CONFIG_LINELEN);
+    memset(BufferName, 0, LINELEN);
+    memset(BufferHost, 0, LINELEN);
+    memset(ProcessName, 0, LINELEN);
+    memset(BufferLine, 0, LINELEN);
+    memset(ProcessLine, 0, LINELEN);
+    memset(ProcessHost, 0, LINELEN);
+    memset(buflineupper, 0, LINELEN);
+    memset(proclineupper, 0, LINELEN);
+    memset(PermissionString, 0, LINELEN);
 
     /* save constructor args */
     free_space = size = s;
@@ -198,15 +199,15 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
     confirm_write = 0;
     disable_final_write_raw_for_dma = 0;
     /* Init string buffers */
-    memset(BufferName, 0, CMS_CONFIG_LINELEN);
-    memset(BufferHost, 0, CMS_CONFIG_LINELEN);
-    memset(ProcessName, 0, CMS_CONFIG_LINELEN);
-    memset(BufferLine, 0, CMS_CONFIG_LINELEN);
-    memset(ProcessLine, 0, CMS_CONFIG_LINELEN);
-    memset(ProcessHost, 0, CMS_CONFIG_LINELEN);
-    memset(buflineupper, 0, CMS_CONFIG_LINELEN);
-    memset(proclineupper, 0, CMS_CONFIG_LINELEN);
-    memset(PermissionString, 0, CMS_CONFIG_LINELEN);
+    memset(BufferName, 0, LINELEN);
+    memset(BufferHost, 0, LINELEN);
+    memset(ProcessName, 0, LINELEN);
+    memset(BufferLine, 0, LINELEN);
+    memset(ProcessLine, 0, LINELEN);
+    memset(ProcessHost, 0, LINELEN);
+    memset(buflineupper, 0, LINELEN);
+    memset(proclineupper, 0, LINELEN);
+    memset(PermissionString, 0, LINELEN);
 
     /* Initialize some variables. */
     read_permission_flag = 0;	/* Allow both read and write by default.  */
@@ -234,8 +235,8 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
     char *bufline = strdup(bufline_in);
     char *procline = strdup(procline_in);
 
-    convert2upper(buflineupper, bufline, CMS_CONFIG_LINELEN);
-    convert2upper(proclineupper, procline, CMS_CONFIG_LINELEN);
+    convert2upper(buflineupper, bufline, LINELEN);
+    convert2upper(proclineupper, procline, LINELEN);
 
     is_phantom = 0;
     max_message_size = 0;

--- a/src/libnml/cms/cms.hh
+++ b/src/libnml/cms/cms.hh
@@ -25,7 +25,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-#include "cms_cfg.hh"		/* CMS_CONFIG_LINELEN */
+#include "linuxcnc.h"		/* LINELEN */
 
 class PHYSMEM_HANDLE;
 struct PM_CARTESIAN;
@@ -351,15 +351,15 @@ class CMS {
     void *subdiv_data;		/* pointer to current subdiv; */
 
     /* Intersting Info Saved from the Configuration File. */
-    char BufferName[CMS_CONFIG_LINELEN];
-    char BufferHost[CMS_CONFIG_LINELEN];
-    char ProcessName[CMS_CONFIG_LINELEN];
-    char BufferLine[CMS_CONFIG_LINELEN];
-    char ProcessLine[CMS_CONFIG_LINELEN];
-    char ProcessHost[CMS_CONFIG_LINELEN];
-    char buflineupper[CMS_CONFIG_LINELEN];
-    char proclineupper[CMS_CONFIG_LINELEN];
-    char PermissionString[CMS_CONFIG_LINELEN];
+    char BufferName[LINELEN];
+    char BufferHost[LINELEN];
+    char ProcessName[LINELEN];
+    char BufferLine[LINELEN];
+    char ProcessLine[LINELEN];
+    char ProcessHost[LINELEN];
+    char buflineupper[LINELEN];
+    char proclineupper[LINELEN];
+    char PermissionString[LINELEN];
     int is_local_master;
     int force_raw;
     bool serial;

--- a/src/libnml/cms/cms_cfg.cc
+++ b/src/libnml/cms/cms_cfg.cc
@@ -105,7 +105,7 @@ int load_nml_config_file(const char *file)
 	loading_config_file = 0;
 	return -1;
     }
-    char line[CMS_CONFIG_LINELEN];	/* Temporary buffer for line from
+    char line[LINELEN];	/* Temporary buffer for line from
 					   file. */
 
     CONFIG_FILE_INFO *info = new CONFIG_FILE_INFO();
@@ -123,7 +123,7 @@ int load_nml_config_file(const char *file)
 	return -1;
     }
     while (!feof(fp)) {
-	if ((fgets(line, CMS_CONFIG_LINELEN, fp)) == NULL) {
+	if ((fgets(line, LINELEN, fp)) == NULL) {
 	    break;
 	}
 	int linelen = strlen(line);
@@ -132,11 +132,11 @@ int load_nml_config_file(const char *file)
 	}
 	while (line[linelen - 1] == '\\') {
 	    int pos = linelen - 2;
-	    if ((fgets(line + pos, CMS_CONFIG_LINELEN - pos, fp)) == NULL) {
+	    if ((fgets(line + pos, LINELEN - pos, fp)) == NULL) {
 		break;
 	    }
 	    linelen = strlen(line);
-	    if (linelen > CMS_CONFIG_LINELEN - 2) {
+	    if (linelen > LINELEN - 2) {
 		break;
 	    }
 	}
@@ -305,7 +305,7 @@ int cms_copy(CMS ** dest, CMS * src, int set_to_server, int set_to_master)
 extern char *get_buffer_line(const char *bufname, const char *filename)
 {
     int line_len, line_number;
-    char linebuf[CMS_CONFIG_LINELEN];	/* Temporary buffer for line from
+    char linebuf[LINELEN];	/* Temporary buffer for line from
 					   file. */
     char *line = linebuf;
     FILE *fp = NULL;		/* FILE ptr to config file.  */
@@ -347,7 +347,7 @@ extern char *get_buffer_line(const char *bufname, const char *filename)
 	    if (feof(fp)) {
 		break;
 	    }
-	    if ((fgets(line, CMS_CONFIG_LINELEN, fp)) == NULL) {
+	    if ((fgets(line, LINELEN, fp)) == NULL) {
 		break;
 	    }
 	}
@@ -356,19 +356,19 @@ extern char *get_buffer_line(const char *bufname, const char *filename)
 	line_len = strlen(line);
 	while (line[line_len - 1] == '\\') {
 	    int pos = line_len - 2;
-	    if ((fgets(line + pos, CMS_CONFIG_LINELEN - pos, fp)) == NULL) {
+	    if ((fgets(line + pos, LINELEN - pos, fp)) == NULL) {
 		break;
 	    }
 	    line_len = strlen(line);
-	    if (line_len > CMS_CONFIG_LINELEN - 2) {
+	    if (line_len > LINELEN - 2) {
 		break;
 	    }
 	    line_number++;
 	}
-	if (line_len > CMS_CONFIG_LINELEN) {
+	if (line_len > LINELEN) {
 	    rcs_print_error
 		("cms_cfg: Line length of line number %d in %s exceeds max length of %d",
-		line_number, filename, CMS_CONFIG_LINELEN);
+		line_number, filename, LINELEN);
 	}
 
 	/* Skip comment lines and lines starting with white space. */
@@ -410,10 +410,10 @@ struct CONFIG_SEARCH_STRUCT {
     const char *bufname_for_procline;
     const char *procname;
     const char *filename;
-    char buffer_line[CMS_CONFIG_LINELEN];	/* Line matching bufname. */
-    char proc_line[CMS_CONFIG_LINELEN];	/* Line matching procname & bufname. */
-    char buffer_type[CMS_CONFIG_LINELEN];	/* "SHMEM" or "GLOBMEM" */
-    char proc_type[CMS_CONFIG_LINELEN];	/* "REMOTE" or "LOCAL" */
+    char buffer_line[LINELEN];	/* Line matching bufname. */
+    char proc_line[LINELEN];	/* Line matching procname & bufname. */
+    char buffer_type[LINELEN];	/* "SHMEM" or "GLOBMEM" */
+    char proc_type[LINELEN];	/* "REMOTE" or "LOCAL" */
 };
 
 void find_proc_and_buffer_lines(CONFIG_SEARCH_STRUCT * s);
@@ -424,8 +424,8 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
     int set_to_server, int set_to_master)
 {
     CONFIG_SEARCH_STRUCT search;
-    char buf[CMS_CONFIG_LINELEN];
-    char buf2[CMS_CONFIG_LINELEN];
+    char buf[LINELEN];
+    char buf2[LINELEN];
     char *default_ptr = 0;
 
     if (0 == bufname || 0 == procname || 0 == filename) {
@@ -451,14 +451,14 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
 	find_proc_and_buffer_lines(&search);
 	if (search.error_type == CONFIG_SEARCH_OK) {
 	    default_ptr = 0;
-	    strncpy(buf, search.proc_line, CMS_CONFIG_LINELEN);
+	    strncpy(buf, search.proc_line, LINELEN);
 	    default_ptr = strstr(buf, "default");
 	    if (default_ptr) {
 		rtapi_strxcpy(buf2, default_ptr + 7);
 		strcpy(default_ptr, bufname);
 		default_ptr += strlen(bufname);
 		strcpy(default_ptr, buf2);
-		strncpy(search.proc_line, buf, CMS_CONFIG_LINELEN);
+		strncpy(search.proc_line, buf, LINELEN);
 	    }
 	    rtapi_strxcat(search.proc_line, " defaultbuf");
 	}
@@ -468,7 +468,7 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
 	search.procname = "default";
 	find_proc_and_buffer_lines(&search);
 	if (search.error_type == CONFIG_SEARCH_OK) {
-	    strncpy(buf, search.proc_line, CMS_CONFIG_LINELEN);
+	    strncpy(buf, search.proc_line, LINELEN);
 	    default_ptr = strstr(buf, "default");
 	    if (default_ptr) {
 		rtapi_strxcpy(buf2, default_ptr + 7);
@@ -482,7 +482,7 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
 		strcpy(default_ptr, bufname);
 		default_ptr += strlen(bufname);
 		strcpy(default_ptr, buf2);
-		strncpy(search.proc_line, buf, CMS_CONFIG_LINELEN);
+		strncpy(search.proc_line, buf, LINELEN);
 	    }
 	    rtapi_strxcat(search.proc_line, " defaultproc defaultbuf");
 	}
@@ -602,7 +602,7 @@ void find_proc_and_buffer_lines(CONFIG_SEARCH_STRUCT * s)
 
     loading_config_file = 1;
     FILE *fp = NULL;		/* FILE ptr to config file.  */
-    char linebuf[CMS_CONFIG_LINELEN];	/* Temporary buffer for line from
+    char linebuf[LINELEN];	/* Temporary buffer for line from
 					   file. */
     char *line = linebuf;
     int line_len, line_number;
@@ -646,7 +646,7 @@ void find_proc_and_buffer_lines(CONFIG_SEARCH_STRUCT * s)
 	    if (feof(fp)) {
 		break;
 	    }
-	    if ((fgets(line, CMS_CONFIG_LINELEN, fp)) == NULL) {
+	    if ((fgets(line, LINELEN, fp)) == NULL) {
 		break;
 	    }
 	}
@@ -658,19 +658,19 @@ void find_proc_and_buffer_lines(CONFIG_SEARCH_STRUCT * s)
 	}
 	while (line[line_len - 1] == '\\') {
 	    int pos = line_len - 2;
-	    if ((fgets(line + pos, CMS_CONFIG_LINELEN - pos, fp)) == NULL) {
+	    if ((fgets(line + pos, LINELEN - pos, fp)) == NULL) {
 		break;
 	    }
 	    line_len = strlen(line);
-	    if (line_len > CMS_CONFIG_LINELEN) {
+	    if (line_len > LINELEN) {
 		break;
 	    }
 	    line_number++;
 	}
-	if (line_len > CMS_CONFIG_LINELEN) {
+	if (line_len > LINELEN) {
 	    rcs_print_error
 		("cms_cfg: Line length of line number %d in %s exceeds max length of %d",
-		line_number, s->filename, CMS_CONFIG_LINELEN);
+		line_number, s->filename, LINELEN);
 	}
 
 	/* Skip comment lines and lines starting with white space. */
@@ -687,8 +687,8 @@ void find_proc_and_buffer_lines(CONFIG_SEARCH_STRUCT * s)
 	if (!s->bufline_found && !strcmp(word[1], s->bufname) &&
 	    line[0] == 'B') {
 	    /* Buffer line found, store the line and type. */
-	    strncpy(s->buffer_line, line, CMS_CONFIG_LINELEN);
-	    convert2upper(s->buffer_type, word[2], CMS_CONFIG_LINELEN);
+	    strncpy(s->buffer_line, line, LINELEN);
+	    convert2upper(s->buffer_type, word[2], LINELEN);
 	    s->bufline_found = 1;
 	    s->bufline_number = line_number;
 	    rcs_print_debug(PRINT_CMS_CONFIG_INFO,
@@ -696,10 +696,10 @@ void find_proc_and_buffer_lines(CONFIG_SEARCH_STRUCT * s)
 	} else if (!s->procline_found && !strcmp(word[1], s->procname) &&
 	    line[0] == 'P' && !strcmp(word[2], s->bufname_for_procline)) {
 	    /* Procedure line found, store the line and type. */
-	    strncpy(s->proc_line, line, CMS_CONFIG_LINELEN);
+	    strncpy(s->proc_line, line, LINELEN);
 	    switch (cms_connection_mode) {
 	    case CMS_NORMAL_CONNECTION_MODE:
-		convert2upper(s->proc_type, word[3], CMS_CONFIG_LINELEN);
+		convert2upper(s->proc_type, word[3], LINELEN);
 		if (!strncmp(s->proc_type, "AUTO", 4)) {
 		    if (!s->bufline_found) {
 			rcs_print_error
@@ -767,8 +767,8 @@ int
 cms_create_from_lines(CMS ** cms, const char *buffer_line_in, const char *proc_line_in,
     int set_to_server, int set_to_master)
 {
-    char proc_type[CMS_CONFIG_LINELEN];
-    char buffer_type[CMS_CONFIG_LINELEN];
+    char proc_type[LINELEN];
+    char buffer_type[LINELEN];
     char *word[4];		/* array of pointers to words from line */
 
     char *proc_line = strdup(proc_line_in);
@@ -778,7 +778,7 @@ cms_create_from_lines(CMS ** cms, const char *buffer_line_in, const char *proc_l
 	return -1;
     }
 
-    convert2upper(proc_type, word[3], CMS_CONFIG_LINELEN);
+    convert2upper(proc_type, word[3], LINELEN);
 
     char *buffer_line = strdup(buffer_line_in);
     if (4 != separate_words(word, 4, buffer_line)) {
@@ -789,7 +789,7 @@ cms_create_from_lines(CMS ** cms, const char *buffer_line_in, const char *proc_l
 	return -1;
     }
 
-    convert2upper(buffer_type, word[2], CMS_CONFIG_LINELEN);
+    convert2upper(buffer_type, word[2], LINELEN);
 
     int result = (cms_create(cms, buffer_line, proc_line,
 	    buffer_type, proc_type, set_to_server, set_to_master));

--- a/src/libnml/cms/cms_cfg.hh
+++ b/src/libnml/cms/cms_cfg.hh
@@ -18,10 +18,6 @@
 
 class CMS;
 
-/* Config File Definitions. */
-#ifndef CMS_CONFIG_LINELEN
-#define CMS_CONFIG_LINELEN 200
-#endif
 #ifndef CMS_CONFIG_COMMENTCHAR
 #define CMS_CONFIG_COMMENTCHAR '#'
 #endif

--- a/src/libnml/inifile/inifile.cc
+++ b/src/libnml/inifile/inifile.cc
@@ -21,6 +21,7 @@
 
 
 #include "config.h"
+#include "emc/linuxcnc.h"
 #include "inifile.hh"
 
 #define MAX_EXTEND_LINES 20

--- a/src/libnml/inifile/inivar.cc
+++ b/src/libnml/inifile/inivar.cc
@@ -27,6 +27,7 @@
 #include <limits.h>
 
 #include "config.h"
+#include "emc/linuxcnc.h"
 #include "inifile.hh"
 
 

--- a/src/libnml/os_intf/_shm.c
+++ b/src/libnml/os_intf/_shm.c
@@ -13,6 +13,7 @@
 * Last change: 
 ********************************************************************/
 
+#include "config.h"
 #include "_shm.h"
 #include "rcs_print.hh"
 #include <stdio.h>		/* NULL */

--- a/src/libnml/posemath/posemath.h
+++ b/src/libnml/posemath/posemath.h
@@ -71,8 +71,6 @@
 #ifndef POSEMATH_H
 #define POSEMATH_H
 
-// #include "config.h"
-
 #ifdef __cplusplus
 
 #define USE_CONST

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -1,4 +1,9 @@
-//    Copyright 2006-2014, various authors
+// Description:  uspace_common.h
+//              Shared methods used by various uspace modules.  Only
+//              included once in any module to avoid conflicting
+//              definitions.
+//
+//    Copyright 2006-2021, various authors
 //
 //    This program is free software; you can redistribute it and/or modify
 //    it under the terms of the GNU General Public License as published by

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -16,6 +16,7 @@
  */
 
 #include "config.h"
+#include "linuxcnc.h"
 
 #ifdef __linux__
 #include <sys/fsuid.h>
@@ -52,8 +53,6 @@
 #include <pthread_np.h>
 #endif
 
-#include "config.h"
-
 #include "rtapi.h"
 #include "hal.h"
 #include "hal/hal_priv.h"
@@ -82,9 +81,6 @@ WithRoot::~WithRoot() {
 #endif
     }
 }
-
-extern "C"
-int rtapi_is_realtime();
 
 namespace
 {

--- a/tests/interp/compile/use-rs274.cc
+++ b/tests/interp/compile/use-rs274.cc
@@ -15,6 +15,7 @@
 //    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 #include <Python.h> // must be first header
+#include "linuxcnc.h"              // LINELEN
 #include "rs274ngc.hh"
 #include "canon.hh"
 


### PR DESCRIPTION
Values not detected at compile time, ie LINELEN, BUFFERLEN, MM_PER_INCH
and INCH_PER_MM, are moved into a new file linuxchc.h.

To avoid having to install the architecture specific config.h file,
restructure includes and introduce linuxcnc.h for definitions used
across the code.  Drop the redundant MM_PER_INCH from
interp_internal.hh and CMS_CONFIG_LINELEN from cms_cfg.hh and use the
value from linuxcnc.h instead.  Made sure all C files depending on
config.h values include it directly.  Make sure no header file include
config.h.

As uspace_common.h is not exposed to API clients, and is a code
fragment and not a normal include file, the use of config.h is left
as it is there.