### PR TITLE
qtplasmac: laser framing and bounds check

### DIFF
--- a/share/qtvcp/screens/qtplasmac/qtplasmac_handler.py
+++ b/share/qtvcp/screens/qtplasmac/qtplasmac_handler.py
@@ -1,4 +1,4 @@
-VERSION = '1.216.111'
+VERSION = '1.216.112'
 
 '''
 qtplasmac_handler.py
@@ -1224,6 +1224,7 @@ class HandlerClass:
                     msg0 = _translate('HandlerClass', 'move would exceed the minimum limit by')
                 msgs += '{} {} {}{}\n'.format(msgList[n], msg0, msgList[n + 2], units)
             STATUS.emit('error', linuxcnc.OPERATOR_ERROR, '{}:\n{}'.format(head, msgs))
+            self.set_run_button_state()
             if self.single_cut_request:
                 self.single_cut_request = False
                 if self.oldFile and not 'single_cut' in self.oldFile:
@@ -1755,28 +1756,28 @@ class HandlerClass:
             units = 'mm'
             if self.gcodeProps['Units'] == 'in':
                 boundsMultiplier = 25.4
-        xMin = float(self.gcodeProps['X'].split()[0]) * boundsMultiplier - xOffset
+        xMin = float(self.gcodeProps['X'].split()[0]) * boundsMultiplier + xOffset
         if xMin < self.xMin:
             amount = float(self.xMin - xMin)
             msgList.append('X')
             msgList.append('MIN')
             msgList.append('{:0.2f}'.format(amount))
             self.boundsError[boundsType] = True
-        xMax = float(self.gcodeProps['X'].split()[2]) * boundsMultiplier - xOffset
+        xMax = float(self.gcodeProps['X'].split()[2]) * boundsMultiplier + xOffset
         if xMax > self.xMax:
             amount = float(xMax - self.xMax)
             msgList.append('X')
             msgList.append('MAX')
             msgList.append('{:0.2f}'.format(amount))
             self.boundsError[boundsType] = True
-        yMin = float(self.gcodeProps['Y'].split()[0]) * boundsMultiplier - yOffset
+        yMin = float(self.gcodeProps['Y'].split()[0]) * boundsMultiplier + yOffset
         if yMin < self.yMin:
             amount = float(self.yMin - yMin)
             msgList.append('Y')
             msgList.append('MIN')
             msgList.append('{:0.2f}'.format(amount))
             self.boundsError[boundsType] = True
-        yMax = float(self.gcodeProps['Y'].split()[2]) * boundsMultiplier - yOffset
+        yMax = float(self.gcodeProps['Y'].split()[2]) * boundsMultiplier + yOffset
         if yMax > self.yMax:
             amount = float(yMax - self.yMax)
             msgList.append('Y')

--- a/share/qtvcp/screens/qtplasmac/versions.html
+++ b/share/qtvcp/screens/qtplasmac/versions.html
@@ -31,6 +31,13 @@
 <br>
 <!--- ****** ADD NEXT VERSION BELOW THIS LINE ****** --->
 
+<br><b><u>v1.216.112 2021 Nov 3</u></b>
+<ul style="margin:0;">
+  <li>fix offset when framing with a laser</li>
+  <li>fix cycle start button state after loading with boundary errors</li>
+</ul>
+<i>Changes submitted by snowgoer540 (Greg Carl)</i><br>
+
 <br><b><u>v1.216.111 2021 Oct 27</u></b>
 <ul style="margin:0;">
   <li>enhanced mode 0 arc ok establishment</li>
@@ -42,12 +49,12 @@
 </ul>
 <i>Changes submitted by snowgoer540 (Greg Carl)</i><br>
 
-<br><b><u>v1.214.109 2021 Oct 27</u></b>
+<br><b><u>v1.215.109 2021 Oct 27</u></b>
 <ul style="margin:0;">
   <li>updated qtvcp IndicatedPushButton</li>
 </ul>
 
-<br><b><u>v1.214.108 2021 Oct 25</u></b>
+<br><b><u>v1.215.108 2021 Oct 25</u></b>
 <ul style="margin:0;">
   <li>fix virtual keyboard error message</li>
 </ul>


### PR DESCRIPTION
1. fix issue where framing with a laser was offset the opposite direction
2. fix issue where cycle start was enabled after a bounds check determined a program would be outside the machine's boundaries