### PR TITLE
Fix typos in src/emc

### DIFF
--- a/src/emc/ini/inijoint.cc
+++ b/src/emc/ini/inijoint.cc
@@ -182,7 +182,7 @@ static int loadJoint(int joint, EmcIniFile *jointIniFile)
         ignore_limits = false;	        // default
         jointIniFile->Find(&ignore_limits, "HOME_IGNORE_LIMITS", jointString);
 
-        sequence = 999;// default: use unrealizable and postive sequence no.
+        sequence = 999;// default: use unrealizable and positive sequence no.
                        // so that joints with unspecified HOME_SEQUENCE=
                        // will not be homed in home-all
         jointIniFile->Find(&sequence, "HOME_SEQUENCE", jointString);

--- a/src/emc/iotask/ioControl.cc
+++ b/src/emc/iotask/ioControl.cc
@@ -33,7 +33,7 @@
 *  only if UEO, EEST are closed when URE gets strobed.
 *  If any of UEO (user requested stop) or EEST (external estop) have been
 *  opened, then EEI will open as well.
-*  After restoring normal condition (UEO and EEST closed), an aditional
+*  After restoring normal condition (UEO and EEST closed), an additional
 *  URE (user-request-enable) is needed, this is either sent by the GUI
 *  (using the EMC_AUX_ESTOP_RESET NML message), or by a hardware button
 *  connected to the ladder driving URE.

--- a/src/emc/iotask/ioControl_v2.cc
+++ b/src/emc/iotask/ioControl_v2.cc
@@ -33,7 +33,7 @@
  *  only if UEO, EEST are closed when URE gets strobed.
  *  If any of UEO (user requested stop) or EEST (external estop) have been
  *  opened, then EEI will open as well.
- *  After restoring normal condition (UEO and EEST closed), an aditional
+ *  After restoring normal condition (UEO and EEST closed), an additional
  *  URE (user-request-enable) is needed, this is either sent by the GUI
  *  (using the EMC_AUX_ESTOP_RESET NML message), or by a hardware button
  *  connected to the ladder driving URE.
@@ -686,7 +686,7 @@ static int read_inputs(void)
 
     if (*iocontrol_data->tool_change) {
 
-        // check wether a toolchanger fault will force an abort of this change
+        // check whether a toolchanger fault will force an abort of this change
         if ((proto > V1) && (*iocontrol_data->toolchanger_faulted))  {
 
             /* unlikely but possible: toolchanger_faulted was asserted since
@@ -1016,7 +1016,7 @@ int main(int argc, char *argv[])
                 // fix race condition by asserting abort-tool-change before
                 // deasserting tool-change and tool-prepare
                 *(iocontrol_data->emc_reason) = ((EMC_TOOL_ABORT *) emcioCommand)->reason;
-                *(iocontrol_data->emc_abort) = 1;      // notify TC of abort conditon
+                *(iocontrol_data->emc_abort) = 1;      // notify TC of abort condition
             }
             *(iocontrol_data->tool_change) = 0;      // abort tool change if in progress
             *(iocontrol_data->tool_prepare) = 0;     // abort tool prepare if in progress
@@ -1182,7 +1182,7 @@ int main(int argc, char *argv[])
             break;
         case EMC_TOOL_SET_NUMBER_TYPE:
         {
-            // changed als in interp_convert.cc to convey the pocket number, not the tool number
+            // changed also in interp_convert.cc to convey the pocket number, not the tool number
            // needed so toolTable[0] can be properly set including offsets
             int idx;
 

--- a/src/emc/kinematics/genhexkins.c
+++ b/src/emc/kinematics/genhexkins.c
@@ -20,7 +20,7 @@
   "genhexKinematicsInverse" are arrays "a[i]" and "b[i]".  The values stored
   in these arrays correspond to the positions of the ends of the i'th
   strut. The value stored in a[i] is the position of the end of the i'th
-  strut attatched to the platform, in platform coordinates. The value
+  strut attached to the platform, in platform coordinates. The value
   stored in b[i] is the position of the end of the i'th strut attached
   to the base, in base (world) coordinates.
 

--- a/src/emc/kinematics/genserfuncs.c
+++ b/src/emc/kinematics/genserfuncs.c
@@ -1,6 +1,6 @@
 /********************************************************************
 * Description: genserfuncs.c
-*   (orginally part of genserkins.c)
+*   (originally part of genserkins.c)
 *   Kinematics for a generalised serial kinematics machine
 *
 *   Derived from a work by Fred Proctor,
@@ -95,7 +95,7 @@ int genser_kin_init(void) {
 }
 
 /* compute the forward jacobian function:
-   the jacobian is a linear aproximation of the kinematics function.
+   the jacobian is a linear approximation of the kinematics function.
    It is calculated using derivation of the position transformation matrix,
    and usually used for feeding velocities through it.
    It is analytically possible to calculate the inverse of the jacobian

--- a/src/emc/kinematics/genserkins.c
+++ b/src/emc/kinematics/genserkins.c
@@ -16,7 +16,7 @@ TEST: switchable kinematics: identity or genserkins
 
 NOTE:
 a) requires *exactly* 6 joints
-b) identity assigments can use any of xyzabcuvw
+b) identity assignments can use any of xyzabcuvw
    but should agree with [TRAJ]COORDINATES
    and may be confusing
 

--- a/src/emc/kinematics/kinematics.h
+++ b/src/emc/kinematics/kinematics.h
@@ -60,7 +60,7 @@ typedef enum {
    indicate this. */
 typedef unsigned long int KINEMATICS_FORWARD_FLAGS;
 
-/* the inverse flags are passed to the inverse kinematics so thay they
+/* the inverse flags are passed to the inverse kinematics so that they
    can resolve ambiguities in the joint angles for a given world coordinate,
    e.g., for robots, this would be elbow-up, elbow-down, etc.
 

--- a/src/emc/kinematics/rotarydeltakins-common.h
+++ b/src/emc/kinematics/rotarydeltakins-common.h
@@ -35,7 +35,7 @@
   The platform is on "top", the origin is in the center of the plane
   containing the three hip joints.  Z points upward, so Z coordinates
   are always negative.  Thighs always point outward, straight out
-  (knee at Z=0) is considerd zero degrees for the angular hip joint.
+  (knee at Z=0) is considered zero degrees for the angular hip joint.
   Positive rotation is knee-downward, so if you rotate all knees
   positive, the Z coordinate will get more negative.
 

--- a/src/emc/kinematics/ugenserkins.c
+++ b/src/emc/kinematics/ugenserkins.c
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
     /* syntax is a.out {i|f # # # # # #} */
     if (argc == 8) {
         if (argv[1][0] == 'f') {
-            /* joints passed, so do interations on forward kins for timing */
+            /* joints passed, so do iterations on forward kins for timing */
             for (t = 0; t < 6; t++) {
                 if (1 != sscanf(argv[t + 2], "%lf", &joints[t])) {
                     fprintf(stderr, "bad value: %s\n", argv[t + 2]);

--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -7,13 +7,13 @@
 * pc says:
 *
 *   Most of the configs would be better off being passed via an ioctl
-*   implimentation leaving pure realtime data to be handled by
+*   implementation leaving pure realtime data to be handled by
 *   emcmotCommandHandler() - This would provide a small performance
 *   increase on slower systems.
 *
 * jmk says:
 *
-*   Using commands to set config parameters is "undesireable", because
+*   Using commands to set config parameters is "undesirable", because
 *   of the large amount of code needed for each parameter.  Today you
 *   need to do the following to add a single new parameter called foo:
 *
@@ -42,7 +42,7 @@
 *       there are about 6 switch statements that need at least a
 *       case label added.
 *   12) Add cases to two giant switch statements in emc.cc, associated
-*       with looking up and formating the command.
+*       with looking up and formatting the command.
 *
 *
 *   Derived from a work by Fred Proctor & Will Shackleford
@@ -1764,7 +1764,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	        emcmotStatus->spindle_status[n].orient_state = EMCMOT_ORIENT_NONE;
 
 	        /* if (emcmotStatus->spindle.orient) { */
-	        /* 	reportError(_("cant turn on spindle during orient in progress")); */
+	        /* 	reportError(_("can\'t turn on spindle during orient in progress")); */
 	        /* 	emcmotStatus->commandStatus = EMCMOT_COMMAND_INVALID_COMMAND; */
 	        /* 	tpAbort(&emcmotDebug->tp); */
 	        /* 	SET_MOTION_ERROR_FLAG(1); */
@@ -1783,7 +1783,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
         }
         emcmotStatus->atspeed_next_feed = emcmotCommand->wait_for_spindle_at_speed;
 
-       // check wether it's passed correctly
+       // check whether it's passed correctly
        if (!emcmotStatus->atspeed_next_feed){
            rtapi_print_msg(RTAPI_MSG_DBG, "SPINDLE_ON without wait-for-atspeed");
        }
@@ -1843,7 +1843,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	        if (*(emcmot_hal_data->spindle[n].spindle_orient)) {
 		    rtapi_print_msg(RTAPI_MSG_DBG, "orient already in progress");
 
-		    // mah:FIXME unsure wether this is ok or an error
+		    // mah:FIXME unsure whether this is ok or an error
 		    /* reportError(_("orient already in progress")); */
 		    /* emcmotStatus->commandStatus = EMCMOT_COMMAND_INVALID_COMMAND; */
 		    /* tpAbort(&emcmotDebug->tp); */

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -276,7 +276,7 @@ void emcmotController(void *arg, long period)
 /***********************************************************************
 *                         LOCAL FUNCTION CODE                          *
 ************************************************************************/
-/* The protoypes and documentation for these functions are located
+/* The prototypes and documentation for these functions are located
    at the top of the file in the section called "local function
    prototypes"
 */
@@ -562,7 +562,7 @@ static void do_forward_kins(void)
    the cartesean coordinates of home, as stored in the global worldHome,
    and we set carte_fb_ok to 0 to indicate that the feedback is invalid.
 \todo  FIXME - maybe setting to home isn't the right thing to do.  We need
-   it to be set to home eventually, (right before the first attemt to
+   it to be set to home eventually, (right before the first attempt to
    run the kins), but that doesn't mean we should say we're at home
    when we're not.
 
@@ -1312,7 +1312,7 @@ static void get_pos_cmds(long period)
             joint->vel_cmd = joint->free_tp.curr_vel;
             //no acceleration output form simple_tp, but the pin will
             //still show the acceleration from the interpolation.
-            //its delayed, but thats ok during jogging or homing.
+            //it's delayed, but that's ok during jogging or homing.
             joint->acc_cmd = 0.0;
             joint->coarse_pos = joint->free_tp.curr_pos;
             /* update joint status flag and overall status flag */
@@ -1581,7 +1581,7 @@ static void get_pos_cmds(long period)
     if ( onlimit ) {
 	if ( ! emcmotStatus->on_soft_limit ) {
         /* Unexpectedly hit a joint soft limit.
-        ** Possibile causes:
+        ** Possible causes:
         **  1) a joint positional limit was reduced by an ini halpin
         **     (like ini.N.max_limit) -- undetected by trajectory planning
         **     including simple_tp
@@ -1804,10 +1804,10 @@ static void compute_screw_comp(void)
      *   
      * Limitations:
      *   Since the compensation adds up to the normal movement, total
-     *   accelleration and total velocity may exceed maximum settings!
+     *   acceleration and total velocity may exceed maximum settings!
      *   Currently this is limited to 150% by implementation.
      *   To fix this, the calculations in get_pos_cmd should include
-     *   information from the backlash corection. This makes things
+     *   information from the backlash correction. This makes things
      *   rather complicated and it might be better to implement the
      *   backlash compensation at another place to prevent this kind
      *   of interaction.
@@ -1817,7 +1817,7 @@ static void compute_screw_comp(void)
      *   movements and less following errors than the original code.
      */
 
-	/* Limit maximum accelleration and velocity 'overshoot'
+	/* Limit maximum acceleration and velocity 'overshoot'
 	 * to 150% of the maximum settings.
 	 * The TP and backlash shouldn't use more than 100%
 	 * (together) but this requires some interaction that

--- a/src/emc/motion/homing.c
+++ b/src/emc/motion/homing.c
@@ -1120,7 +1120,7 @@ void do_homing(void)
 	    case HOME_FINAL_MOVE_START:
 		/* This state is called once the joint coordinate system is
 		   set properly.  It moves to the actual 'home' position,
-		   which is not neccessarily the position of the home switch
+		   which is not necessarily the position of the home switch
 		   or index pulse. */
 		/* is the joint already moving? */
 		if (joint->free_tp.active) {

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -82,7 +82,7 @@ typedef struct {
     hal_float_t *motor_offset;	/* RPI: motor offset, for checking homing stability */
     hal_float_t *motor_pos_cmd;	/* WPI: commanded position, with comp */
     hal_float_t *motor_pos_fb;	/* RPI: position feedback, with comp */
-    hal_float_t *joint_pos_cmd;	/* WPI: commanded position w/o comp, mot ofs */
+    hal_float_t *joint_pos_cmd;	/* WPI: commanded position w/o comp, not ofs */
     hal_float_t *joint_pos_fb;	/* RPI: position feedback, w/o comp */
     hal_float_t *f_error;	/* RPI: following error */
     hal_float_t *f_error_lim;	/* RPI: following error limit */

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -132,7 +132,7 @@ static int export_axis(char c, axis_hal_t  * addr);
 static int export_spindle(int num, spindle_hal_t * addr);
 
 /* init_comm_buffers() allocates and initializes the command,
-   status, and error buffers used to communicate witht the user
+   status, and error buffers used to communicate with the user
    space parts of emc.
 */
 static int init_comm_buffers(void);

--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -145,9 +145,9 @@ extern "C" {
 	EMCMOT_SET_WORLD_HOME,	/* set pose for world home */
 
 	EMCMOT_SET_DEBUG,       /* sets the debug level */
-	EMCMOT_SET_DOUT,        /* sets or unsets a DIO, this can be imediate or synched with motion */
-	EMCMOT_SET_AOUT,	/* sets or unsets a AIO, this can be imediate or synched with motion */
-        EMCMOT_SET_SPINDLESYNC, /* syncronize motion to spindle encoder */
+	EMCMOT_SET_DOUT,        /* sets or unsets a DIO, this can be immediate or synched with motion */
+	EMCMOT_SET_AOUT,	/* sets or unsets a AIO, this can be immediate or synched with motion */
+        EMCMOT_SET_SPINDLESYNC, /* synchronize motion to spindle encoder */
 	EMCMOT_SPINDLE_ON,	/* start the spindle */
 	EMCMOT_SPINDLE_OFF,	/* stop the spindle */
 	EMCMOT_SPINDLE_INCREASE,	/* spindle faster */
@@ -251,7 +251,7 @@ extern "C" {
 	double maxFerror;	/* max following error */
 	int wdWait;		/* cycle to wait before toggling wd */
 	int debug;		/* debug level, from DEBUG in .ini file */
-	unsigned char now, out, start, end;	/* these are related to synched AOUT/DOUT. now=wether now or synched, out = which gets set, start=start value, end=end value */
+	unsigned char now, out, start, end;	/* these are related to synched AOUT/DOUT. now=whether now or synched, out = which gets set, start=start value, end=end value */
 	unsigned char mode;	/* used for turning overrides etc. on/off */
 	double comp_nominal, comp_forward, comp_reverse; /* compensation triplet, nominal, forward, reverse */
     unsigned char probe_type; /* ~1 = error if probe operation is unsuccessful (ngc default)
@@ -616,7 +616,7 @@ Suggestion: Split this in to an Error and a Status flag register..
 	EmcPose world_home;	/* cartesean coords of home position */
 	emcmot_joint_status_t joint_status[EMCMOT_MAX_JOINTS];	/* all joint status data */
     emcmot_axis_status_t axis_status[EMCMOT_MAX_AXIS];	/* all axis status data */
-    int spindleSync;    /* spindle used for syncronised moves. -1 = none */
+    int spindleSync;    /* spindle used for synchronised moves. -1 = none */
     spindle_status_t spindle_status[EMCMOT_MAX_SPINDLES]; /* all spindle data */
 
 
@@ -766,7 +766,7 @@ Suggestion: Split this in to an Error and a Status flag register..
 	unsigned char tail;	/* flag count for mutex detect */
     } emcmot_internal_t;
 
-/* error structure - A ring buffer used to pass formatted printf stings to usr space */
+/* error structure - A ring buffer used to pass formatted printf strings to usr space */
     typedef struct emcmot_error_t {
 	unsigned char head;	/* flag count for mutex detect */
 	char error[EMCMOT_ERROR_NUM][EMCMOT_ERROR_LEN];

--- a/src/emc/nml_intf/canon.hh
+++ b/src/emc/nml_intf/canon.hh
@@ -587,7 +587,7 @@ extern void SELECT_TOOL(int tool);
 
 extern void CHANGE_TOOL_NUMBER(int number);
 
-/* In extention to the comment above - for CHANGE_TOOL, sometimes on 
+/* In extension to the comment above - for CHANGE_TOOL, sometimes on 
 startup one would want to tell emc2 what tool it has loaded. As the last
 toolnumber before shutdown isn't currently written, there is no provision
 to allow emc2 to safely restart knowing what tool is in the spindle.

--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -51,7 +51,7 @@ class EMC_OPERATOR_ERROR:public RCS_CMD_MSG {
 
 /**
  * Send a textual information message to the operator.
- * This is similiar to EMC_OPERATOR_ERROR message except that the messages are
+ * This is similar to EMC_OPERATOR_ERROR message except that the messages are
  * sent in situations not necessarily considered to be errors.
  */
 class EMC_OPERATOR_TEXT:public RCS_CMD_MSG {
@@ -189,7 +189,7 @@ class EMC_JOINT_CMD_MSG:public RCS_CMD_MSG {
 
 /**
  * Set the joint type to linear or angular.
- * Similiar to the JOINT_TYPE field in the ".ini" file.
+ * Similar to the JOINT_TYPE field in the ".ini" file.
  */
 class EMC_JOINT_SET_JOINT:public EMC_JOINT_CMD_MSG {
   public:
@@ -1133,7 +1133,7 @@ class EMC_MOTION_SET_AOUT:public EMC_MOTION_CMD_MSG {
     unsigned char index;	// which to set
     double start;		// value at start
     double end;			// value at end
-    unsigned char now;		// wether command is imediate or synched with motion
+    unsigned char now;		// whether command is immediate or synched with motion
 };
 
 class EMC_MOTION_SET_DOUT:public EMC_MOTION_CMD_MSG {
@@ -1148,7 +1148,7 @@ class EMC_MOTION_SET_DOUT:public EMC_MOTION_CMD_MSG {
     unsigned char index;	// which to set
     unsigned char start;	// binary value at start
     unsigned char end;		// binary value at end
-    unsigned char now;		// wether command is imediate or synched with motion
+    unsigned char now;		// whether command is immediate or synched with motion
 };
 
 class EMC_MOTION_ADAPTIVE:public EMC_MOTION_CMD_MSG {
@@ -2111,7 +2111,7 @@ class EMC_IO_STAT:public EMC_IO_STAT_MSG {
     double cycleTime;
     int debug;			// copy of EMC_DEBUG global
     int reason;			// to communicate abort/fault cause
-    int fault;                  //  0 on succes, 1 on fault during M6
+    int fault;                  //  0 on success, 1 on fault during M6
     // aggregate of IO-related status classes
     EMC_TOOL_STAT tool;
     EMC_COOLANT_STAT coolant;

--- a/src/emc/nml_intf/emcargs.cc
+++ b/src/emc/nml_intf/emcargs.cc
@@ -61,7 +61,7 @@ int emcGetArgs(int argc, char *argv[])
 	    nmlSetHostAlias(qhost, "localhost");	/* If localhost
 							   appears in .nml
 							   file it will
-							   overriden by this
+							   overridden by this
 							   argument. */
 	    nmlForceRemoteConnection();
 	    /* The only good reason for aliasing the host that I know of is
@@ -79,7 +79,7 @@ int emcGetArgs(int argc, char *argv[])
 								   appears in 
 								   .nml file
 								   it will
-								   overriden
+								   overridden
 								   by this
 								   argument. */
 		nmlForceRemoteConnection();

--- a/src/emc/nml_intf/emcglb.h
+++ b/src/emc/nml_intf/emcglb.h
@@ -52,7 +52,7 @@ extern "C" {
     extern unsigned char have_tool_change_position;
 
 
-/*just used to keep track of unneccessary debug printing. */
+/*just used to keep track of unnecessary debug printing. */
     extern int taskplanopen;
 
     extern int emcGetArgs(int argc, char *argv[]);

--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -358,7 +358,7 @@ int PythonPlugin::configure(const char *iniFilename,
 	    reload_on_change = (atoi(inistring) > 0);
 
 	if (realpath(toplevel, real_path) == NULL) {
-	    logPP(-1, "cant resolve path to '%s'", toplevel);
+	    logPP(-1, "can\'t resolve path to '%s'", toplevel);
 	    status = PLUGIN_BAD_PATH;
 	    return status;
 	}

--- a/src/emc/pythonplugin/testpp.cc
+++ b/src/emc/pythonplugin/testpp.cc
@@ -146,7 +146,7 @@ main (int argc, char **argv)
     }
 
     if (!PythonPlugin::instantiate(builtins ? builtin_modules : NULL)) {
-	fprintf (stderr,"instantiate: cant instantiate Python plugin");
+	fprintf (stderr,"instantiate: can\'t instantiate Python plugin");
     }
 
     // creates the singleton instance

--- a/src/emc/rs274ngc/interp_array.cc
+++ b/src/emc/rs274ngc/interp_array.cc
@@ -321,6 +321,6 @@ const read_function_pointer Interp::default_readers[256] = {
 and _readers. */
 
 /* The notion of "global variables" is a misnomer - These last four should only
-   be accessable by the interpreter and not exported to the rest of emc */
+   be accessible by the interpreter and not exported to the rest of emc */
 
 

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -2603,7 +2603,7 @@ int Interp::convert_home(int move,       //!< G code, must be G_28 or G_30
 Returned Value: int
    If any of the following errors occur, this returns the error shown.
    Otherwise, it returns INTERP_OK.
-   1. The g_code argument isnt G_20 or G_21:
+   1. The g_code argument isn't G_20 or G_21:
       NCE_BUG_CODE_NOT_G20_OR_G21
    2. Cutter radius compensation is on:
       NCE_CANNOT_CHANGE_UNITS_WITH_CUTTER_RADIUS_COMP
@@ -3165,8 +3165,8 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
   /* The M62-65 commands are used for DIO */
   /* M62 sets a DIO synched with motion
      M63 clears a DIO synched with motion
-     M64 sets a DIO imediately
-     M65 clears a DIO imediately 
+     M64 sets a DIO immediately
+     M65 clears a DIO immediately 
      M66 waits for an input
      M67 reads a digital input
      M68 reads an analog input*/

--- a/src/emc/rs274ngc/interp_find.cc
+++ b/src/emc/rs274ngc/interp_find.cc
@@ -127,7 +127,7 @@ This finds the coordinates of a point, "end", in the currently
 active coordinate system, and sets the values of the pointers to the
 coordinates (which are the arguments to the function).
 
-In all cases, if no value for the coodinate is given in the block, the
+In all cases, if no value for the coordinate is given in the block, the
 current value for the coordinate is used. When cutter radius
 compensation is on, this function is called before compensation
 calculations are performed, so the current value of the programmed

--- a/src/emc/rs274ngc/interp_internal.cc
+++ b/src/emc/rs274ngc/interp_internal.cc
@@ -44,7 +44,7 @@ Side effects: See below
 Called by:  read_text
 
 To simplify handling upper case letters, spaces, and tabs, this
-function removes spaces and and tabs and downcases everything on a
+function removes spaces and tabs and downcases everything on a
 line which is not part of a comment.
 
 Comments are left unchanged in place. Comments are anything

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -509,7 +509,7 @@ struct block_struct
 
 
     // there might be several remapped items in a block, but at any point
-    // in time there's only one excuting
+    // in time there's only one executing
     // conceptually blocks[1..n] are also the 'remap frames'
     remap_pointer executing_remap; // refers to config descriptor
     std::set<int> remappings; // all remappings in this block (enum phases)
@@ -518,7 +518,7 @@ struct block_struct
     // the strategy to get the builtin behaviour of a code in a remap procedure is as follows:
     // if recursion is detected in find_remappings() (called by parse_line()), that *step* 
     // (roughly the modal group) is NOT added to the set of remapped steps in a block (block->remappings)
-    // in the convert_* procedures we test if the step is remapped with the macro below, and wether
+    // in the convert_* procedures we test if the step is remapped with the macro below, and whether
     // it is the current code which is remapped (IS_USER_MCODE, IS_USER_GCODE etc). If both
     // are true, we execute the remap procedure; if not, use the builtin code.
 #define STEP_REMAPPED_IN_BLOCK(bp, step) (bp->remappings.find(step) != bp->remappings.end())
@@ -526,7 +526,7 @@ struct block_struct
     // true if in a remap procedure the code being remapped was
     // referenced, which caused execution of the builtin semantics
     // reason for recording the fact: this permits an epilog to do the
-    // right thing depending on wether the builtin was used or not.
+    // right thing depending on whether the builtin was used or not.
     bool builtin_used; 
 };
 

--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -212,7 +212,7 @@ int Interp::fetch_ini_param( const char *nameBuf, int *status, double *value)
 	}
 	if (!inifile.Open(iniFileName)) {
 	    *status = 0;
-	    ERS(_("cant open ini file '%s'"), iniFileName);
+	    ERS(_("can\'t open ini file '%s'"), iniFileName);
 	}
 
 	char capName[LINELEN];

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -225,7 +225,7 @@ int Interp::execute_call(setup_pointer settings,
 
 	// Set up return to next block (may be overridden by M98)
 	if (settings->file_pointer == NULL)
-	    // if the previous file was NULL, mark positon as -1 so as not to
+	    // if the previous file was NULL, mark position as -1 so as not to
 	    // reopen it on return.
 	    previous_frame->position = -1;
 	else
@@ -292,7 +292,7 @@ int Interp::execute_call(setup_pointer settings,
 	    previous_frame->filename = strstore(settings->filename);
 	    plist.append(*settings->pythis); // self
 	    for(int i = 0; i < eblock->param_cnt; i++)
-		plist.append(eblock->params[i]); // positonal args
+		plist.append(eblock->params[i]); // positional args
 	    current_frame->pystuff.impl->tupleargs = bp::tuple(plist);
 	    current_frame->pystuff.impl->kwargs = bp::dict();
 

--- a/src/emc/rs274ngc/interp_python.cc
+++ b/src/emc/rs274ngc/interp_python.cc
@@ -89,7 +89,7 @@ int Interp::py_reload()
     return INTERP_OK;
 }
 
-// determine wether [module.]funcname is callable
+// determine whether [module.]funcname is callable
 bool Interp::is_pycallable(setup_pointer settings,
 			   const char *module,
 			   const char *funcname)
@@ -117,7 +117,7 @@ int Interp::pycall(setup_pointer settings,
     if (_setup.loggingLevel > 4)
 	logPy("pycall(%s.%s) \n", module ? module : "", funcname);
 
-    CHKS(!PYUSABLE, "pycall(%s): Pyhton plugin not initialized",funcname);
+    CHKS(!PYUSABLE, "pycall(%s): Python plugin not initialized",funcname);
     frame->pystuff.impl->py_return_type = 0;
 
     switch (calltype) {

--- a/src/emc/rs274ngc/interp_read.cc
+++ b/src/emc/rs274ngc/interp_read.cc
@@ -2008,7 +2008,7 @@ stored in parameter 2):
 
 Parameter setting is done in parallel, not sequentially. For example
 if #1 is 5 before the line "#1=10 #2=#1" is read, then after the line
-is is executed, #1 is 10 and #2 is 5. If parameter setting were done
+is executed, #1 is 10 and #2 is 5. If parameter setting were done
 sequentially, the value of #2 would be 10 after the line was executed.
 
 ADDED by K. Lerman
@@ -2583,7 +2583,7 @@ The manual provides that operations of the same precedence should be
 processed left to right.
 
 The first version of this function is commented out. It is suitable
-for when there are only two precendence levels. It is an improvement
+for when there are only two precedence levels. It is an improvement
 over the version used in interpreters before 2000, but not as general
 as the second version given here.
 

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -165,7 +165,7 @@ int Interp::convert_remapped_code(block_pointer block,
 // also, generate a kwargs style dictionary of required and optional items
 // in case a Python prolog is called
 //
-// 1. add all requried and  present optional words.
+// 1. add all required and  present optional words.
 // 2. error on missing but required words.
 // 4. handle '>' as to require a positive feed.
 // 5. handle '^' as to require a positive speed.
@@ -227,7 +227,7 @@ int Interp::add_parameters(setup_pointer settings,
         catch (const bp::error_already_set&) {					\
 	    PyErr_Print();						\
 	    PyErr_Clear();						\
-	    ERS("add_parameters: cant add '%s' to args",name);		\
+	    ERS("add_parameters: can\'t add '%s' to args",name);		\
 	}								\
     }									\
     if (posarglist) {							\
@@ -441,7 +441,7 @@ int Interp::parse_remap(const char *inistring, int lineno)
 	}
 	if (!strncasecmp(kw,"ngc",kwlen)) {
 	    if (r.remap_py) {
-		Error("cant remap to an ngc file and a Python function: -  %d:REMAP = %s",
+		Error("can\'t remap to an ngc file and a Python function: -  %d:REMAP = %s",
 		      lineno,inistring);
 		errored = true;
 		continue;
@@ -459,7 +459,7 @@ int Interp::parse_remap(const char *inistring, int lineno)
 	}
 	if (!strncasecmp(kw,"python",kwlen)) {
 	    if (r.remap_ngc ) {
-		Error("cant remap to an ngc file and a Python function: -  %d:REMAP = %s",
+		Error("can\'t remap to an ngc file and a Python function: -  %d:REMAP = %s",
 		      lineno,inistring);
 		errored = true;
 		continue;
@@ -545,7 +545,7 @@ int Interp::parse_remap(const char *inistring, int lineno)
 	}
 	if ( gcode == -1) {
 	    if (sscanf(code + 1, "%d", &gcode) != 1) {
-		Error("code '%s' : cant parse G-code : %d:REMAP = %s",
+		Error("code '%s' : can\'t parse G-code : %d:REMAP = %s",
 		      code, lineno, inistring);
 		goto fail;
 	    }

--- a/src/emc/rs274ngc/interp_write.cc
+++ b/src/emc/rs274ngc/interp_write.cc
@@ -119,7 +119,7 @@ int Interp::write_g_codes(block_pointer block,   //!< pointer to a block of RS27
     (settings->control_mode == CANON_CONTINUOUS) ? G_64 :
     (settings->control_mode == CANON_EXACT_PATH) ? G_61 : G_61_1;
   gez[12] = -1;
-  gez[13] = //I don't even know how to display the mode of an arbitray number of spindles (andypugh 17/6/16)
+  gez[13] = //I don't even know how to display the mode of an arbitrary number of spindles (andypugh 17/6/16)
     (settings->spindle_mode[0] == CONSTANT_RPM) ? G_97 : G_96;
   gez[14] = (settings->ijk_distance_mode == MODE_ABSOLUTE) ? G_90_1 : G_91_1;
   gez[15] = (settings->lathe_diameter_mode) ? G_7 : G_8;

--- a/src/emc/rs274ngc/pyemctypes.cc
+++ b/src/emc/rs274ngc/pyemctypes.cc
@@ -78,7 +78,7 @@ void export_EmcTypes()
 
     // PmCartesian and EmcPose make sense to be instantiable 
     // within Python, since some canon calls take these as parameter
-    class_<PmCartesian, noncopyable>("PmCartesian","EMC cartesian postition")
+    class_<PmCartesian, noncopyable>("PmCartesian","EMC cartesian position")
 	.def_readwrite("x",&PmCartesian::x)
 	.def_readwrite("y",&PmCartesian::y)
 	.def_readwrite("z",&PmCartesian::z)

--- a/src/emc/rs274ngc/pyparamclass.cc
+++ b/src/emc/rs274ngc/pyparamclass.cc
@@ -75,7 +75,7 @@ double ParamClass::setitem(bp::object sub, double dvalue)
 	int status = interp.add_named_param(varname, varname[0] == '_' ? PA_GLOBAL :0);
 	status = interp.store_named_param(&interp._setup,varname, dvalue, 0);
 	if (status != INTERP_OK)
-	    throw std::runtime_error("cant assign value to parameter: " +
+	    throw std::runtime_error("can\'t assign value to parameter: " +
 				     std::string(varname));
 
     } else

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -664,7 +664,7 @@ int read_inputs(setup_pointer settings);
 #define OWORD_MODULE "oword"
 #define REMAP_MODULE "remap"
 #define NAMEDPARAMS_MODULE "namedparams"
-    // describes intented use, and hence parameter and return value
+    // describes intended use, and hence parameter and return value
     // interpretation
     enum py_calltype { PY_OWORDCALL,
 		       PY_FINISH_OWORDCALL,

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -6,7 +6,7 @@
 * Author:
 * License: GPL Version 2
 * System: Linux
-*    
+*
 * Copyright (c) 2004 All rights reserved.
 *
 * Last change:
@@ -134,7 +134,7 @@ Interp::Interp()
   init_named_parameters();  // need this before Python init.
  
   if (!PythonPlugin::instantiate(builtin_modules)) {  // factory
-    Error("Interp ctor: cant instantiate Python plugin");
+    Error("Interp ctor: can\'t instantiate Python plugin");
     return;
   }
 
@@ -315,7 +315,7 @@ int Interp::_execute(const char *command)
   // process control functions -- will skip if skipping
   if ((eblock->o_name != 0) || _setup.mdi_interrupt)  {
       status = convert_control_functions(eblock, &_setup);
-      CHP(status); // relinquish control if INTERP_EXCUTE_FINISH, INTERP_ERROR etc
+      CHP(status); // relinquish control if INTERP_EXECUTE_FINISH, INTERP_ERROR etc
       
       // let MDI code call subroutines.
       // !!!KL not clear what happens if last execution failed while in
@@ -413,7 +413,7 @@ int Interp::_execute(const char *command)
       // 8. In Auto mode, we do an initial execute(0) to get things going, thereafer
       //   task will do it for us.
       //
-      // 9. When a replacment sub finishes, remap_finished() continues execution of
+      // 9. When a replacement sub finishes, remap_finished() continues execution of
       //   the current remapped block until done.
       //
       if (eblock->remappings.size() > 0) {
@@ -1167,7 +1167,7 @@ int Interp::init()
   _setup.arc_not_allowed = false;
   _setup.cycle_il_flag = false;
   _setup.distance_mode = MODE_ABSOLUTE;
-  _setup.ijk_distance_mode = MODE_INCREMENTAL;  // backwards compatability
+  _setup.ijk_distance_mode = MODE_INCREMENTAL;  // backwards compatibility
   _setup.feed_mode = UNITS_PER_MINUTE;
 //_setup.feed_override set in Interp::synch
 //_setup.feed_rate set in Interp::synch
@@ -1265,7 +1265,7 @@ int Interp::init()
       catch (const bp::error_already_set&) {
 	  std::string exception_msg;
 	  bool unexpected = false;
-	  // KeyError is ok - this means the namedparams module doesnt exist
+	  // KeyError is ok - this means the namedparams module doesn't exist
 	  if (!PyErr_ExceptionMatches(PyExc_KeyError)) {
 	      // something else, strange
 	      exception_msg = handle_pyerror();
@@ -1510,7 +1510,7 @@ int Interp::_read(const char *command)  //!< may be NULL or a string to read
   // this input reading code is in the wrong place. It should be executed
   // in sync(), not here. This would make correct parameter values available 
   // without doing a read() (e.g. from Python).
-  // Unfortunately synch() isnt called in preview (gcodemodule)
+  // Unfortunately synch() isn't called in preview (gcodemodule)
 
 #if 0
   if (_setup.probe_flag) {
@@ -1552,7 +1552,7 @@ int Interp::_read(const char *command)  //!< may be NULL or a string to read
   // of times. So they need to be called again post-sync and post-read-input possibly several times.
   // 
   // the task readahead logic assumes a block execution may result in a single INTERP_EXECUTE_FINISH
-  // and readahead is started therafter immediately. Modifying the readahead logic would be a massive
+  // and readahead is started thereafter immediately. Modifying the readahead logic would be a massive
   // change. Therefore we use the trick to suppress reading the next block as required, which means
   // we will get several calls to execute() in a row which are used to finish the handlers. This is
   // needed for remapped codes which might involve up to three Python handlers, and Python oword subs.
@@ -2590,7 +2590,7 @@ int Interp::enter_remap(void)
     _setup.remap_level++;
     if (_setup.remap_level == MAX_NESTED_REMAPS) {
 	_setup.remap_level = 0;
-	ERS("maximum nesting of remapped blocks execeeded");
+	ERS("maximum nesting of remapped blocks exceeded");
     }
 
     // push onto block stack

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -3177,7 +3177,7 @@ void CLEAR_MOTION_OUTPUT_BIT(int index)
   right away.
   The pin gets set with value 1 at the begin of motion, and stays 1 at the end of motion
   (this behaviour can be changed if needed)
-  you can use any number of these, as the effect is imediate  
+  you can use any number of these, as the effect is immediate  
 */
 void SET_AUX_OUTPUT_BIT(int index)
 {
@@ -3189,7 +3189,7 @@ void SET_AUX_OUTPUT_BIT(int index)
   dout_msg.index = index;
   dout_msg.start = 1;		// startvalue = 1
   dout_msg.end = 1;		// endvalue = 1, means it doesn't get reset after current motion
-  dout_msg.now = 1;		// immediate, we don't care about synching for AUX
+  dout_msg.now = 1;		// immediate, we don't care about syncing for AUX
 
   interp_list.append(dout_msg);
 
@@ -3203,7 +3203,7 @@ void SET_AUX_OUTPUT_BIT(int index)
   right away.
   The pin gets set with value 0 at the begin of motion, and stays 0 at the end of motion
   (this behaviour can be changed if needed)
-  you can use any number of these, as the effect is imediate  
+  you can use any number of these, as the effect is immediate  
 */
 void CLEAR_AUX_OUTPUT_BIT(int index)
 {
@@ -3214,7 +3214,7 @@ void CLEAR_AUX_OUTPUT_BIT(int index)
   dout_msg.index = index;
   dout_msg.start = 0;           // startvalue = 1
   dout_msg.end = 0;		// endvalue = 0, means it stays 0 after current motion
-  dout_msg.now = 1;		// immediate, we don't care about synching for AUX
+  dout_msg.now = 1;		// immediate, we don't care about syncing for AUX
 
   interp_list.append(dout_msg);
 

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -89,7 +89,7 @@ fpu_control_t __fpu_control = _FPU_IEEE & ~(_FPU_MASK_IM | _FPU_MASK_ZM | _FPU_M
 static emcmot_config_t emcmotConfig;
 
 /* time after which the user interface is declared dead
- * because it would'nt read any more messages
+ * because it wouldn't read any more messages
  */
 #define DEFAULT_EMC_UI_TIMEOUT 5.0
 
@@ -119,7 +119,7 @@ static int emcTaskNoDelay = 0;
 static int emcTaskEager = 0;
 
 static int no_force_homing = 0; // forces the user to home first before allowing MDI and Program run
-//can be overriden by [TRAJ]NO_FORCE_HOMING=1
+//can be overridden by [TRAJ]NO_FORCE_HOMING=1
 
 static double EMC_TASK_CYCLE_TIME_ORIG = 0.0;
 
@@ -2240,7 +2240,7 @@ static int emcTaskIssueCommand(NMLmsg * cmd)
 		    mdi_execute_level = -1;
 		} else if (level > 0) {
 		    // Still insude call. Need another execute(0) call
-		    // but only if we didnt encounter an error
+		    // but only if we didn't encounter an error
 		    if (execRetval == INTERP_ERROR) {
 			mdi_execute_next = 0;
 		    } else {

--- a/src/emc/task/signalhandler.cc
+++ b/src/emc/task/signalhandler.cc
@@ -106,7 +106,7 @@ void setup_signal_handlers()
     // determine pathname of running program for gdb
     snprintf(path, sizeof(path),"/proc/%d/exe", getpid());
     if (readlink(path, exe, sizeof(exe)) < 0) {
-	fprintf(stderr, "signal_handler: cant readlink(%s): %s\n",path,strerror(errno));
+	fprintf(stderr, "signal_handler: can\'t readlink(%s): %s\n",path,strerror(errno));
 	return;
     }
     progname = strdup(exe);
@@ -138,7 +138,7 @@ int main(int argc, const char *argv[]) {
     sleep(10);  // during which a SIGUSR2 will generate a backtrace
 
     void *foo = 0;
-    memset(foo,0,47); // this segfault  whould warp us into the gdb window
+    memset(foo,0,47); // this segfault would warp us into the gdb window
 
     return 0;
 }

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -310,7 +310,7 @@ int emcTaskOnce(const char *filename)
 
     extern struct _inittab builtin_modules[];
     if (!PythonPlugin::instantiate(builtin_modules)) {
-	rcs_print("emcTaskOnce: cant instantiate Python plugin\n");
+	rcs_print("emcTaskOnce: can\'t instantiate Python plugin\n");
 	goto no_pytask;
     }
     if (python_plugin->configure(filename, "PYTHON") == PLUGIN_OK) {
@@ -329,13 +329,13 @@ int emcTaskOnce(const char *filename)
 	    if (typetest.check()) {
 		task_methods = bp::extract< Task * >(result);
 	    } else {
-		rcs_print("cant extract a Task instance out of '%s'\n", instance_name);
+		rcs_print("can\'t extract a Task instance out of '%s'\n", instance_name);
 		task_methods = NULL;
 	    }
 	} catch(bp::error_already_set &) {
 	    std::string msg = handle_pyerror();
 	    if (emc_debug & EMC_DEBUG_PYTHON_TASK) {
-		// this really just means the task python backend wasnt configured.
+		// this really just means the task python backend wasn't configured.
 		rcs_print("emcTaskOnce: extract(%s): %s\n", instance_name, msg.c_str());
 	    }
 	    PyErr_Clear();

--- a/src/emc/task/taskintf.cc
+++ b/src/emc/task/taskintf.cc
@@ -1790,14 +1790,14 @@ int emcMotionSetDebug(int debug)
 }
 
 /*! \function emcMotionSetAout()
-    
+
     This function sends a EMCMOT_SET_AOUT message to the motion controller.
     That one plans a AOUT command when motion starts or right now.
 
-    @parameter	index	which output gets modified
-    @parameter	now	wheather change is imediate or synched with motion
-    @parameter	start	value set at start of motion
-    @parameter	end	value set at end of motion
+    @parameter index   which output gets modified
+    @parameter now     whether change is immediate or synched with motion
+    @parameter start   value set at start of motion
+    @parameter end     value set at end of motion
 */
 int emcMotionSetAout(unsigned char index, double start, double end, unsigned char now)
 {
@@ -1813,14 +1813,14 @@ int emcMotionSetAout(unsigned char index, double start, double end, unsigned cha
 }
 
 /*! \function emcMotionSetDout()
-    
+
     This function sends a EMCMOT_SET_DOUT message to the motion controller.
     That one plans a DOUT command when motion starts or right now.
 
-    @parameter	index	which output gets modified
-    @parameter	now	wheather change is imediate or synched with motion
-    @parameter	start	value set at start of motion
-    @parameter	end	value set at end of motion
+    @parameter index   which output gets modified
+    @parameter now     whether change is immediate or synched with motion
+    @parameter start   value set at start of motion
+    @parameter end     value set at end of motion
 */
 int emcMotionSetDout(unsigned char index, unsigned char start,
 		     unsigned char end, unsigned char now)

--- a/src/emc/tp/blendmath.h
+++ b/src/emc/tp/blendmath.h
@@ -72,7 +72,7 @@ typedef struct {
     double tolerance;   /* Net blend tolerance (min of line 1 and 2) */
     double L1;          /* Available part of line 1 to blend over */
     double L2;          /* Available part of line 2 to blend over */
-    double v_req;       /* requsted velocity for the blend arc */
+    double v_req;       /* requested velocity for the blend arc */
     double a_max;       /* max acceleration allowed for blend */
 
     /* These fields are considered "output", and may be refactored into a

--- a/src/emc/tp/tc.c
+++ b/src/emc/tp/tc.c
@@ -273,7 +273,7 @@ int pmCircleTangentVector(PmCircle const * const circle,
 
 
 /**
- * Calulate the unit tangent vector at the start of a move for any segment.
+ * Calculate the unit tangent vector at the start of a move for any segment.
  */
 int tcGetStartTangentUnitVector(TC_STRUCT const * const tc, PmCartesian * const out) {
 
@@ -295,7 +295,7 @@ int tcGetStartTangentUnitVector(TC_STRUCT const * const tc, PmCartesian * const 
 }
 
 /**
- * Calulate the unit tangent vector at the end of a move for any segment.
+ * Calculate the unit tangent vector at the end of a move for any segment.
  */
 int tcGetEndTangentUnitVector(TC_STRUCT const * const tc, PmCartesian * const out) {
 

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -2518,7 +2518,7 @@ STATIC int tpUpdateMovementStatus(TP_STRUCT * const tp, TC_STRUCT const * const 
     EmcPose tc_pos;
     tcGetEndpoint(tc, &tc_pos);
 
-    tc_debug_print("tc id = %u canon_type = %u mot type = %u\n",
+    tc_debug_print("tc id = %u canon_type = %u motion_type = %u\n",
             tc->id, tc->canon_motion_type, tc->motion_type);
     tp->motionType = tc->canon_motion_type;
     tp->activeDepth = tc->active_depth;

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -1620,13 +1620,13 @@ STATIC int tpComputeOptimalVelocity(TP_STRUCT const * const tp, TC_STRUCT * cons
  * Walk along the queue from the back to the front. Based on the "current"
  * segment's final velocity, calculate the previous segment's maximum allowable
  * final velocity. The depth we walk along the queue is controlled by the
- * TP_LOOKAHEAD_DEPTH constant for now. The process safetly aborts early due to
+ * TP_LOOKAHEAD_DEPTH constant for now. The process safely aborts early due to
  * a short queue or other conflicts.
  */
 STATIC int tpRunOptimization(TP_STRUCT * const tp) {
     // Pointers to the "current", previous, and 2nd previous trajectory
     // components. Current in this context means the segment being optimized,
-    // NOT the currently excecuting segment.
+    // NOT the currently executing segment.
 
     TC_STRUCT *tc;
     TC_STRUCT *prev1_tc;

--- a/src/emc/tp/tp_types.h
+++ b/src/emc/tp/tp_types.h
@@ -73,7 +73,7 @@ typedef enum {
 } tp_err_t;
 
 /**
- * Persistant data for spindle status within tpRunCycle.
+ * Persistent data for spindle status within tpRunCycle.
  * This structure encapsulates some static variables to simplify refactoring of
  * synchronized motion code.
  */
@@ -87,7 +87,7 @@ typedef struct {
 
 /**
  * Trajectory planner state structure.
- * Stores persistant data for the trajectory planner that should be accessible
+ * Stores persistent data for the trajectory planner that should be accessible
  * by outside functions.
  */
 typedef struct {
@@ -112,7 +112,7 @@ typedef struct {
     double aLimit;        /* max accel (unused) */
 
     double wMax;		/* rotational velocity max */
-    double wDotMax;		/* rotational accelleration max */
+    double wDotMax;		/* rotational acceleration max */
     int nextId;
     int execId;
     struct state_tag_t execTag; /* state tag corresponding to running motion */

--- a/src/emc/usr_intf/axis/extensions/togl.c
+++ b/src/emc/usr_intf/axis/extensions/togl.c
@@ -792,7 +792,7 @@ void Togl_ResetDefaultCallbacks( void )
 
 
 /*
- * Chnage the create callback for a specific Togl widget.
+ * Change the create callback for a specific Togl widget.
  */
 void Togl_SetCreateFunc( struct Togl *togl, Togl_Callback *proc )
 {
@@ -3187,7 +3187,7 @@ int main(int argc, char *argv[])
  *
  * MacintoshInit --
  *
- *	This procedure calls Mac specific initilization calls.  Most of
+ *	This procedure calls Mac specific initialization calls.  Most of
  *	these calls must be made as soon as possible in the startup
  *	process.
  *
@@ -3216,7 +3216,7 @@ int Togl_MacInit(void)
 
    /*
     * Tk needs us to set the qd pointer it uses.  This is needed
-    * so Tk doesn't have to assume the availablity of the qd global
+    * so Tk doesn't have to assume the availability of the qd global
     * variable.  Which in turn allows Tk to be used in code resources.
     */
    tcl_macQdPtr = &qd;

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -4165,7 +4165,7 @@ if os.path.exists(rcfile):
         root_window.tk.call("nf_dialog", ".error", _("Error in ~/.axisrc"),
             tb, "error", 0, _("OK"))
 
-# call an empty function that can be overidden
+# call an empty function that can be overridden
 # by an .axisrc user_hal_pins() function
 # then set HAL component ready if the .axisui didn't
 if hal_present == 1 :

--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -110,7 +110,7 @@
   connection. If no parameters are specified, it will itemize the available commands.
   If a command is specified, it will provide usage information for the specified
   command. Help will respond regardless of whether a "Hello" has been
-  successsfully negotiated.
+  successfully negotiated.
   
   
   LinuxCNC sub-commands:
@@ -1424,7 +1424,7 @@ int commandSet(connectionRecType *context)
     case rtCustomError: // Custom error response entered in buffer
       return write(context->cliSock, context->outBuf, strlen(context->outBuf));
       break;
-    case rtCustomHandledError: ;// Custom error respose handled, take no action
+    case rtCustomHandledError: ;// Custom error response handled, take no action
     }
   return 0;
 }
@@ -2492,7 +2492,7 @@ int commandGet(connectionRecType *context)
     case rtCustomError: // Custom error response entered in buffer
       sockWrite(context);
       break;
-    case rtCustomHandledError: ;// Custom error respose handled, take no action
+    case rtCustomHandledError: ;// Custom error response handled, take no action
     }
   return 0;
 }

--- a/src/emc/usr_intf/gmoccapy/dialogs.py
+++ b/src/emc/usr_intf/gmoccapy/dialogs.py
@@ -2,7 +2,7 @@
 
 '''
     This class is used to handle the dialogs from gmoccapy,
-    it is just a coppy of a class from gscreen and has been slighly modified
+    it is just a copy of a class from gscreen and has been slightly modified
 
     Copyright 2014 Norbert Schechner
     nieson@web.de

--- a/src/emc/usr_intf/gmoccapy/getiniinfo.py
+++ b/src/emc/usr_intf/gmoccapy/getiniinfo.py
@@ -2,7 +2,7 @@
 
 '''
     This class is used to get information from a config.ini file,
-    It will return cleared informations, so the checks for valid values 
+    It will return cleared information, so the checks for valid values 
     is away from the GUI code
 
     Copyright 2014 Norbert Schechner
@@ -141,7 +141,7 @@ class GetIniInfo:
                 # OK we have a special case here, we need to take care off
                 # i.e. a Gantry XYYZ config
                 double_axis_letter.append(axisletter)
-                print("Fount double letter ", double_axis_letter)
+                print("Found double letter ", double_axis_letter)
 
         if self.get_joints() == len(coordinates):
             prev_double_axis_leter = ""

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -4266,8 +4266,8 @@
                                                             <property name="visible">True</property>
                                                             <property name="can_focus">False</property>
                                                             <property name="has_tooltip">True</property>
-                                                            <property name="tooltip_markup">Displayes the programmed feed rate</property>
-                                                            <property name="tooltip_text" translatable="yes">Displayes the programmed feed rate</property>
+                                                            <property name="tooltip_markup">Displays the programmed feed rate</property>
+                                                            <property name="tooltip_text" translatable="yes">Displays the programmed feed rate</property>
                                                             <property name="label">F 275</property>
                                                             <attributes>
                                                             <attribute name="weight" value="bold"/>
@@ -4398,7 +4398,7 @@
                               <object class="GtkLabel" id="lbl_frm_info_emb_keyb">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label">Embeded keyboard</property>
+                                <property name="label">Embedded keyboard</property>
                               </object>
                               <packing>
                                 <property name="position">1</property>
@@ -6796,7 +6796,7 @@ clicking on the DRO</property>
                                                   <object class="GtkLabel" id="lbl_frm_probe">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="label" translatable="yes">&lt;b&gt;Probe Informations&lt;/b&gt;</property>
+                                                    <property name="label" translatable="yes">&lt;b&gt;Probe Information&lt;/b&gt;</property>
                                                     <property name="use_markup">True</property>
                                                   </object>
                                                 </child>
@@ -8720,7 +8720,7 @@ F12 or $ key does the same</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">apply the changes you made, G43 will be excecuted only if it is active g-code</property>
+                    <property name="tooltip_text" translatable="yes">apply the changes you made, G43 will be executed only if it is active g-code</property>
                     <signal name="clicked" handler="on_btn_apply_tool_changes_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -8913,7 +8913,7 @@ F12 or $ key does the same</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Move to parrent directory</property>
+                    <property name="tooltip_text" translatable="yes">Move to parent directory</property>
                     <property name="image">img_dir_up</property>
                     <signal name="clicked" handler="on_btn_dir_up_clicked" swapped="no"/>
                   </object>
@@ -8944,7 +8944,7 @@ F12 or $ key does the same</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Select the previos file</property>
+                    <property name="tooltip_text" translatable="yes">Select the previous file</property>
                     <property name="image">img_sel_prev</property>
                     <property name="image_position">top</property>
                     <signal name="clicked" handler="on_btn_sel_prev_clicked" swapped="no"/>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -100,7 +100,7 @@ _BB_TOOL = 7
 _BB_LOAD_FILE = 8
 #_BB_HOME_JOINTS will not be used, we will reorder the notebooks to get the correct page shown
 
-_TEMPDIR = tempfile.gettempdir()  # Now we know where the tempdir is, usualy /tmp
+_TEMPDIR = tempfile.gettempdir()  # Now we know where the tempdir is, usually /tmp
 
 # set up paths to files
 BASE = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
@@ -146,7 +146,7 @@ class gmoccapy(object):
         locale.bindtextdomain("gmoccapy", LOCALEDIR)
         gettext.install("gmoccapy", localedir=LOCALEDIR)
 
-        # needed components to comunicate with hal and linuxcnc
+        # needed components to communicate with hal and linuxcnc
         self.halcomp = hal.component("gmoccapy")
         self.command = linuxcnc.command()
         self.stat = linuxcnc.stat()
@@ -170,8 +170,8 @@ class gmoccapy(object):
 
         self.start_line = 0  # needed for start from line
 
-        self.active_gcodes = []   # this are the formated G code values
-        self.active_mcodes = []   # this are the formated M code values
+        self.active_gcodes = []   # this are the formatted G code values
+        self.active_mcodes = []   # this are the formatted M code values
         self.gcodes = []          # this are the unformatted G code values to check if an update is required
         self.mcodes = []          # this are the unformatted M code values to check if an update is required
 
@@ -501,7 +501,7 @@ class gmoccapy(object):
         self.jog_increments = self.get_ini_info.get_increments()
         # check if NO_FORCE_HOMING is used in ini
         self.no_force_homing = self.get_ini_info.get_no_force_homing()
-        # do we use a identity kinematics or do we have to distingish 
+        # do we use a identity kinematics or do we have to distinguish 
         # JOINT and Axis modes?
         self.trivial_kinematics = self.get_ini_info.get_trivial_kinematics()
         units = self.get_ini_info.get_machine_units()
@@ -1072,7 +1072,7 @@ class gmoccapy(object):
             return
 
         # if shift = True, then the user pressed SHIFT for Jogging and
-        # want's to jog at full speed
+        # wants to jog at full speed
         # This can only happen on keyboard jogging, not with the on screen jog button
         # We just only use one function for both cases
         if shift:
@@ -1773,7 +1773,7 @@ class gmoccapy(object):
             if "ntb_preview" in tab_locations:
                 self.widgets.ntb_preview.set_property( "show-tabs", True )
 
-            # This is normaly only used for the plasma screen layout
+            # This is normally only used for the plasma screen layout
             if "box_coolant_and_spindle" in tab_locations:
                 widgetlist = ["box_spindle", "box_cooling", "frm_spindle"]
                 for widget in widgetlist:
@@ -1899,7 +1899,7 @@ class gmoccapy(object):
         else:
             print (_("**** GMOCCAPY INFO ****"))
             print (_("**** no audio available! ****"))
-            print(_("**** PYGST libray not installed? ****"))
+            print(_("**** PYGST library not installed? ****"))
             print(_("**** is python-gstX.XX installed? ****"))
 
             self.widgets.audio_alert_chooser.set_sensitive(False)
@@ -1958,7 +1958,7 @@ class gmoccapy(object):
         self._set_enable_tooltips(not self.hide_tooltips)
 
 # =============================================================
-# Onboard keybord handling Start
+# Onboard keyboard handling Start
 
     # shows "Onboard" virtual keyboard if available
     # else error message
@@ -2041,7 +2041,7 @@ class gmoccapy(object):
             except:
                 pass
 
-# Onboard keybord handling End
+# Onboard keyboard handling End
 # =============================================================
 
     def _init_offsetpage(self):
@@ -2250,7 +2250,7 @@ class gmoccapy(object):
     # every 100 milli seconds this gets called
     # check linuxcnc for status, error and then update the readout
     def _periodic(self):
-        # we put the poll comand in a try, so if the linuxcnc pid is killed
+        # we put the poll command in a try, so if the linuxcnc pid is killed
         # from an external command, we also quit the GUI
         try:
             self.stat.poll()
@@ -2393,7 +2393,7 @@ class gmoccapy(object):
             # homed the second time, unfortunately we will then
             # not get out of MDI mode any more
             # That happen, because the tool in spindle did not change, so the 
-            # tool info is not updated and we self.change_tool will not be reseted
+            # tool info is not updated and we self.change_tool will not be reset
             if self.stat.tool_in_spindle != 0:
                 return
             self.reload_tool()
@@ -2459,7 +2459,7 @@ class gmoccapy(object):
             widgetlist.append("btn_tool_touchoff_z")
             widgetlist.append("btn_touch")
 
-        # This happen because hal_glib does emmit the signals in the order that idle is emited later that estop
+        # This happen because hal_glib does emit the signals in the order that idle is emitted later that estop
         if self.stat.task_state == linuxcnc.STATE_ESTOP or self.stat.task_state == linuxcnc.STATE_OFF:
             self._sensitize_widgets(widgetlist, False)
         else:
@@ -2788,7 +2788,7 @@ class gmoccapy(object):
         # set up the hal pin status of tool measurement
         # could not be done prior to this, as the hal pin are not created before
         # the tool measure check, due to the reason we need to know if creation
-        # of tool measurement button is needed. So we call the toogle action to
+        # of tool measurement button is needed. So we call the toggle action to
         # set all up and running
         self.on_chk_use_tool_measurement_toggled(self.widgets.chk_use_tool_measurement)
 
@@ -2835,7 +2835,7 @@ class gmoccapy(object):
         self.command.mdi(command)
         for btn in self.macrobuttons:
             btn.set_sensitive(False)
-        # we change the widget_image (doen by hal status)
+        # we change the widget_image (done by hal status)
         # and use the button to interrupt running macros
         if not self.onboard:
             self.macro_dic["keyboard"].set_sensitive(True)
@@ -2893,7 +2893,7 @@ class gmoccapy(object):
         # get the keyname
         keyname = Gdk.keyval_name(event.keyval)
 
-        # estop with F1 shold work every time
+        # estop with F1 should work every time
         # so should also escape abort actions
         if keyname == "F1":  # will estop the machine, but not reset estop!
             self.command.state(linuxcnc.STATE_ESTOP)
@@ -3378,7 +3378,7 @@ class gmoccapy(object):
         # but not from the ones we created dynamically
         for widget in self.widgets_with_tooltips:
             widget.set_has_tooltip(value)
-        # the dynamicaly created widgets are in ordert in dictionarys
+        # the dynamically created widgets are in ordered in dictionaries
         # self.joints_button_dic (only in non trivial kinematics)
         # self.ref_button_dic
         # self.touch_button_dic
@@ -3812,7 +3812,7 @@ class gmoccapy(object):
 
         # if we do not check this, we will get an error in auto mode and sub
         # calls from MDI containing i.e. G96 would not run, as the speed will
-        # be setted to the commanded value due the next code part
+        # be set to the commanded value due to the next code part
         if self.stat.task_mode != linuxcnc.MODE_MANUAL:
             if self.stat.interp_state == linuxcnc.INTERP_READING or self.stat.interp_state == linuxcnc.INTERP_WAITING:
                 if self.stat.spindle[0]['direction'] > 0:
@@ -4448,7 +4448,7 @@ class gmoccapy(object):
 
     # Here we create a manual tool change dialog
     def on_tool_change(self, widget):
-        print("on tool chnage")
+        print("on tool change")
         change = self.halcomp['toolchange-change']
         toolnumber = self.halcomp['toolchange-number']
         if change:
@@ -4505,7 +4505,7 @@ class gmoccapy(object):
 
         if self.widgets.tooledit1.get_selected_tool() != self.stat.tool_in_spindle:
             message = _("you can not touch of a tool, witch is not mounted in the spindle")
-            message += _("your selection has been reseted to the tool in spindle")
+            message += _("your selection has been reset to the tool in spindle")
             self.dialogs.warning_dialog(self, _("Warning Tool Touch off not possible!"), message)
             self.widgets.tooledit1.reload(self)
             self.widgets.tooledit1.set_selected_tool(self.stat.tool_in_spindle)
@@ -5100,7 +5100,7 @@ class gmoccapy(object):
         elif "v-button" in pin.name:
             location = "right"
         else:
-            print(_("Recieved a not clasified signal from pin {0}".format(pin.name)))
+            print(_("Received a not classified signal from pin {0}".format(pin.name)))
             return
 
         number = int(pin.name[-1])

--- a/src/emc/usr_intf/gmoccapy/notification.py
+++ b/src/emc/usr_intf/gmoccapy/notification.py
@@ -26,7 +26,7 @@
 #        the messages are placed correct, until you reached the given max, then
 #        the popup will jump one message height down. As far as I found out till now
 #        it is caused because the height of the first message is not taken in care
-#        calculating the hight of the popup.
+#        calculating the height of the popup.
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -149,13 +149,13 @@ class Notification(Gtk.Window):
         #labelnumber.show()
         self.vbox.show()
 
-    # add a message, the message is a string, it will be line wraped
+    # add a message, the message is a string, it will be line wrapped
     # if to long for the frame
     def add_message(self, message, icon_file_name):
         '''Notification.add_message(messagetext, icon_file_name)
         
            messagetext = a string to display
-           icon_file_name = a valid absolut path to an icon or None
+           icon_file_name = a valid absolute path to an icon or None
         '''
         self.popup.hide()
         self.popup.resize(1, 1)
@@ -206,7 +206,7 @@ class Notification(Gtk.Window):
             self._refill_messages()
             return True
         elif messagenumber > len(self.messages) or messagenumber < 0:
-            self.add_message(_('Error trying to delet the message with number {0}'.format(messagenumber), None))
+            self.add_message(_('Error trying to delete the message with number {0}'.format(messagenumber), None))
             return False
         try:
             del self.messages[int(messagenumber)]
@@ -216,20 +216,20 @@ class Notification(Gtk.Window):
         return True
 
     # this is the recomendet way to delete a message, by clicking the
-    # close button of the coresponding frame
+    # close button of the corresponding frame
     def _on_btn_close_clicked(self, widget, labelnumber):
         del self.messages[int(labelnumber)]
         self.emit("message_deleted", self.messages)
         self._refill_messages()
 
     def _refill_messages(self):
-        # first we have to hide all messages, otherwise the popup window will mantain
+        # first we have to hide all messages, otherwise the popup window will maintain
         # all the old messages
         childs = self.popup.get_children()[0].get_children()
         for child in childs:
             child.hide()
         # then we rezise the popup window to a very small size, otherwise the dimensions
-        # of the window will be mantained
+        # of the window will be maintained
         self.popup.resize(1, 1)
         # if it was the last message, than we can hide the popup window
         if len(self.messages) == 0:

--- a/src/emc/usr_intf/gmoccapy/player.py
+++ b/src/emc/usr_intf/gmoccapy/player.py
@@ -2,7 +2,7 @@
 
 '''
     This class is used to handle sound messages from gmoccapy,
-    it is just a coppy of a class from gscreen and has been slighly modified
+    it is just a copy of a class from gscreen and has been slightly modified
 
     Copyright 2014 Norbert Schechner
     nieson@web.de
@@ -57,7 +57,7 @@ class Player:
             self.player.set_state(gst.STATE_NULL)
             self.loop.quit()
         elif t == gst.MESSAGE_ERROR:
-            # Error ocurred, print and stop
+            # Error occurred, print and stop
             self.player.set_state(gst.STATE_NULL)
             err, debug = message.parse_error()
             print ("Error: %s" % err, debug)

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -26,7 +26,7 @@ ver 3.1.3.6
   Thanks to hansu for reporting
 
 ver 3.1.3.5
-- wrong translation of "Follow System Theme" leaded to a wrong 
+- wrong translation of "Follow System Theme" led to a wrong 
   theme when loading the GUI.
   Will correct the translation files with a different commit
 
@@ -45,7 +45,7 @@ ver 3.1.3.3
   Thanks to hansu for reporting
 
 ver 3.1.3.2
-- change og gmoccapy hal pin gmoccapy.jog.jog-inc-N leaded to an
+- change og gmoccapy hal pin gmoccapy.jog.jog-inc-N led to an
   aboart() command, so changing that pin i.e. in AUTO mode stops
   Spindle and program execution. That is not the expected behavior.
 
@@ -64,7 +64,7 @@ ver 3.1.3.1
 
 ver 3.1.3
 - added a dialog asking the user to save changes
-- when in min screen resolution the editing page was wrong formated
+- when in min screen resolution the editing page was wrong formatted
   while using German language, because of too long strings
   Thanks to Hans470 for reporting this bugs
 
@@ -82,8 +82,8 @@ ver 3.1.2.2
 ver 3.1.2.1
 - still a bug in handling ignore limits solved
   issue #1000 reported by Hans470
-  solved by using new hal staus signal and deleted 
-  some unneded code
+  solved by using new hal status signal and deleted 
+  some unneeded code
 
 ver 3.1.2
 - connecting macro button to physical button did send
@@ -91,20 +91,20 @@ ver 3.1.2
   This bug has been reported from ulistermclame
 
 ver 3.1.1
-- setting analog-enable hal pins signal allways resetted
+- setting analog-enable hal pins signal always reset
   the jog vel of the slider. This has been reported from hans23
   solved with this update
 
 ver 3.1.0
 - added the ability to hide the tooltips to
-  make the use with touch monitors more usefull
+  make the use with touch monitors more useful
   Thanks to neilwhelcher for the code and pointing this out
 
 ver 3.0.10
 - bug in handling ignore limits solved
   issue #1000 reported by Hans470
-  solved by using new hal staus signal and deleted 
-  some unneded code
+  solved by using new hal status signal and deleted 
+  some unneeded code
 
 ver 3.0.9.1
 - bug in handling back tool lathe solved
@@ -120,7 +120,7 @@ ver 3.0.8.3
   that hold available axes to be in the same order as defined.
   in python 2.7 that is not the default behavior of dicts.
   So the function (with a XYZAB machine for example) gave two
-  sets of row/coloumn numbers for four buttons, leading to two
+  sets of row/column numbers for four buttons, leading to two
   buttons not being available.
   Thanks to Chris Morley for fixing this
 
@@ -193,7 +193,7 @@ ver 3.0.2
 - get rid of the screen2 stuff, as screens can be displayed using hal commands
 
 ver 3.0.1
-- bug being in full-size preview in auto mode and loading a file leaded to
+- bug being in full-size preview in auto mode and loading a file led to
   normal view as expected, but the full-size button stayed activated
 
 ver 3.0.0
@@ -242,7 +242,7 @@ ver 2.3.3.4
   Thanks to COlger81 and Chris Morley for reporting the bug
 
 ver 2.3.3.3
-- editing offsets, leaded to a error output in the console, due to missing
+- editing offsets, led to a error output in the console, due to missing
   widget btn_zero_x
 
 ver 2.3.3.2
@@ -273,12 +273,12 @@ ver 2.3.2.2
 - ongoing reformatting the code to new .format style
 
 ver 2.3.2.1
-- formating bug in Vc, when over 100, float can not be formated as int
+- formatting bug in Vc, when over 100, float can not be formatted as int
 
 ver 2.3.2
 - added a new label to toolinfo box, showing the cutting speed Vc
   it uses the tool diameter on mill and the x-relative value for lathe
-- first code updates to the new string formating (not % but .format),
+- first code updates to the new string formatting (not % but .format),
   as this will be needed to switch over to python 3
 
 ver 2.3.1.9
@@ -308,7 +308,7 @@ ver 2.3.1.6
 ver 2.3.1.5
 - some code clearance, as the tooleditor stuff was reparted on several places
   Now it is together in _init_tooleditor.
-  This is the begining of finding the bug of decimal separator handling
+  This is the beginning of finding the bug of decimal separator handling
   Push reload will replace the German "," with the "." Why = ?????
 
 ver 2.3.1.4
@@ -342,7 +342,7 @@ ver 2.3.0
 ver 2.2.5.2
 - if the GUI tries to reload a tool on restart and that tool was not found in 
   the tool table, the GUI remained in MDI mode, while it was showing the manual 
-  view. This leaded to the problem, that jogging was not possible, but users 
+  view. This led to the problem, that jogging was not possible, but users 
   thought they where in MANUAL mode, where jogging should be allowed.
 
 ver 2.2.5.1
@@ -380,7 +380,7 @@ ver 2.2.3.1
   homed the second time, unfortunately we will then
   not get out of MDI mode any more
   That happen, because the tool in spindle did not change, so the 
-  tool info is not updated and we self.change_tool will not be reseted
+  tool info is not updated and we self.change_tool will not be reset
   Thanks to timmert for reporting
 
 ver. 2.2.3
@@ -481,7 +481,7 @@ ver. 2.1.1
   possible to JOG_STOP with machine in OFF state
 
 ver. 2.1.0
-- reworked Combi_DRO to fit the needs of JA requierements
+- reworked Combi_DRO to fit the needs of JA requirements
 - some configs must be adapted to the new hal pin names, as they are
   put together in groups, so all stuff with jog is in that group
 - Hiding the jog button in world mode is possible with a command line argument
@@ -575,7 +575,7 @@ ver. 2.0.15
 - added a togglebutton to switch from joint to teleop, this button 
   will be hidden on identity kinematics machines
 - small bug in spc_spinlde handling 
-  (to many get and set leaded to jumping values)
+  (to many get and set led to jumping values)
 
 ver. 2.0.14
 - deleted adj_spinlde and changes the code to use directly the settings
@@ -635,7 +635,7 @@ ver. 2.0.2
 - added logo as command line argument
 
 ver. 2.0.1
-- when using hardware button to jog the axis, the 5th axis wath not 
+- when using hardware button to jog the axis, the 5th axis was not 
   recognized, resulting in a jog of the 4th axis. I solved this bug
   and introduced a new config to test this.
   Thanks to Ludwig for reporting the bug
@@ -697,10 +697,10 @@ ver. 1.5.6.8
   INI file a default value of 150 will be used.
 
 ver. 1.5.6.7
-- reading of subroutine paths did not take care of ":" separeted paths
+- reading of subroutine paths did not take care of ":" separated paths
   so it was not possible to use NativeCAM together with gmoccapy macros
   I corrected that misbehavior of gmoccapy. That change was used to
-  clear some macro code and I transfered some checking to get_ini_info
+  clear some macro code and I transferred some checking to get_ini_info
 
 ver. 1.5.6.6
 - check at start if there is a INI entry for DEFAULT_SPINDLE_SPEED
@@ -735,7 +735,7 @@ ver. 1.5.6.2.1
 - bug in initialize optional stops
 
 ver. 1.5.6.2
-- bugfix: run from line was trying to set an entry in the alarm page, whitch
+- bugfix: run from line was trying to set an entry in the alarm page, which
   I dropped in 1.5.6 
   I cleared the code from unneeded imports and comments
 
@@ -797,7 +797,7 @@ ver. 1.5.4.1
   to be the same place in auto and manual mode.
 
 ver. 1.5.4
-- changing in auto mode, being in full-size preview to edit page leaded
+- changing in auto mode, being in full-size preview to edit page led
   to blank screen, I corrected that bug.
 
 ver. 1.5.3.1
@@ -823,7 +823,7 @@ ver. 1.5.2
 - Some code clearance 
 
 ver. 1.5.1.4
-- Two missing self. leaded to errors if logging was active, 
+- Two missing self. led to errors if logging was active, 
   Thanks to Frans (franstrein) for reporting
 
 ver. 1.5.1.3
@@ -912,7 +912,7 @@ ver. 1.5.0
 ver. 1.4.2
 - removed the save and run button from the edit page, 
   because of security reasons
-- removed the integrated terminal, as it was not real usefull
+- removed the integrated terminal, as it was not real useful
   and all terminal work can be done from normal terminal
 - translations for German and Spanish has been updated
 
@@ -954,7 +954,7 @@ ver. 1.3.5
 ver. 1.3.4
 - if no virtual keyboard was installed (nor onboard or matchbox),
   the checkboxes on the settings page has not been sensitized and the
-  settings has not been reseted correctly from the preference file
+  settings has not been reset correctly from the preference file
   Thanks to Roland (concierge) for finding this one
 
 ver. 1.3.3
@@ -1036,11 +1036,11 @@ ver. 1.1.5.8
 ver. 1.1.5.7
 - init dynamic tab now in try except to avoid python exception
   on user typos in ini file
-- loading a tool using remap, leaded to an error if no file has been 
+- loading a tool using remap, led to an error if no file has been 
   loaded before the change, we do check for that now to avoid the error
 
 ver. 1.1.5.6
-- introduced three new hal-pin to signal program progress informations
+- introduced three new hal-pin to signal program progress information
   gmoccapy.program.length = S32, OUT (total number of program lines)
   gmoccapy.program.current-line =S32, OUT (current executed line)
   gmoccapy.program.progress = FLOAT, OUT (progress in %)
@@ -1072,7 +1072,7 @@ ver. 1.1.5.2
   previous mode.
 
 ver. 1.1.5.1
-- solved a bug related to the gmoccapy error pin. This pin has not been reseted
+- solved a bug related to the gmoccapy error pin. This pin has not been reset
   if the user used the mouse or touch screen and erased the message by clicking
   the message button. It was only done right if the delete-message pin was used.
   I modified notification.py to emit a signal if a message has been deleted and 
@@ -1177,7 +1177,7 @@ ver. 1.0.7.1
   and the GUI changed state making several widgets sensitive, that behavior
   was wrong, solved that.
 - If you feed override has been changed and the machine went into estop, 
-  a estop reset also reseted feed override to 100 % , now it will remain with 
+  a estop reset also reset feed override to 100 % , now it will remain with 
   the value it had before estop.
 - If a user activate logging actions, the logging was lost after shutting
   down the GUI, now the content of alarm_history will be written to a 
@@ -1272,7 +1272,7 @@ ver. 0.9.9.9.16
 ver. 0.9.9.9.15
 - new hal pin gscreen.error as bit out, to show an error to the
   hardware, so a light can lit or even stop the machine. It will
-  reseted with the pin gscreen.delete-message. This command will
+  reset with the pin gscreen.delete-message. This command will
   delete the first error and reset the gscreen.error pin to False 
   after the last error has been cleared. Messages or user infos
   will not affect this pin!  
@@ -1645,7 +1645,7 @@ ver. 0.9.6
 ver. 0.9.5.1
 - bug in spindle switching while in LOG Mode
 - ESC and F1 keys will work now, even if use Keyboard shortcuts is not activated
-- solved a bug in run_from_line, the start line was not reseted after program stop, 
+- solved a bug in run_from_line, the start line was not reset after program stop, 
   and I missed to reset self.data.restart_dialog to None
 
 ver. 0.9.5
@@ -1659,7 +1659,7 @@ ver. 0.9.5
 - fixed a bug in tooledit, trying to touch of a tool not in spindle, I must check if this should be allowed
   or if it better only allowing touch off with the tool in spindle
 - changed gmoccapy keyboard to "onboard", if the layout is not correct, the following command will correct it
-  setxkbmap -layout <your contry letters>       
+  setxkbmap -layout <your country letters>       
   gb for Great Britan, de for germany, etc.
 - changes in gscreen broke gmoccapy cycle start seems that hal_action run is not any longer permitted,
   now hal toggle action is needed, corrected this
@@ -1679,7 +1679,7 @@ ver. 0.9.4
 - there was still an error in key handling with incremental jogging, hope I solved it now for final
 - changed the dialog "run_from_line" to use gscreens default, resulting in the need to rename
   "hal_sourceview" to "gcode_view"
-- renamed all pins and definitions from "overide" to "override" because of typo
+- renamed all pins and definitions from "override" to "override" because of typo
 - avoid getting to the touch off button, while the machine is not homed
 - hide Y touch off buttons in lathe mode
 - solved a bug executing a command constantly related with feed and periodic
@@ -1687,7 +1687,7 @@ ver. 0.9.4
 - the tool in spindle will be checked if you enter the tool editor.
 
 ver. 0.9.3.2
-- alligned the jog_button and jog_rates frame on the top (just cosmetic)
+- aligned the jog_button and jog_rates frame on the top (just cosmetic)
 - The Page-up and Page_Down keyboard keys moved the Z axis in opposite directions
 - Feed values will only be shown with digit if G95 is active
 - added classicladder button to the list of buttons to be able to handle it with hardware button
@@ -1761,7 +1761,7 @@ ver. 0.9.0
 - I forgot an letter in hal pin feed-override-counts
 - The button Rel/Abs changes its label according to the active coordinate system
   and its background color does change if G54 is not active
-- solved the estop error not showing the correct sate on start up
+- solved the estop error not showing the correct state on start up
 - solved a bug giving value 0 to macro, the entry widget checked this value as False
 - merged with new master and also with gscreen with new widget names
 - gscreen fired a error when there is no keyhandling in gmoccapy, 
@@ -1813,7 +1813,7 @@ ver. 0.8.8
   I fixed this, if you reduce max-vel lower than jog_vel, jog vel will be reduced too
 - spindle bar won't grow with negative values (spindle reverse); I know it worked already, why
   did I have to fix this again?
-- entering the MDI Mode sets the focus directly to the enty of hal_mdihistory
+- entering the MDI Mode sets the focus directly to the entty of hal_mdihistory
  
 ver. 0.8.7
 - changed the button to delete status bar messages from text to icon
@@ -1922,7 +1922,7 @@ ver. 0.7.08
  
 ver. 0.7.07
 - solved a problem switching main button list, wait on tool change has not
-  been reseted properly
+  been reset properly
 - now I hide the hbuttonbox of tooledit widget instead of every button,
   this saved 6 lines of code :-)
 
@@ -1951,7 +1951,7 @@ ver. 0.7.04
 
 ver. 0.7.03
 - added Release Number to title bar,
-  so it is easer for users to see if they got
+  so it is easier for users to see if they got
   the latest release
 
 ver. 0.7.02

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -876,7 +876,7 @@ ver. 1.5.0
 
 - gmoccapy will now react to some halui pin as counts or direct value
   Be aware, that some of this may have side affects, it is strongly 
-  recomended to use the corresponding gmoccapy hal pin. 
+  recommended to use the corresponding gmoccapy hal pin. 
 
   * halui.spindle-override.counts
   * halui.feed-override.counts
@@ -1694,7 +1694,7 @@ ver. 0.9.3.2
 - changed hardware button handling to fit also to lathe mode
 - included a test to avoid speeding the spindle over its limit using the spindle speed override
   i.e. max = 6000 but S = 5500 and override = 120 % would result in 6600, but only 6000 is possible
-- also check spindle speed if the commands are given trough MDI and override is to high will reduce
+- also check spindle speed if the commands are given through MDI and override is to high will reduce
   the override value to max allowed
 
 ver. 0.9.3.1

--- a/src/emc/usr_intf/gmoccapy/widgets.py
+++ b/src/emc/usr_intf/gmoccapy/widgets.py
@@ -2,7 +2,7 @@
 
 '''
     This class is just to handle the widgets of gmoccapy,
-    it is just a copy of a class from gscreen and has been slighly modified
+    it is just a copy of a class from gscreen and has been slightly modified
 
     Copyright 2014 Norbert Schechner
     nieson@web.de

--- a/src/emc/usr_intf/gremlin/gremlin.py
+++ b/src/emc/usr_intf/gremlin/gremlin.py
@@ -440,7 +440,7 @@ class Gremlin(Gtk.DrawingArea,rs274.glcanon.GlCanonDraw,glnav.GlNavBase):
         button3 = event.state & Gdk.ModifierType.BUTTON3_MASK
         shift = event.state & Gdk.ModifierType.SHIFT_MASK
         # for lathe or plasmas rotation is not used, so we check for it
-        # recomended to use mode 6 for that type of machines
+        # recommended to use mode 6 for that type of machines
         cancel = bool(self.lathe_option)
         
         # 0 = default: left rotate, middle move, right zoom

--- a/src/emc/usr_intf/gremlin/qt5_graphics.py
+++ b/src/emc/usr_intf/gremlin/qt5_graphics.py
@@ -193,7 +193,7 @@ class Lcnc_3dGraphics(QGLWidget,  glcanon.GlCanonDraw, glnav.GlNavBase):
             a = self.colors[s + "_alpha"]
             s = self.colors[s]
             return [int(x * 255) for x in s + (a,)]
-        # requires linuxcnc running before laoding this widget
+        # requires linuxcnc running before loading this widget
         inifile = os.environ.get('INI_FILE_NAME', '/dev/null')
 
         # if status is not available then we are probably
@@ -202,7 +202,7 @@ class Lcnc_3dGraphics(QGLWidget,  glcanon.GlCanonDraw, glnav.GlNavBase):
         try:
             stat.poll()
         except:
-            LOG.warning('linuxcnc staus failed, Assuming linuxcnc is not running so using fake status for a XYZ machine')
+            LOG.warning('linuxcnc status failed, Assuming linuxcnc is not running so using fake status for a XYZ machine')
             stat = fakeStatus()
 
         self.inifile = linuxcnc.ini(inifile)
@@ -290,7 +290,7 @@ class Lcnc_3dGraphics(QGLWidget,  glcanon.GlCanonDraw, glnav.GlNavBase):
         self.addTimer()
 
     # add a 100ms timer to poll linuxcnc stats
-    # this may be overriden in sub widgets
+    # this may be overridden in sub widgets
     def addTimer(self):
         self.timer = QTimer()
         self.timer.timeout.connect(self.poll)
@@ -500,7 +500,7 @@ class Lcnc_3dGraphics(QGLWidget,  glcanon.GlCanonDraw, glnav.GlNavBase):
         glcanon.GlCanonDraw.realize(self)
         if s.file: self.load()
 
-    # gettter / setters
+    # getter / setters
     def get_font_info(self):
         return self.font_charwidth, self.font_linespace, self.font_base
     def get_program_alpha(self): return self.program_alpha

--- a/src/emc/usr_intf/gscreen/emc_interface.py
+++ b/src/emc/usr_intf/gscreen/emc_interface.py
@@ -236,7 +236,7 @@ class emc_control:
         # if Linuxcnc is paused then pushing cycle start will step the program
         # else the program starts from restart_line_number
         # after restarting it resets the restart_line_number to 0.
-        # You must explicitily set a different restart line each time
+        # You must explicitly set a different restart line each time
         def cycle_start(self):
                 if self.emcstat.task_mode != self.emc.MODE_AUTO:
                     self.emccommand.mode(self.emc.MODE_AUTO)

--- a/src/emc/usr_intf/gscreen/gscreen.py
+++ b/src/emc/usr_intf/gscreen/gscreen.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-#    Gscreen a GUI for linuxcnc cnc controller 
+#    Gscreen a GUI for linuxcnc cnc controller
 #    Chris Morley copyright 2012
 #
 #    This program is free software; you can redistribute it and/or modify
@@ -20,7 +20,7 @@
 """
 # Gscreen is made for running linuxcnc CNC machines
 # Gscreen was built with touchscreens in mind though a mouse works too.
-# a keyboard is necessary for editting gcode
+# a keyboard is necessary for editing gcode
 # Gscreen is, at it's heart, a gladevcp program though loaded in a non standard way.
 # one can also use a second monitor to display a second glade panel
 # this would probably be most useful for user's custom status widgets.
@@ -76,7 +76,7 @@ update_spindle_bar_error_ct_max = 3
 #--------------------------------------------------------
 
 # try to add a notify system so messages use the
-# nice intergrated pop-ups
+# nice integrated pop-ups
 # Ubuntu kinda wrecks this be not following the
 # standard - you can't set how long the message stays up for.
 # I suggest fixing this with a PPA off the net
@@ -100,11 +100,11 @@ try:
     _AUDIO_AVAILABLE = True
     print("**** GSCREEN INFO: audio available!")
 except:
-    print("**** GSCREEN WARNING: no audio alerts available - Is python-gst0.10 libray installed?")
+    print("**** GSCREEN WARNING: no audio alerts available - Is python-gst0.10 library installed?")
 
 # BASE is the absolute path to linuxcnc base
 # libdir is the path to Gscreen python files
-# datadir is where the standarad GLADE files are
+# datadir is where the standard GLADE files are
 # imagedir is for icons
 # themedir is path to system's GTK2 theme folder
 BASE = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
@@ -221,7 +221,7 @@ class Player:
             self.player.set_state(gst.STATE_NULL)
             self.loop.quit()
         elif t == gst.MESSAGE_ERROR:
-            #Error ocurred, print and stop
+            #Error occurred, print and stop
             self.player.set_state(gst.STATE_NULL)
             err, debug = message.parse_error()
             print( "Error: %s" % err, debug)
@@ -613,7 +613,7 @@ class Gscreen:
         self.xml.connect_signals(handlers)
 
         # Look for an optional preferece file path otherwise it uses ~/.gscreen_preferences
-        # then initiate access to saved prefernces
+        # then initiate access to saved preferences
         temp = self.inifile.find("DISPLAY","PREFERENCE_FILE_PATH")
         dbg("**** GSCREEN INFO: Preference file path: %s"%temp)
         self.prefs = preferences.preferences(temp)
@@ -923,7 +923,7 @@ class Gscreen:
         self.widgets.window1.connect('key_release_event', self.on_key_event,0)
 
     def initialize_preferences(self):
-        """Convience function, calls separate functions\n
+        """Convenience function, calls separate functions\n
         calls:
         self.init_dro_pref()
         self.init_theme_pref()
@@ -1054,7 +1054,7 @@ class Gscreen:
 
     # initialize default widgets
     def initialize_widgets(self):
-        """Convience function, calls separate functions\n
+        """Convenience function, calls separate functions\n
         calls:
         self.init_show_windows()
         self.init_dynamic_tabs()
@@ -1119,7 +1119,7 @@ class Gscreen:
 
 
     def show_try_errors(self):
-        """ Gscreen uses try/except alot to not show errors if a user deletes/renames a widget
+        """ Gscreen uses try/except a lot to not show errors if a user deletes/renames a widget
         But this makes it hard to see real errors,
         so in debug mode
         we print all those errors.
@@ -1209,7 +1209,7 @@ class Gscreen:
         self.set_dtg_color()
 
     def init_screen2(self):
-        """Sets the button that selects the optional second window visibilty
+        """Sets the button that selects the optional second window visibility
             the second window is meant to be placed on a second monitor
         """
         self.widgets.use_screen2.set_active(self.data.use_screen2)
@@ -1220,7 +1220,7 @@ class Gscreen:
         self.widgets.fullscreen1.set_active(self.data.fullscreen1)
 
     def init_gremlin(self):
-        """ initalizes the plot screen options from the data class
+        """ initializes the plot screen options from the data class
             expects the plot widget to be called gremlin
         """ 
         self.widgets.show_offsets.set_active( self.data.show_offsets )
@@ -1232,7 +1232,7 @@ class Gscreen:
 
     def init_manual_spindle_controls(self):
         """ set spindle default start rpm
-            set spindle control widgets to corespond to data class 
+            set spindle control widgets to correspond to data class 
         """
         self.widgets.spindle_start_rpm.set_value(self.data.spindle_start_rpm)
         self.block("s_display_fwd")
@@ -1438,7 +1438,7 @@ class Gscreen:
 
     # buttons that need to be sensitive based on the interpreter running or being idle
     def init_sensitive_run_idle(self):
-        """creates a list of widgets that need to be sensitive to interpeter run/idle
+        """creates a list of widgets that need to be sensitive to interpreter run/idle
            list is held in data.sensitive_run/idle
         """
         self.data.sensitive_run_idle = ["button_edit","button_load","button_mode","button_restart"]
@@ -1547,7 +1547,7 @@ class Gscreen:
     # select this if you want all the default pins or select each call for 
     # which ones you want
     def initialize_pins(self):
-        """convience function that calls all default functions for HAL pins
+        """convenience function that calls all default functions for HAL pins
            calls:
         self.init_spindle_pins()
         self.init_coolant_pins()
@@ -1660,7 +1660,7 @@ class Gscreen:
         """This calls check_mode() for manual mode
            if in manual mode, jogs X axis positively
            by calling do_key_jog()
-           It will ether start or stop the jog based on 'state'
+           It will either start or stop the jog based on 'state'
         """
         if self.data._MAN in self.check_mode(): # manual mode required
             self.do_key_jog(_X,1,state)
@@ -1669,7 +1669,7 @@ class Gscreen:
         """This calls check_mode() for manual mode
            if in manual mode, jogs X axis negatively
            by calling do_key_jog()
-           It will ether start or stop the jog based on 'state'
+           It will either start or stop the jog based on 'state'
         """
         if self.data._MAN in self.check_mode(): # manual mode required
             self.do_key_jog(_X,0,state)
@@ -1678,7 +1678,7 @@ class Gscreen:
         """This calls check_mode() for manual mode
            if in manual mode, jogs Y axis positively
            by calling do_key_jog()
-           It will ether start or stop the jog based on 'state'
+           It will either start or stop the jog based on 'state'
         """
         if self.data._MAN in self.check_mode(): # manual mode required
             self.do_key_jog(_Y,1,state)
@@ -1687,7 +1687,7 @@ class Gscreen:
         """This calls check_mode() for manual mode
            if in manual mode, jogs Y axis negatively
            by calling do_key_jog()
-           It will ether start or stop the jog based on 'state'
+           It will either start or stop the jog based on 'state'
         """
         if self.data._MAN in self.check_mode(): # manual mode required
             self.do_key_jog(_Y,0,state)
@@ -1696,7 +1696,7 @@ class Gscreen:
         """This calls check_mode() for manual mode
            if in manual mode, jogs Z axis positively
            by calling do_key_jog()
-           It will ether start or stop the jog based on 'state'
+           It will either start or stop the jog based on 'state'
         """
         if self.data._MAN in self.check_mode(): # manual mode required
             self.do_key_jog(_Z,1,state)
@@ -1705,7 +1705,7 @@ class Gscreen:
         """This calls check_mode() for manual mode
            if in manual mode, jogs Z axis negatively
            by calling do_key_jog()
-           It will ether start or stop the jog based on 'state'
+           It will either start or stop the jog based on 'state'
         """
         if self.data._MAN in self.check_mode(): # manual mode required
             self.do_key_jog(_Z,0,state)
@@ -1714,7 +1714,7 @@ class Gscreen:
         """This calls check_mode() for manual mode
            if in manual mode, jogs A axis positively
            by calling do_key_jog()
-           It will ether start or stop the jog based on 'state'
+           It will either start or stop the jog based on 'state'
         """
         if self.data._MAN in self.check_mode(): # manual mode required
             self.do_key_jog(_A,1,state)
@@ -1723,7 +1723,7 @@ class Gscreen:
         """This calls check_mode() for manual mode
            if in manual mode, jogs A axis negatively
            by calling do_key_jog()
-           It will ether start or stop the jog based on 'state'
+           It will either start or stop the jog based on 'state'
         """
         if self.data._MAN in self.check_mode(): # manual mode required
             self.do_key_jog(_A,0,state)
@@ -1756,7 +1756,7 @@ class Gscreen:
         """This sets the angular_jog adjustment flag
             then jog adjustment changes will adjust angular rather then linear rates.
             This is a callback function from a widget.
-            Tthe widget can be called anything but
+            The widget can be called anything but
             must have an active state such as a toggle button.
         """
         self.data.angular_jog_adjustment_flag = widget.get_active()
@@ -1876,7 +1876,7 @@ class Gscreen:
             If Gscreen is in AUTO mode it will cycle start.
             If Gscreen is in MDI mode it will submit the MDI entry.
             GScreen mode is from data.mode_oder[0]
-            Requires a run toogle action widget called hal_toogleaction_run
+            Requires a run toggle action widget called hal_toogleaction_run
             Requires a MDI widget called hal_mdihistory
             adds button press entries to the alarm page
         """
@@ -1901,7 +1901,7 @@ class Gscreen:
 
     def on_feed_hold_changed(self,hal_object):
         """This is Gscreen's feedhold HAL pin callback function.
-            Requires a toogle action pause widget called hal_action_stop
+            Requires a toggle action pause widget called hal_action_stop
         """
         print("feed-hold change")
         h = self.halcomp
@@ -1911,7 +1911,7 @@ class Gscreen:
     # This can be overridden in a handler file
     def on_tool_change(self,widget):
         """This is a callback function to launch a default manual tool change dialog.
-            This also manupulates the tool change pins:
+            This also manipulates the tool change pins:
             change-tool
             tool-number
             tool-changed
@@ -2035,7 +2035,7 @@ class Gscreen:
         self.data.index_tool_dialog.connect("response", self.on_index_tool_return,calc)
 
     def on_index_tool_return(self,widget,result,calc):
-        """This is a callbck function from the maunal toolchange dialog.
+        """This is a callback function from the maunal toolchange dialog.
         """
         if result == Gtk.ResponseType.ACCEPT:
             raw = calc.get_value()
@@ -2049,7 +2049,7 @@ class Gscreen:
 
     def set_grid_size(self,widget):
         """ This is a callback function for setting the graphics display grid size
-            reguires the grahics display to be called gremlin.
+            reguires the graphics display to be called gremlin.
             requires the calling widget to return a float value
             records the preference in the preference file.
         """
@@ -2059,7 +2059,7 @@ class Gscreen:
 
     # from prefererence page
     def set_spindle_start_rpm(self,widget):
-        """This is a callbck function to set the preset spindle speed.
+        """This is a callback function to set the preset spindle speed.
             requires the calling widget to return a float value.
             calls preset_spindle_speed() function
         """
@@ -2083,7 +2083,7 @@ class Gscreen:
     def change_sound(self,widget,sound):
         """This is a callback function that changes the default sound selected.
             Requires the widget to return a filename.
-            records it in the peference file.
+            records it in the preference file.
         """
         file = widget.get_filename()
         if file:
@@ -2131,7 +2131,7 @@ class Gscreen:
     def on_eventbox_gremlin_enter_notify_event(self,widget,event):
         """This is a callback function facilitate zoom and rotate with touchscreen.
             Requires graphics plot widget to be called 'gremlin'.
-            Requires a graphics selection toogle button 'button_graphics'
+            Requires a graphics selection toggle button 'button_graphics'
             Requires a zoom selection toggle button 'button_zoom'
             Requires a rotate selection toggle button'button_rotate_v'
         """
@@ -2144,7 +2144,7 @@ class Gscreen:
 
     # for plot view controls with touchscreen
     def on_eventbox_gremlin_leave_notify_event(self,widget,event):
-        """This is a callbck function to facilitate touchscreen controls
+        """This is a callback function to facilitate touchscreen controls
         """
         self.widgets.gremlin.select_fire(event.x,event.y)
 
@@ -2155,10 +2155,10 @@ class Gscreen:
         """This is a callback function to control graphics adjustments using
             a mouse or a touchscreen, with selections from screen buttons.
             Requires graphics display to be called 'gremlin'
-            Requires a graphics selection toogle button 'button_graphics'
+            Requires a graphics selection toggle button 'button_graphics'
             Requires a zoom selection toggle button 'button_zoom'
-            Requires a pan vertical selection toogle button 'button_pan_v'
-            Requires a pan horizontal selection toogle button 'button_pan_h'
+            Requires a pan vertical selection toggle button 'button_pan_v'
+            Requires a pan horizontal selection toggle button 'button_pan_h'
             Requires a rotate vertical selection toggle button'button_rotate_v'
             Requires a rotate horixontal selection toggle button'button_rotate_h'
         """
@@ -2504,7 +2504,7 @@ class Gscreen:
             If button_override is active then an override adjustment dialog is launched
             otherwise set_axis_checks() is called.
         """
-        # adjust overrrides
+        # adjust overrides
         if self.widgets.button_override.get_active():
             self.launch_numerical_input("on_adj_overrides_entry_return",widget,True,title=_("Override Entry"))
         # offset origin
@@ -2665,14 +2665,14 @@ class Gscreen:
 
     # This is part of the user message system
     # There is status that prints to the status bar
-    # There is Okdialog that prints a dialog that the user must acknoledge
+    # There is Okdialog that prints a dialog that the user must acknowledge
     # there is yes/no dialog where the user must choose between yes or no
     # you can combine status and dialog messages so they print to the status bar 
     # and pop a dialog
     def on_printmessage(self, pin, pinname,boldtext,text,type):
         """This is a callback function that is part of the user message system
             There is 'status' option that prints to the status bar
-            There is 'okdialog' option that prints a dialog that the user must acknoledge
+            There is 'okdialog' option that prints a dialog that the user must acknowledge
             there is 'yes/no' option where the user must choose between yes or no
             you can combine status and dialog messages so they print to the status bar 
             and pop a dialog
@@ -2719,7 +2719,7 @@ class Gscreen:
         self.update_hal_override_pins()
 
     def toggle_graphic_overrides(self,widget,data):
-        """This is a callback function to toggle between grahic display adjustment buttons.
+        """This is a callback function to toggle between graphic display adjustment buttons.
             Requires toggle buttons widgets named:
             'zoom'
             'pan_v'
@@ -2737,7 +2737,7 @@ class Gscreen:
             self.unblock(button)
 
     def on_hal_status_interp_run(self,widget):
-        """This is a callback function called when linuxcnc's interpeter is running.
+        """This is a callback function called when linuxcnc's interpreter is running.
             It sensitives widgets in a string list called data.sensitive_run_idle
             calls function sensitize_widgets(self.data.sensitive_run_idle,False)
         """
@@ -2745,7 +2745,7 @@ class Gscreen:
         self.sensitize_widgets(self.data.sensitive_run_idle,False)
 
     def on_hal_status_interp_idle(self,widget):
-        """This is a callback function called when linuxcnc's interpeter is idle.
+        """This is a callback function called when linuxcnc's interpreter is idle.
             It un-sensitives widgets in a string list called data.sensitive_run_idle
             calls function sensitize_widgets(self.data.sensitive_run_idle,True)
             It un/sensitizes widgets in a string list called self.data.sensitive_all_homed.
@@ -2923,7 +2923,7 @@ class Gscreen:
         """This is a callback function to set state of gcode edit mode.
             Requires a calling widget that returns state
             Requires a notebook widget called notebook_main
-            Requires a toogle button called button_full_view
+            Requires a toggle button called button_full_view
             Requires a box widget called search_box
             if state False calls edited_gcode_check()
             Calls edit_mode(state)
@@ -2960,7 +2960,7 @@ class Gscreen:
 
     def check_mode(self):
         """This function checks if Gscreen is in jog mode and manual mode
-            Trys to call check_mode() in a handler file instead of this default function
+            Tries to call check_mode() in a handler file instead of this default function
             Requires a notebook widget called notebook_main
             Assumes page 0 is the manual page
             Requires a jog mode toggle button called button_jog_mode
@@ -3043,7 +3043,7 @@ class Gscreen:
     def launch_keyboard(self,args="",x="",y=""):
         """This is a function to show 'Onboard' or 'matchbox' virtual keyboard if available.
             check for key_box widget - if there is, and embedded flag, embed Onboard in it.
-            else launch an independant Onboard inside a dialog so it works in fullscreen
+            else launch an independent Onboard inside a dialog so it works in fullscreen
             (otherwise it hides when main screen is touched)
             else error message
         """
@@ -3132,8 +3132,8 @@ class Gscreen:
             except:
                 self.show_try_errors()
 
-    # this installs local signals unless overriden by custom handlers
-    # HAL pin signal call-backs are covered in the HAL pin initilization functions
+    # this installs local signals unless overridden by custom handlers
+    # HAL pin signal call-backs are covered in the HAL pin initialization functions
     def connect_signals(self, handlers):
 
         signal_list = [
@@ -3272,7 +3272,7 @@ class Gscreen:
                 print(e)
                 print ("**** GSCREEN WARNING: could not connect %s to %s"% (i[1],i[3]))
 
-        # setup signals that can be blocked but not overriden 
+        # setup signals that can be blocked but not overridden 
         for axis in self.data.axis_list:
             cb = "axis_%s"% axis
             i = "_sighandler_axis_%s"% axis
@@ -3858,7 +3858,7 @@ class Gscreen:
         tab_cmd   = self.inifile.findall("DISPLAY", "EMBED_TAB_COMMAND")
 
         if len(tab_names) != len(tab_cmd):
-            print (_("Invalid embeded tab configuration")) # Complain somehow
+            print (_("Invalid embedded tab configuration")) # Complain somehow
         if len(tab_location) != len(tab_names):
             for num,i in enumerate(tab_names):
                 try:
@@ -4596,7 +4596,7 @@ class Gscreen:
         self.widgets.led_on.set_active(self.data.machine_on)
 
     def update_limit_override(self):
-        # ignore limts led
+        # ignore limits led
         self.widgets.led_ignore_limits.set_active(self.data.or_limits)
 
     def update_override_label(self):

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -1622,7 +1622,7 @@ static bool jogging_selected_axis(local_halui_str &hal) {
 
 
 // this function looks if any of the hal pins has changed
-// and sends appropiate messages if so
+// and sends appropriate messages if so
 static void check_hal_changes()
 {
     hal_s32_t counts;
@@ -2096,7 +2096,7 @@ static void check_hal_changes()
 }
 
 // this function looks at the received NML status message
-// and modifies the appropiate HAL pins
+// and modifies the appropriate HAL pins
 static void modify_hal_pins()
 {
     int joint;

--- a/src/emc/usr_intf/pncconf/pages.py
+++ b/src/emc/usr_intf/pncconf/pages.py
@@ -651,7 +651,7 @@ class Pages:
         if self.w.laddertouchz.get_active():
             i = self.d.gladevcphaluicmds
             self.w["halui_cmd%d"%(i)].set_text("G38.2 Z-2 F16   ( search for touch off plate )")
-            self.w["halui_cmd%d"%(i+1)].set_text("G10 L20 P0 Z.25 ( Ofset current Origin by plate thickness )")
+            self.w["halui_cmd%d"%(i+1)].set_text("G10 L20 P0 Z.25 ( Offset current Origin by plate thickness )")
             self.w["halui_cmd%d"%(i+2)].set_text("G0 Z.5           ( Rapid away from touch off plate )")
 
     def on_xusecomp_toggled(self, *args): self.a.comp_toggle('x')

--- a/src/emc/usr_intf/pyui/commands.py
+++ b/src/emc/usr_intf/pyui/commands.py
@@ -313,7 +313,7 @@ class CNC_COMMANDS():
         # if Linuxcnc is paused then pushing cycle start will step the program
         # else the program starts from restart_line_number
         # after restarting it resets the restart_line_number to 0.
-        # You must explicitily set a different restart line each time
+        # You must explicitly set a different restart line each time
         def smart_cycle_start(self, wname, cmd=None):
             self.emcstat.poll()
             if self.emcstat.task_mode != self.emc.MODE_AUTO:

--- a/src/emc/usr_intf/pyui/master.py
+++ b/src/emc/usr_intf/pyui/master.py
@@ -62,7 +62,7 @@ class keyboard():
                     self.r_c[value] = idname
                 metadata[attribute.upper()] = value
 
-            # intialize the widget
+            # initialize the widget
             widget.hal_init(self, self.hal, idname, metadata, 
                     self.cmd, self.widgets, DBG_state)
             self.widgets[idname] = widget

--- a/src/emc/usr_intf/pyui/panelui_handler.py
+++ b/src/emc/usr_intf/pyui/panelui_handler.py
@@ -20,7 +20,7 @@ class HandlerClass:
     # def some_name(self, widget_instance, arguments from widget):
     # widget_instance gives access to the calling widget's function/data
     # arguments can be a list of arguments, a single argument, or None
-    # depending on what was given in the confuration file.
+    # depending on what was given in the configuration file.
     def hello_world(self, wname, m):
         # print to terminal so we know it worked
         print('\nHello world\n')

--- a/src/emc/usr_intf/pyui/panelui_spec.ini
+++ b/src/emc/usr_intf/pyui/panelui_spec.ini
@@ -9,7 +9,7 @@
 # The first level: [GROUP_NAME] defines the groups name
 # KEY=None
 # OUTPUT= HAL PIN TYPE (S32 U32 or FLOAT)
-# DEFAULT= KEYNAME of the default slected key in level two
+# DEFAULT= KEYNAME of the default selected key in level two
 
     [[__many__]]
         KEY = string

--- a/src/emc/usr_intf/qtplasmac/qtplasmac-plasmac2qt.py
+++ b/src/emc/usr_intf/qtplasmac/qtplasmac-plasmac2qt.py
@@ -291,7 +291,7 @@ class Converter(QMainWindow, object):
     # CHECK IF VALID PLASMAC CONFIG
         if not os.path.exists('{}/plasmac'.format(os.path.dirname(self.iniIn))):
             msg  = '{}\n'.format(self.iniIn)
-            msg += '\n is not a PlasmaC configurtion\n'
+            msg += '\n is not a PlasmaC configuration\n'
             self.dialog_ok('CONFIG ERROR', msg)
             self.fromFile.setFocus()
             return

--- a/src/emc/usr_intf/schedrmt.cc
+++ b/src/emc/usr_intf/schedrmt.cc
@@ -110,7 +110,7 @@
   connection. If no parameters are specified, it will itemize the available commands.
   If a command is specified, it will provide usage information for the specified
   command. Help will respond regardless of whether a "Hello" has been
-  successsfully negotiated.
+  successfully negotiated.
   
   
   EMC sub-commands:
@@ -683,7 +683,7 @@ int commandSet(connectionRecType *context)
     case rtCustomError: // Custom error response entered in buffer
       return write(context->cliSock, context->outBuf, strlen(context->outBuf));
       break;
-    case rtCustomHandledError: ;// Custom error respose handled, take no action
+    case rtCustomHandledError: ;// Custom error response handled, take no action
     }
   return 0;
 }
@@ -926,7 +926,7 @@ int commandGet(connectionRecType *context)
     case rtCustomError: // Custom error response entered in buffer
       sockWrite(context);
       break;
-    case rtCustomHandledError: ;// Custom error respose handled, take no action
+    case rtCustomHandledError: ;// Custom error response handled, take no action
     }
   return 0;
 }

--- a/src/emc/usr_intf/sockets.c
+++ b/src/emc/usr_intf/sockets.c
@@ -1,6 +1,6 @@
 /********************************************************************
 * Description: sockets.c
-*   socket utilites
+*   socket utilities
 *
 * Copyright(c) 2001, Joris Robijn
 *          (c) 2003, Rene Wagner

--- a/src/emc/usr_intf/sockets.h
+++ b/src/emc/usr_intf/sockets.h
@@ -1,6 +1,6 @@
 /********************************************************************
 * Description: sockets.c
-*   socket utilites
+*   socket utilities
 *
 * Copyright(c) 2001, Joris Robijn
 *          (c) 2003, Rene Wagner

--- a/src/emc/usr_intf/stepconf/build_HAL.py
+++ b/src/emc/usr_intf/stepconf/build_HAL.py
@@ -347,7 +347,7 @@ class HAL:
 
         # Same as from pncconf
         # the jump list allows multiple hal files to be loaded postgui
-        # this simplifies the problem of overwritting the users custom HAL code
+        # this simplifies the problem of overwriting the users custom HAL code
         # when they change pyvcp sample options
         # if the user picked existing pyvcp option and the postgui_call_list is present
         # don't overwrite it. otherwise write the file.

--- a/src/emc/usr_intf/stepconf/pages.py
+++ b/src/emc/usr_intf/stepconf/pages.py
@@ -56,7 +56,7 @@ class Pages:
         else:
             return True
 
-    # seaches (self._p.available_page) from the current page forward,
+    # searches (self._p.available_page) from the current page forward,
     # for the next page that is True or till second-to-last page.
     # if state found True: call current page finish function.
     # If that returns False then call the next page prepare function and show page
@@ -84,13 +84,13 @@ class Pages:
         elif u == len(self._p.available_page):
             name,text,state = self._p.available_page[cur]
             self['%s_finish'%name]()
-        # if comming from page 0 to page 1 sensitize 
+        # if coming from page 0 to page 1 sensitize 
         # the back button and change fwd button text
         if cur == 0:
             self.w.button_back.set_sensitive(True)
             self.w.label_fwd.set_text(self._p.MESS_FWD)
 
-    # seaches (self._p.available_page) from the current page backward,
+    # searches (self._p.available_page) from the current page backward,
     # for the next page that is True or till first page.
     # if state found True: call current page finish function.
     # If that returns False then call the next page prepare function and show page

--- a/src/emc/usr_intf/stepconf/stepconf.py
+++ b/src/emc/usr_intf/stepconf/stepconf.py
@@ -5,7 +5,7 @@
 #    Copyright 2007 Jeff Epler <jepler@unpythonic.net>
 #
 #    stepconf 1.1 revamped by Chris Morley 2014
-#    replaced Gnome Druid as that is not available in future linux distrubutions
+#    replaced Gnome Druid as that is not available in future linux distributions
 #    and because of GTK/GLADE bugs, the GLADE file could only be edited with Ubuntu 8.04
 #
 #    This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.ts,./share,./docs/man/es,./configs/attic -L ans,doubleclick,dout,halp,parm`