### PR TITLE
d/README.source: Instruction how to prepare git snapshot

### DIFF
--- a/debian/README.source
+++ b/debian/README.source
@@ -14,7 +14,6 @@ required for Debian unstable.
 Steps
 -----
 
-
 1. Generate the source tarball, This will use the version as specified
    in the first line of tthe debian/changelog file. And maybe remove
    anything outdated, just to avoid confusions:
@@ -23,16 +22,23 @@ Steps
    then set the version in debian/changelog. For git checkout, the
    version stated in debian/changelog receives the suffix +gitYYYYMMDD.githash
 
-   rm -fi ../linuxcnc_*
-   debian/rules get-orig-source
-   unset WORKDIR
+   VERSION=$(head -n1 debian/changelog |cut -f2 -d' ' | tr -d "()" | sed -e 's/^\d://' )
+
+   If the current source tree is not the regular release but git checkout also
+   create the fitting tarball:
+
+   VERSION=$(git log --date=format:%Y%m%d --pretty=${VERSION}+git%cd.%h| head -n1)
+   echo $VERSION
+   foldername=$(basename $(pwd))
+   (cd .. && tar --exclude=.git -cJvf linuxcnc_${VERSION}.orig.tar.xz $foldername)
+   du -sh ../$foldername
 
 2. Prepare shell to work in temp directory
 
+   export VERSION
    export WORKDIR=$(mktemp -d)
-   mv linuxcnc_*.orig.tar.xz ${WORKDIR}/
-   bash
-   pushd $WORKDIR
+   mv "../linuxcnc_${VERSION}.orig.tar.xz" ${WORKDIR}/ && \
+   pushd $WORKDIR && bash
    echo -n "I: Now working in "; pwd
 
 3. Unpack
@@ -49,8 +55,7 @@ Steps
 
 5. Slightly adapt for upload to d/unstable
 
-   sed -i '/^Standards-Version: /s/ [0-9.]*/ 4.6.0/' debian/control
-   sed -i '1s/ stable;/ unstable;/' debian/changelog
+   sed -i '1s/ UNRELEASED;/ unstable;/' debian/changelog
 
    mkdir -p debian/source
    echo "3.0 (quilt)" > debian/source/format
@@ -81,7 +86,6 @@ Steps
 
    exit
    mv ${WORKDIR}/linuxcnc_* ..
-
 
 Above sketched differences are not impeding routine workflows of Debian
 packaging. For instance we found that the routine-update script (from the

--- a/debian/README.source
+++ b/debian/README.source
@@ -22,7 +22,7 @@ Steps
    then set the version in debian/changelog. For git checkout, the
    version stated in debian/changelog receives the suffix +gitYYYYMMDD.githash
 
-   VERSION=$(head -n1 debian/changelog |cut -f2 -d' ' | tr -d "()" | sed -e 's/^\d://' )
+   VERSION=$(head -n1 debian/changelog |cut -f2 -d' ' | tr -d "()" | sed -e 's/^[0-9]://' )
 
    If the current source tree is not the regular release but git checkout also
    create the fitting tarball:
@@ -30,7 +30,7 @@ Steps
    VERSION=$(git log --date=format:%Y%m%d --pretty=${VERSION}+git%cd.%h| head -n1)
    echo $VERSION
    foldername=$(basename $(pwd))
-   (cd .. && tar --exclude=.git -cJvf linuxcnc_${VERSION}.orig.tar.xz $foldername)
+   (cd .. && tar --exclude=.git -cJvf "linuxcnc_${VERSION}.orig.tar.xz" "$foldername")
    du -sh ../$foldername
 
 2. Prepare shell to work in temp directory
@@ -61,9 +61,7 @@ Steps
    echo "3.0 (quilt)" > debian/source/format
 
    # debian version
-   if ! head -n 1 debian/changelog | grep -q -- "-1)"; then sed -i '1s/) /-1) /' debian/changelog; else echo "I: dversion already set"; fi
-   # no epoch
-   sed -i '1s/([0-9]:/(/' debian/changelog
+   sed -i "1s/^.*;/linuxcnc ($VERSION-1) unstable;/" debian/changelog
 
 6a. build Debian package if in doubt - optional
 


### PR DESCRIPTION
When preparing from git snapshot the date and hash should be specified. This is also possible with uscan, but uscan should only inform us about new releases, not about every patch, so that dependency on single commits should be external to uscan as an exception.

Did not change it with this commit, but just to have mentioned it: We can introduce the epoch any time. I suggest to upload without the epoch. Could well imagine that someone with a running linuxcnc install from the current repository would not want to accidentally update it when all that was wanted is a system update.

The package currently does not build because of an update of asciidoc.

I thought I had created an ITP for LinuxCNC but apparently I have not: Could not find it at least. And since there is a package for LinuxCNC already for a couple of decades, maybe we also do not need it.