### PR TITLE
Fix realtime script location

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -614,6 +614,7 @@ install-dirs:
 	$(DIR) $(DESTDIR)$(initd_dir) $(DESTDIR)$(EMC2_RTLIB_DIR) \
 		$(DESTDIR)$(sysconfdir)/linuxcnc $(DESTDIR)$(bindir) \
 		$(DESTDIR)$(libdir) $(DESTDIR)$(includedir)/linuxcnc \
+		$(DESTDIR)/usr/lib/linuxcnc \
 		$(DESTDIR)$(docsdir) $(DESTDIR)$(ncfilesdir) \
 		$(DESTDIR)/etc/X11/app-defaults $(DESTDIR)$(tcldir)/bin \
 		$(DESTDIR)$(tcldir)/scripts \
@@ -645,7 +646,7 @@ install-kernel-indep: install-dirs
 	$(FILE) $(filter-out %/skeleton.3rtapi, $(wildcard ../docs/man/man3/*.3rtapi)) $(DESTDIR)$(mandir)/man3
 	$(FILE) $(filter-out %/skeleton.9, $(wildcard ../docs/man/man9/*.9)) $(DESTDIR)$(mandir)/man9
 	$(FILE) objects/*.msg $(DESTDIR)$(tcldir)/msgs
-	$(EXE) ../scripts/realtime $(DESTDIR)$(libdir)/linuxcnc
+	$(EXE) ../scripts/realtime $(DESTDIR)/usr/lib/linuxcnc/realtime
 	$(EXE) ../scripts/halrun $(DESTDIR)$(bindir)
 	$(EXE) ../scripts/halcmd_twopass $(DESTDIR)$(bindir)
 	$(EXE) ../scripts/haltcl $(DESTDIR)$(bindir)


### PR DESCRIPTION
I think there might have been a mixup introduced in https://github.com/LinuxCNC/linuxcnc/commit/eb7997d2390fde047866d5ba6bd401dd03018e60#diff-ae87d3a8398b892f1dc4cda159b07e561414e9da8c18c17710c530b28a80cb6e regarding the location of the `scripts/realtime` file. This PR tries to address that.

Please note that I'm not sure if `lib/linuxcnc/` is a sound location for the file to begin with. Maybe this should be put into something like `${bindir}` or `$(datadir)/linuxcnc/`.