### PR TITLE
Fix typos in config/sim

### DIFF
--- a/configs/sim/axis/external_offsets/opa.txt
+++ b/configs/sim/axis/external_offsets/opa.txt
@@ -18,7 +18,7 @@ Usage:
      panel On/Off buttons
   6) Select parameters:
        Astart ----- starting angle
-       fmult ------ frequency multipler
+       fmult ------ frequency multiplier
        rfraction -- amplitude (radius fraction)
        func ------- function
                     0  polygon (inside)

--- a/configs/sim/axis/external_offsets/queuebuster.ngc
+++ b/configs/sim/axis/external_offsets/queuebuster.ngc
@@ -22,7 +22,7 @@ o<queuebuster> sub
 
     o<um66> if [#<use_m66> GT 0]
       (debug, m66 queuebuster follows)
-      m66p0l0   ;QB wait on input l0=imediate
+      m66p0l0   ;QB wait on input l0=immediate
     o<um66> endif
 
     o<um38> if [#<use_m38> GT 0]

--- a/configs/sim/axis/iocontrolv2/axis-iocontrolv2-demo.ini
+++ b/configs/sim/axis/iocontrolv2/axis-iocontrolv2-demo.ini
@@ -68,7 +68,7 @@ PROTOCOL_VERSION = 1.1
 
 #  explicitly support the start-change protocol.
 #  needs to be explicitly enabled for backwards compatibility.
-#  NB: if the start-change pin isnt used it needs to be looped like below to
+#  NB: if the start-change pin isn't used it needs to be looped like below to
 #  start-change-ack or an M6 will hang waiting for start-change-ack:
 #  net start-change iocontrol.0.start-change  iocontrol.0.start-change-ack
 

--- a/configs/sim/axis/iocontrolv2/g8812.ini
+++ b/configs/sim/axis/iocontrolv2/g8812.ini
@@ -117,7 +117,7 @@ NO_FORCE_HOMING = 1
 
 #  explicitly support the start-change protocol.
 #  needs to be explicitly enabled for backwards compatibility.
-#  NB: if the start-change pin isnt used it needs to be looped like below to
+#  NB: if the start-change pin isn't used it needs to be looped like below to
 #  start-change-ack or an M6 will hang waiting for start-change-ack:
 #  net start-change iocontrol.0.start-change  iocontrol.0.start-change-ack
 #EMCIO = iov2 -support-start-change

--- a/configs/sim/axis/iocontrolv2/m66track.ini
+++ b/configs/sim/axis/iocontrolv2/m66track.ini
@@ -98,7 +98,7 @@ NO_FORCE_HOMING = 1
 
 #  explicitly support the start-change protocol.
 #  needs to be explicitly enabled for backwards compatibility.
-#  NB: if the start-change pin isnt used it needs to be looped like below to
+#  NB: if the start-change pin isn't used it needs to be looped like below to
 #  start-change-ack or an M6 will hang waiting for start-change-ack:
 #  net start-change iocontrol.0.start-change  iocontrol.0.start-change-ack
 #EMCIO = iov2 -support-start-change

--- a/configs/sim/axis/iocontrolv2/owordm6-ui-ns.ini
+++ b/configs/sim/axis/iocontrolv2/owordm6-ui-ns.ini
@@ -99,7 +99,7 @@ NO_FORCE_HOMING = 1
 
 #  explicitly support the start-change protocol.
 #  needs to be explicitly enabled for backwards compatibility.
-#  NB: if the start-change pin isnt used it needs to be looped like below to
+#  NB: if the start-change pin isn't used it needs to be looped like below to
 #  start-change-ack or an M6 will hang waiting for start-change-ack:
 #  net start-change iocontrol.0.start-change  iocontrol.0.start-change-ack
 #EMCIO = iov2 -support-start-change

--- a/configs/sim/axis/iocontrolv2/owordm6-ui.ini
+++ b/configs/sim/axis/iocontrolv2/owordm6-ui.ini
@@ -79,7 +79,7 @@ POSITION_FILE = position_mm.txt
 
 #  explicitly support the start-change protocol.
 #  needs to be explicitly enabled for backwards compatibility.
-#  NB: if the start-change pin isnt used it needs to be looped like below to
+#  NB: if the start-change pin isn't used it needs to be looped like below to
 #  start-change-ack or an M6 will hang waiting for start-change-ack:
 #  net start-change iocontrol.0.start-change  iocontrol.0.start-change-ack
 #EMCIO = iov2 -support-start-change

--- a/configs/sim/axis/moveoff/6_zretract.txt
+++ b/configs/sim/axis/moveoff/6_zretract.txt
@@ -28,7 +28,7 @@ Demo:
 
 The ini file sets:
   1) offset amount and its velocity and acceleration
-  2) state of the external-enable signal at starup
+  2) state of the external-enable signal at startup
   3) autoresume delay interval
   4) location and size of the moveoff_gui display
 

--- a/configs/sim/axis/moveoff/moveoff_display_8.hal
+++ b/configs/sim/axis/moveoff/moveoff_display_8.hal
@@ -1,6 +1,6 @@
 # connections for gladevcp panel, example embed command:
 # EMBED_TAB_COMMAND=halcmd loadusr -Wn gladevcp8 gladevcp -c gladevcp8  -x {XID} ./moveoff_gladevcp_8.ui
-# note the expecte name prefix is 'gladevcp8' (specified with -Wn arg and -c arg)
+# note the expected name prefix is 'gladevcp8' (specified with -Wn arg and -c arg)
 
 # connect to signals created by moveoff_external.hal
 # to inputs from gladevcp panel:

--- a/configs/sim/axis/orphans/iocontrol-removed/python/customtask.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/customtask.py
@@ -42,7 +42,7 @@ except ImportError:
     from nulluserfuncs import UserFuncs
 
 def debug():
-    # interpreter.this isnt usable until after Interpreter.init has been called
+    # interpreter.this isn't usable until after Interpreter.init has been called
     if hasattr(interpreter,'this'):
         return interpreter.this.debugmask &  0x00040000 # EMC_DEBUG_PYTHON_TASK
     return 
@@ -273,7 +273,7 @@ class CustomTask(emctask.Task,UserFuncs):
     def emcToolUnload(self):
         if debug(): print "py:  emcToolUnload"
         self.io.tool.toolInSpindle = 0
-        # this isnt in ioControlv1, but I think it should be.
+        # this isn't in ioControlv1, but I think it should be.
         self.hal["tool-number"] = self.io.tool.toolInSpindle
         self.io.status  = emctask.RCS_STATUS.RCS_DONE
         return 0

--- a/configs/sim/axis/orphans/py.ini.notworking
+++ b/configs/sim/axis/orphans/py.ini.notworking
@@ -300,7 +300,7 @@ NO_FORCE_HOMING =       1
 # Name of IO controller program, e.g., io
 #  explicitly support the start-change protocol.
 #  needs to be explicitly enabled for backwards compatibility.
-#  NB: if the start-change pin isnt used it needs to be looped like below to
+#  NB: if the start-change pin isn't used it needs to be looped like below to
 #  start-change-ack or an M6 will hang waiting for start-change-ack:
 #  net start-change iocontrol.0.start-change  iocontrol.0.start-change-ack
 #EMCIO = 		iov2 -support-start-change

--- a/configs/sim/axis/orphans/pyiocontrol.ini.notworking
+++ b/configs/sim/axis/orphans/pyiocontrol.ini.notworking
@@ -320,7 +320,7 @@ NO_FORCE_HOMING =       1
 # Name of IO controller program, e.g., io
 #  explicitly support the start-change protocol.
 #  needs to be explicitly enabled for backwards compatibility.
-#  NB: if the start-change pin isnt used it needs to be looped like below to
+#  NB: if the start-change pin isn't used it needs to be looped like below to
 #  start-change-ack or an M6 will hang waiting for start-change-ack:
 #  net start-change iocontrol.0.start-change  iocontrol.0.start-change-ack
 #EMCIO = 		iov2 -support-start-change

--- a/configs/sim/axis/orphans/pysubs/customtask.py
+++ b/configs/sim/axis/orphans/pysubs/customtask.py
@@ -267,7 +267,7 @@ class CustomTask(emctask.Task,UserFuncs):
     def emcToolUnload(self):
         if debug(): print "py:  emcToolUnload"
         self.io.tool.toolInSpindle = 0
-        # this isnt in ioControlv1, but I think it should be.
+        # this isn't in ioControlv1, but I think it should be.
         self.hal["tool-number"] = self.io.tool.toolInSpindle
         self.io.status  = emctask.RCS_STATUS.RCS_DONE
         return 0

--- a/configs/sim/axis/orphans/pysubs/remap.py
+++ b/configs/sim/axis/orphans/pysubs/remap.py
@@ -91,7 +91,7 @@ def change_prolog(self, userdata,**words):
 		self.set_errormsg("Cannot change tools with cutter radius compensation on")
 		return INTERP_ERROR
 
-	# bug in interp_convert.cc: WONT WORK - isnt valid anymore
+	# bug in interp_convert.cc: WONT WORK - isn't valid anymore
 	## 	    settings->selected_pocket);
 	## 	    settings->tool_table[0].toolno, <--- BROKEN
 	## 	    block->t_number,

--- a/configs/sim/axis/panelui-demo/panelui_handler.py
+++ b/configs/sim/axis/panelui-demo/panelui_handler.py
@@ -20,7 +20,7 @@ class HandlerClass:
     # def some_name(self, widget_instance, arguments from widget):
     # widget_instance gives access to the calling widget's function/data
     # arguments can be a list of arguments, a single argument, or None
-    # depending on what was given in the confuration file.
+    # depending on what was given in the configuration file.
     def hello_world(self, wname, m):
         # print to terminal so we know it worked
         print ('\nHello world\n')

--- a/configs/sim/axis/remap/getting-started/demo.ini
+++ b/configs/sim/axis/remap/getting-started/demo.ini
@@ -91,7 +91,7 @@ REMAP= M410  modalgroup=10 argspec=@Pq ngc=m410
 #
 # -------------------------------------------------------------------------
 #
-# up to here you wouldnt need the PYTHON section to be defined since no
+# up to here you wouldn't need the PYTHON section to be defined since no
 # Python code was used.
 # Examples below refer to Python handlers and hence need the plugin configured.
 #

--- a/configs/sim/axis/twopass/twopass.ini
+++ b/configs/sim/axis/twopass/twopass.ini
@@ -51,7 +51,7 @@ HALFILE = sim_spindle_encoder.hal
 HALFILE = axis_manualtoolchange.hal
 HALFILE = simulated_home.hal
 HALFILE = load_for_postgui.hal
-# demonstrate exluding a file from twopass processing:
+# demonstrate excluding a file from twopass processing:
 HALFILE = twopass_excluded.hal
 POSTGUI_HALFILE = postgui.hal
 

--- a/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzac-trt.ini
+++ b/configs/sim/axis/vismach/5axis/table-rotary-tilting/xyzac-trt.ini
@@ -65,7 +65,7 @@ HALCMD = net  :z-offset     xyzac-trt-kins.z-offset    xyzac-trt-gui.z-offset
 HALCMD = sets :y-offset     20
 HALCMD = sets :z-offset     10
 
-# not currenty supported by xyzac-trt-gui:
+# not currently supported by xyzac-trt-gui:
 HALCMD = setp xyzac-trt-kins.x-rot-point 0
 HALCMD = setp xyzac-trt-kins.y-rot-point 0
 HALCMD = setp xyzac-trt-kins.z-rot-point 0

--- a/configs/sim/axis/vismach/hexapod-sim/README
+++ b/configs/sim/axis/vismach/hexapod-sim/README
@@ -7,9 +7,9 @@ hexapod.ini
 ---------------
 Config file for a general hexapod.
 To get it working with your machine you need to adjust base and platform joints coordinates in kinematics.hal and specify [KINS]KINEMATICS=genhexkins.
-If you change the HOME location in TRAJ, make sure you change the appropiate HOME locations of the AXES as well, and make sure the position match (when run through the kinematics).
+If you change the HOME location in TRAJ, make sure you change the appropriate HOME locations of the AXES as well, and make sure the position match (when run through the kinematics).
 
-NOTE: The line "HALCMD = net ..." establishes a hal connection to enable switching kinematics betwen genhexkins, identity, and a user-defined kinematics
+NOTE: The line "HALCMD = net ..." establishes a hal connection to enable switching kinematics between genhexkins, identity, and a user-defined kinematics
 
 
 LIB:basic_sim.tcl

--- a/configs/sim/axis/vismach/millturn/millturn.ini
+++ b/configs/sim/axis/vismach/millturn/millturn.ini
@@ -24,7 +24,7 @@ SUBROUTINE_PATH = ./remap_subs
    HAL_PIN_VARS = 1
           REMAP = M428  modalgroup=10  ngc=428remap
           REMAP = M429  modalgroup=10  ngc=429remap
-# Set startup offets
+# Set startup offsets
 RS274NGC_STARTUP_CODE =    G10 L2 P7 X-290 Y0 Z-160 A0 G59.1
 
 

--- a/configs/sim/axis/xhc-hb04/README
+++ b/configs/sim/axis/xhc-hb04/README
@@ -102,7 +102,7 @@ The scale factor for each joint can be set with the scales item.
 When require_pendant = no, the xhc-hb04 hal pins will be created even if the pendant is not connected at startup.  A new connection, a disconnect, and a reconnect are supported.
 ----------------------------------
 jogmodes:
-  normal: postion mode, the joint will move exactly regardless of how long it takes.  Beware: the machine may keep moving after you stop rotating the jog wheel.
+  normal: position mode, the joint will move exactly regardless of how long it takes.  Beware: the machine may keep moving after you stop rotating the jog wheel.
 
   vnormal: velocity mode, the joint will stop when the wheel stops.  Beware: the amount moved per wheel detent may be less than specified if the machine velocity and acceleration cannot accomplish the move in time.
 

--- a/configs/sim/gmoccapy/gmoccapy_messages.ini
+++ b/configs/sim/gmoccapy/gmoccapy_messages.ini
@@ -48,7 +48,7 @@ INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm ,1.2345 in
 #                  Closing the message will reset the waiting pin
 #       yesnodialog : Will hold focus on the message dialog and will activate a "-waiting" Hal_Pin bit OUT
 #                     it will also give access to an "-responce" Hal_Pin Bit Out, this pin will hold 1 if the
-#                     user klicks OK, and in all other states it will be 0
+#                     user clicks OK, and in all other states it will be 0
 #                     Closing the message will reset the waiting pin
 #                     The responce Hal Pin will remain 1 until the dialog is called again
 # MESSAGE_PINNAME = is the name of the hal pin group to be created

--- a/configs/sim/gmoccapy/gmoccapy_plasma/plasma.glade
+++ b/configs/sim/gmoccapy/gmoccapy_plasma/plasma.glade
@@ -559,7 +559,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="lbl_treshold">
+                          <object class="GtkLabel" id="lbl_threshold">
                             <property name="visible">True</property>
                             <property name="label" translatable="yes">Threshold %</property>
                           </object>
@@ -736,7 +736,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkHBox" id="hbx_programed_volt">
+                      <object class="GtkHBox" id="hbx_programmed_volt">
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="lbl_prog_volt">

--- a/configs/sim/gmoccapy/gmoccapy_plasma/plasma.py
+++ b/configs/sim/gmoccapy/gmoccapy_plasma/plasma.py
@@ -202,7 +202,7 @@ class PlasmaClass:
     def _on_destroy(self, obj, data = None):
         self.ini.save_state(self)
 
-    # What to do on button pres events?
+    # What to do on button press events?
     def on_btn_THC_speed_pressed(self, widget, dir):
         increment = self.thcspeedincr * dir
         self.thcspeedval = self.adj_THC_speed.get_value() + increment

--- a/configs/sim/gmoccapy/macros/macro_Instructions.txt
+++ b/configs/sim/gmoccapy/macros/macro_Instructions.txt
@@ -1,13 +1,13 @@
 This is a small instruction to include macros in gmoccapy.
 
 In your INI File you need to introduce a section called [MACROS]
-and for every macro you wan't to include one line like so:
+and for every macro you'll need to include a one-liner like so:
 
 MACRO = jog_around
 or 
 MACRO = increment xinc yinc
 
-where xinc and yinc are place holders
+where xinc and yinc are placeholders
 
 During execution of the macro, you will be asked to enter the values. 
 

--- a/configs/sim/gmoccapy/messages.ini
+++ b/configs/sim/gmoccapy/messages.ini
@@ -48,7 +48,7 @@ INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm ,1.2345 in
 #                  Closing the message will reset the waiting pin
 #       yesnodialog : Will hold focus on the message dialog and will activate a "-waiting" Hal_Pin bit OUT
 #                     it will also give access to an "-responce" Hal_Pin Bit Out, this pin will hold 1 if the
-#                     user klicks OK, and in all other states it will be 0
+#                     user clicks OK, and in all other states it will be 0
 #                     Closing the message will reset the waiting pin
 #                     The responce Hal Pin will remain 1 until the dialog is called again
 # MESSAGE_PINNAME = is the name of the hal pin group to be created

--- a/configs/sim/gmoccapy/plasma_config/plasma.glade
+++ b/configs/sim/gmoccapy/plasma_config/plasma.glade
@@ -559,7 +559,7 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel" id="lbl_treshold">
+                          <object class="GtkLabel" id="lbl_threshold">
                             <property name="visible">True</property>
                             <property name="label" translatable="yes">Threshold %</property>
                           </object>
@@ -736,7 +736,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkHBox" id="hbx_programed_volt">
+                      <object class="GtkHBox" id="hbx_programmed_volt">
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkLabel" id="lbl_prog_volt">

--- a/configs/sim/gmoccapy/plasma_config/plasma.py
+++ b/configs/sim/gmoccapy/plasma_config/plasma.py
@@ -202,7 +202,7 @@ class PlasmaClass:
     def _on_destroy(self, obj, data = None):
         self.ini.save_state(self)
 
-    # What to do on button pres events?
+    # What to do on button press events?
     def on_btn_THC_speed_pressed(self, widget, dir):
         increment = self.thcspeedincr * dir
         self.thcspeedval = self.adj_THC_speed.get_value() + increment

--- a/configs/sim/qtvcp_screens/qtvcp_custom/custom_screencode/qtdefault_ngc/qtdefault_ngc.ui
+++ b/configs/sim/qtvcp_screens/qtvcp_custom/custom_screencode/qtdefault_ngc/qtdefault_ngc.ui
@@ -2059,7 +2059,7 @@ border-image: url(/home/chris/emc-dev/share/qtscreen/images/frame_bg_grey.png) 0
      <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="is_limits_overriden_status" stdset="0">
+     <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
     </widget>

--- a/configs/sim/qtvcp_screens/qtvcp_experimental/custom_screencode/qtdefault_ngc/qtdefault_ngc.ui
+++ b/configs/sim/qtvcp_screens/qtvcp_experimental/custom_screencode/qtdefault_ngc/qtdefault_ngc.ui
@@ -2059,7 +2059,7 @@ border-image: url(/home/chris/emc-dev/share/qtscreen/images/frame_bg_grey.png) 0
      <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="is_limits_overriden_status" stdset="0">
+     <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
     </widget>

--- a/configs/sim/qtvcp_screens/qtvcp_experimental/qtdefault_gladevcp/qtdefault_gladevcp.ui
+++ b/configs/sim/qtvcp_screens/qtvcp_experimental/qtdefault_gladevcp/qtdefault_gladevcp.ui
@@ -2059,7 +2059,7 @@ border-image: url(/home/chris/emc-dev/share/qtscreen/images/frame_bg_grey.png) 0
      <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="is_limits_overriden_status" stdset="0">
+     <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
     </widget>

--- a/docs/man/man1/iov2.1
+++ b/docs/man/man1/iov2.1
@@ -165,7 +165,7 @@ mechanism) of the tool requested by the most recent T-word.
 (BIT,IN) Acknowledgment line for start\-change.
 .TP
 \fBiocontrol.0.toolchanger\-fault
-(BIT,IN) Toolchanger signals fault. This line is contionuously monitored. A fault toogles a flag in iocontrol which is reflected in the toolchanger\-faulted pin.
+(BIT,IN) Toolchanger signals fault. This line is contionuously monitored. A fault toggles a flag in iocontrol which is reflected in the toolchanger\-faulted pin.
 .TP
 \fBiocontrol.0.toolchanger\-fault\-ack
 (BIT,OUT) Handshake line for above signal. will be set by iov2 after above fault line True is recognized and deasserted when toolchanger\-fault drops. Toolchanger is free to interpret the ack; reading the \-ack lines assures fault has been received and acted upon.

--- a/docs/src/config/iov2.adoc
+++ b/docs/src/config/iov2.adoc
@@ -127,7 +127,7 @@ Additional pins added by I/O Control V2
 * start-change-ack: (Bit, In) acknowledgment line for start-change. 
 
 * toolchanger-fault: (Bit, In) toolchanger signals fault. This line is
-  contionuously monitored. A fault toogles a flag in iocontrol which is
+  contionuously monitored. A fault toggles a flag in iocontrol which is
   reflected in the toolchanger-faulted pin.
 
 * toolchanger-fault-ack: (Bit, Out) handshake line for above signal. will be set

--- a/lib/python/gladevcp/combi_dro.py
+++ b/lib/python/gladevcp/combi_dro.py
@@ -268,7 +268,7 @@ class Combi_DRO(Gtk.VBox):
         else:
             if not self.toggle_readout:
                 return
-            self.toogle_readout()
+            self.toggle_readout()
 
     # Get propertys
     def do_get_property(self, property):
@@ -524,7 +524,7 @@ class Combi_DRO(Gtk.VBox):
     # this will toggle the DRO around, mainly used to maintain all DRO
     # at the same state, because a click on one will only change that DRO
     # This can be used to change also the others
-    def toogle_readout(self, Data = None):
+    def toggle_readout(self, Data = None):
         '''
         toggles the order of the DRO in the widget
 
@@ -610,7 +610,7 @@ class Combi_DRO(Gtk.VBox):
         '''
         self._ORDER = order
         self._set_labels()
-        self.toogle_readout(Data=True)
+        self.toggle_readout(Data=True)
 
     # This will return the position information of all three DRO
     # it will be in the order Abs, Rel, DTG

--- a/lib/python/qtvcp/widgets/action_button.py
+++ b/lib/python/qtvcp/widgets/action_button.py
@@ -690,7 +690,7 @@ class ActionButton(IndicatedPushButton, _HalWidgetBase):
                 text = '%s mm' % str(self.jog_incr_mm)
             else:
                 incr = 0
-                text = 'Continous'
+                text = 'Continuous'
             if self.template_label:
                 self._set_alt_text(self.jog_incr_mm)
         else:
@@ -700,7 +700,7 @@ class ActionButton(IndicatedPushButton, _HalWidgetBase):
                 text = '''%s "''' % str(self.jog_incr_imperial)
             else:
                 incr = 0
-                text = 'Continous'
+                text = 'Continuous'
             if self.template_label:
                 self._set_text(self.jog_incr_imperial)
         ACTION.SET_JOG_INCR(incr , text)
@@ -709,7 +709,7 @@ class ActionButton(IndicatedPushButton, _HalWidgetBase):
         if self.jog_incr_angle < 0: return
         elif self.jog_incr_angle == 0:
             incr = 0
-            text = 'Continous'
+            text = 'Continuous'
         else:
             incr = self.jog_incr_angle
             text = '''%s deg''' % str(self.jog_incr_angle)

--- a/share/qtvcp/screens/qt_cnc/qt_cnc.ui
+++ b/share/qtvcp/screens/qt_cnc/qt_cnc.ui
@@ -2560,7 +2560,7 @@ file</string>
      <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="is_limits_overriden_status" stdset="0">
+     <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
     </widget>

--- a/share/qtvcp/screens/qt_cnc/qt_cnc_enum.ui
+++ b/share/qtvcp/screens/qt_cnc/qt_cnc_enum.ui
@@ -2077,7 +2077,7 @@ border-image: url(/home/chris/emc-dev/share/qtscreen/images/frame_bg_grey.png) 0
      <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="is_limits_overriden_status" stdset="0">
+     <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
@@ -2592,7 +2592,7 @@ border-image: url(/home/chris/emc-dev/share/qtscreen/images/frame_bg_grey.png) 0
       </rect>
      </property>
      <property name="text">
-      <string>Continous</string>
+      <string>Continuous</string>
      </property>
      <property name="indicator_option" stdset="0">
       <bool>true</bool>

--- a/share/qtvcp/screens/qt_cnc_800x600/qt_cnc_800x600_handler.py
+++ b/share/qtvcp/screens/qt_cnc_800x600/qt_cnc_800x600_handler.py
@@ -206,21 +206,21 @@ class HandlerClass:
         if '-' in source.text():
             d = -1
         if 'X' in source.text():
-            self.continous_jog(0, d)
+            self.continuous_jog(0, d)
         elif 'Y' in source.text():
-            self.continous_jog(1, d)
+            self.continuous_jog(1, d)
         elif 'Z' in source.text():
-            self.continous_jog(2, d)
+            self.continuous_jog(2, d)
 
     def jog_released(self):
         source = self.w.sender()
         #print source.objectName(), 'released'
         if 'X' in source.text():
-            self.continous_jog(0, 0)
+            self.continuous_jog(0, 0)
         elif 'Y' in source.text():
-            self.continous_jog(1, 0)
+            self.continuous_jog(1, 0)
         elif 'Z' in source.text():
-            self.continous_jog(2, 0)
+            self.continuous_jog(2, 0)
 
     def home_clicked(self):
         print('home click')
@@ -283,7 +283,7 @@ class HandlerClass:
         else:
             ACTION.JOG(joint, 0, 0, 0)
 
-    def continous_jog(self, axis, direction):
+    def continuous_jog(self, axis, direction):
         ACTION.DO_JOG(axis, direction)
 
     #####################

--- a/share/qtvcp/screens/qt_cnc_9_axis/qt_cnc_9_axis.ui
+++ b/share/qtvcp/screens/qt_cnc_9_axis/qt_cnc_9_axis.ui
@@ -2035,7 +2035,7 @@ border-image: url(/home/chris/emc-dev/share/qtscreen/images/frame_bg_grey.png) 0
      <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
-     <property name="is_limits_overriden_status" stdset="0">
+     <property name="is_limits_overridden_status" stdset="0">
       <bool>true</bool>
      </property>
     </widget>
@@ -2522,7 +2522,7 @@ border-image: url(/home/chris/emc-dev/share/qtscreen/images/frame_bg_grey.png) 0
       </rect>
      </property>
      <property name="text">
-      <string>Continous</string>
+      <string>Continuous</string>
      </property>
      <property name="indicator_option" stdset="0">
       <bool>true</bool>

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1495,7 +1495,7 @@ def jogspeed_incremental(dir=1):
         cursel = int(cursel)
     if dir == 1:
         if cursel > 0:
-            # If it was "Continous" just before, then don't change last jog increment!
+            # If it was "Continuous" just before, then don't change last jog increment!
             jogincr_index_last += 1
         if jogincr_index_last >= jogincr_size:
             jogincr_index_last = jogincr_size - 1

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -3206,7 +3206,7 @@
                                   <object class="GtkLabel" id="label4">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label">Manuell</property>
+                                    <property name="label">Manual</property>
                                   </object>
                                   <packing>
                                     <property name="tab_fill">False</property>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -4665,7 +4665,7 @@
                     <property name="can_focus">True</property>
                     <property name="tab_pos">left</property>
                     <child>
-                      <object class="GtkHBox" id="hbox_setup_apear">
+                      <object class="GtkHBox" id="hbox_setup_appear">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>

--- a/src/emc/usr_intf/pncconf/tests.py
+++ b/src/emc/usr_intf/pncconf/tests.py
@@ -1539,8 +1539,8 @@ class PyApp(Gtk.Window):
             brdnotebook.append_page(self.data2["notebook%d"%boardnum], label)
             for concount,connector in enumerate(self.d["mesa%d_currentfirmwaredata"% (boardnum)][_PD._NUMOFCNCTRS]) :
                 table = Gtk.Table(12, 3, False)
-                seperator = Gtk.VSeparator()
-                table.attach(seperator, 1, 2, 0, 12,True)
+                separator = Gtk.VSeparator()
+                table.attach(separator, 1, 2, 0, 12,True)
                 for pin in range (0,24):
                     if pin >11:
                         column = 2

--- a/src/emc/usr_intf/stepconf/halui_page.glade
+++ b/src/emc/usr_intf/stepconf/halui_page.glade
@@ -6,7 +6,7 @@
     <columns>
       <!-- column-name gint1 -->
       <column type="gint"/>
-      <!-- column-name comando -->
+      <!-- column-name command -->
       <column type="gchararray"/>
     </columns>
   </object>


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.ts,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.* -L ans,ba,bulle,componentes,doubleclick,dout,dum,fo,halp,inout,parm,parms,te,ue,wille`