### PR TITLE
Remove initd_dir since it's no longer used

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -611,7 +611,7 @@ install: install-kernel-dep install-kernel-indep
 	$(ECHO) "Installed in DESTDIR='$(DESTDIR)' with prefix $(prefix)"
 
 install-dirs:
-	$(DIR) $(DESTDIR)$(initd_dir) $(DESTDIR)$(EMC2_RTLIB_DIR) \
+	$(DIR) $(DESTDIR)$(EMC2_RTLIB_DIR) \
 		$(DESTDIR)$(sysconfdir)/linuxcnc $(DESTDIR)$(bindir) \
 		$(DESTDIR)$(libdir) $(DESTDIR)$(includedir)/linuxcnc \
 		$(DESTDIR)$(docsdir) $(DESTDIR)$(ncfilesdir) \

--- a/src/Makefile.inc.in
+++ b/src/Makefile.inc.in
@@ -62,7 +62,6 @@ LANGUAGES = @LANGUAGES@
 
 #still needs discussion
 # do we really need these?
-initd_dir = /etc/init.d
 docsdir = ${prefix}/share/doc/linuxcnc
 sampleconfsdir = ${prefix}/share/doc/linuxcnc/examples/sample-configs
 ncfilesdir = ${prefix}/share/linuxcnc/ncfiles


### PR DESCRIPTION
Since https://github.com/LinuxCNC/linuxcnc/commit/eb7997d2390fde047866d5ba6bd401dd03018e60 was merged, `initd_dir` seems to be no longer necessary since `realtime` was the only file put into `/etc/init.d`