### PR TITLE
Fix typos in src/libnml

### DIFF
--- a/src/libnml/buffer/locmem.cc
+++ b/src/libnml/buffer/locmem.cc
@@ -3,7 +3,7 @@
 *   Implements LOCMEM which is a derived class of CMS that serves
 *   primarily to provide addresses that match when matching buffer
 *   names are passed to the constructor. It is useful in allowing
-*   control modules to use the same inteface to communicate as would
+*   control modules to use the same interface to communicate as would
 *   be required if they were not running in the same process even
 *   though to use LOCMEM they must be.
 *

--- a/src/libnml/buffer/locmem.hh
+++ b/src/libnml/buffer/locmem.hh
@@ -3,7 +3,7 @@
 *   Implements LOCMEM which is a derived class of CMS that serves
 *   primarily to provide addresses that match when matching buffer
 *   names are passed to the constructor. It is useful in allowing
-*   control modules to use the same inteface to communicate as would
+*   control modules to use the same interface to communicate as would
 *   be required if they were not running in the same process even
 *   though to use LOCMEM they must be.
 *

--- a/src/libnml/buffer/rem_msg.hh
+++ b/src/libnml/buffer/rem_msg.hh
@@ -137,7 +137,7 @@ struct REMOTE_WRITE_REQUEST:public REMOTE_CMS_REQUEST {
 /* Structure returned by server to client after a write. */
 struct REMOTE_WRITE_REPLY:public REMOTE_CMS_REPLY {
     long write_id;		/* Id from the buffer. */
-    long was_read;		/* Was the message to be overwriten ever
+    long was_read;		/* Was the message to be overwritten ever
 				   read? */
     int confirm_write;
 };

--- a/src/libnml/buffer/tcpmem.cc
+++ b/src/libnml/buffer/tcpmem.cc
@@ -102,7 +102,7 @@ TCPMEM::TCPMEM(const char *_bufline, const char *_procline):CMS(_bufline, _procl
     }
     server_host_entry = NULL;
 
-    /* Set up the socket address stucture. */
+    /* Set up the socket address structure. */
     memset(&server_socket_address, 0, sizeof(server_socket_address));
     server_socket_address.sin_family = AF_INET;
     server_socket_address.sin_port = htons(((u_short) tcp_port_number));

--- a/src/libnml/cms/cms.cc
+++ b/src/libnml/cms/cms.cc
@@ -1,6 +1,6 @@
 /********************************************************************
 * Description: cms.cc
-*   C++ file for the  Communication Management System (CMS).
+*   C++ file for the Communication Management System (CMS).
 *   Includes member functions for class CMS.
 *   See cms_in.cc for the internal interface member functions and
 *   cms_up.cc for the update functions.
@@ -10,10 +10,10 @@
 * Author:
 * License: LGPL Version 2
 * System: Linux
-*    
+*
 * Copyright (c) 2004 All rights reserved.
 *
-* Last change: 
+* Last change:
 ********************************************************************/
 
 #include "rcsversion.h"
@@ -151,7 +151,7 @@ CMS::CMS(long s)
     disable_diag_store = 0;
     diag_offset = 0;
 
-    /* Initailize some variables. */
+    /* Initialize some variables. */
     read_permission_flag = 0;	/* Allow both read and write by default.  */
     write_permission_flag = 0;
     queuing_enabled = 0;
@@ -304,7 +304,7 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
     buffer_type_name = word[2];
 
     /* strtol should allow us to use the C syntax for specifying the radix of 
-       the numbers in the configuration file. (i.e. 0x???? for hexidecimal,
+       the numbers in the configuration file. (i.e. 0x???? for hexadecimal,
        0??? for octal and ???? for decimal.) */
     size = (long) strtol(word[4], (char **) NULL, 0);
     neutral = (int) strtol(word[5], (char **) NULL, 0);
@@ -313,7 +313,7 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
     total_connections = strtol(word[8], (char **) NULL, 0);
     free_space = size;
 
-    /* Check errno to see if all of the strtol's were sucessful. */
+    /* Check errno to see if all of the strtol's were successful. */
     if (ERANGE == errno) {
 	rcs_print_error("CMS: Error in buffer line from config file.\n");
 	rcs_print_error("%s\n", bufline);
@@ -504,7 +504,7 @@ CMS::CMS(const char *bufline_in, const char *procline_in, int set_to_server)
 	    return;
 	}
     }
-    /* Check errno to see if all of the strtol's were sucessful. */
+    /* Check errno to see if all of the strtol's were successful. */
     if (ERANGE == errno) {
 	rcs_print_error("CMS: Error in proc line from config file.\n");
 	rcs_print_error("%s\n", procline);
@@ -732,7 +732,7 @@ void CMS::open(void)
 	nfactor = updater->neutral_size_factor;
     }
 
-    /* Set some varaibles to let the user know how much space is left. */
+    /* Set some variables to let the user know how much space is left. */
     size_without_diagnostics = size;
     diag_offset = 0;
     if (enable_diagnostics) {
@@ -1522,7 +1522,7 @@ const char *CMS::status_string(int status_type)
 
     case CMS_NO_MASTER_ERROR:
 	return
-	    ("CMS_NO_MASTER_ERROR: An error occurred becouse the master was not started.");
+	    ("CMS_NO_MASTER_ERROR: An error occurred because the master was not started.");
 
     case CMS_CONFIG_ERROR:
 	return ("CMS_CONFIG_ERROR: There was an error in the configuration.");

--- a/src/libnml/cms/cms.hh
+++ b/src/libnml/cms/cms.hh
@@ -47,7 +47,7 @@ enum CMS_STATUS {
     CMS_UPDATE_ERROR = -2,	/* An error occurred during an update. */
     CMS_INTERNAL_ACCESS_ERROR = -3,	/* An error occurred during an
 					   internal access function. */
-    CMS_NO_MASTER_ERROR = -4,	/* An error occurred becouse the master was
+    CMS_NO_MASTER_ERROR = -4,	/* An error occurred because the master was
 				   not started */
     CMS_CONFIG_ERROR = -5,	/* There was an error in the configuration */
     CMS_TIMED_OUT = -6,		/* operation timed out. */
@@ -350,7 +350,7 @@ class CMS {
     void *data;			/* pointer to local copy of data (raw) */
     void *subdiv_data;		/* pointer to current subdiv; */
 
-    /* Intersting Info Saved from the Configuration File. */
+    /* Interesting Info Saved from the Configuration File. */
     char BufferName[LINELEN];
     char BufferHost[LINELEN];
     char ProcessName[LINELEN];

--- a/src/libnml/cms/cms_in.cc
+++ b/src/libnml/cms/cms_in.cc
@@ -15,7 +15,7 @@
 *   CMS_HEADER before each message. Non-queuing buffers have only a
 *   CMS_HEADER before the only message.
 *   If they end in "encoded" they are for buffers that will neutrally
-*   encoded in some processor architecture independant data format such
+*   encoded in some processor architecture independent data format such
 *   as XDR (eXternal Data Representation), otherwise the buffer must be
 *   in the format used by the same compiler as this is compiled in and
 *   for the same processor architecture and the function name will end
@@ -48,7 +48,7 @@ int cms_print_queue_full_messages = 1;
 * the memory at _global.
 * Parameters:
 * _local - Address of local buffer where user has stored messages in or will
-* read messages from whithin this process.
+* read messages from within this process.
 * _global - Address of shared or global memory buffer used to communicate with
 * other  process.
 ************************************************************************/
@@ -1387,7 +1387,7 @@ CMS_STATUS CMS::write_raw(void *user_data, int *serial_number)
 }
 
 /* It takes several steps to perform a write operation when queuing is enabled. */
-/* 1. Read the qeuing header at the begining of the buffer. */
+/* 1. Read the qeuing header at the beginning of the buffer. */
 /* 2. Determine the amount of free space and where the next node can be placed.*/
 /* 3. Set up message header from info in the queuing header. */
 /* 4. Write the message header and message  at the tail of the queue. */
@@ -1600,7 +1600,7 @@ CMS_STATUS CMS::write_encoded()
 }
 
 /* It takes several steps to perform a write operation when queuing is enabled. */
-/* 1. Read the qeuing header at the begining of the buffer. */
+/* 1. Read the qeuing header at the beginning of the buffer. */
 /* 2. Determine the amount of free space and where the next node can be placed.*/
 /* 3. Set up message header from info in the queuing header. */
 /* 4. Write the message header and message  at the tail of the queue. */
@@ -1822,7 +1822,7 @@ CMS_STATUS CMS::write_if_read_raw(void *user_data, int *serial_number)
 }
 
 /* It takes several steps to perform a write operation when queuing is enabled. */
-/* 1. Read the qeuing header at the begining of the buffer. */
+/* 1. Read the qeuing header at the beginning of the buffer. */
 /* 2. Determine the amount of free space and where the next node can be placed.*/
 /* 3. Set up message header from info in the queuing header. */
 /* 4. Write the message header and message  at the tail of the queue. */
@@ -2044,7 +2044,7 @@ CMS_STATUS CMS::write_if_read_encoded()
 }
 
 /* It takes several steps to perform a write operation when queuing is enabled. */
-/* 1. Read the qeuing header at the begining of the buffer. */
+/* 1. Read the qeuing header at the beginning of the buffer. */
 /* 2. Determine the amount of free space and where the next node can be placed.*/
 /* 3. Set up message header from info in the queuing header. */
 /* 4. Write the message header and message  at the tail of the queue. */

--- a/src/libnml/cms/cms_up.hh
+++ b/src/libnml/cms/cms_up.hh
@@ -2,18 +2,18 @@
 * Description: cms_up.hh
 *   This C++ header file defines the abstract CMS_UPDATER class
 *   that defines the interface used by CMS to convert between local
-*   machine-specific data representations and network machine-independant
-*   represantations such as XDR via the derived classes of CMS_UPDATER.
+*   machine-specific data representations and network machine-independent
+*   representations such as XDR via the derived classes of CMS_UPDATER.
 *
 *   Derived from a work by Fred Proctor & Will Shackleford
 *
 * Author:
 * License: LGPL Version 2
 * System: Linux
-*    
+*
 * Copyright (c) 2004 All rights reserved.
 *
-* Last change: 
+* Last change:
 ********************************************************************/
 
 #ifndef CMS_UP_HH

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -7,10 +7,10 @@
 * Author:
 * License: LGPL Version 2
 * System: Linux
-*    
+*
 * Copyright (c) 2004 All rights reserved.
 *
-* Last change: 
+* Last change:
 ********************************************************************/
 
 #define __STDC_FORMAT_MACROS
@@ -281,7 +281,7 @@ void NML::reconstruct(NML_FORMAT_PTR f_ptr, const char *buf, const char *proc,
 	register_with_server();
     }
     add_to_channel_list();
-    // FAST MODE is a combination of options which allow certian checks
+    // FAST MODE is a combination of options which allow certain checks
     // during
     // a read or write operation to be avoided and therefore reduce the
     // NML/CMS
@@ -707,7 +707,7 @@ int NML::reset()
 	}
 	register_with_server();
 	add_to_channel_list();
-	// FAST MODE is a combination of options which allow certian checks
+	// FAST MODE is a combination of options which allow certain checks
 	// during
 	// a read or write operation to be avoided and therefore reduce the
 	// NML/CMS
@@ -889,7 +889,7 @@ int NML::clear()
 /************************************************************
 * NML Member Function: clean_buffers()
 *  Tells cms to set buffers to zero so that we eliminate strange
-* history effects. -- Should only be used by progams testing CMS/NML.
+* history effects. -- Should only be used by programs testing CMS/NML.
 ************************************************************/
 void NML::clean_buffers()
 {
@@ -976,7 +976,7 @@ int NML::get_space_available()
 * NML Member Function: valid()
 * Purpose:
 * Provides a check which can be used after an NML object is
-* constructed to determine if everthing is in order.
+* constructed to determine if everything is in order.
 * Returns: 1 if everything is O.K. 0 otherwise.
 *************************************************************/
 int NML::valid()
@@ -1390,7 +1390,7 @@ NMLTYPE NML::peek()
 * NML Member Function: format_output()
 * Purpose: Formats the data read from a CMS buffer as required
 * by the process that created this NML. The formatting converts
-* messages from some platform indepent format to a platform
+* messages from some platform independent format to a platform
 * specific format or vice versa. (Performing byte-swapping etc.)
 * Returns:
 *  0  The format was successful.
@@ -1400,9 +1400,9 @@ NMLTYPE NML::peek()
 * called.
 *     i. The data is being read out as is. (cms->mode == CMS_RAW_OUT).
 *    ii. A user needs the data in the local platform-specific or raw format
-*        but the buffer has been encoded in a platform-independant or
+*        but the buffer has been encoded in a platform-independent or
 *         neutral format.   (cms->mode == CMS_DECODE).
-*   iii. An NML_SERVER needs the data encoded in a platform-independant
+*   iii. An NML_SERVER needs the data encoded in a platform-independent
 *        or neutral format to send it out over the network but the buffer
 *        is in a local platform-specific or raw format.
 *         (cms->mode == CMS_ENCODE)
@@ -1628,7 +1628,7 @@ int NML::write(NMLmsg * nml_msg, int *serial_number)
     /* Set CMS to a write mode. */
     cms->set_mode(CMS_WRITE);
 
-    /* Format the message if neccessary. */
+    /* Format the message if necessary. */
     if (-1 == format_input(nml_msg)) {
 	error_type = NML_FORMAT_ERROR;
 	return -1;
@@ -1808,9 +1808,9 @@ int NML::write_if_read(NMLmsg * nml_msg, int *serial_number)
 
 /*******************************************************************
 * NML Member Function: format_input()
-* Purpose: Formats the in an NML message to be writen to a CMS buffer
+* Purpose: Formats the in an NML message to be written to a CMS buffer
 *  as required by the configuration file. The formatting converts
-*  messages from some platform indepent format to a platform
+*  messages from some platform independent format to a platform
 *  specific format or vice versa. (Performing byte-swapping etc.)
 * Parameters:
 * NMLmsg *nml_msg - The address of the NML message.

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -116,7 +116,7 @@ void *NML::operator new(size_t size)
 	cptr += sizeof(int) - (((size_t) cptr) % sizeof(int));
 	*((int *) cptr) = dynamic_list_id;
     }
-    rcs_print_debug(PRINT_NML_CONSTRUCTORS, "%p = NML::operater new(%zd)\n",
+    rcs_print_debug(PRINT_NML_CONSTRUCTORS, "%p = NML::operator new(%zd)\n",
 	nml_space, size);
     return nml_space;
 }
@@ -126,7 +126,7 @@ void NML::operator delete(void *nml_space)
     int dynamic_list_id = 0;
     char *cptr = (char *) NULL;
 
-    rcs_print_debug(PRINT_NML_DESTRUCTORS, "NML::operater delete(%p)\n",
+    rcs_print_debug(PRINT_NML_DESTRUCTORS, "NML::operator delete(%p)\n",
 	nml_space);
 
     if (NULL == nml_space) {

--- a/src/libnml/nml/nml.hh
+++ b/src/libnml/nml/nml.hh
@@ -66,8 +66,8 @@ class NML_DIAGNOSTICS_INFO;
 class NML:public virtual CMS_USER {
   protected:
     int run_format_chain(NMLTYPE, void *);
-    int format_input(NMLmsg * nml_msg);	/* Format message if neccessary */
-    int format_output();	/* Decode message if neccessary. */
+    int format_input(NMLmsg * nml_msg);	/* Format message if necessary */
+    int format_output();	/* Decode message if necessary. */
 
   public:
     void *operator                          new(size_t);

--- a/src/libnml/nml/nmlmsg.hh
+++ b/src/libnml/nml/nmlmsg.hh
@@ -6,10 +6,10 @@
 * Author:
 * License: LGPL Version 2
 * System: Linux
-*    
+*
 * Copyright (c) 2004 All rights reserved.
 *
-* Last change: 
+* Last change:
 ********************************************************************/
 
 #ifndef NMLMSG_HH
@@ -44,7 +44,7 @@ class NMLmsg {
       NMLmsg(NMLTYPE t, size_t s);
 
     /* This second constructor never clears the message regardless of what is
-       in nmlmsg. The value of noclear is irrelevent but adding it changes
+       in nmlmsg. The value of noclear is irrelevant but adding it changes
        which constructor is called. */
       NMLmsg(NMLTYPE t, long s, int noclear);
 
@@ -55,7 +55,7 @@ class NMLmsg {
 					   to zero in the constructor. */
     NMLTYPE type;		/* Each derived type should have a unique id */
     long size;			/* The size is used so that the entire buffer 
-				   is not copied unneccesarily. */
+				   is not copied unnecessarily. */
 
     void update(CMS *);
 };

--- a/src/libnml/os_intf/_sem.c
+++ b/src/libnml/os_intf/_sem.c
@@ -23,7 +23,7 @@
 #include <inttypes.h>
 
 /* There are two types of posix semaphores named and unnamed.
-   unamed semaphores can either have the pshared flag set or not
+   unnamed semaphores can either have the pshared flag set or not
    determining whether it can be shared between processes.
    Currently (12/27/02), Linux implements only unnamed posix semaphores
    that are not shared between processes. This is useless to RCSLIB so
@@ -98,7 +98,7 @@ rcs_sem_t *rcs_sem_open(key_t name, int oflag, /* int mode */ ...)
     rcs_sem_t semid, *retval;	/* semaphore id returned */
     int semflg = 0;		/* flag for perms, create, etc. */
 
-    /* if IPC_CREAT is specified for creating the sempahore, then the
+    /* if IPC_CREAT is specified for creating the semaphore, then the
        optional arg is the mode */
     if (oflag & IPC_CREAT) {
 	va_start(ap, oflag);
@@ -173,7 +173,7 @@ int rcs_sem_trywait(rcs_sem_t * sem)
 }
 
 #ifndef _GNU_SOURCE
-#error Must compile with -D_GNU_SOURCE else impliment your own semtimedop() \
+#error Must compile with -D_GNU_SOURCE else implement your own semtimedop() \
        function. 
 #endif
 

--- a/src/libnml/os_intf/timer.hh
+++ b/src/libnml/os_intf/timer.hh
@@ -42,7 +42,7 @@ typedef int (*RCS_TIMERFUNC) (void *_arg);
 difficult */
 #ifdef RCS_TIMER_USE_ITIMER
 
-/* prototype for signal hander function */
+/* prototype for signal handler function */
 typedef void (*RCS_SIGFUNC) (...);
 
 #endif /* RCS_TIMER_USE_ITIMER */
@@ -85,7 +85,7 @@ there are ways to check if the function took longer than the cycle period after 
 */
 class RCS_TIMER {
   public:
-/* Getting rid of this stuff which noone uses and makes porting more
+/* Getting rid of this stuff which no one uses and makes porting more
 difficult */
     RCS_TIMER(double timeout, RCS_TIMERFUNC function =
 	(RCS_TIMERFUNC) NULL, void *arg = NULL);

--- a/src/libnml/posemath/_posemath.c
+++ b/src/libnml/posemath/_posemath.c
@@ -444,7 +444,7 @@ int pmMatQuatConvert(PmRotationMatrix const * const m, PmQuaternion * const q)
        and leave it pos. 2) if e1 is largest then if c21 < 0 then take the
        negative for e2 if c31 < 0 then take the negative for e3 3) else if e2 
        is largest then if c21 < 0 then take the negative for e1 if c32 < 0
-       then take the negative for e3 4) else if e3 is larget then if c31 < 0
+       then take the negative for e3 4) else if e3 is larger then if c31 < 0
        then take the negative for e1 if c32 < 0 then take the negative for e2
 
        Note: c21 in the space book is m->x.y in this C code */
@@ -1750,7 +1750,7 @@ int pmCircleInit(PmCircle * const circle,
 #ifdef PM_DEBUG
     if (0 == circle) {
 #ifdef PM_PRINT_ERROR
-        pmPrintError("error: pmCircleInit cirle pointer is null\n");
+        pmPrintError("error: pmCircleInit circle pointer is null\n");
 #endif
         return pmErrno = PM_ERR;
     }

--- a/src/libnml/posemath/gomath.c
+++ b/src/libnml/posemath/gomath.c
@@ -329,7 +329,7 @@ int go_mat_rvec_convert(const go_mat * m, go_rvec * r)
   3) else if e2 is largest then
   if c21 < 0 then take the negative for e1
   if c32 < 0 then take the negative for e3
-  4) else if e3 is larget then
+  4) else if e3 is larger then
   if c31 < 0 then take the negative for e1
   if c32 < 0 then take the negative for e2
 

--- a/src/libnml/posemath/posemath.cc
+++ b/src/libnml/posemath/posemath.cc
@@ -1317,7 +1317,7 @@ PM_QUATERNION operator /(const PM_QUATERNION &q, double s)
 #if 0
 	// g++/gcc versions 2.8.x and 2.9.x
 	// will complain that the call to PM_QUATERNION(PM_QUATERNION) is
-	// ambigous. (2.7.x and some others allow it)
+	// ambiguous. (2.7.x and some others allow it)
 	return qout =
 	    PM_QUATERNION((double) 0, (double) 0, (double) 0, (double) 0);
 #else

--- a/src/libnml/posemath/posemath.h
+++ b/src/libnml/posemath/posemath.h
@@ -727,7 +727,7 @@ extern "C" {
 /* how close r.s is for a rotation vector to be considered 0 */
 
 #define QSIN_FUZZ (1.0e-6)
-/* how close sin(a/2) is to 0 to be zero rotat */
+/* how close sin(a/2) is to 0 to be zero rotation */
 
 #define V_FUZZ (1.0e-8)
 /* how close elements of a V must be to be equal */

--- a/src/libnml/rcs/rcs_print.hh
+++ b/src/libnml/rcs/rcs_print.hh
@@ -112,9 +112,9 @@ extern "C" {
 #define PRINT_CMS_DESTRUCTORS           0x00000010	/* 16 */
 #define PRINT_NML_CONSTRUCTORS          0x00000020	/* 32 */
 #define PRINT_NML_DESTRUCTORS           0x00000040	/* 64 */
-#define PRINT_COMMANDS_RECIEVED         0x00000100	/* 256 */
+#define PRINT_COMMANDS_RECEIVED         0x00000100	/* 256 */
 #define PRINT_COMMANDS_SENT             0x00000200	/* 512 */
-#define PRINT_STATUS_RECIEVED           0x00000400	/* 1024 */
+#define PRINT_STATUS_RECEIVED           0x00000400	/* 1024 */
 #define PRINT_STATUS_SENT               0x00000800	/* 2048 */
 #define PRINT_NODE_CYCLES               0x00001000	/* 4096 */
 #define PRINT_NODE_MISSED_CYCLES        0x00002000	/* 8192 */

--- a/src/libnml/read.me
+++ b/src/libnml/read.me
@@ -2,7 +2,7 @@
 This directory contains the sources for a lean'n'mean replacement for
 the NIST rcslib. Much of the original code is used, but without the
 multitude of platform specific macros and sources. This is a linux
-only implimentation with the ability to communicate with another 
+only implementation with the ability to communicate with another 
 computer running the NIST rcslib.
 
 Initially, only shared memory buffers will be supported along with xdr and


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.ts,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,*_es -L ans,ba,breal,bulle,componentes,currenty,dashs,doubleclick,dout,dum,extint,fo,fpr,halp,ihs,inout,parm,parms,ser,te,ue,wille,wont`