### PR TITLE
mb2hal: Fixed error message HAL: ERROR: pin_new() called with already-initialized memory 

### DIFF
--- a/src/hal/user_comps/mb2hal/mb2hal_hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_hal.c
@@ -59,7 +59,7 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
             return retERR;
         }
         memset(mb_tx->bit, 0, sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);
-        memset(mb_tx->bit_inv, 1, sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);    
+        memset(mb_tx->bit_inv, 0, sizeof(hal_bit_t *) * mb_tx->mb_tx_nelem);    
         break;
 
     case mbtx_03_READ_HOLDING_REGISTERS:


### PR DESCRIPTION
When initializing memory for pin with other values than '0' before calling pin_new(), this error message shows up:

`HAL: ERROR: pin_new(mb2hal.ModbusIO02.00.bit-inv) called with already-initialized memory`

when using a config like this:

```
[TRANSACTION_01]
MB_TX_CODE=fnct_01_read_coils
FIRST_ELEMENT=0
NELEMENTS=4
HAL_TX_NAME=ModbusIO02
MAX_UPDATE_RATE=1
```

Initializing to zero resolves this.