### PR TITLE
Specify PYTHON env also for configure

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -40,7 +40,7 @@ DEV_PACKAGE_NAME=@MAIN_PACKAGE_NAME@-dev
 
 override_dh_auto_configure:
 	cd src && ./autogen.sh
-	cd src && ./configure \
+	cd src && PYTHON=/usr/bin/python3 ./configure \
 	    --prefix=/usr --sysconfdir=/etc \
 	    --mandir=/usr/share/man \
 	    $(configure_realtime_arg) \


### PR DESCRIPTION
This just happened to me and I do not know why. @petterreinholdtsen , can you confirm this problem? From my perception it happened with Python 3.10 that arrived in Debian unstable and only to break the configure scripts. My fix was to just specify PYTHON=/usr/bin/python3 also for the configure script.

My hunch is that the problem is with Python3.9 and Python3.10 being installed in parallel und the "--version" being executed on what was multiple executables, not just. But that is pure speculation. I like the specification of that PYTHON env for both configure and build for the sake of consistency - configure should test what it is built against, no matter what,
 
```
checking for boostlib >=  (102000)... yes
checking for python build information... 
checking for python3.10... python3.10
checking for main in -lpython3.10... yes
<string>:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
<string>:1: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
  results of the Python check:
    Binary:      python3.10
    Library:     python3.10
    Include Dir: /usr/include/python3.10
checking for python3.10... /usr/bin/python3.10
checking for python... (cached) /usr/bin/python3.10
checking for a version of Python >= '2.1.0'... yes
checking for a version of Python >='3.6'... no
configure: error: this package requires Python >='3.6'.
If you have it installed, but it isn't the default Python
interpreter in your system path, please pass the PYTHON_VERSION
variable to configure. See ``configure --help'' for reference.

make[1]: *** [debian/rules:43: override_dh_auto_configure] Error 1
make[1]: Leaving directory '/tmp/tmp.gXHIM3oBrF/linuxcnc'
make: *** [debian/rules:39: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```
The problem is triggered by `src/m4/ax_python_devel.m4` which is maintained on https://github.com/autoconf-archive/autoconf-archive/blob/master/m4/ax_python_devel.m4 .  If I looked right then in August this script was updated to what is also in the autoconf github.