### PR TITLE
Enhance halshow tool

### DIFF
--- a/src/po/de.po
+++ b/src/po/de.po
@@ -4983,11 +4983,11 @@ msgstr "Pins aufklappen"
 
 #: tcl/bin/halconfig.tcl:177 tcl/bin/halshow.tcl:116
 msgid "Expand Parameters"
-msgstr "Parameters aufklappen"
+msgstr "Parameter aufklappen"
 
 #: tcl/bin/halconfig.tcl:179 tcl/bin/halshow.tcl:118
 msgid "Expand Signals"
-msgstr "Signals aufklappen"
+msgstr "Signale aufklappen"
 
 #: tcl/bin/halconfig.tcl:182 tcl/bin/halshow.tcl:121
 msgid "Erase Watch"
@@ -5064,13 +5064,12 @@ msgid " WATCH "
 msgstr " BEOBACHTEN "
 
 #: tcl/bin/halshow.tcl:87
-#, fuzzy
 msgid "Save Watch List"
-msgstr "Beobachtungsliste laden"
+msgstr "Beobachtungsliste speichern"
 
 #: tcl/bin/halshow.tcl:88
 msgid "Save Watch List (multiline)"
-msgstr ""
+msgstr "Beobachtungsliste speichern (mehrzeilig)"
 
 #: tcl/bin/halshow.tcl:93
 msgid "Load Watch List"

--- a/tcl/bin/cbutton.tcl
+++ b/tcl/bin/cbutton.tcl
@@ -1,0 +1,284 @@
+ # ----------------------------------------------------------------------
+ #
+ # cbutton.tcl --
+ #
+ #       Example of how to provide button-like behavior on canvas
+ #       items. (Posted on comp.lang.tcl by Kevin Kenny)
+ #
+ #       source: https://wiki.tcl-lang.org/page/Canvas+Buttons
+ 
+ set ::RCSID([info script]) \
+   {$Id: 1383,v 1.3 2006-09-24 06:00:06 jcw Exp $}
+ 
+ package provide canvasbutton 1.0
+ 
+ namespace eval canvasbutton {
+ 
+ # nexttag - Next unique tag number for a "button" being
+ #           created
+ 
+ variable nexttag 0
+ 
+ # command - command(tag#) contains the command to execute when
+ #           a "button" is selected.
+ 
+ variable command
+ 
+ # cursor - cursor(pathName) contains the (saved) cursor
+ #          symbol of the widget when the pointer is in
+ #          a "button"
+ 
+ variable cursor
+ 
+ # enteredButton - contains the tag number of the button
+ #                 containing the pointer.
+ 
+ variable enteredButton {}
+ 
+ # pressedButton - contains the tag number of the "button"
+ #                 in which the mouse button was pressed
+ 
+ variable pressedButton {}
+ 
+ namespace export canvasbutton
+ }
+ 
+ # ----------------------------------------------------------------------
+ #
+ # canvasbutton::canvasbutton --
+ #
+ #       Create a button-like object on a canvas.
+ #
+ # Parameters:
+ #       w       Path name of the canvas
+ #       x0      Canvas X co-ordinate of left edge
+ #       y0      Canvas Y co-ordinate of top edge
+ #       x1      Canvas X co-ordinate of right edge
+ #       y1      Canvas Y co-ordinate of bottom edge
+ #       text    Text to display in the button
+ #       cmd     Command to execute when the button is selected.
+ #
+ # Results:
+ #       Unique canvas tag assigned to the items that make
+ #       up the button.
+ #
+ # Side effects:
+ #       A rectangle and a text item are created in the canvas,
+ #       and bindings are established to give them button-like
+ #       behavior.
+ #
+ #----------------------------------------------------------------------
+ 
+ proc canvasbutton::canvasbutton {w x0 y0 x1 y1 text cmd} {
+     variable nexttag
+     variable command
+ 
+     set btag [list canvasb# [incr nexttag]]
+ 
+     set command($btag) $cmd
+ 
+     $w create rectangle $x0 $y0 $x1 $y1 \
+             -fill lightgray -outline black -width 1 \
+             -tags [list canvasb $btag [linsert $btag end frame]]
+ 
+     set x [expr { ($x0+$x1) / 2 }]
+     set y [expr { ($y0+$y1) / 2 }]
+     
+     $w create text $x $y -anchor center -justify center \
+             -text $text \
+             -tags [list canvasb $btag [linsert $btag end text]]
+ 
+     $w bind canvasb <Enter> [list [namespace current]::enter %W]
+     $w bind canvasb <Leave> [list [namespace current]::leave %W]
+     $w bind canvasb <ButtonPress-1> \
+             [list [namespace current]::press %W]
+     $w bind canvasb <ButtonRelease-1> \
+             [list [namespace current]::release %W]
+ 
+     return $btag
+ }
+ 
+ # ----------------------------------------------------------------------
+ #
+ # canvasbutton::enter --
+ #
+ #       Process the <Enter> event on a canvas-button.
+ #
+ # Parameters:
+ #       w       Path name of the canvas
+ #
+ # Results:
+ #       None.
+ #
+ # Side effects:
+ #       When the mouse pointer is in a button, the button is
+ #       highlighted with a broad outline and the cursor
+ #       symbol changes to an arrow.  When the active button
+ #       is pressed, it is highlighted in green.
+ #
+ # ----------------------------------------------------------------------
+ 
+ proc canvasbutton::enter {w} {
+     variable enteredButton
+     variable pressedButton
+     variable cursor
+ 
+     set enteredButton [findBtag $w]
+     set frame [linsert $enteredButton end frame]
+     set cursor($w) [$w cget -cursor]
+     $w configure -cursor arrow
+     #$w itemconfigure $frame -width 3
+     $w itemconfigure $frame -fill {white smoke}
+     if {![string compare $enteredButton $pressedButton]} {
+         $w itemconfigure $frame -fill gray
+     }
+ }
+ 
+ # ----------------------------------------------------------------------
+ #
+ # canvasbutton::leave --
+ #
+ #       Process the <Leave> event on a canvas-button.
+ #
+ # Parameters:
+ #       w       Path name of the canvas
+ #
+ # Results:
+ #       None.
+ #
+ # Side effects:
+ #       Reverts the cursor symbol, the border width
+ #       if needed, the highlight color of the button.
+ #
+ # ----------------------------------------------------------------------
+ 
+ proc canvasbutton::leave {w} {
+     variable enteredButton
+     variable pressedButton
+     variable cursor
+     if {[string compare $enteredButton {}]} {
+         set btag [findBtag $w]
+         set frame [linsert $btag end frame]
+         #$w itemconfigure $frame -width 1
+         $w itemconfigure $frame -fill lightgray
+         $w configure -cursor $cursor($w)
+         unset cursor($w)
+         if {![string compare $btag $pressedButton]} {
+             $w itemconfigure $frame -fill white
+         }
+         set enteredButton {}
+     }
+     return
+ }
+ 
+ # ----------------------------------------------------------------------
+ #
+ # canvasbutton::press --
+ #
+ #       Process the <ButtonPress-1> event on a canvas-button.
+ #
+ # Parameters:
+ #       w       Path name of the canvas
+ #
+ # Results:
+ #       None.
+ #
+ # Side effects:
+ #       Highlights the selected button in green.
+ #
+ # ----------------------------------------------------------------------
+ 
+ proc canvasbutton::press {w} {
+     variable pressedButton
+     set pressedButton [findBtag $w]
+     $w itemconfigure [linsert $pressedButton end frame] \
+             -fill gray
+     return
+ }
+ 
+ # ----------------------------------------------------------------------
+ #
+ # canvasbutton::release --
+ #
+ #       Process the <ButtonRelease-1> event on a canvas-button.
+ #
+ # Parameters:
+ #       w       Path name of the canvas
+ #
+ # Results:
+ #       None.
+ #
+ # Side effects:
+ #       Reverts the highlight color on the button.  If the
+ #       mouse has not left the button, invokes the button's
+ #       command.
+ #
+ # ----------------------------------------------------------------------
+ 
+ proc canvasbutton::release {w} {
+     variable enteredButton
+     variable pressedButton
+     variable command
+ 
+     set pressedButtonWas $pressedButton
+     set pressedButton {}
+ 
+     $w itemconfigure [linsert $pressedButtonWas end frame] \
+             -fill {white smoke}
+ 
+     if {![string compare $enteredButton $pressedButtonWas]} {
+         uplevel #0 $command($pressedButtonWas)
+     }
+     return
+ }
+ 
+ # ----------------------------------------------------------------------
+ #
+ # canvasbutton::btag --
+ #
+ #       Locate the unique tag of a canvas-button
+ #
+ # Parameters:
+ #       w       Path name of the canvas
+ #
+ # Results:
+ #       Button tag, or the null string if the current
+ #       item is not a canvas-button
+ #
+ # Side effects:
+ #       Searches the tag list of the current canvas item
+ #       for a tag that begins with the string, `canvasb#',
+ #       and returns the first two elements of the tag
+ #       interpreted as a Tcl list.
+ #
+ # ----------------------------------------------------------------------
+ 
+ proc canvasbutton::findBtag {w} {
+     foreach tag [$w itemcget current -tags] {
+         if {[regexp {^canvasb#} [lindex $tag 0]]} {
+             return [lrange $tag 0 1]
+         }
+     }
+     return {}
+ }
+ 
+ if {![string compare $argv0 [info script]]} {
+ 
+     grid [canvas .c -width 300 -height 200 -cursor crosshair]
+     
+     namespace import canvasbutton::*
+ 
+     .c create text 150 150 -anchor n -tags label \
+             -font {Helvetica 10 bold}
+ 
+     canvasbutton .c 10 60 90 140 "First\nButton" {
+         .c itemconfigure label -text One
+     }
+     canvasbutton .c 110 60 190 140 "Second\nButton" {
+         .c itemconfigure label -text Two
+     }
+     canvasbutton .c 210 60 290 140 "Third\nButton" {
+         .c itemconfigure label -text Three
+     }
+     canvasbutton .c 240 160 290 190 "Quit" exit
+ }

--- a/tcl/bin/cbutton.tcl
+++ b/tcl/bin/cbutton.tcl
@@ -69,7 +69,7 @@
  #
  #----------------------------------------------------------------------
  
- proc canvasbutton::canvasbutton {w x0 y0 x1 y1 text cmd} {
+ proc canvasbutton::canvasbutton {w x0 y0 x1 y1 text cmd state} {
      variable nexttag
      variable command
  
@@ -77,23 +77,33 @@
  
      set command($btag) $cmd
  
-     $w create rectangle $x0 $y0 $x1 $y1 \
-             -fill lightgray -outline black -width 1 \
-             -tags [list canvasb $btag [linsert $btag end frame]]
+
  
      set x [expr { ($x0+$x1) / 2 }]
      set y [expr { ($y0+$y1) / 2 }]
-     
-     $w create text $x $y -anchor center -justify center \
-             -text $text \
-             -tags [list canvasb $btag [linsert $btag end text]]
- 
-     $w bind canvasb <Enter> [list [namespace current]::enter %W]
-     $w bind canvasb <Leave> [list [namespace current]::leave %W]
-     $w bind canvasb <ButtonPress-1> \
-             [list [namespace current]::press %W]
-     $w bind canvasb <ButtonRelease-1> \
-             [list [namespace current]::release %W]
+
+    if {$state} {
+
+        $w create rectangle $x0 $y0 $x1 $y1 \
+                -fill lightgray -outline black -width 1 \
+                -tags [list canvasb $btag [linsert $btag end frame]]
+
+        $w create text $x $y -anchor center -justify center \
+                -text $text \
+                -tags [list canvasb $btag [linsert $btag end text]]
+    
+        $w bind canvasb <Enter> [list [namespace current]::enter %W]
+        $w bind canvasb <Leave> [list [namespace current]::leave %W]
+        $w bind canvasb <ButtonPress-1> \
+                [list [namespace current]::press %W]
+        $w bind canvasb <ButtonRelease-1> \
+                [list [namespace current]::release %W]
+    } else {
+        $w create rectangle $x0 $y0 $x1 $y1 \
+                -fill lightgray -outline grey65 -width 1 
+        $w create text $x $y -anchor center -justify center \
+                -text $text -fill grey65
+    }
  
      return $btag
  }
@@ -128,9 +138,9 @@
      set cursor($w) [$w cget -cursor]
      $w configure -cursor arrow
      #$w itemconfigure $frame -width 3
-     $w itemconfigure $frame -fill {white smoke}
+     $w itemconfigure $frame -fill grey93
      if {![string compare $enteredButton $pressedButton]} {
-         $w itemconfigure $frame -fill gray
+         $w itemconfigure $frame -fill grey60
      }
  }
  
@@ -192,7 +202,7 @@
      variable pressedButton
      set pressedButton [findBtag $w]
      $w itemconfigure [linsert $pressedButton end frame] \
-             -fill gray
+             -fill grey60
      return
  }
  
@@ -224,7 +234,7 @@
      set pressedButton {}
  
      $w itemconfigure [linsert $pressedButtonWas end frame] \
-             -fill {white smoke}
+             -fill grey93
  
      if {![string compare $enteredButton $pressedButtonWas]} {
          uplevel #0 $command($pressedButtonWas)

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -505,7 +505,7 @@ proc popupmenu {label index writable which x y} {
     if {$writable == -1} {
         $m add command -label "unlink pin" -command [list unlinkp $label $index]
     }
-    $m add command -label "remove" -command [list watchReset $which]
+    $m add command -label "remove" -command [list watchReset $label]
     # show menu
     tk_popup $m $x $y
     bind $m <FocusOut> [list destroy $m]
@@ -615,7 +615,8 @@ proc watchReset {del} {
             return
         }
         default {
-            set place [lsearch $::watchlist $del]
+            set item [string map {+ "\\+"} $del]; # escape '+' for regexp
+            set place [lsearch -regexp $::watchlist $item]
             if {$place != -1 } {
                 set ::watchlist [lreplace $::watchlist $place $place]
                 set watchlist_copy $::watchlist

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -464,27 +464,26 @@ proc watchHAL {which} {
         $::cisp create text 100 [expr $i * 20 + 12] -text $label \
             -anchor w -tag $label
 
-        if {$writable} {
-            canvasbutton::canvasbutton $::cisp  390 [expr $i * 20 + 4] 414 [expr $i * 20 + 21] "set" [list hal_setp $label 1]
-            canvasbutton::canvasbutton $::cisp  417 [expr $i * 20 + 4] 441 [expr $i * 20 + 21] "clr" [list hal_setp $label 0]
-        } 
-        if {$writable == -1} {
-            # @todo: gray out text (and border)
-            canvasbutton::canvasbutton $::cisp  390 [expr $i * 20 + 4] 414 [expr $i * 20 + 21] " " [list hal_setp $label 1]
-            canvasbutton::canvasbutton $::cisp  417 [expr $i * 20 + 4] 441 [expr $i * 20 + 21] " " [list hal_setp $label 0]
+        if {$writable == 1} {
+            canvasbutton::canvasbutton $::cisp  390 [expr $i * 20 + 4] 414 [expr $i * 20 + 21] "set" [list hal_setp $label 1] 1
+            canvasbutton::canvasbutton $::cisp  417 [expr $i * 20 + 4] 441 [expr $i * 20 + 21] "clr" [list hal_setp $label 0] 1
+        } elseif {$writable == -1} {
+            canvasbutton::canvasbutton $::cisp  390 [expr $i * 20 + 4] 414 [expr $i * 20 + 21] "set" [list hal_setp $label 1] 0
+            canvasbutton::canvasbutton $::cisp  417 [expr $i * 20 + 4] 441 [expr $i * 20 + 21] "clr" [list hal_setp $label 0] 0
         }
     } else {
         $::cisp create text 10 [expr $i * 20 + 12] -text "" \
             -anchor w -tag text$i
         $::cisp create text 100 [expr $i * 20 + 12] -text $label \
             -anchor w -tag $label
-        if {$writable} {
-            canvasbutton::canvasbutton $::cisp  390 [expr $i * 20 + 4] 441 [expr $i * 20 + 21] "set val" [list set_value $label]
+        if {$writable == 1} {
+            canvasbutton::canvasbutton $::cisp  390 [expr $i * 20 + 4] 441 [expr $i * 20 + 21] "set val" [list set_value $label] 1
+        } elseif {$writable == -1} {
+            canvasbutton::canvasbutton $::cisp  390 [expr $i * 20 + 4] 441 [expr $i * 20 + 21] "set val" [list set_value $label] 0
         }
     }
 
     $::cisp bind $label <Button-3> [list popupmenu $label $i $writable $which %X %Y]
-
     $::cisp configure -scrollregion [$::cisp bbox all]
     $::cisp yview moveto 1.0
     set tmplist [split $which +]
@@ -500,7 +499,7 @@ proc popupmenu {label index writable which x y} {
     # add entries
     $m add command -label "copy" -command [list copy_name $label]
     if {$writable} {
-        $m add command -label "change" -command [list set_value $label]
+        $m add command -label "set to .." -command [list set_value $label]
     }
     if {$writable == -1} {
         $m add command -label "unlink pin" -command [list unlinkp $label $index]
@@ -530,7 +529,7 @@ proc set_value {label} {
 }
 
 proc unlinkp {label i} {
-    # when unlink command succesful --> refresh list
+    # when unlink command successful --> rebuild list
      if {[eval hal "unlinkp $label"] == "Pin '$label' unlinked"} {
         set watchlist_copy $::watchlist
         watchReset all

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -281,7 +281,7 @@ proc makeShow {} {
     pack [scrollbar $f1.top.sc -orient vert -command "$::disp yview"]\
          -side left -fill y
 
-    set f2 [frame $::showhal.f2 -relief ridge -borderwidth 5]
+    set f2 [frame .f2 -borderwidth 5]
     pack $f2 -fill x -expand 0
     pack [frame $f2.b] \
          -side top -fill x -anchor w

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -522,7 +522,11 @@ proc copy_name {label} {
 }
 
 proc set_value {label} {
-    tk_messageBox -message "No function yet"
+    set val [eval hal "getp $label"]
+    set val [entrybox $val "Set" $label]
+    if {$val != "cancel"} {
+        eval hal "setp $label $val"
+    }
 }
 
 proc unlinkp {label i} {
@@ -534,6 +538,28 @@ proc unlinkp {label i} {
     }
 }
 
+proc entrybox {defVal buttonText label} {
+    set wn [toplevel .top]
+    wm title $wn "Set value"
+    set xpos "[ expr {[winfo rootx [winfo parent $wn]]+([winfo width [winfo parent $wn]]-[winfo reqwidth $wn])/2}]"
+    set ypos "[ expr {[winfo rooty [winfo parent $wn]]+([winfo height [winfo parent $wn]]-[winfo reqheight $wn])/2}]"
+    wm geometry $wn "+$xpos+$ypos"
+    variable entryVal
+    set entryVal $defVal
+    label .top.lbl -text $label
+    entry .top.en -textvariable entryVal
+    .top.en icursor end
+    button .top.but -command {set ret $entryVal} -text $buttonText
+    bind .top.en <Return> {set ret $entryVal}
+    wm protocol .top WM_DELETE_WINDOW {set ret "cancel"}; # on X clicked
+    pack {*}[winfo children .top]
+    focus .top.en
+    vwait ret
+    unset -nocomplain ret
+    unset -nocomplain entryVal
+    destroy .top
+    return $::ret
+}
 
 # watchHAL prepares a string of {i HALtype name} sets
 # watchLoop submits these to halcmd and sets canvas

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -503,8 +503,10 @@ proc watchReset {del} {
         default {
             set place [lsearch $::watchlist $del]
             if {$place != -1 } {
-            set ::watchlist [lreplace $::watchlist $place]
-                foreach var $::watchlist {
+                set ::watchlist [lreplace $::watchlist $place $place]
+                set watchlist_copy $::watchlist
+                set ::watchlist ""
+                foreach var $watchlist_copy {
                     watchHAL $var
                 }
             } else {            

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -302,6 +302,17 @@ proc makeShow {} {
                  -width 0 -height 1  \
                  -borderwidth 2 -relief groove ]
     pack $::showtext -side left -fill both -anchor w -expand 1
+
+    bind $::disp <Button-3> {copySelection 1}
+    bind . <Control-KeyPress-c> {copySelection 0}
+}
+
+proc copySelection {clear} {
+    clipboard clear
+    catch {clipboard append [selection get]}
+    if {$clear} {
+        selection clear
+    }
 }
 
 proc makeWatch {} {

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -293,6 +293,8 @@ proc makeShow {} {
     set ex [button $f2.b.execute -text [msgcat::mc "Execute"] \
             -command {showEx $halcommand} ]
     pack $ex -side left -padx 5 -pady 3
+    bind $com <Up> {hist_move %W -1}
+    bind $com <Down> {hist_move %W 1} 
 
     pack [frame $f2.show -height 5] \
          -side top -fill both -expand 1
@@ -353,11 +355,32 @@ proc showHAL {which} {
 }
 
 proc showEx {what} {
+    hist_add $what
     set str [eval hal $what]
     $::disp configure -state normal
     $::disp delete 1.0 end
     $::disp insert end $str
     $::disp configure -state disabled
+}
+
+set ::hist ""
+set ::i_hist 0
+proc hist_add {s} {
+    if {$s == ""} return
+    if [string compare $s [lindex $::hist end]] {
+        lappend ::hist $s
+        set ::i_hist [expr [llength $::hist]-1]
+    }
+}
+
+proc hist_move {w where} {
+    incr ::i_hist $where
+    if {[set ::i_hist]<0} {set ::i_hist 0}
+    if {[set ::i_hist]>=[llength $::hist]+1} {
+        set ::i_hist [llength $::hist]
+    }
+    set ::[$w cget -textvariable] [lindex $::hist [set ::i_hist]]
+    $w icursor end
 }
 
 set ::last_watchfile_tail my.halshow


### PR DESCRIPTION
Added several useful features to halshow.  
In detail:

1. Added buttons for manipulating the pins
2. Added context menu to
   - copy pin name
   - set value
   - unlink pin (if connected to signal)
   - remove pin from list  
  
![halshow-changes-2](https://user-images.githubusercontent.com/67957916/142768592-cebd36ce-373b-43ff-a5b0-c91e7af3c6b7.png)

3. Added entry dialog to set int/float values


![halshow-changes-3](https://user-images.githubusercontent.com/67957916/142768656-da806cb6-27b1-4ec0-9d6c-a1f5bc37986d.png)

4. Made text copy-able by right click and Ctrl+C
5. Moved entry dialog to main frame for greater width  

![halshow-changes-1](https://user-images.githubusercontent.com/67957916/142768334-bc779b55-54bc-434e-9f4b-65c68c677536.png)


I hope you like it :smile: 


For the buttons i used code from https://wiki.tcl-lang.org/page/Canvas+Buttons:
> License statement
>
> Tcl and extensions such as Tk, Expect, tcllib are distributed under the tems of this license , a BSD-type license, which is much less restrictive than the GPL.
> 
> It is safe to assume that any code posted on this Wiki (or that you post on this wiki) is, unless otherwise explicitly specified, under the same license.

I'm not 100% sure if it complies with the LinuxCNC license model. So please check this if someone knows more about that.

