### PR TITLE
Add support for checking "text/x-script.python" in pycheck

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -538,10 +538,10 @@ pycheck-python-files:
 	done
 
 pycheck-python-script:
-	@echo 'Checking "text/x-python" (by MIME type) files python3 compatibility...'
+	@echo 'Checking "text/x-python" and "text/x-script.python" (by MIME type) files python3 compatibility...'
 	@for d in ../tests; do \
 		filelist=$(shell mktemp) && \
-		find $$d -type f -exec file -F ':' -i {} \; | grep 'text/x-python' | awk -F ':' '{print $$1}' > $$filelist && \
+		find $$d -type f -exec file -F ':' -i {} \; | grep -e 'text/x-python' -e 'text/x-script.python' | awk -F ':' '{print $$1}' > $$filelist && \
 		cat $$filelist | xargs /usr/bin/env python3 -m py_compile && \
 		rm -f $$filelist; \
 	done


### PR DESCRIPTION
Fixes pycheck error on Fedora >=35:
 Checking "text/x-python" (by MIME type) files python3 compatibility...
 make: Leaving directory '/builddir/build/BUILD/linuxcnc-39d63664bee51ce4fed43d2f46ea71b5e1f4f3bc/src'
 usage: py_compile.py [-h] [-q] filenames [filenames ...]
 py_compile.py: error: the following arguments are required: filenames
 make: *** [Makefile:541: pycheck-python-script] Error 123
 error: Bad exit status from /var/tmp/rpm-tmp.DkTMua (%check)
     Bad exit status from /var/tmp/rpm-tmp.DkTMua (%check)

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>