### PR TITLE
Unify realtime script installation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -612,8 +612,8 @@ install: install-kernel-dep install-kernel-indep
 
 install-dirs:
 	$(DIR) $(DESTDIR)$(EMC2_RTLIB_DIR) \
-		$(DESTDIR)$(sysconfdir)/linuxcnc $(DESTDIR)$(bindir) \
-		$(DESTDIR)$(libdir) $(DESTDIR)$(includedir)/linuxcnc \
+		$(DESTDIR)$(sysconfdir)/linuxcnc $(DESTDIR)$(bindir) $(DESTDIR)$(libdir) \
+		$(DESTDIR)/lib/linuxcnc $(DESTDIR)$(includedir)/linuxcnc \
 		$(DESTDIR)$(docsdir) $(DESTDIR)$(ncfilesdir) \
 		$(DESTDIR)/etc/X11/app-defaults $(DESTDIR)$(tcldir)/bin \
 		$(DESTDIR)$(tcldir)/scripts \
@@ -645,7 +645,7 @@ install-kernel-indep: install-dirs
 	$(FILE) $(filter-out %/skeleton.3rtapi, $(wildcard ../docs/man/man3/*.3rtapi)) $(DESTDIR)$(mandir)/man3
 	$(FILE) $(filter-out %/skeleton.9, $(wildcard ../docs/man/man9/*.9)) $(DESTDIR)$(mandir)/man9
 	$(FILE) objects/*.msg $(DESTDIR)$(tcldir)/msgs
-	$(EXE) ../scripts/realtime $(DESTDIR)$(libdir)/linuxcnc
+	$(EXE) ../scripts/realtime $(DESTDIR)$(prefix)/lib/linuxcnc
 	$(EXE) ../scripts/halrun $(DESTDIR)$(bindir)
 	$(EXE) ../scripts/halcmd_twopass $(DESTDIR)$(bindir)
 	$(EXE) ../scripts/haltcl $(DESTDIR)$(bindir)


### PR DESCRIPTION
Unifies installation of 'realtime' script in the same
directory as expected by the configure.ac script.

Fixes regression introduced on #1326 which causes 'realtime'
script being installed in directory referred by ${libdir}
while the configure.ac expected it to be installed on 'lib' directory.
On systems (e.g. Fedora, CentOS) where ${libdir} != 'lib'
this generates discrepancy.

Also fixes proper $(prefix)/lib/linuxcnc directory creation.
When this was not created it caused 'realtime' script to be installed
as $(prefix)/lib/linuxcnc instaed of $(prefix)/lib/linuxcnc/realtime.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>