### PR TITLE
Feature/update gtk icons

### DIFF
--- a/lib/python/gladevcp/iconview.py
+++ b/lib/python/gladevcp/iconview.py
@@ -7,7 +7,7 @@
     it is based on a tutorial from ZetCode PyGTK tutorial
     the original code is under the BSD license
     author: jan bodnar
-    website: zetcode.com 
+    website: zetcode.com
 
     Copyright 2012 Norbert Schechner
     nieson@web.de
@@ -102,7 +102,7 @@ class IconFileSelection(Gtk.HBox):
         # This will hold the path we will return
         self.path = ""
         self.button_state = {}
-        self.old_button_state = {}        
+        self.old_button_state = {}
 
         # Make the GUI and connect signals
         vbox = Gtk.VBox(homogeneous = False, spacing = 0)
@@ -115,7 +115,7 @@ class IconFileSelection(Gtk.HBox):
         self.btn_home = Gtk.Button()
         self.btn_home.set_size_request(56, 56)
         image = Gtk.Image()
-        pixbuf = Gtk.IconTheme.get_default().load_icon("gtk-home", 48, 0)
+        pixbuf = Gtk.IconTheme.get_default().load_icon("go-home", 48, 0)
         image.set_from_pixbuf(pixbuf)
         self.btn_home.set_image(image)
         self.btn_home.set_tooltip_text(_("Move to your home directory"))
@@ -124,7 +124,7 @@ class IconFileSelection(Gtk.HBox):
         self.btn_dir_up = Gtk.Button();
         self.btn_dir_up.set_size_request(56, 56)
         image = Gtk.Image()
-        pixbuf = Gtk.IconTheme.get_default().load_icon("gtk-goto-top", 48, 0)
+        pixbuf = Gtk.IconTheme.get_default().load_icon("go-top", 48, 0)
         image.set_from_pixbuf(pixbuf)
         self.btn_dir_up.set_image(image)
         self.btn_dir_up.set_tooltip_text(_("Move to parent directory"))
@@ -133,7 +133,7 @@ class IconFileSelection(Gtk.HBox):
         self.btn_sel_prev = Gtk.Button()
         self.btn_sel_prev.set_size_request(56, 56)
         image = Gtk.Image()
-        pixbuf = Gtk.IconTheme.get_default().load_icon("gtk-go-back-ltr", 48, 0)
+        pixbuf = Gtk.IconTheme.get_default().load_icon("go-previous", 48, 0)
         image.set_from_pixbuf(pixbuf)
         self.btn_sel_prev.set_image(image)
         self.btn_sel_prev.set_tooltip_text(_("Select the previous file"))
@@ -142,7 +142,7 @@ class IconFileSelection(Gtk.HBox):
         self.btn_sel_next = Gtk.Button()
         self.btn_sel_next.set_size_request(56, 56)
         image = Gtk.Image()
-        pixbuf = Gtk.IconTheme.get_default().load_icon("gtk-go-forward-ltr", 48, 0)
+        pixbuf = Gtk.IconTheme.get_default().load_icon("go-next", 48, 0)
         image.set_from_pixbuf(pixbuf)
         self.btn_sel_next.set_image(image)
         self.btn_sel_next.set_tooltip_text(_("Select the next file"))
@@ -176,7 +176,7 @@ class IconFileSelection(Gtk.HBox):
         self.btn_select = Gtk.Button()
         self.btn_select.set_size_request(56, 56)
         image = Gtk.Image()
-        pixbuf = Gtk.IconTheme.get_default().load_icon("gtk-media-play-ltr", 48, 0)
+        pixbuf = Gtk.IconTheme.get_default().load_icon("media-playback-start", 48, 0)
         image.set_from_pixbuf(pixbuf)
         self.btn_select.set_image(image)
         self.btn_select.set_tooltip_text(_("select the highlighted file and return the path"))
@@ -185,7 +185,7 @@ class IconFileSelection(Gtk.HBox):
         self.btn_exit = Gtk.Button()
         self.btn_exit.set_size_request(56, 56)
         image = Gtk.Image()
-        pixbuf = Gtk.IconTheme.get_default().load_icon("gtk-quit", 48, 0)
+        pixbuf = Gtk.IconTheme.get_default().load_icon("application-exit", 48, 0)
         image.set_from_pixbuf(pixbuf)
         self.btn_exit.set_image(image)
         self.btn_exit.set_tooltip_text(_("Close without returning a file path"))
@@ -202,7 +202,7 @@ class IconFileSelection(Gtk.HBox):
         vbox.pack_start(self.file_label, False, True, 0)
 
         self.store = self._create_store()
-        
+
         self.iconView = Gtk.IconView.new()
         self.iconView.set_model(self.store)
         self.iconView.set_selection_mode(Gtk.SelectionMode.SINGLE)
@@ -230,20 +230,20 @@ class IconFileSelection(Gtk.HBox):
         # will be emitted if the selection has changed, this happens also if the user clicks ones on an icon
         self.iconView.connect("selection-changed",  self._on_selection_changed)
         # will be emitted, when the widget is destroyed
-        self.connect("destroy", Gtk.main_quit)      
-        
+        self.connect("destroy", Gtk.main_quit)
+
         self.add(vbox)
         self.show_all()
 
         # To use the the events, we have to unmask them
         self.iconView.add_events(Gdk.EventMask.BUTTON_PRESS_MASK)
         self.iconView.connect("button_press_event", self._button_press)
-        
+
         self._fill_store()
         self._init_button_state()
 #        self.realized = True
-        
-    def _init_button_state(self):    
+
+    def _init_button_state(self):
         # we need this to check for differences in the button state
         self.button_state["btn_home"] = self.btn_home.get_sensitive()
         self.button_state["btn_dir_up"] = self.btn_dir_up.get_sensitive()
@@ -252,7 +252,7 @@ class IconFileSelection(Gtk.HBox):
         self.button_state["btn_jump_to"] = self.btn_jump_to.get_sensitive()
         self.button_state["btn_select"] = self.btn_select.get_sensitive()
         self.old_button_state = self.button_state.copy()
-        
+
     # With the left mouse button and a dobble click, the file can be selected
     def _button_press(self, widget, event):
         # left button used?
@@ -283,7 +283,7 @@ class IconFileSelection(Gtk.HBox):
     def _fill_store(self):
         if self.cur_dir == None:
             return
-        
+
         try:
             self.store.clear()
             number = 0
@@ -316,19 +316,19 @@ class IconFileSelection(Gtk.HBox):
 
             if self.sortorder not in [_ASCENDING, _DESCENDING, _FOLDERFIRST, _FILEFIRST]:
                 self.sortorder = _FOLDERFIRST
-    
+
             if self.sortorder == _ASCENDING or self.sortorder == _DESCENDING:
                 allobjects = dirs
                 allobjects.extend(files)
                 allobjects.sort(reverse = not self.sortorder == _ASCENDING)
-    
+
                 for obj in allobjects:
                     if os.path.isdir(os.path.join(self.cur_dir, obj)):
                         self.store.append([obj, self.dirIcon, True])
                     else:
                         icon = self._get_icon(obj)
                         self.store.append([obj, icon, False])
-            
+
             dirs.sort(key = None, reverse = False)
             files.sort(key = None, reverse = False)
             if self.sortorder == _FOLDERFIRST:
@@ -349,9 +349,9 @@ class IconFileSelection(Gtk.HBox):
         finally:
             # check the stat of the button and set them as they should be
             self.check_button_state()
-        
+
     def check_button_state(self):
-        state = True 
+        state = True
         if not self.iconView.get_cursor()[0]:
             state = False
         elif self.model.get_iter_first() == None:
@@ -375,9 +375,9 @@ class IconFileSelection(Gtk.HBox):
         self.button_state["btn_jump_to"] = not state
         state = self.iconView.get_cursor() == None
         self.btn_select.set_sensitive(not state)
-        self.button_state["btn_select"] = not state        
+        self.button_state["btn_select"] = not state
         self.state_changed()
-        
+
     def state_changed(self):
         # find the difference
         diff = set(self.button_state.items()) - set(self.old_button_state.items())
@@ -387,7 +387,7 @@ class IconFileSelection(Gtk.HBox):
                     self.emit("sensitive",key, self.button_state[key])
             except Exception as e:
                 print(e)
-                continue 
+                continue
 
         self.old_button_state = self.button_state.copy()
 
@@ -425,7 +425,7 @@ class IconFileSelection(Gtk.HBox):
         try:
             actual = self.iconView.get_cursor()[1]
             iter = self.model.get_iter(actual)
-               
+
             pos = int(self.model.get_string_from_iter(iter))
             first = int(self.model.get_string_from_iter(self.model.get_iter_first()))
             pos = pos - 1
@@ -476,7 +476,7 @@ class IconFileSelection(Gtk.HBox):
 #        print("This is the row :", row)
 #        print(self.iconView.get_columns())
 
-        
+
 #        self.iconView.item_activated(self.iconView.get_cursor()[0])
 #        print("go down")
 #        print("columns = ",self.iconView.get_columns())
@@ -604,7 +604,7 @@ def main():
     window.show_all()
     window.set_size_request(680, 480)
     Gtk.main()
-    
+
 
 if __name__ == "__main__":
     main()

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -261,12 +261,12 @@
   <object class="GtkImage" id="img_home">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-home</property>
+    <property name="icon_name">go-home</property>
   </object>
   <object class="GtkImage" id="img_jump_to">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-jump-to</property>
+    <property name="icon_name">go_jump</property>
   </object>
   <object class="GtkImage" id="img_machine_on">
     <property name="visible">True</property>
@@ -296,7 +296,7 @@
   <object class="GtkImage" id="img_open">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-open</property>
+    <property name="icon_name">document-open</property>
   </object>
   <object class="GtkImage" id="img_ref_all">
     <property name="visible">True</property>
@@ -324,32 +324,32 @@
   <object class="GtkImage" id="img_sel_next">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-go-forward</property>
+    <property name="icon_name">go-next</property>
   </object>
   <object class="GtkImage" id="img_sel_next1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-go-forward</property>
+    <property name="icon_name">go-next</property>
   </object>
   <object class="GtkImage" id="img_sel_prev">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-go-back</property>
+    <property name="icon_name">go-previous</property>
   </object>
   <object class="GtkImage" id="img_sel_prev1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-go-back</property>
+    <property name="icon_name">go-previous</property>
   </object>
   <object class="GtkImage" id="img_sel_prev2">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-go-back</property>
+    <property name="icon_name">go-previous</property>
   </object>
   <object class="GtkImage" id="img_select">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-ok</property>
+    <property name="icon_name">document-open</property>
   </object>
   <object class="GtkImage" id="img_sstop">
     <property name="width_request">48</property>
@@ -7951,6 +7951,8 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkButton" id="btn_reload">
+                    <property name="width_request">85</property>
+                    <property name="height_request">56</property>
                     <property name="related_action">hal_action_reload</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -8570,7 +8572,7 @@ F12 or $ key does the same</property>
                         <property name="height_request">48</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="stock">gtk-new</property>
+                        <property name="icon_name">document-new</property>
                       </object>
                     </child>
                   </object>

--- a/src/emc/usr_intf/gmoccapy/notification.py
+++ b/src/emc/usr_intf/gmoccapy/notification.py
@@ -116,7 +116,7 @@ class Notification(Gtk.Window):
         Pango_ok = True
         try:
             # The GError exception is raised if an error occurs while parsing the markup text.
-            Pango.parse_markup(text)        
+            Pango.parse_markup(text)
         except:
             Pango_ok = False
         if Pango_ok:
@@ -126,9 +126,8 @@ class Notification(Gtk.Window):
         hbox.pack_start(label, False, False, 0)
         btn_close = Gtk.Button()
         image = Gtk.Image()
-        pixbuf = Gtk.IconTheme.get_default().load_icon("gtk-cancel", self.icon_size, 0)
+        pixbuf = Gtk.IconTheme.get_default().load_icon("window-close", self.icon_size, 0)
         image.set_from_pixbuf(pixbuf)
-        
         btn_close.set_image(image)
         btn_close.set_border_width(2)
         btn_close.connect('clicked', self._on_btn_close_clicked, labelnumber.get_text())
@@ -155,7 +154,7 @@ class Notification(Gtk.Window):
     # if to long for the frame
     def add_message(self, message, icon_file_name):
         '''Notification.add_message(messagetext, icon_file_name)
-        
+
            messagetext = a string to display
            icon_file_name = a valid absolut path to an icon or None
         '''
@@ -198,7 +197,7 @@ class Notification(Gtk.Window):
     def del_message(self, messagenumber):
         '''del_message(messagenumber)
            delete the message with the given number
-           
+
            messagenumber = integer
                            -1 will erase all messages
         '''


### PR DESCRIPTION
Since GTK 3.10 the usage of the so called "stock icons" is deprecated.
Instead named icons according to the [Freedesktop icon naming spec](https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html) should be used.

I've changed them in gmoccapy related files.

This should fix the problems mentioned here: #1182 

Closes: #1182