### PR TITLE
Disable fuzzy mode for po file generation

### DIFF
--- a/src/po/Submakefile
+++ b/src/po/Submakefile
@@ -70,7 +70,7 @@ po/linuxcnc.pot:
 TARGETS += po/linuxcnc.pot
 
 pofiles: po/linuxcnc.pot
-	set -x; for i in po/*.po; do msgmerge -U $$i po/linuxcnc.pot; done
+	set -x; for i in po/*.po; do msgmerge -U -N $$i po/linuxcnc.pot; done
 
 po/linuxcnc.pot: emc/task/emctaskmain.cc $(LIBRS274SRCS) emc/rs274ngc/rs274ngc_return.hh
 po/linuxcnc.pot: hal/utils/meter.c \


### PR DESCRIPTION
Per default msgmerge uses fuzzy mode. That leads to lots of wrong translations if not manually checked and corrected after generation. Unfortunately we have a lot of these actually. Just search the po files for "fuzzy". I would recommend to rather have no translation instead of a wrong one.