### PR TITLE
emc: fix source typo

### DIFF
--- a/src/emc/usr_intf/pyui/widgets.py
+++ b/src/emc/usr_intf/pyui/widgets.py
@@ -3,9 +3,9 @@ import linuxcnc
 import json
 
 DBG_state = 0
-DBG_supress = True
+DBG_suppress = True
 def DBG(str):
-    if not DBG_state or DBG_supress: return
+    if not DBG_state or DBG_suppress: return
     print(str)
 
 """ Set of base classes """
@@ -16,7 +16,7 @@ class _WidgetBase:
         self.metadata = metadata
         self.widgets = widgets
         self.cmd = command
-        global DBG_supress
+        global DBG_suppress
         global DBG_state
         DBG_state = dbg
         self.state = False
@@ -112,9 +112,9 @@ class _ToggleBase(_WidgetBase):
             self.hal_status_pin_not = self.hal.newpin(self.hal_name+ "-state-not", hal.HAL_BIT, hal.HAL_OUT)
         # Update the pin to the proper state, but don't print debug for this
         if pintype not in ('COMMAND','ZMQ'):
-            DBG_supress = True
+            DBG_suppress = True
             self.hal_update()
-            DBG_supress = False
+            DBG_suppress = False
 
     # This finds the function in either command class or
     # the optionally loaded custom handler class
@@ -240,9 +240,9 @@ class GROUP(_WidgetBase):
         self.widgets[i].set_state(True)
         self.widgets[i].hal_update()
         self.toggle_state(i)
-        DBG_supress = True
+        DBG_suppress = True
         self.hal_update()
-        DBG_supress = False
+        DBG_suppress = False
 
     def add_list(self,grouplist):
         self.group_list = grouplist


### PR DESCRIPTION
Correct typo `DBG_supress` -> `DBG_suppress`