### PR TITLE
Stop removing POT files in clean target

### DIFF
--- a/src/po/Submakefile
+++ b/src/po/Submakefile
@@ -67,7 +67,6 @@ po/linuxcnc.pot:
 	$(ECHO) Localizing linuxcnc.pot
 	$(Q)(cd ..; $(XGETTEXT) --from-code=UTF-8 -k_ -o src/$@ `$(PYTHON) src/po/fixpaths.py -j src $^`)
 	$(Q)touch $@
-TARGETS += po/linuxcnc.pot
 
 pofiles: po/linuxcnc.pot
 	set -x; for i in po/*.po; do msgmerge -U $$i po/linuxcnc.pot; done
@@ -137,7 +136,6 @@ po/gmoccapy/gmoccapy.pot: $(GMOCCAPY_I18N_SRCS)
 	$(XGETTEXT) --from-code=UTF-8 --language=Python \
 		--keyword=_ --keyword=N_ \
 		--output=$@ $^
-TARGETS += po/gmoccapy/gmoccapy.pot
 
 clean: gmoccapy_i18n_clean
 gmoccapy_i18n_clean:


### PR DESCRIPTION
As the POT files are kept in git, it is best to not remove them in the
'clean' target.