### PR TITLE
Prevent spurious limits exceeded errors

### DIFF
--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -1559,11 +1559,11 @@ static void get_pos_cmds(long period)
         }
 
 	/* check for soft limits */
-	if (joint->pos_cmd > joint->max_pos_limit) {
+	if (joint->pos_cmd > joint->max_pos_limit + 0.000000000001) {
 	    joint_limit[joint_num][1] = 1;
             onlimit = 1;
         }
-        else if (joint->pos_cmd < joint->min_pos_limit) {
+        else if (joint->pos_cmd < joint->min_pos_limit - 0.000000000001) {
 	    joint_limit[joint_num][0] = 1;
             onlimit = 1;
         }


### PR DESCRIPTION
These changes are of similar vein to [PR 1047](https://github.com/LinuxCNC/linuxcnc/pull/1047)

I was getting incorrect minimum limit errors on joint 0 when sending multiple MDI commands from a GUI.