### PR TITLE
Fix QTimer start() argument

### DIFF
--- a/lib/python/qtvcp/qt_istat.py
+++ b/lib/python/qtvcp/qt_istat.py
@@ -80,7 +80,7 @@ class _IStat(object):
             self.CYCLE_TIME = int(ct * 1000)
         else:
             self.CYCLE_TIME = int(ct)
-        self.GRAPHICS_CYCLE_TIME = float(self.INI.find('DISPLAY', 'GRAPHICS_CYCLE_TIME') or 100) # in seconds
+        self.GRAPHICS_CYCLE_TIME = int(self.INI.find('DISPLAY', 'GRAPHICS_CYCLE_TIME') or 100) # in seconds
         self.HALPIN_CYCLE_TIME = float(self.INI.find('DISPLAY', 'HALPIN_CYCLE_TIME') or 100) # in seconds
         self.MDI_HISTORY_PATH = self.INI.find('DISPLAY', 'MDI_HISTORY_FILE') or '~/.axis_mdi_history'
         self.QTVCP_LOG_HISTORY_PATH = self.INI.find('DISPLAY', 'LOG_FILE') or '~/qtvcp.log'


### PR DESCRIPTION
Fixes:
  File "/home/dw/projects/linuxcnc/lib/python/qt5_graphics.py", line 299, in __init__
    self.addTimer()
  File "/home/dw/projects/linuxcnc/lib/python/qtvcp/widgets/gcode_graphics.py", line 86, in addTimer
    self.timer.start(INFO.GRAPHICS_CYCLE_TIME)
TypeError: arguments did not match any overloaded call:
  start(self, int): argument 1 has unexpected type 'float'
  start(self): too many arguments

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>