### PR TITLE
Fix QColor() argument

### DIFF
--- a/lib/python/qtvcp/widgets/gcode_graphics.py
+++ b/lib/python/qtvcp/widgets/gcode_graphics.py
@@ -55,7 +55,7 @@ class  GCodeGraphics(Lcnc_3dGraphics, _HalWidgetBase):
         self._overlayColor = QColor(0, 0, 0, 0)
 
         self.colors['back'] = (0.0, 0.0, 0.75)  # blue
-        self._backgroundColor = QColor(0, 0, 0.75, 150)
+        self._backgroundColor = QColor(0, 0, 191, 150)
         self._jogColor = QColor(0, 0, 0, 0)
         self._feedColor = QColor(0, 0, 0, 0)
         self._rapidColor = QColor(0, 0, 0, 0)
@@ -367,7 +367,7 @@ class  GCodeGraphics(Lcnc_3dGraphics, _HalWidgetBase):
         self.colors['overlay_background'] = (value.redF(), value.greenF(), value.blueF())
         self.updateGL()
     def resetOverlayColor(self):
-        self._overlayColor = QColor(0, 0, .75, 150)
+        self._overlayColor = QColor(0, 0, 191, 150)
     overlay_color = pyqtProperty(QColor, getOverlayColor, setOverlayColor, resetOverlayColor)
 
     def getBackgroundColor(self):


### PR DESCRIPTION
Fixes:
  File "/home/dw/projects/linuxcnc/lib/python/qtvcp/widgets/gcode_graphics.py", line 58, in __init__
    self._backgroundColor = QColor(0, 0, 0.75, 150)
TypeError: arguments did not match any overloaded call:
  QColor(Qt.GlobalColor): argument 1 has unexpected type 'int'
  QColor(int): too many arguments
  QColor(QRgba64): argument 1 has unexpected type 'int'
  QColor(Any): too many arguments
  QColor(): too many arguments
  QColor(int, int, int, alpha: int = 255): argument 3 has unexpected type 'float'
  QColor(str): argument 1 has unexpected type 'int'
  QColor(Union[QColor, Qt.GlobalColor, QGradient]): argument 1 has unexpected type 'int'

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>