### PR TITLE
Fix addWidget() argument

### DIFF
--- a/lib/python/qtvcp/widgets/calculator.py
+++ b/lib/python/qtvcp/widgets/calculator.py
@@ -87,7 +87,7 @@ class Calculator(QDialog):
         mainLayout.addWidget(self.addToMemoryButton, 5, 0)
 
         for i in range(1, Calculator.NumDigitButtons):
-            row = ((9 - i) / 3) + 2
+            row = ((9 - i) // 3) + 2
             column = ((i - 1) % 3) + 1
             mainLayout.addWidget(self.digitButtons[i], row, column)
 


### PR DESCRIPTION
Fixes:
  File "/home/dw/projects/linuxcnc/lib/python/qtvcp/widgets/calculator.py", line 92, in __init__
    mainLayout.addWidget(self.digitButtons[i], row, column)
TypeError: arguments did not match any overloaded call:
  addWidget(self, QWidget): too many arguments
  addWidget(self, QWidget, int, int, alignment: Union[Qt.Alignment, Qt.AlignmentFlag] = Qt.Alignment()): argument 2 has unexpected type 'float'
  addWidget(self, QWidget, int, int, int, int, alignment: Union[Qt.Alignment, Qt.AlignmentFlag] = Qt.Alignment()): argument 2 has unexpected type 'float'

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>