### PR TITLE
Fix drawEllipse() arguments

### DIFF
--- a/lib/python/qtvcp/widgets/led_widget.py
+++ b/lib/python/qtvcp/widgets/led_widget.py
@@ -86,7 +86,7 @@ class LED(QWidget, _HalWidgetBase):
         elif self._alignment & Qt.AlignRight:
             x = self.width() - self._diameter
         elif self._alignment & Qt.AlignHCenter:
-            x = (self.width() - self._diameter) / 2
+            x = (self.width() - self._diameter) // 2
         elif self._alignment & Qt.AlignJustify:
             x = 0
 
@@ -95,7 +95,7 @@ class LED(QWidget, _HalWidgetBase):
         elif self._alignment & Qt.AlignBottom:
             y = self.height() - self._diameter
         elif self._alignment & Qt.AlignVCenter:
-            y = (self.height() - self._diameter) / 2
+            y = (self.height() - self._diameter) // 2
 
         gradient = QRadialGradient(x + self._diameter / 2, y + self._diameter / 2,
                                    self._diameter * 0.4, self._diameter * 0.4, self._diameter * 0.4)


### PR DESCRIPTION
Fixes:
Traceback (most recent call last):
  File "/home/dw/projects/linuxcnc/lib/python/qtvcp/widgets/led_widget.py", line 114, in paintEvent
    painter.drawEllipse(x, y, self._diameter - 1, self._diameter - 1)
TypeError: arguments did not match any overloaded call:
  drawEllipse(self, QRectF): argument 1 has unexpected type 'float'
  drawEllipse(self, QRect): argument 1 has unexpected type 'float'
  drawEllipse(self, int, int, int, int): argument 1 has unexpected type 'float'
  drawEllipse(self, Union[QPointF, QPoint], float, float): argument 1 has unexpected type 'float'
  drawEllipse(self, QPoint, int, int): argument 1 has unexpected type 'float'

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>