### PR TITLE
Improve error logging by adding full python traceback

### DIFF
--- a/lib/python/qtvcp/core.py
+++ b/lib/python/qtvcp/core.py
@@ -7,6 +7,7 @@ from gi.repository import GObject
 import inspect
 import _hal
 import hal
+import traceback
 from PyQt5.QtCore import QObject, QTimer, pyqtSignal
 from hal_glib import GStat
 from qtvcp.qt_istat import _IStat as IStatParent
@@ -152,6 +153,7 @@ class _QHal(object):
             t = inspect.getframeinfo(inspect.currentframe().f_back)
             log.error("Qhal: Error making new HAL pin: {}\n    {}\n    Line {}\n    Function: {}".
                 format(e, t[0], t[1], t[2]))
+            log.error("Qhal: {}".format(traceback.format_exc()))
             p = DummyPin(*a, ERROR=e)
         return p
 


### PR DESCRIPTION
Adds traceback to output log to make it easier
to identify the error location.

Existing output:

[QTvcp.QTVCP.CORE][ERROR]  Qhal: Error making new HAL pin: arguments did not match any overloaded call:
  start(self, int): argument 1 has unexpected type 'float'
  start(self): too many arguments
    /home/dw/projects/machinekit/linuxcnc/lib/python/qtvcp/widgets/simple_widgets.py
    Line 1102
    Function: _hal_init (core.py:154)

Added traceback:

[QTvcp.QTVCP.CORE][ERROR]  Qhal: Traceback (most recent call last):
  File "/home/dw/projects/linuxcnc/lib/python/qtvcp/core.py", line 149, in newpin
    p = QPin(_hal.component.newpin(self.comp, *a, **kw))
  File "/home/dw/projects/linuxcnc/lib/python/qtvcp/core.py", line 48, in __init__
    self.update_start()
  File "/home/dw/projects/linuxcnc/lib/python/qtvcp/core.py", line 88, in update_start
    cls.timer.start(INI.HALPIN_CYCLE_TIME)

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>