### PR TITLE
Fix QTimer start() argument (HALPIN_CYCLE_TIME)

### DIFF
--- a/lib/python/qtvcp/qt_istat.py
+++ b/lib/python/qtvcp/qt_istat.py
@@ -81,7 +81,7 @@ class _IStat(object):
         else:
             self.CYCLE_TIME = int(ct)
         self.GRAPHICS_CYCLE_TIME = float(self.INI.find('DISPLAY', 'GRAPHICS_CYCLE_TIME') or 100) # in seconds
-        self.HALPIN_CYCLE_TIME = float(self.INI.find('DISPLAY', 'HALPIN_CYCLE_TIME') or 100) # in seconds
+        self.HALPIN_CYCLE_TIME = int(self.INI.find('DISPLAY', 'HALPIN_CYCLE_TIME') or 100) # in seconds
         self.MDI_HISTORY_PATH = self.INI.find('DISPLAY', 'MDI_HISTORY_FILE') or '~/.axis_mdi_history'
         self.QTVCP_LOG_HISTORY_PATH = self.INI.find('DISPLAY', 'LOG_FILE') or '~/qtvcp.log'
         self.MACHINE_LOG_HISTORY_PATH = self.INI.find('DISPLAY', 'MACHINE_LOG_PATH') or '~/.machine_log_history'


### PR DESCRIPTION
Fixes:
 [QTvcp.QTVCP.CORE][ERROR] Qhal: Error making new HAL pin: arguments did not match any overloaded call:
 start(self, int): argument 1 has unexpected type 'float'
 start(self): too many arguments
 /home/dw/projects/linuxcnc/lib/python/qtvcp/widgets/simple_widgets.py
 Line 1102
 Function: _hal_init (core.py:154)
 [QTvcp.QTVCP.CORE][ERROR] Qhal: Traceback (most recent call last):
 File "/home/dw/projects/linuxcnc/lib/python/qtvcp/core.py", line 149, in newpin
 p = QPin(_hal.component.newpin(self.comp, *a, **kw))
 File "/home/dw/projects/linuxcnc/lib/python/qtvcp/core.py", line 48, in init
 self.update_start()
 File "/home/dw/projects/linuxcnc/lib/python/qtvcp/core.py", line 88, in update_start
 cls.timer.start(INI.HALPIN_CYCLE_TIME)

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>