### PR TITLE
Fix qtplasma camview QPoint() argument

### DIFF
--- a/lib/python/qtvcp/widgets/camview_widget.py
+++ b/lib/python/qtvcp/widgets/camview_widget.py
@@ -313,7 +313,7 @@ class CamView(QtWidgets.QWidget, _HalWidgetBase):
         rady = self.diameter/2
         # draw red circles
         gp.setPen(self.circle_color)
-        center = QtCore.QPoint(w/2, h/2)
+        center = QtCore.QPoint(w//2, h//2)
         gp.drawEllipse(center, radx, rady)
 
     def drawCrossHair(self, event, gp):


### PR DESCRIPTION
Fixes:
 Traceback (most recent call last):
   File "/usr/lib/python3.10/site-packages/qtvcp/widgets/camview_widget.py", line 293, in paintEvent
     self.drawCircle(event, qp)
   File "/usr/lib/python3.10/site-packages/qtvcp/widgets/camview_widget.py", line 316, in drawCircle
     center = QtCore.QPoint(w/2, h/2)
 TypeError: arguments did not match any overloaded call:
   QPoint(): too many arguments
   QPoint(int, int): argument 1 has unexpected type 'float'
   QPoint(QPoint): argument 1 has unexpected type 'float'

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>