### PR TITLE
Fix qtplasma camview drawLine() argument

### DIFF
--- a/lib/python/qtvcp/widgets/camview_widget.py
+++ b/lib/python/qtvcp/widgets/camview_widget.py
@@ -318,8 +318,8 @@ class CamView(QtWidgets.QWidget, _HalWidgetBase):
 
     def drawCrossHair(self, event, gp):
         size = self.size()
-        w = size.width()/2
-        h = size.height()/2
+        w = size.width()//2
+        h = size.height()//2
         pen0 = QPen(self.cross_pointer_color, 1, QtCore.Qt.SolidLine)
         pen = QPen(self.cross_color, 1, QtCore.Qt.SolidLine)
         gp.translate(w, h)


### PR DESCRIPTION
Fixes:
  Traceback (most recent call last):
   File "/home/dw/projects/machinekit/linuxcnc/lib/python/qtvcp/widgets/camview_widget.py", line 294, in paintEvent
     self.drawCrossHair(event, qp)
   File "/home/dw/projects/machinekit/linuxcnc/lib/python/qtvcp/widgets/camview_widget.py", line 328, in drawCrossHair
     gp.drawLine(0, 0-self.gap, 0, -h)
 TypeError: arguments did not match any overloaded call:
   drawLine(self, QLineF): argument 1 has unexpected type 'int'
   drawLine(self, QLine): argument 1 has unexpected type 'int'
   drawLine(self, int, int, int, int): argument 4 has unexpected type 'float'
   drawLine(self, QPoint, QPoint): argument 1 has unexpected type 'int'
   drawLine(self, Union[QPointF, QPoint], Union[QPointF, QPoint]): argument 1 has unexpected type 'int'

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>