### PR TITLE
Fix qtplasma documentation - unify VELOCITY ANTI DIVE

### DIFF
--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -849,8 +849,8 @@ The main purpose of this is to allow a quick test for a shorted torch tip.
 This box defaults to unfilled (disabled) when QtPlasmaC is first run. +
 This box must be filled to change it to "Torch Enabled" before material cutting can commence. +
 If this box is not filled, then running a loaded program will cause the machine to run the cycle without firing the torch. This is sometimes referred to as a "dry run".
-|VELOCITY A/DIVE|0, 1, 2|Indicates that the THC is locked at the current height due to the cut velocity falling below the VAD Threshold percentage set on the <<qt_parameters-tab, PARAMETERS Tab>>.
-|VELOCITY A/DIVE ENABLE|0, 1, 2|This box toggles between Enabling and Disabling VELOCITY A/DIVE.
+|VELOCITY ANTI DIVE|0, 1, 2|Indicates that the THC is locked at the current height due to the cut velocity falling below the VAD Threshold percentage set on the <<qt_parameters-tab, PARAMETERS Tab>>.
+|VELOCITY ANTI DIVE ENABLE|0, 1, 2|This box toggles between Enabling and Disabling VELOCITY ANTI DIVE.
 |VOID A/DIVE|0, 1|Indicates that the THC is locked due to a void being sensed.
 |VOID A/DIVE ENABLE|0, 1|This box toggles between Enabling and Disabling VOID A/DIVE.
 |MESH MODE|0, 1, 2|This box will enable or disable <<qt_mesh-mode, Mesh Mode>> for the cutting of expanded metal. This check box may be enabled or disabled at any time during normal cutting. +

--- a/share/qtvcp/screens/qtplasmac/languages/qtplasmac.py
+++ b/share/qtvcp/screens/qtplasmac/languages/qtplasmac.py
@@ -5494,7 +5494,7 @@ class Ui_MainWindow(object):
         self.use_auto_volts_lbl.setText(_translate("MainWindow", "AUTO VOLTS"))
         self.label_72.setText(_translate("MainWindow", "VOID A/DIVE"))
         self.label_73.setText(_translate("MainWindow", "ENABLE"))
-        self.label_70.setText(_translate("MainWindow", "VELOCITY A/DIVE"))
+        self.label_70.setText(_translate("MainWindow", "VELOCITY ANTI DIVE"))
         self.label_71.setText(_translate("MainWindow", "ENABLE"))
         self.sensor_label.setText(_translate("MainWindow", "SENSOR"))
         self.label_49.setText(_translate("MainWindow", "FLOAT"))

--- a/share/qtvcp/screens/qtplasmac/qtplasmac.ui
+++ b/share/qtvcp/screens/qtplasmac/qtplasmac.ui
@@ -4265,7 +4265,7 @@ EDGE</string>
                           </size>
                          </property>
                          <property name="text">
-                          <string>VELOCITY A/DIVE</string>
+                          <string>VELOCITY ANTI DIVE</string>
                          </property>
                          <property name="alignment">
                           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>


### PR DESCRIPTION
Currently part of the documentation refers to either:
"VELOCITY A/DIVE" or "VELOCITY ANTI DIVE" which makes
it difficult to search for it.

Currently:
 $ git grep -- 'VELOCITY A/DIVE'
 docs/src/plasma/qtplasmac.adoc:|VELOCITY A/DIVE|0, 1, 2|\
    Indicates that the THC is locked at the current height due to \
    the cut velocity falling below the VAD Threshold percentage \
    set on the <<qt_parameters-tab, PARAMETERS Tab>>.
 docs/src/plasma/qtplasmac.adoc:|VELOCITY A/DIVE ENABLE|0, 1, 2|\
    This box toggles between Enabling and Disabling VELOCITY A/DIVE.
 share/qtvcp/screens/qtplasmac/languages/qtplasmac.py:\
    self.label_70.setText(_translate("MainWindow", "VELOCITY A/DIVE"))
 share/qtvcp/screens/qtplasmac/qtplasmac.ui:\
    <string>VELOCITY A/DIVE</string>

 $ git grep -- 'VELOCITY ANTI DIVE'
 docs/src/plasma/qtplasmac.adoc:If the cut velocity falls below a \
   percentage of *CutFeedRate* (as defined by the VAD Threshold % \
   value in the THC frame of the CONFIGURATION section of the \
   <<qt_parameters-tab, PARAMETERS Tab>>) the THC will be locked \
   until the cut velocity returns to at least 99.9% of *CutFeedRate*. \
   This will be made apparent by the *VELOCITY ANTI DIVE* indicator \
   illuminating in the <<qt_control-panel, CONTROL Panel>> on the \
   <<qt_main-tab, MAIN Tab>>.
 docs/src/plasma/qtplasmac.adoc:|Toggle corner Lock enable|\
    qtplasmac.ext_cornerlock_enable|VELOCITY ANTI DIVE ENABLE
 share/qtvcp/screens/qtplasmac_4x3/qtplasmac_4x3.ui:\
    <string>VELOCITY ANTI DIVE</string>
 share/qtvcp/screens/qtplasmac_9x16/qtplasmac_9x16.ui:\
    <string>VELOCITY ANTI DIVE</string>

Fix that by using full name:
 $ sed -i 's#VELOCITY A/DIVE#VELOCITY ANTI DIVE#g' \
     docs/src/plasma/qtplasmac.adoc
 $ sed -i 's#VELOCITY A/DIVE#VELOCITY ANTI DIVE#g' \
     share/qtvcp/screens/qtplasmac/languages/qtplasmac.py
 $ sed -i 's#VELOCITY A/DIVE#VELOCITY ANTI DIVE#g' \
     share/qtvcp/screens/qtplasmac/qtplasmac.ui

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>