### PR TITLE
Fix redefinition of INCH_PER_MM (fixes #1417)

### DIFF
--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -500,7 +500,6 @@ static enum {
 #define CLOSE(a,b,eps) ((a)-(b) < +(eps) && (a)-(b) > -(eps))
 #define LINEAR_CLOSENESS 0.0001
 #define ANGULAR_CLOSENESS 0.0001
-#define INCH_PER_MM (1.0/25.4)
 #define CM_PER_MM 0.1
 #define GRAD_PER_DEG (100.0/90.0)
 #define RAD_PER_DEG TO_RAD	// from posemath.h


### PR DESCRIPTION
Fixes the following waring:
 emc/usr_intf/halui.cc:503: warning: "INCH_PER_MM" redefined
   503 | #define INCH_PER_MM (1.0/25.4)
       |
 In file included from emc/nml_intf/emc_nml.hh:17,
                  from emc/usr_intf/halui.cc:32:
 emc/linuxcnc.h:25: note: this is the location of the previous definition
    25 | #define INCH_PER_MM (1.0/MM_PER_INCH)
       |

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>