### PR TITLE
halscope: save logs as csv files

### DIFF
--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -537,14 +537,14 @@ static void define_menubar(GtkWidget *vboxtop) {
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), sep1);
     gtk_widget_show(sep1);
 
-    fileopendatafile = gtk_menu_item_new_with_mnemonic(_("O_pen Data File..."));
+    fileopendatafile = gtk_menu_item_new_with_mnemonic(_("O_pen Log File"));
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), fileopendatafile);
     g_signal_connect_swapped(fileopendatafile, "activate",
             G_CALLBACK(menuitem_response), "file/open datafile");
     gtk_widget_set_sensitive(GTK_WIDGET(fileopendatafile), FALSE); // XXX
     gtk_widget_show(fileopendatafile);
 
-    filesavedatafile = gtk_menu_item_new_with_mnemonic(_("S_ave Data File..."));
+    filesavedatafile = gtk_menu_item_new_with_mnemonic(_("S_ave Log File"));
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), filesavedatafile);
     g_signal_connect_swapped(filesavedatafile, "activate",
             G_CALLBACK(log_popup), 0);

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -547,7 +547,7 @@ static void define_menubar(GtkWidget *vboxtop) {
     filesavedatafile = gtk_menu_item_new_with_mnemonic(_("S_ave Log File"));
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), filesavedatafile);
     g_signal_connect_swapped(filesavedatafile, "activate",
-            G_CALLBACK(log_popup), 0);
+            G_CALLBACK(save_log_cb), 0);
     gtk_widget_show(filesavedatafile);
 
     gtk_menu_shell_append(GTK_MENU_SHELL(filemenu), sep2);

--- a/src/hal/utils/scope_files.c
+++ b/src/hal/utils/scope_files.c
@@ -111,6 +111,7 @@ typedef struct {
 *                     LOCAL FUNCTION PROTOTYPES                        *
 ************************************************************************/
 
+static void write_sample(FILE *fp, scope_data_t *dptr, hal_type_t type);
 static int parse_command(char *in);
 /* the following functions implement halscope config items
    each is called with a pointer to a single argument (the parser
@@ -319,7 +320,7 @@ void write_log_file (char *filename)
 						if ((n % sample_len) != 0) {
 							fprintf(fp, ";");
 						}
-						write_sample(fp, label[chan_num], dptr, type[chan_num]);
+						write_sample(fp, dptr, type[chan_num]);
 						/* point to next sample */
 						n++;
 					}
@@ -330,7 +331,7 @@ void write_log_file (char *filename)
 					n=chan_num;
 					while (n <= samples) {
 						dptr=start+n;
-						write_sample( fp, label[chan_num], dptr, type[chan_num]);
+						write_sample(fp, dptr, type[chan_num]);
 						fprintf( fp, "\n");
 						/* point to next sample */
 						n += sample_len;
@@ -346,7 +347,7 @@ void write_log_file (char *filename)
 }
 
 /* format the data and print it */
-void write_sample(FILE *fp, char *label, scope_data_t *dptr, hal_type_t type)
+static void write_sample(FILE *fp, scope_data_t *dptr, hal_type_t type)
 {
 	double data_value;
 	switch (type) {

--- a/src/hal/utils/scope_files.c
+++ b/src/hal/utils/scope_files.c
@@ -343,7 +343,7 @@ void write_log_file (char *filename)
     fclose(fp);
     setlocale(LC_NUMERIC, saved_locale);
     free(saved_locale);
-    fprintf(stderr, "Log file '%s' written.\n", filename );
+    printf("Log file '%s' written.\n", filename);
 }
 
 /* format the data and print it */

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -780,9 +780,9 @@ void log_popup(GtkWindow *parent)
                                         _("_Cancel"), GTK_RESPONSE_CANCEL,
                                         _("_Save"), GTK_RESPONSE_ACCEPT, NULL);
 
-    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(filew), "halscope.log");
+    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(filew), "halscope.csv");
     chooser = GTK_FILE_CHOOSER(filew);
-    set_file_filter(chooser, "Halscope log", "*.log");
+    set_file_filter(chooser, "Text CSV (.csv)", "*.csv");
     gtk_file_chooser_set_do_overwrite_confirmation(chooser, TRUE);
 
     if (gtk_dialog_run(GTK_DIALOG(filew)) == GTK_RESPONSE_ACCEPT) {

--- a/src/hal/utils/scope_horiz.c
+++ b/src/hal/utils/scope_horiz.c
@@ -77,6 +77,7 @@ static void acquire_popup(GtkWidget * widget, gpointer gdata);
 static void dialog_realtime_not_loaded(void);
 static void dialog_realtime_not_linked(void);
 static void dialog_realtime_not_running(void);
+static void log_popup(GtkWindow *parent);
 static void acquire_selection_made(GtkWidget *widget, gpointer data);
 static int set_sample_thread_name(char *name);
 static int activate_sample_thread(void);
@@ -770,7 +771,34 @@ static void dialog_realtime_not_running(void)
     }
 }
 
-void log_popup(GtkWindow *parent)
+void save_log_cb(GtkWindow *parent)
+{
+    scope_vert_t *vert;
+    GtkWidget *dialog;
+    int i;
+
+    /* Only create log if one or more channels is selected. */
+    vert = &(ctrl_usr->vert);
+    for (i = 0; i < 16; i++) {
+        if (vert->chan_enabled[i] == 1) {
+            log_popup(parent);
+            return;
+        }
+    }
+
+    dialog = gtk_message_dialog_new(NULL,
+                                    GTK_DIALOG_MODAL,
+                                    GTK_MESSAGE_INFO,
+                                    GTK_BUTTONS_OK,
+                                    _("No channels selected"));
+    gtk_message_dialog_format_secondary_text(
+            GTK_MESSAGE_DIALOG(dialog),
+            _("You need to choose at least one channel."));
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+}
+
+static void log_popup(GtkWindow *parent)
 {
     GtkWidget *filew;
     GtkFileChooser *chooser;

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -182,21 +182,6 @@ typedef struct {
     int selected_part;
 } scope_disp_t;
 
-/* this struct holds data relating to logging */
-
-typedef enum { INTERLACED, NOT_INTERLACED } log_order_t;
-typedef enum { OVERWRITE, APPEND } log_append_t;
-typedef struct {
-	/* logging preferences */
-	log_order_t order; /* order that fields are written */
-	int auto_save; /* save log every trigger */
-	char *filename, *default_filename;
-	log_append_t append;
-	GtkWidget *log_win;
-	GtkWidget *log_prefs_button;
-	GtkWidget *log_prefs_label;
-} scope_log_t;
-
 /* this is the master user space control structure */
 
 typedef enum { STOP = 0, NORMAL, SINGLE, ROLL } scope_run_mode_t;
@@ -232,7 +217,6 @@ typedef struct {
     scope_vert_t vert;		/* vertical control data */
     scope_trig_t trig;		/* triggering data */
     scope_disp_t disp;		/* display data */
-	scope_log_t log;  		/* logging preferences */
 } scope_usr_control_t;
 
 /***********************************************************************

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -272,7 +272,6 @@ void write_horiz_config(FILE *fp);
 void write_vert_config(FILE *fp);
 void write_trig_config(FILE *fp);
 void write_log_file (char *filename);
-void write_sample(FILE *fp, char *label, scope_data_t *dptr, hal_type_t type);
 
 /* the following functions set various parameters, they are normally
    called by the GUI, but can also be called by code reading a file

--- a/src/hal/utils/scope_usr.h
+++ b/src/hal/utils/scope_usr.h
@@ -281,5 +281,5 @@ int set_trigger_polarity(int setting);
 int set_trigger_mode(int mode);
 int set_run_mode(int mode);
 void prepare_scope_restart(void);
-void log_popup(GtkWindow *parent);
+void save_log_cb(GtkWindow *parent);
 #endif /* SCOPE_USR_H */


### PR DESCRIPTION
Changes the log format to csv.

During creation of the log, it temporarily changes the locale `LC_NUMERIC` to `C`, so the number format will be identical regardless of the locale that was set previously. I believe this will make it simpler if we ever want to read the values back in. It also makes it possible to use comma `,` as a delimiter if we choose. Currently the delimiter is set to semicolon `;`.

Remove some code that was never used, regarding logging an log functionality.

Require at least one active channel to create a log file.

Fixed some minor issues  when we create a log with less active channels then enabled, and if the active channels is not continuous from channel 1.