### PR TITLE
Typos2 - changed all occurences of linuxCNC to LinuxCNC

### DIFF
--- a/configs/sim/axis/ngcgui/README
+++ b/configs/sim/axis/ngcgui/README
@@ -2,13 +2,13 @@ ngcgui -- Create tabs in the axis gui for subroutines.
 
 pyngcgui -- python, gladevcp implementation of ngcgui that can be embedded in guis like touchy, gscreen gmoccapy
 
-In the packaged version of linuxCNC, ngcgui_lib is created as a symbolic link to a system directory owned by root:
+In the packaged version of LinuxCNC, ngcgui_lib is created as a symbolic link to a system directory owned by root:
 
 /usr/share/linuxcnc/ncfiles/ngcgui_lib
 
 This library is not ordinarily changed by the user.  To modify a library .ngc file, copy the .ngc file to the [DISPLAY]PROGRAM_PREFIX directory or to a directory that is included in the path specified by [RS274NGC]SUBROUTINE_PATH and (optionally) change the filename.
 
-The search path for linuxCNC and ngcgui is:
+The search path for LinuxCNC and ngcgui is:
    [DISPLAY]PROGRAM_PREFIX
 
 followed in order by all the colon (:) separated directories listed in:

--- a/configs/sim/axis/ngcgui/README_es
+++ b/configs/sim/axis/ngcgui/README_es
@@ -2,7 +2,7 @@ ngcgui -- Crea pestañas en el gui Axis para las subrutinas.
 
 pyngcgui -- implementación de ngcgui python, gladevcp que se puede incrustar en guis como gmoccapy, touchy, gscreen
 
-En la versión empaquetada de linuxCNC, ngcgui_lib se crea como un enlace simbólico a un directorio del sistema propiedad root:
+En la versión empaquetada de LinuxCNC, ngcgui_lib se crea como un enlace simbólico a un directorio del sistema propiedad root:
 
 /usr/share/linuxcnc/ncfiles/ngcgui_lib
 
@@ -10,7 +10,7 @@ Esta biblioteca normalmente no es cambiada por el usuario. Para modificar un arc
 copie el archivo .ngc en el directorio [DISPLAY]PROGRAM_PREFIX o en un directorio que esté incluido en la
 ruta especificada por [RS274NGC]SUBROUTINE_PATH y (opcionalmente) cambie el nombre del archivo.
 
-La ruta de búsqueda para linuxCNC y ngcgui es:
+La ruta de búsqueda para LinuxCNC y ngcgui es:
    [DISPLAY]PROGRAM_PREFIX
 
 Seguido en orden por todos los directorios listados separados por dos puntos (:) en:

--- a/debian/extras/usr/share/icons/hicolor/scalable/apps/linuxcncicon.svg
+++ b/debian/extras/usr/share/icons/hicolor/scalable/apps/linuxcncicon.svg
@@ -634,7 +634,7 @@
   <g
      inkscape:groupmode="layer"
      id="layer5"
-     inkscape:label="linuxCNC"
+     inkscape:label="LinuxCNC"
      style="display:inline">
     <rect
        style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke-width:2.50003;stroke-miterlimit:4;stroke-dasharray:none"

--- a/docs/src/common/linux-faq_es.adoc
+++ b/docs/src/common/linux-faq_es.adoc
@@ -9,7 +9,7 @@ las páginas del manual con el comando man.
 
 == Login automatico (((Automatic Login)))
 
-Al instalar linuxCNC con el CD de Ubuntu por defecto se tiene que iniciar
+Al instalar LinuxCNC con el CD de Ubuntu por defecto se tiene que iniciar
 sesión cada vez que encienda el ordenador. Para activar autentificacion automática
 vaya a 'System > Administration > Login Window'. Si se trata
 de una instalación nueva, la ventana de inicio de sesión puede tardar
@@ -41,7 +41,7 @@ $ /usr/sbin/lightdm --show-config
 
 == Inicio automatico de LinuxCNC (((Automatic Startup)))
 
-Para tener un inicio automático de linuxCNC con su configuración después
+Para tener un inicio automático de LinuxCNC con su configuración después
 de encender el equipo vaya a 'System > Preferences > Sessions > Startup Applications',
 seleccione la opcion agregar nuevo.
 Vaya a su carpeta de configuración y

--- a/docs/src/getting-started/system-requirements.adoc
+++ b/docs/src/getting-started/system-requirements.adoc
@@ -90,7 +90,7 @@ and compile LinuxCNC from source to utilise it.
 
 === RTAI with linuxcnc-uspace
 
-It is also possible to run linuxCNC with RTAI in user-space mode. As
+It is also possible to run LinuxCNC with RTAI in user-space mode. As
 with Xenomai you will need to compile from source to do this.
 
 

--- a/docs/src/gui/axis.adoc
+++ b/docs/src/gui/axis.adoc
@@ -1268,7 +1268,7 @@ print 'value is a',type(value),'value of',value
 # button names are 'manual-tab', 'mdi-tab', 'preview-tab', 'dro-tab', 'user0-tab'
 # the user_0 tab if it exists would be the first GladeVCP embedded tab
 
-# for linuxCNC 2.8+ branch
+# for LinuxCNC 2.8+ branch
 
 def user_live_update():
     try:

--- a/docs/src/gui/axis_es.adoc
+++ b/docs/src/gui/axis_es.adoc
@@ -1185,7 +1185,7 @@ print 'value is a',type(value),'value of',value
 # los nombres de los botones son 'manual-tab', 'mdi-tab', 'preview-tab', 'dro-tab', 'user0-tab'
 # la pestaña user_0, si existe, sería la primera pestaña incrustada GladeVCP
 
-# para la rama linuxCNC 2.8+
+# para la rama LinuxCNC 2.8+
 
 def user_live_update():
     try:

--- a/docs/src/gui/ngcgui.adoc
+++ b/docs/src/gui/ngcgui.adoc
@@ -106,7 +106,7 @@ example G code subroutine (.ngc) files and G code-meta-compiler (.gcmc) files:
 ** 'wheels.gcmc' - gcmc demo of complex patterns
 
 To try a demonstration, select a sim configuration and start
-the linuxCNC program.
+the LinuxCNC program.
 
 If using the axis gui, press the 'E-Stop'
 image:images/tool_estop.png[] then 'Machine Power'
@@ -129,7 +129,7 @@ may be different.
 ===============================
 The demonstration configs create tab pages for just a few of the provided
 examples.  Any gui with a <<ngcgui-ini,custom tab>> can open any of the library
-example subroutines or any user file if it is in the linuxCNC subroutine
+example subroutines or any user file if it is in the LinuxCNC subroutine
 path.
 
 To see special key bindings, click inside an ngcgui tab page to get
@@ -143,7 +143,7 @@ before running on a real machine.
 
 == Library Locations
 
-In linuxCNC installations installed from deb packages, the simulation configs
+In LinuxCNC installations installed from deb packages, the simulation configs
 for ngcgui use symbolic links to non-user-writable LinuxCNC libraries for:
 
 * 'nc_files/ngcgui_lib'             ngcgui-compatible subfiles
@@ -153,7 +153,7 @@ for ngcgui use symbolic links to non-user-writable LinuxCNC libraries for:
 * 'nc_files/ngcgui_lib/mfiles'      User M files
 
 These libraries are located by ini file items that specify the search
-paths used by linuxCNC (and ngcgui):
+paths used by LinuxCNC (and ngcgui):
 
 ----
 [RS274NGC]
@@ -267,12 +267,12 @@ Notes:
       One set of files can be specified from cmdline.
       Multiple sets of files can be specified from an inifile.
       If --ini is NOT specified:
-         search for a running linuxCNC and use its inifile
+         search for a running LinuxCNC and use its inifile
 ----
     
 [NOTE]
 As a standalone application, pyngcgui can read an ini file (or a
-running linuxCNC application) to create tab pages for multiple
+running LinuxCNC application) to create tab pages for multiple
 subfiles.
 
 == Embedding NGCGUI
@@ -349,8 +349,8 @@ use custom Mfiles which must be in a directory specified by the
 
 The Gcode-meta-compiler (gcmc) can include statements like:
   include("filename.inc.gcmc");
-By default, gcmc includes the current directory which, for linuxCNC,  will be
-the directory containing the linuxCNC ini file.  Additional directories can be
+By default, gcmc includes the current directory which, for LinuxCNC,  will be
+the directory containing the LinuxCNC ini file.  Additional directories can be
 prepended to the gcmc search order with the GCMC_INCLUDE_PATH item.
 
 .Sample axis-gui-based INI
@@ -427,7 +427,7 @@ Note:    Optional, specifies filename for preamble used for ttt created subfiles
 
 === INI File Path Specifications
 
-Ngcgui uses the linuxCNC search path to find files.
+Ngcgui uses the LinuxCNC search path to find files.
 
 The search path begins with the standard directory specified by:
 
@@ -470,7 +470,7 @@ for multiple directories and shows the use of relative and absolute paths.
 [RS274NGC]SUBROUTINE_PATH = ../../nc_files/ngcgui_lib:../../nc_files/ngcgui_lib/utilitysubs:/tmp/tmpngc`
 ----
 
-This is one long line, do not continue on multiple lines.  When linuxCNC and/or
+This is one long line, do not continue on multiple lines.  When LinuxCNC and/or
 ngcgui searches for files, the first file found in the search is used.
 
 LinuxCNC (and ngcgui) must be able to find all subroutines including helper routines
@@ -515,7 +515,7 @@ Note:    Optional, needed to locate custom user mfiles
 Item:    [DISPLAY]EMBED_TAB_NAME = name to display on embedded tab page
 Example: [DISPLAY]EMBED_TAB_NAME = Pyngcgui
 Note:    The entries: EMBED_TAB_NAME,EMBED_TAB_COMMAND,EMBED_TAB_LOCATION
-         define an embedded application for several linuxCNC guis
+         define an embedded application for several LinuxCNC guis
 
 Item:    [DISPLAY]EMBED_TAB_COMMAND = programname followed by arguments
 Example: [DISPLAY]EMBED_TAB_COMMAND = gladevcp -x {XID} pyngcgui_axis.ui
@@ -529,7 +529,7 @@ Note:    See example INI files for possible locations
 
 Item:    [DISPLAY]PROGRAM_PREFIX = dirname
 Example: [DISPLAY]PROGRAM_PREFIX = ../../nc_files
-Note:    Mandatory and needed for numerous linuxCNC functions
+Note:    Mandatory and needed for numerous LinuxCNC functions
          It is the first directory used in the search for files
 
 
@@ -574,10 +574,10 @@ Note:    Multiple options are separated by blanks.
          By default, ngcgui configures tab pages so that:
             1) a user can make new tabs
             2) a user can remove tabs (except for the last remaining one)
-            3) finalized files are automatically sent to linuxCNC
+            3) finalized files are automatically sent to LinuxCNC
             4) an image frame (iframe) is made available to display
                an image for the subfile (if an image is provided)
-            5) the ngcgui result file sent to linuxCNC is terminated with
+            5) the ngcgui result file sent to LinuxCNC is terminated with
                an m2 (and incurs m2 side-effects)
 
          The options nonew, noremove, noauto, noiframe, nom2 respectively
@@ -697,7 +697,7 @@ global context that is difficult to maintain. Using numbered parameters #1
 thru #30 as subroutine inputs should be sufficient to satisfy a wide range of
 design requirements.
 
-While input global named parameters are discouraged, linuxCNC subroutines must use
+While input global named parameters are discouraged, LinuxCNC subroutines must use
 global named parameters for returning results. Since ngcgui-compatible
 subfiles are aimed at gui usage, return values are not a common requirement.
 However, ngcgui is useful as a testing tool for subroutines which do return
@@ -778,7 +778,7 @@ Files for the Gcode-meta-compiler (gcmc) are read by ngcgui and it
 creates entry boxes for variables tagged in the file.  When a feature
 for the file is finalized, ngcgui passes the file as input to the gcmc
 compiler and, if the compile is successful, the resulting gcode file
-is sent to linuxCNC for execution.  The resulting file is formatted as
+is sent to LinuxCNC for execution.  The resulting file is formatted as
 single-file subroutine; .gcmc files and .ngc files can be intermixed
 by ngcgui. 
 

--- a/docs/src/gui/ngcgui_es.adoc
+++ b/docs/src/gui/ngcgui_es.adoc
@@ -93,7 +93,7 @@ ejemplo de archivos de subrutina de código G (.ngc) y archivos de metacompilado
 ** 'star.gcmc': demostración de gcmc que ilustra funciones y matrices
 ** 'wheels.gcmc': demostración de gcmc de patrones complejos
 
-Para probar una demostración, seleccione una configuración sim y comience linuxCNC.
+Para probar una demostración, seleccione una configuración sim y comience LinuxCNC.
 
 Si utiliza la interfaz gráfica de usuario Axis, presione 'E-Stop'
 image:images/tool_estop.png[] luego 'Encender Máquina'
@@ -111,7 +111,7 @@ Otras guis tendrán una funcionalidad similar pero los botones y nombres pueden 
 .Notas
 [NOTE]
 ===============================
-Las configuraciones de demostración crean páginas con pestañas solo para algunos ejemplos. Cualquier interfaz gráfica de usuario con una <<ngcgui-ini,pestaña personalizada>> puede abrir cualquiera de las subrutinas de bibliotecas de ejemplo o cualquier archivo de usuario si está en el path de la subrutina linuxCNC.
+Las configuraciones de demostración crean páginas con pestañas solo para algunos ejemplos. Cualquier interfaz gráfica de usuario con una <<ngcgui-ini,pestaña personalizada>> puede abrir cualquiera de las subrutinas de bibliotecas de ejemplo o cualquier archivo de usuario si está en el path de la subrutina LinuxCNC.
 
 Para ver las combinaciones de teclas especiales, haga clic dentro de una página de pestaña ngcgui para obtener foco y luego presione Control-k.
 
@@ -120,7 +120,7 @@ Las subrutinas de demostración deben ejecutarse en configuraciones de máquina 
 
 == Ubicaciones de la biblioteca
 
-En las instalaciones de linuxCNC desde paquetes deb, las configuraciones de simulación ngcgui usan enlaces simbólicos a bibliotecas LinuxCNC que no se pueden escribir por el usuario para:
+En las instalaciones de LinuxCNC desde paquetes deb, las configuraciones de simulación ngcgui usan enlaces simbólicos a bibliotecas LinuxCNC que no se pueden escribir por el usuario para:
 
 * 'nc_files/ngcgui_lib' subfiles compatibles con ngcgui
 * 'nc_files/ngcgui_lib/lathe' subfiles de torno compatibles con ngcgui
@@ -128,7 +128,7 @@ En las instalaciones de linuxCNC desde paquetes deb, las configuraciones de simu
 * 'nc_files/ngcgui_lib/utilitysubs' Subrutinas de ayuda
 * 'nc_files/ngcgui_lib/mfiles' Archivos M de usuario
 
-Estas bibliotecas están ubicadas por elementos de archivo ini que especifican las rutas de búsqueda utilizadas por linuxCNC (y ngcgui):
+Estas bibliotecas están ubicadas por elementos de archivo ini que especifican las rutas de búsqueda utilizadas por LinuxCNC (y ngcgui):
 
 ----
 [RS274NGC]
@@ -231,11 +231,11 @@ Notas:
       Se puede especificar un conjunto de archivos desde cmdline.
       Se pueden especificar múltiples conjuntos de archivos desde un inifile.
       Si --ini NO se especifica:
-         busque un linuxCNC en ejecución y use su inifile
+         busque un LinuxCNC en ejecución y use su inifile
 ----
     
 [NOTE]
-Como aplicación independiente, pyngcgui puede leer un archivo ini (o una aplicación linuxCNC ejecutandose) para crear páginas con pestañas para múltiples subarchivos.
+Como aplicación independiente, pyngcgui puede leer un archivo ini (o una aplicación LinuxCNC ejecutandose) para crear páginas con pestañas para múltiples subarchivos.
 
 == Incrustar NGCGUI
 === Incrustar NGCGUI en Axis
@@ -293,8 +293,8 @@ Este es un ejemplo de NGCGUI incrustado en Axis. Las subrutinas deben estar en u
 
 Gcode-meta-compiler (gcmc) puede incluir declaraciones como:
   include ("filename.inc.gcmc");
-Por defecto, gcmc incluye el directorio actual que, para linuxCNC, será
-el directorio que contiene el archivo ini linuxCNC. Directorios adicionales pueden ser antepuestos al orden de búsqueda de gcmc con el elemento GCMC_INCLUDE_PATH.
+Por defecto, gcmc incluye el directorio actual que, para LinuxCNC, será
+el directorio que contiene el archivo ini LinuxCNC. Directorios adicionales pueden ser antepuestos al orden de búsqueda de gcmc con el elemento GCMC_INCLUDE_PATH.
 
 .Muestra de INI basado en GUI Axis.
 ----
@@ -364,7 +364,7 @@ Note:    Opcional, especifica el nombre de archivo para el preámbulo utilizado 
 ....
 === Especificaciones de ruta en archivo INI
 
-Ngcgui usa la ruta de búsqueda de linuxCNC.
+Ngcgui usa la ruta de búsqueda de LinuxCNC.
 
 La ruta de búsqueda comienza con el directorio estándar especificado por:
 
@@ -404,7 +404,7 @@ para múltiples directorios y muestra el uso de rutas relativas y absolutas.
 [RS274NGC]SUBROUTINE_PATH = ../../nc_files/ngcgui_lib:../../nc_files/ngcgui_lib/utilitysubs:/tmp/tmpngc`
 ----
 
-Esta es una línea larga, no continúa en varias líneas. Cuando linuxCNC y/o
+Esta es una línea larga, no continúa en varias líneas. Cuando LinuxCNC y/o
 ngcgui busca archivos, se utiliza el primer archivo encontrado en la búsqueda.
 
 LinuxCNC (y ngcgui) debe poder encontrar todas las subrutinas, incluidas las rutinas auxiliares que se llaman desde subfiles ngcgui. Es conveniente colocar
@@ -436,7 +436,7 @@ Nota:     Opcional, necesario para localizar archivos de usuario personalizados
 Elemento: [DISPLAY]EMBED_TAB_NAME = nombre para mostrar en la página de pestaña incrustada
 Ejemplo:  [DISPLAY]EMBED_TAB_NAME = Pyngcgui
 Nota:     Las entradas: EMBED_TAB_NAME, EMBED_TAB_COMMAND, EMBED_TAB_LOCATION
-          definen una aplicación integrada para varias guis linuxCNC
+          definen una aplicación integrada para varias guis LinuxCNC
 
 Elemento: [DISPLAY]EMBED_TAB_COMMAND = nombre del programa seguido de argumentos
 Ejemplo:  [DISPLAY]EMBED_TAB_COMMAND = gladevcp -x {XID} pyngcgui_axis.ui
@@ -450,7 +450,7 @@ Nota:     Vea archivos INI de ejemplo para posibles ubicaciones.
 
 Elemento: [DISPLAY]PROGRAM_PREFIX = dirname
 Ejemplo:  [DISPLAY]PROGRAM_PREFIX = ../../nc_files
-Nota:     Obligatorio y necesario para numerosas funciones de linuxCNC
+Nota:     Obligatorio y necesario para numerosas funciones de LinuxCNC
           Es el primer directorio utilizado en la búsqueda de archivos.
 
 
@@ -499,10 +499,10 @@ Nota:     las opciones múltiples están separadas por espacios en blanco.
           Por defecto, ngcgui configura páginas de pestañas para que:
             1) un usuario puede hacer nuevas pestañas
             2) un usuario puede eliminar pestañas (excepto la última restante)
-            3) los archivos finalizados se envían automáticamente a linuxCNC
+            3) los archivos finalizados se envían automáticamente a LinuxCNC
             4) un marco de imagen (iframe) está disponible para mostrar
                una imagen para el subarchivo (si se proporciona una imagen)
-            5) el archivo de resultados ngcgui enviado a linuxCNC finaliza con
+            5) el archivo de resultados ngcgui enviado a LinuxCNC finaliza con
                un m2 (e incurre en efectos secundarios de m2)
 
          Las opciones nonew, noremove, noauto, noiframe, nom2 respectivamente
@@ -602,7 +602,7 @@ Como en muchos lenguajes de programación, el uso de globales es poderoso pero a
 
 Se desaconseja pasar información a subrutinas utilizando parámetros con nombre globales dado que dicho uso requiere el establecimiento y mantenimiento de un bien definido contexto global que es difícil de mantener. Usando los parámetros numerados de  #1 a #30 como entradas de subrutina debería ser suficiente para satisfacer una amplia gama de requerimientos de diseño.
 
-Si bien no se recomiendan los parámetros con nombre global de entrada, las subrutinas linuxCNC deben usar parámetros globales con nombre para devolver resultados. Los subarchivos ngcgui-compatible están destinados al uso de GUI; los valores de retorno no son un requisito común. Sin embargo, ngcgui es útil como herramienta de prueba para subrutinas que devuelven parámetros con nombre global y es común que los subfiles compatibles con ngcgui llamen archivos de subrutina de utilidad que devuelven resultados con parámetros globales con nombre.
+Si bien no se recomiendan los parámetros con nombre global de entrada, las subrutinas LinuxCNC deben usar parámetros globales con nombre para devolver resultados. Los subarchivos ngcgui-compatible están destinados al uso de GUI; los valores de retorno no son un requisito común. Sin embargo, ngcgui es útil como herramienta de prueba para subrutinas que devuelven parámetros con nombre global y es común que los subfiles compatibles con ngcgui llamen archivos de subrutina de utilidad que devuelven resultados con parámetros globales con nombre.
 
 Para admitir estos usos, ngcgui ignora los parámetros globales con nombre que incluyen dos puntos (:) en su nombre. El uso de los dos puntos (:) en el nombre evita que ngcgui haga cuadros de entrada para estos parámetros.
 
@@ -658,7 +658,7 @@ Se pueden encontrar subrutinas adicionales para usuarios en el Foro, en la secci
 
 === Requisitos del archivo Gcode-meta-compiler (.gcmc)
 Ngcgui lee los archivos de Gcode-meta-compiler (gcmc) y crea cuadros de entrada para variables etiquetadas en el archivo. Cuando una característica del archivo
-finaliza, ngcgui pasa el archivo como entrada al compilador gcmc y, si la compilación es exitosa, el archivo gcode resultante se envía a linuxCNC para su ejecución. El archivo resultante está formateado como subrutina de un solo archivo; Los archivos .gcmc y los archivos .ngc se pueden mezclar en ngcgui.
+finaliza, ngcgui pasa el archivo como entrada al compilador gcmc y, si la compilación es exitosa, el archivo gcode resultante se envía a LinuxCNC para su ejecución. El archivo resultante está formateado como subrutina de un solo archivo; Los archivos .gcmc y los archivos .ngc se pueden mezclar en ngcgui.
 
 Las variables identificadas para su inclusión en ngcgui están etiquetadas con líneas que parecerán comentarios al compilador gcmc.
 

--- a/lib/python/tooldb.py
+++ b/lib/python/tooldb.py
@@ -3,7 +3,7 @@ import sys
 # A python interface for LinuxCNC tool database usage
 
 #Notes
-#  1) host (linuxCNC) pushes commands to this program
+#  1) host (LinuxCNC) pushes commands to this program
 #  2) all writes to stdout go to host
 #     (use stderr for debug prints)
 #-----------------------------------------------------------

--- a/src/emc/usr_intf/pncconf/help.glade
+++ b/src/emc/usr_intf/pncconf/help.glade
@@ -51,7 +51,7 @@ Beta 1 version</property>
   possible</property>
   </object>
   <object class="GtkTextBuffer" id="textbuffer1">
-    <property name="text" translatable="yes">Separate Home and Limt Switches Example
+    <property name="text" translatable="yes">Separate Home and Limit Switches Example
 
     The negative and positive directions are based on Tool Movement which can be different
     then the actual machine movement. ie on a mill typically the table moves rather then the tool.

--- a/src/emc/usr_intf/pncconf/main_page.glade
+++ b/src/emc/usr_intf/pncconf/main_page.glade
@@ -283,7 +283,7 @@ Data</property>
                   <object class="GtkLabel" id="opening_text">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">This program creates configuration files (.ini and .hal) for  milling machines and lathes connected to a Mesa Card.
+                    <property name="label" translatable="yes">This program creates configuration files (.ini and .hal) for milling machines and lathes connected to a Mesa Card.
 
 It is a recommended stategy to start with very basic axes options, get them functional then go back and add other options such as VFD spindle control  or advanced limit/home control etc.</property>
                     <property name="wrap">True</property>

--- a/src/hal/components/mux_generic.c
+++ b/src/hal/components/mux_generic.c
@@ -29,7 +29,7 @@
 
 /* module information */
 MODULE_AUTHOR("Andy Pugh");
-MODULE_DESCRIPTION("Generic mux component for linuxCNC");
+MODULE_DESCRIPTION("Generic mux component for LinuxCNC");
 MODULE_LICENSE("GPL");
 
 #define MAX_CHAN 100

--- a/tcl/ngcgui_app.tcl
+++ b/tcl/ngcgui_app.tcl
@@ -48,7 +48,7 @@ from axis.py (LinuxCNC 2.5) or"] \[DISPLAY\]USER_COMMAND_FILE (LinuxCNC 2.4)"
     # this can occur due to obsolete USER_COMMAND_FILE
     puts "[_ "Unexpected: multiple startups for ngcgui"] <$ngcgui>"
     puts "\n[_ LinuxCNC version"] = $::version"
-    puts "[_ "for linuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"]\n"
+    puts "[_ "for LinuxCNC 2.5.xxx, Do not include tkapp.py in the ini file"]\n"
     return -code error "[_ "Unexpected: multiple startups for ngcgui"] <$ngcgui>"
   }
 


### PR DESCRIPTION
Weblate asked for separate translations for either variant, so I thought this should be fixed and then I was surprised that there are about 30 files with the lower-case one (1200 with the upper case).