### PR TITLE
EMC2 -> LinuxCNC

### DIFF
--- a/docs/archive/UPDATING
+++ b/docs/archive/UPDATING
@@ -85,7 +85,7 @@ happen if the following conditions are true:
 	while on the wrong side of the switch, it will run to the end of the 
 	axis. There is NO possible software solution to that scenario - the 
 	proper solution is a home switch that remains on all the way to the end 
-	of the axis. With such a switch, EMC2's homing algorithm will always work.
+	of the axis. With such a switch, LinuxCNC's homing algorithm will always work.
 			  
 7. connect motion.spindle-speed-in for Feed Per Revolution (G95) mode
 The new pin motion.spindle-speed-in must be connected for Feed Per Revolution 

--- a/docs/src/common/emc-history.adoc
+++ b/docs/src/common/emc-history.adoc
@@ -104,8 +104,8 @@ LINUX® trademark from the Linux Foundation (www.linuxfoundation.org),
 protecting our use of the LinuxCNC name. (LINUX® is the registered trademark
 of Linus Torvalds in the U.S. and other countries.)
 
-The rebranding effort will include the linuxcnc.org website, the IRC
-channels, and versions of the software and documentation starting with
+The rebranding effort included the linuxcnc.org website, the IRC
+channels, and versions of the software and documentation since version
 2.5.0.
 
 == Additional Info

--- a/docs/src/docs.xml
+++ b/docs/src/docs.xml
@@ -6,8 +6,8 @@
 <doc name="common_emc2-intro" title="Overleaf Image"/>
 <doc name="common_overleaf" title="Overleaf Text"/>
 <doc name="common_System_Requirements" title="System Requirements"/>
-<doc name="common_Getting_EMC" title="Getting EMC2"/>
-<doc name="common_Updating_EMC" title="Updating EMC2"/>
+<doc name="common_Getting_EMC" title="Getting LinuxCNC"/>
+<doc name="common_Updating_EMC" title="Updating LinuxCNC"/>
 <doc name="quickstart_stepper_quickstart" title="Stepper Quickstart"/>
 <doc name="config_stepconf" title="Configuration Wizard for Stepper-Based Machines"/>
 <doc name="config_pncconf" title="Point and Click Configuration Wizard (for Machines using Mesa)"/>
@@ -28,7 +28,7 @@
 <doc name="gcode_overview" title="G-code Overview"/>
 <doc name="gcode_coordinates" title="G-code Coordinates"/>
 <doc name="gcode_tool-compensation" title="G-code Tool Compensation"/>
-<doc name="gcode_main" title="The EMC2 G-code Language"/>
+<doc name="gcode_main" title="The LinuxCNC G-code Language"/>
 <doc name="gcode_mill_canned" title="G-code Mill Canned Cycle Examples"/>
 <doc name="lathe_lathe-user" title="Lathe User Information"/>
 <doc name="plasma_qtplasmac" title="GUI: QtPlasmaC"/>
@@ -69,7 +69,7 @@
 <doc name="config_ini-config" title="Basic Configuration"/>
 <doc name="config_ini-homing" title="Homing Configuration"/>
 <doc name="config_lathe-config" title="Lathe Configuration"/>
-<doc name="config_core-components" title="EMC2 interface to HAL"/>
+<doc name="config_core-components" title="LinuxCNC interface to HAL"/>
 <doc name="config_stepper" title="Stepper Configuration"/>
 <doc name="hal_pyvcp" title="Python Virtual Control Panels (pyVCP)"/>
 <doc name="hal_pyvcp-examples" title="pyVCP Examples"/>
@@ -105,8 +105,8 @@
 
 <doc name="common/overleaf.html" title="Texte de la page couverture (en anglais)"/>
 <doc name="common/System_Requirements_es.html" title="Configuration requise"/>
-<doc name="common/Getting_EMC_es.html" title="Où trouver EMC2"/>
-<doc name="common/Updating_EMC_es.html" title="Mise à jour d'EMC2"/>
+<doc name="common/Getting_EMC_es.html" title="Où trouver LinuxCNC"/>
+<doc name="common/Updating_EMC_es.html" title="Mise à jour d'LinuxCNC"/>
 <doc name="quickstart/stepper_quickstart_es.html" title="Démarrage rapide"/>
 <doc name="config/stepconf_es.html" title="L'assistant de configuration StepConf"/>
 <doc name="config/pncconf_es.html" title="L'assistant de configuration PncConf (pour les machines utilisant Mesa)"/>
@@ -127,7 +127,7 @@
 <doc name="gcode/overview_es.html" title="Aperçu G-code"/>
 <doc name="gcode/coordinates_es.html" title="Les systèmes de coordonnées"/>
 <doc name="gcode/tool_compensation_es.html" title="Les compensations d'outil"/>
-<doc name="gcode/main_es.html" title="Le langage G-code EMC2"/>
+<doc name="gcode/main_es.html" title="Le langage G-code de LinuxCNC"/>
 <doc name="gcode/mill_canned_es.html" title="Les cycles préprogrammés"/>
 <doc name="lathe/lathe-user_es.html" title="Informations spécifiques aux tours"/>
 <doc name="gcode/rs274ngc_es.html" title="Le language G-code RS274/NGC"/>

--- a/docs/src/drivers/vfs11.adoc
+++ b/docs/src/drivers/vfs11.adoc
@@ -293,7 +293,7 @@ set. Operating parameters are still read while bus control is
 disabled. Exiting the vfs11_vfd driver in a controlled way will release
 the VFD from the bus and restore panel control.
 
-See the EMC2 Integrators Manual for more information. For a detailed
+See the LinuxCNC Integrators Manual for more information. For a detailed
 register description of the Toshiba VFD's, see the "TOSVERT VF-S11
 Communications Function Instruction Manual" (Toshiba document number
 E6581222) and the "TOSVERT VF-S11 Instruction manual" (Toshiba

--- a/docs/src/emc2.sty
+++ b/docs/src/emc2.sty
@@ -1,5 +1,5 @@
 %%
-%% Fixed EMC2 Documentation style
+%% Fixed LinuxCNC (formerly known as EMC2) Documentation style
 %%
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{emc2doc}[2011/02/10 EMC2 Style]

--- a/src/emc/nml_intf/emc.cc
+++ b/src/emc/nml_intf/emc.cc
@@ -4,8 +4,8 @@
 *   An auto-generated file to handle the update functions and
 *   routing of messages to the correct buffer/processes.
 *
-*   NOTICE:  this file has been manually edited for EMC2, the
-*   Java CodeGen utility should _NOT_ be used for EMC2, it will
+*   NOTICE:  this file has been manually edited for LinuxCNC, the
+*   Java CodeGen utility should _NOT_ be used for LinuxCNC, it will
 *   overwrite this file!!
 *
 * Author:

--- a/src/emc/usr_intf/pncconf/pncconf-help/help-axisconfig.txt
+++ b/src/emc/usr_intf/pncconf/pncconf-help/help-axisconfig.txt
@@ -25,12 +25,12 @@ on a typical lathe:
     AXIS graphical display can not be made to reflect this. 
 
 When using homing and / or limit switches
-EMC2 expects the HAL signals to be true when 
+LinuxCNC expects the HAL signals to be true when 
 the switch is being pressed / tripped.
 If the signal is wrong for a limit switch then
-EMC2 will think the machine is on end of limit
+LinuxCNC will think the machine is on end of limit
 all the time. If the home switch search logic is wrong
-EMC2 will seem to home in the wrong direction.
+LinuxCNC will seem to home in the wrong direction.
 What it actually is doing is trying to BACK off 
 the home switch.
 
@@ -43,9 +43,9 @@ the home switch.
     should be 'active low' on the machine. eg. power runs through
     the switches all the time - a loss of power (open switch) trips.
     While one could wire them the other way, this is fail safe.
-    This may need to be inverted so that the HAL signal in EMC
+    This may need to be inverted so that the HAL signal in LinuxCNC
     in 'active high' - a TRUE means the switch was tripped. When
-    starting EMC if you get an on-limit warning, and axis is NOT
+    starting LinuxCNC if you get an on-limit warning, and axis is NOT
     tripping the switch, inverting the signal is probably the
     solution. (use HALMETER to check the corresponding HAL signal  
     eg. axis.0.pos-lim-sw-in  X axis positive limit switch)
@@ -63,7 +63,7 @@ the home switch.
     course home and the index will be the actual home location.
 
 -Decide on the MACHINE ORIGIN position.
-    MACHINE ORIGIN is what EMC uses to reference all user coordinate
+    MACHINE ORIGIN is what LinuxCNC uses to reference all user coordinate
     systems from.
     I can think of little reason it would need to be in any particular
     spot. There are only a few G codes that can access the 
@@ -74,7 +74,7 @@ the home switch.
 
 -Decide on the (final) HOME POSITION.
     this just places the carriage at a consistent and convenient position 
-    after EMC figures out where the ORIGIN is.
+    after LinuxCNC figures out where the ORIGIN is.
 
 -Measure / calculate the positive / negative axis travel distances.
     Move the axis to the origin. Mark a reference on the movable
@@ -87,9 +87,9 @@ the home switch.
 (machine) ORIGIN:
     The Origin is the MACHINE zero point. (not
     the zero point you set your cutter / material at).
-    EMC2 uses this point to reference everything else
+    LinuxCNC uses this point to reference everything else
     from. It should be inside the software limits.
-    EMC uses the home switch location to calculate 
+    LinuxCNC uses the home switch location to calculate 
     the origin position (when using home switches
     or must be manually set if not using home switches.
 
@@ -160,7 +160,7 @@ Home latch Direction:
     or opposite of the search direction.
 
 Use Encoder Index For Home:
-    EMC2 will search for an encoder index pulse while in
+    LinuxCNC will search for an encoder index pulse while in
     the latch stage of homing.
 
 Use Compensation File:

--- a/src/hal/classicladder/README.txt
+++ b/src/hal/classicladder/README.txt
@@ -329,7 +329,7 @@ You should take a look at the MAT project. Classicladder has been integrated to 
 have a relay ladder logic to program this PLC.
 http://mat.sourceforge.net/
 
-Another project using ClassicLadder: EMC2, used to control machine tools.
+Another project using ClassicLadder: LinuxCNC, used to control machine tools.
 http://www.linuxcnc.org/
 
 Comedi project at www.comedi.org

--- a/src/hal/classicladder/classicladder_gtk.c
+++ b/src/hal/classicladder/classicladder_gtk.c
@@ -20,7 +20,7 @@
 /* You should have received a copy of the GNU Lesser General Public */
 /* License along with this library; if not, write to the Free Software */
 /* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA. */
-// Chris Morley (EMC2) Jan 08
+// Chris Morley (LinuxCNC) Jan 08
 
 #include <locale.h>
 #include <libintl.h>

--- a/src/hal/classicladder/emc_mods.c
+++ b/src/hal/classicladder/emc_mods.c
@@ -1,6 +1,6 @@
 // classicladder v7.124 adaptation for emc2 January 08
 
-// this is a collection of completely new functions added for the adaptation to EMC2
+// this is a collection of completely new functions added for the adaptation to LinuxCNC
 // it is easier to keep them all together in one place --I hope!
 // please add all new functions here!
 

--- a/src/hal/components/abs.comp
+++ b/src/hal/components/abs.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2006 John Kasunich <jmkasunich at sourceforge dot net>
 //
 //   This program is free software; you can redistribute it and/or

--- a/src/hal/components/abs_s32.comp
+++ b/src/hal/components/abs_s32.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2011 Sebastian Kuzminsky <seb@highlab.com>
 //
 //   This program is free software; you can redistribute it and/or

--- a/src/hal/components/biquad.comp
+++ b/src/hal/components/biquad.comp
@@ -28,7 +28,7 @@
  * codes, and the authors of this software can not, and do not, take
  * any responsibility for such compliance.
  *
- * This code was written as part of the EMC HAL project.  For more
+ * This code was written as part of the LinuxCNC HAL project.  For more
  * information, go to www.linuxcnc.org.
  *
  ******************************************************************************/

--- a/src/hal/components/blend.comp
+++ b/src/hal/components/blend.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2006 Jeff Epler <jepler@unpythonic.net>
 //
 //   This program is free software; you can redistribute it and/or modify

--- a/src/hal/components/charge_pump.comp
+++ b/src/hal/components/charge_pump.comp
@@ -1,4 +1,4 @@
-//   This is a 'charge-pump' component for EMC2 HAL
+//   This is a 'charge-pump' component for LinuxCNC HAL
 //   Copyright 2006 Jeff Epler <jepler@unpythonic.net>
 //
 //   This program is free software; you can redistribute it and/or modify

--- a/src/hal/components/ddt.comp
+++ b/src/hal/components/ddt.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2006 Jeff Epler <jepler@unpythonic.net>
 //
 //   This program is free software; you can redistribute it and/or modify

--- a/src/hal/components/edge.comp
+++ b/src/hal/components/edge.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2006 Jeff Epler <jepler@unpythonic.net>
 //
 //   This program is free software; you can redistribute it and/or modify

--- a/src/hal/components/feedcomp.comp
+++ b/src/hal/components/feedcomp.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2008 Eric H. Johnson
 //
 //   This program is free software; you can redistribute it and/or

--- a/src/hal/components/invert.comp
+++ b/src/hal/components/invert.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2008 Stephen Wille Padnos <swpadnos at sourceforge dot net>
 //
 //   This program is free software; you can redistribute it and/or

--- a/src/hal/components/joyhandle.comp
+++ b/src/hal/components/joyhandle.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2008 Paul Willutzki <paul[at]willutzki[dot]de>
 //
 //   This program is free software; you can redistribute it and/or

--- a/src/hal/components/knob2float.comp
+++ b/src/hal/components/knob2float.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2007 John Kasunich <jmkasunich AT sourceforge DOT net>
 //
 //   This program is free software; you can redistribute it and/or modify

--- a/src/hal/components/maj3.comp
+++ b/src/hal/components/maj3.comp
@@ -1,4 +1,4 @@
-//   This is a 'majority-of-3' component for EMC2 HAL
+//   This is a 'majority-of-3' component for LinuxCNC HAL
 //   Copyright 2006 Jeff Epler <jepler@unpythonic.net>
 //
 //   This program is free software; you can redistribute it and/or modify

--- a/src/hal/components/message.comp
+++ b/src/hal/components/message.comp
@@ -30,7 +30,7 @@
  * codes, and the authors of this software can not, and do not, take
  * any responsibility for such compliance.
  *
- * This code was written as part of the EMC HAL project.  For more
+ * This code was written as part of the LinuxCNC HAL project.  For more
  * information, go to www.linuxcnc.org.
  *
 *************************************************************************/

--- a/src/hal/components/multiswitch.comp
+++ b/src/hal/components/multiswitch.comp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-EMC2 HAL component to implement Multistate toggle switch
+LinuxCNC HAL component to implement Multistate toggle switch
 Authors ArcEye 15122011 schooner30@tiscali.co.uk / Andy Pugh andy@bodgesoc.org
 License GPL
 Copyright 2011 

--- a/src/hal/components/offset.comp
+++ b/src/hal/components/offset.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2006 Jeff Epler <jepler@unpythonic.net>
 //
 //   This program is free software; you can redistribute it and/or modify

--- a/src/hal/components/oneshot.comp
+++ b/src/hal/components/oneshot.comp
@@ -1,4 +1,4 @@
-//   This is a component for EMC2 HAL
+//   This is a component for LinuxCNC HAL
 //   Copyright 2006 John Kasunich <jmkasunich@users.sourceforge.net>
 //
 //   This program is free software; you can redistribute it and/or modify

--- a/src/hal/components/spindle.comp
+++ b/src/hal/components/spindle.comp
@@ -30,7 +30,7 @@
  * codes, and the authors of this software can not, and do not, take
  * any responsibility for such compliance.
  *
- * This code was written as part of the EMC HAL project.  For more
+ * This code was written as part of the LinuxCNC HAL project.  For more
  * information, go to www.linuxcnc.org.
  *
 *************************************************************************/

--- a/src/hal/components/ton.comp
+++ b/src/hal/components/ton.comp
@@ -1,6 +1,6 @@
 /********************************************************************
 * Description: ton.comp
-*   IEC_61131-3 Time On timer for HAL bit signals.
+*   IEC_61131-3 Time On timer for LinuxCNC HAL bit signals.
 *
 *   This is a HAL component that can be used to delay rising edge signals
 *   for a certain amount of time.

--- a/src/hal/components/tp.comp
+++ b/src/hal/components/tp.comp
@@ -1,6 +1,6 @@
 /********************************************************************
 * Description: tp.comp
-*   IEC_61131-3 Pulse Time timer for HAL bit signals.
+*   IEC_61131-3 Pulse Time timer for LinuxCNC HAL bit signals.
 *
 *   This is a HAL component that can be used to send a pulse signal
 *   for a certain amount of time.

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -1,6 +1,6 @@
 /********************************************************************
 * Description: halrmt.cc
-*   Simple telnet interface to EMC2 HAL commands (halcmd)
+*   Simple telnet interface to LinuxCNC HAL commands (halcmd)
 *
 *   Derived from work by jmkasunich
 *


### PR DESCRIPTION
A follow-up to a comment from @SebKuzminsky in #1515 on remnants of the original name EMC in our source code and documentation.