### PR TITLE
qtplasmac: various enhancements

### DIFF
--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -815,9 +815,10 @@ See <<qt_custom-user-buttons, custom user buttons>> for detailed information on 
 |===
 |*Name*|*Description*
 |EDIT|This button opens a G-Code editor for the currently loaded program.
-|MDI|This button places QtPlasmaC into Manual Data Input mode which will display the MDI HISTORY and an entry box over top of the G-Code window. +
+|MDI|This button places QtPlasmaC into Manual Data Input (MDI) mode which will display the MDI HISTORY and an entry box over top of the G-Code window. +
 Once pressed, this button will display "MDI CLOSE". +
-Pressing *MDI CLOSE* will close the MDI.
+Pressing *MDI CLOSE* will close the MDI. +
+Please see the <<qt_mdi, MDI>> section for additional MDI information.
 |OHMIC TEST|This button will enable the Ohmic Probe Enable output signal and if the Ohmic Probe input is sensed, the LED indicator in the SENSOR Panel will light. +
 The main purpose of this is to allow a quick test for a shorted torch tip.
 |PROBE TEST|This button will initiate a <<qt_probe-test, Probe Test>>.
@@ -2325,6 +2326,8 @@ In order to utilize them, *KB Shortcuts* must be enabled in the *GUI SETTINGS* s
 |F2|Toggles the GUI power button.
 |F9|Toggles the "Cutting" command, used to begin or end a manual cut.
 |F12|Show stylesheet editor.
+|ALT + RETURN|Places QtPlasmaC into Manual Data Input (MDI) mode. +
+Note that ALT + ENTER will achieve the same result.
 |1|Changes jog speed to 10% of the value present in the DEFAULT_LINEAR_VELOCITY variable in the [DISPLAY] section of the <machine_name>.ini file.
 |2|Changes jog speed to 20% of the value present in the DEFAULT_LINEAR_VELOCITY variable in the [DISPLAY] section of the <machine_name>.ini file.
 |3|Changes jog speed to 30% of the value present in the DEFAULT_LINEAR_VELOCITY variable in the [DISPLAY] section of the <machine_name>.ini file.
@@ -2376,6 +2379,33 @@ In order to utilize them, *KB Shortcuts* must be enabled in the *GUI SETTINGS* s
 |- (+ Jog Key)|The minus key can be used with any jog key to invoke a slow jog (10% of the displayed jog speed) +
    If SLOW jogging is already active, the axis will jog at the displayed jog speed.
 |===
+
+[[qt_mdi]]
+=== MDI
+
+In addition to the typical G and M codes that are allowed by LinuxCNC in MDI mode, the MDI in QtPlasmaC can be used to access several other handy features.
+
+NOTE: M3, M4, and M5 are not allowed in the QtPlasmaC MDI.
+
+These can be accessed by pressing the MDI button and entering the following commands which are not case sensitive:
+
+[width="100%",cols="4,16"]
+|===
+|*Command*|*Description*
+|PREFERENCE|Opens a read only version of qtplasmac.prefs from the current machine's config folder
+|HALMETER|Starts LinuxCNC utility link:http://linuxcnc.org/docs/devel/html/hal/tutorial.html#sec:tutorial-halmeter[Halmeter].
+|HALSHOW|Starts LinuxCNC utility link:http://linuxcnc.org/docs/devel/html/hal/halshow.html#cha:halshow[Halshow].
+|HALSCOPE|Starts LinuxCNC utility link:http://linuxcnc.org/docs/devel/html/hal/tutorial.html#sec:tutorial-halscope[Halscope].
+|CALIBRATION|Starts LinuxCNC utility link:http://linuxcnc.org/docs/devel/html/getting-started/updating-linuxcnc.html#_calibration_emccalib_tcl[Calibration].
+|CLASSICLADDER|Starts the link:http://linuxcnc.org/docs/devel/html/ladder/classic-ladder.html[ClassicLadder GUI] if the ClassicLadder realtime HAL component was loaded by the machine's config files.
+|STATUS|Starts LinuxCNC utility link:https://linuxcnc.org/docs//html/man/man1/linuxcnctop.1.html[Status].
+|CLEAR HISTORY|Clears the MDI history.
+|SETP|Sets the value of a pin or a parameter. Valid values depend on the object type of the pin or parameter. An error will result if the data types do not match or the pin is connected to a signal. +
+Syntax: setp <pin/parameter-name> <value> +
+Example: setp plasmac.resolution 100
+|===
+
+*In addition, pressing RETURN (or ENTER) with no entry in the MDI will close the MDI window.*
 
 [[qt_shape-library]]
 
@@ -3392,6 +3422,16 @@ The following example would set the distance from Z MAX_LIMIT to 10mm:
 ----
 setp plasmac.max-offset 10
 ----
+
+=== Enable Tabs During Automated Motion
+
+By default, all tabs except the <<qt_main-tab, MAIN Tab>> are disabled during automated motion. It is possible for every tab but the <<qt_conversational-tab, CONVERSATIONAL Tab>> to be enabled during automated motion by setting the following HAL pin True:
+
+----
+setp qtplasmac.tabs_always_enabled 1
+----
+
+WARNING: It is the responsibility of the operator to ensure that the machine is equipped with a suitable, working hardware ESTOP. If using only a touchscreen to navigate the QtPlasmaC GUI, there is no way to stop automated machine motion on any tab but the MAIN tab.
 
 === QtPlasmaC State Outputs
 

--- a/share/qtvcp/screens/qtplasmac/versions.html
+++ b/share/qtvcp/screens/qtplasmac/versions.html
@@ -30,68 +30,88 @@
 </table>
 <br>
 <!--- ****** ADD NEXT VERSION BELOW THIS LINE ****** --->
+<br><b><u>v1.221.158 2021 Jan 24</u></b>
+<ul style="margin:0;">
+  <li>MDI enhancements:</li>
+    <ol>
+      <li>alt+return (or enter) opens the MDI</li>
+      <li>return (or enter) with no entry closes the MDI</li>
+      <li>add the ability to 'clear history'</li>
+      <li>add the ability to 'setp' pins/params</li>
+      <li>inhibit M4 commands in MDI</li>
+      <li>history doesn't log entries with errors (thanks phillc54)</li>
+      <li>history doesn't log consecutive duplicate entries (thanks phillc54)</li>
+    </ol>
+  <li>file editor now opens blank after file_clear</li>
+  <li>show table view if editor is closed with no file loaded and no changes</li>
+  <li>fix autorepeat turning off when MDI or editor were open and the main tab was left and returned to</li>
+  <li>edit button is always active</li>
+  <li>add hal pin to enable some tabs during run</li>
+  <li>docs updates</li>
+</ul>
+<i>Changes submitted by snowgoer540 (Greg Carl)</i><br>
 
-<br><b><u>v1.220.157 2021 Jan 22</u></b>
+<br><b><u>v1.221.157 2021 Jan 22</u></b>
 <ul style="margin:0;">
   <li>fix update check</li>
   <li>update sim configs</li>
 </ul>
 
-<br><b><u>v1.220.156 2021 Jan 19</u></b>
+<br><b><u>v1.221.156 2021 Jan 19</u></b>
 <ul style="margin:0;">
   <li>add table view to the preview window</li>
 </ul>
 <i>A snowgoer540 and phillc54 collaboration</i><br>
 
-<br><b><u>v1.220.155 2021 Jan 18</u></b>
+<br><b><u>v1.221.155 2021 Jan 18</u></b>
 <ul style="margin:0;">
   <li>inhibit external cut recovery functions when not paused</li>
 </ul>
 
-<br><b><u>v1.220.154 2021 Jan 18</u></b>
+<br><b><u>v1.221.154 2021 Jan 18</u></b>
 <ul style="margin:0;">
   <li>prep work for simpler updating</li>
 </ul>
 
-<br><b><u>v1.220.153 2021 Jan 11</u></b>
+<br><b><u>v1.221.153 2021 Jan 11</u></b>
 <ul style="margin:0;">
   <li>ensure OS autorepeat is on and log files are saved on close</li>
   <li>docs update</li>
 </ul>
 <i>Changes submitted by snowgoer540 (Greg Carl)</i><br>
 
-<br><b><u>v1.220.152 2022 Jan 08</u></b>
+<br><b><u>v1.221.152 2022 Jan 08</u></b>
 <ul style="margin:0;">
   <li>don't reload file if not previously loaded</li>
 </ul>
 
-<br><b><u>v1.220.151 2022 Jan 08</u></b>
+<br><b><u>v1.221.151 2022 Jan 08</u></b>
 <ul style="margin:0;">
   <li>fix user button gcode motion</li>
 </ul>
 
-<br><b><u>v1.220.150 2022 Jan 02</u></b>
+<br><b><u>v1.221.150 2022 Jan 02</u></b>
 <ul style="margin:0;">
   <li>ensure preview joint dro is removed after homing</li>
 </ul>
 
-<br><b><u>v1.220.149 2022 Jan 01</u></b>
+<br><b><u>v1.221.149 2022 Jan 01</u></b>
 <ul style="margin:0;">
   <li>remove redundant parameter</li>
 </ul>
 
-<br><b><u>v1.220.148 2022 Jan 01</u></b>
+<br><b><u>v1.221.148 2022 Jan 01</u></b>
 <ul style="margin:0;">
   <li>add toggle laser to user buttons</li>
   <li>change default font</li>
 </ul>
 
-<br><b><u>v1.220.147 2021 Dec 22</u></b>
+<br><b><u>v1.221.147 2021 Dec 22</u></b>
 <ul style="margin:0;">
   <li>improve bounds checking</li>
 </ul>
 
-<br><b><u>v1.220.146 2021 Dec 20</u></b>
+<br><b><u>v1.221.146 2021 Dec 20</u></b>
 <ul style="margin:0;">
   <li>add exception handling for pulse-halpin</li>
 </ul>
@@ -367,7 +387,7 @@
 <br><b><u>v1.214.104 2021 Oct 18</u></b>
 <ul style="margin:0;">
   <li>add external hal pins for:</li>
-    <ul>
+    <ol>
       <li>thc enable</li>
       <li>torch enable</li>
       <li>corner lock enable</li>
@@ -377,8 +397,7 @@
       <li>mesh mode</li>
       <li>ignore arc ok</li>
       <li>cut recovery</li>
-    </ul>
-  </li>
+    </ol>
 </ul>
 <i>Changes submitted by fupeama (Martin Kaplan)</i><br>
 
@@ -452,7 +471,6 @@
   <li>fix text error in conversational triangle</li>
 </ul>
 
-</ul>
 <br><b><u>v1.0.93 2021 Sep 13</u></b>
 <ul style="margin:0;">
   <li>fix disabled states if cycle stopped while cycle paused</li>


### PR DESCRIPTION
-MDI enhancements:
1. alt+return (or enter) opens the MDI
2. return (or enter) with no entry closes the MDI
3. add the ability to 'clear history'
4. add the ability to 'setp' pins/params
5. inhibit M4 commands in MDI
6. history doesn't log entries with errors (thanks phillc54)
7. history doesn't log consecutive duplicate entries (thanks phillc54)
-file editor now opens blank after file_clear
-show table view if editor is closed with no file loaded and no changes
-fix autorepeat turning off when MDI or editor were open and the main 
tab was left and returned to
-edit button is always active
-add hal pin to enable some tabs during run
-docs updates