### PR TITLE
Allow regular libreadline-dev as an alternative for home use

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -36,7 +36,7 @@ fi
 EXTRA_FILES=
 EXTRA_BUILD=
 PYTHON_VERSION_NEXT=$(python3 -c 'import sys; print (sys.version[:2] + str(1+int(sys.version[2])))')
-LIBREADLINE_DEV=libreadline-gplv2-dev
+LIBREADLINE_DEV="libreadline-gplv2-dev | libreadline-dev"
 
 ENABLE_BUILD_DOCUMENTATION=--enable-build-documentation=pdf
 


### PR DESCRIPTION
The build demon will use the GPL-ed variant, but the home user has an alternative - just ran into this on an odroid:
```
$ cat /etc/debian_version 
10.10
$ cat /etc/armbian-release 
# PLEASE DO NOT EDIT THIS FILE
BOARD=odroidn2
BOARD_NAME="Odroid N2"
BOARDFAMILY=meson-g12b
BUILD_REPOSITORY_URL=https://github.com/armbian/build
BUILD_REPOSITORY_COMMIT=428a20876-dirty
DISTRIBUTION_CODENAME=buster
DISTRIBUTION_STATUS=supported
VERSION=21.05.6
LINUXFAMILY=meson64
ARCH=arm64
IMAGE_TYPE=stable
BOARD_TYPE=conf
INITRD_ARCH=arm64
KERNEL_IMAGE_TYPE=Image
BRANCH=current
```
For the package to build, the configure flag still needs to be adapted. This could be done automatically but you please say if this is so desired. I think so, since Debian only builds from source-only uploads and get all first-choice dependencies, and so does Ubuntu IIRC, I do not see any problem for our redistributors.
