### PR TITLE
Correct documentation regarding max string argument lengths

### DIFF
--- a/docs/src/config/python-interface.adoc
+++ b/docs/src/config/python-interface.adoc
@@ -638,10 +638,10 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
     set debug level via EMC_SET_DEBUG message.
 
 `display_msg(string)`::
-    sends a operator display message to the screen. (max 256 characters)
+    sends a operator display message to the screen. (max 254 characters)
 
 `error_msg(string)`::
-    sends a operator error message to the screen. (max 256 characters)
+    sends a operator error message to the screen. (max 254 characters)
 
 `feedrate(float)`::
     set the feedrate.
@@ -686,7 +686,7 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
     set maximum velocity
 
 `mdi(string)`::
-    send an MDI command. Maximum 255 chars.
+    send an MDI command. Maximum 254 chars.
 
 `mist(int)`:: turn on/off mist. +
     Syntax: +
@@ -749,7 +749,7 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
     SPINDLE_DECREASE, or SPINDLE_CONSTANT.
 
 `text_msg(string)`::
-    sends a operator text message to the screen. (max 256 characters)
+    sends a operator text message to the screen. (max 254 characters)
 
 [source, python]
 ---------------------------------------------------------------------

--- a/docs/src/config/python-interface_es.adoc
+++ b/docs/src/config/python-interface_es.adoc
@@ -676,7 +676,7 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
     establecer la velocidad máxima
 
 `mdi(string)`::
-    Enviar un comando MDI. Máximo 255 caracteres.
+    Enviar un comando MDI. Máximo 254 caracteres.
 
 `mist(int)`:: activa/desactiva la niebla. +
     Sintaxis: +


### PR DESCRIPTION
Documentation indicated the following methods of linuxcnc.command accepted longer string arguments than they actually do:
- display_msg (states 256 chars max)
- text_msg (states 256 chars max)
- error_msg (states 256 chars max)
- mdi (states 255 chars max)

For all of the above,  their implementations in `src/emc/usr_intf/axis/extensions/emcmodule.cc` copies these strings to a maximum length of `LINELEN` (255), then writes a null terminator byte to index 254 (255th byte).

Thus the longest string any of the above will accept without truncation or failure is 254 characters.