### PR TITLE
Gmoccapy: fix window size by reducing button padding with CSS

### DIFF
--- a/lib/python/gladevcp/calculatorwidget.py
+++ b/lib/python/gladevcp/calculatorwidget.py
@@ -30,6 +30,7 @@ locale.bindtextdomain("linuxcnc", LOCALEDIR)
 import gi
 gi.require_version("Gtk","3.0")
 from gi.repository import Gtk
+from gi.repository import Gdk
 from gi.repository import GObject
 from gi.repository import Pango
 
@@ -93,6 +94,14 @@ class Calculator( Gtk.VBox ):
         self.window = self.calc_box.get_parent()
         self.window.remove(self.calc_box)
         self.add(self.calc_box)
+        
+        # Use CSS style for buttons
+        screen = Gdk.Screen.get_default()
+        provider = Gtk.CssProvider()
+        style_context = Gtk.StyleContext()
+        style_context.add_provider_for_screen(screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        css = b"button {padding: 0;}"
+        provider.load_from_data(css)
 
     def num_pad_only( self, value ):
         self.has_num_pad_only = value

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -146,6 +146,18 @@ class gmoccapy(object):
         locale.bindtextdomain("gmoccapy", LOCALEDIR)
         gettext.install("gmoccapy", localedir=LOCALEDIR)
 
+        # CSS styling
+        screen = Gdk.Screen.get_default()
+        provider = Gtk.CssProvider()
+        style_context = Gtk.StyleContext()
+        style_context.add_provider_for_screen(screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        css = b"""
+            button {
+                padding: 0;
+            }
+        """
+        provider.load_from_data(css)
+
         # needed components to communicate with hal and linuxcnc
         self.halcomp = hal.component("gmoccapy")
         self.command = linuxcnc.command()


### PR DESCRIPTION
As Gtk3 has per default a much larger padding between label and button border than Gtk2, this results also in a bigger main window.
Reducing this, makes it possible to run Gmoccapy on a 1024x768 screen again.


## Before
<img src="https://user-images.githubusercontent.com/67957916/151843461-2cad8068-35a0-466d-85de-856ff7329fa0.png" width="608" />

## After
<img src="https://user-images.githubusercontent.com/67957916/151843430-2a779ea1-d797-4f80-b5c3-fc10187c2256.png" width="501" />

## 2.8 version
<img src="https://user-images.githubusercontent.com/67957916/151842984-7fd2fca0-679a-41eb-82ed-06878a09fd87.png" width="515" />

## ... and we could also set the background with CSS like in 2.8 if this is still wanted
<img src="https://user-images.githubusercontent.com/67957916/151843562-02251b3f-c6e7-4b75-9bcc-dd7858f88c45.png" width="501" />

## BUT still some problemes with the size. Embedding a VCP like this makes the window bigger. In 2.8 this worked.
<img src="https://user-images.githubusercontent.com/67957916/151843556-64d4247d-b36d-4406-a469-bd5280a495dc.png" width="539" />


### For reference:
https://shallowsky.com/blog/programming/styling-gtk3-with-css-python.html
https://docs.gtk.org/gtk3/css-overview.html
https://docs.gtk.org/gtk3/css-properties.html