### PR TITLE
halshow: keep window on top

### DIFF
--- a/docs/src/hal/halshow.adoc
+++ b/docs/src/hal/halshow.adoc
@@ -37,7 +37,7 @@ Notes:
 ----
 
 Example to limit number of decimal points for floats
-and used a file named my.halshow in the current directory:
+and use a file named my.halshow in the current directory:
 
 ----
 $ halshow  --fformat "%.5f" ./my.halshow

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -43,6 +43,7 @@ set x [expr ($xmax - $masterwidth )  / 2 ]
 set y [expr ($ymax - $masterheight )  / 2]
 wm geometry . "${masterwidth}x${masterheight}+$x+$y"
 wm  minsize . $masterwidth $masterheight
+wm attributes . -topmost yes
 
 # trap mouse click on window manager delete and ask to save
 wm protocol . WM_DELETE_WINDOW askKill


### PR DESCRIPTION
The argument _--ontop true_ will attempt to keep the halshow window above other windows.