### PR TITLE
gmoccapy: center button labels with property instead of spaces

### DIFF
--- a/lib/python/gladevcp/offsetpage.glade
+++ b/lib/python/gladevcp/offsetpage.glade
@@ -439,8 +439,14 @@
             <property name="visible">True</property>
             <child>
               <object class="GtkButton" id="zero_g92_button">
-                <property name="label" translatable="yes">Zero
+                <child>
+                  <object class="GtkLabel" id="zero_g92_button_label">
+                    <property name="label" translatable="yes">Zero
 G92</property>
+                    <property name="visible">1</property>
+                    <property name="justify">center</property>
+                  </object>
+                </child>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -453,8 +459,14 @@ G92</property>
             </child>
             <child>
               <object class="GtkButton" id="zero_rot_button">
-                <property name="label" translatable="yes">    Zero
+                <child>
+                  <object class="GtkLabel" id="zero_rot_button_label">
+                  <property name="label" translatable="yes">Zero
 Rotational</property>
+                  <property name="visible">1</property>
+                  <property name="justify">center</property>
+                  </object>
+                </child>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -8830,8 +8830,14 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkButton" id="btn_tool_touchoff_z">
-                    <property name="label" translatable="yes">touchoff
-  tool z</property>
+                    <child>
+                      <object class="GtkLabel" id="btn_tool_touchoff_z_label">
+                        <property name="label" translatable="yes">touchoff
+tool z</property>
+                        <property name="visible">1</property>
+                        <property name="justify">center</property>
+                      </object>
+                    </child>                   
                     <property name="use_action_appearance">False</property>
                     <property name="width_request">85</property>
                     <property name="height_request">56</property>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -893,7 +893,11 @@ class gmoccapy(object):
             # we will have 3 buttons on the right side
             end -= 1
 
-        btn = Gtk.ToggleButton.new_with_label(_("  edit\noffsets"))
+        lbl = Gtk.Label.new(_("edit\noffsets"))
+        lbl.set_visible(True)
+        lbl.set_justify(Gtk.Justification.CENTER)
+        btn = Gtk.ToggleButton.new()
+        btn.add(lbl)      
         btn.connect("toggled", self.on_tbtn_edit_offsets_toggled)
         btn.set_property("tooltip-text", _("Press to edit the offsets"))
         btn.set_property("name", "edit_offsets")
@@ -941,7 +945,8 @@ class gmoccapy(object):
             self.widgets.hbtb_touch_off.pack_start(lbl,True,True,0)
             lbl.show()
 
-        btn = Gtk.Button.new_with_label(_("zero\nG92"))
+        btn = self.widgets.offsetpage1.wTree.get_object("zero_g92_button")
+        self.widgets.offsetpage1.buttonbox.remove(btn)
         btn.connect("clicked", self.on_btn_zero_g92_clicked)
         btn.set_property("tooltip-text", _("Press to reset all G92 offsets"))
         btn.set_property("name", "zero_offsets")


### PR DESCRIPTION
The text of some multi-line buttons was manually centred with spaces. But this is not helpful for the translated labels.
So I removed the spaces and added a label as child to be able to set the 'justify' property to 'center'.