### PR TITLE
int (also literals as it seems) are signed by default

### DIFF
--- a/src/emc/usr_intf/emcsched.cc
+++ b/src/emc/usr_intf/emcsched.cc
@@ -190,7 +190,7 @@ void SchedEntry::setTool(int t) {
 
 static void crcInit() {
   crc rmdr;
-  int i;
+  unsigned int i;
   uint32_t bit;
 
   for (i = 0; i < 256; ++i)

--- a/src/hal/drivers/hal_gm.c
+++ b/src/hal/drivers/hal_gm.c
@@ -1126,7 +1126,6 @@ read(void *arg, long period)
 {
     	gm_device_t	*device = (gm_device_t *)arg;
     	card	*pCard = device->pCard;
-    	int		i;
 	hal_u32_t temp;
 	
       //basic card functionality: watchdog, switches, estop
@@ -1134,10 +1133,10 @@ read(void *arg, long period)
 
       //read parallel IOs
 	temp=pCard->gpio;
-    	for(i = 0; i < 32; i++)
+    	for(unsigned int i = 0; i < 32; i++)
 	{
-		*(device->gpio[i].in) = (hal_bit_t)((temp & (0x0001 << i)) == 0 ? 0 : 1);
-		*(device->gpio[i].inNot) = (hal_bit_t)((temp & (0x0001 << i)) == 0 ? 1 : 0);
+		*(device->gpio[i].in) = (hal_bit_t)((temp & ((unsigned int) 1 << i)) == 0 ? 0 : 1);
+		*(device->gpio[i].inNot) = (hal_bit_t)((temp & ((unsigned int) 1 << i)) == 0 ? 1 : 0);
 	}
 
       //Read Encoders

--- a/src/hal/drivers/hal_gm.c
+++ b/src/hal/drivers/hal_gm.c
@@ -1126,14 +1126,15 @@ read(void *arg, long period)
 {
     	gm_device_t	*device = (gm_device_t *)arg;
     	card	*pCard = device->pCard;
+	unsigned int i;
 	hal_u32_t temp;
-	
+
       //basic card functionality: watchdog, switches, estop
 	card_mgr(arg, period);
 
       //read parallel IOs
 	temp=pCard->gpio;
-    	for(unsigned int i = 0; i < 32; i++)
+    	for(i = 0; i < 32; i++)
 	{
 		*(device->gpio[i].in) = (hal_bit_t)((temp & ((unsigned int) 1 << i)) == 0 ? 0 : 1);
 		*(device->gpio[i].inNot) = (hal_bit_t)((temp & ((unsigned int) 1 << i)) == 0 ? 1 : 0);

--- a/src/hal/drivers/opto_ac5.c
+++ b/src/hal/drivers/opto_ac5.c
@@ -402,6 +402,7 @@ Device_DigitalOutWrite(void *arg, long period)
     board_data_t			*pboard = (board_data_t *)arg;
     DigitalPinsParams			*pDigital;
     int					portnum=0;
+    unsigned int			i,j;
     unsigned long			pins, offset=DATA_WRITE_OFFSET_0,mask;
 
     // For each port.
@@ -412,7 +413,7 @@ Device_DigitalOutWrite(void *arg, long period)
 			pins=0;
 
    			// For each pin.
-			for(unsigned int j = 0; j < 24; j++, pDigital++)
+			for(j = 0; j < 24; j++, pDigital++)
 			{
 				if ((pboard->port[portnum].mask & mask) !=0) //is it an output?
 				{
@@ -421,19 +422,19 @@ Device_DigitalOutWrite(void *arg, long period)
 				       ( *(pDigital->pValue) &&  (pDigital->invert) ))
 					 {	pins |= mask;	    }
 				}
-	   			 mask <<=1; // shift mask
+	   			mask <<=1; // shift mask
 				
 			}
 
 			// CHECK LED PINS
 			pDigital = &pboard->port[portnum].io[23];//one before what we want to check
-			for (unsigned int i = 0; i < 2; i++)
-				{
-			 		mask = (unsigned int) 1 << (31-i);
-					pDigital++;
+			for (i = 0; i < 2; i++)
+			{
+				mask = (unsigned int) 1 << (31-i);
+				pDigital++;
 				
-					if ( *(pDigital->pValue) == 0 ) {	pins |= mask;	    }	
-				}
+				if ( *(pDigital->pValue) == 0 ) {	pins |= mask;	    }	
+			}
 			// Write digital I/O register.
 			writel(pins,pboard->base + (offset));
 			portnum++;

--- a/src/hal/drivers/opto_ac5.c
+++ b/src/hal/drivers/opto_ac5.c
@@ -401,7 +401,7 @@ Device_DigitalOutWrite(void *arg, long period)
 {
     board_data_t			*pboard = (board_data_t *)arg;
     DigitalPinsParams			*pDigital;
-    int					i, j, portnum=0;
+    int					portnum=0;
     unsigned long			pins, offset=DATA_WRITE_OFFSET_0,mask;
 
     // For each port.
@@ -412,7 +412,7 @@ Device_DigitalOutWrite(void *arg, long period)
 			pins=0;
 
    			// For each pin.
-			for(j = 0; j < 24; j++, pDigital++)
+			for(unsigned int j = 0; j < 24; j++, pDigital++)
 			{
 				if ((pboard->port[portnum].mask & mask) !=0) //is it an output?
 				{
@@ -427,16 +427,16 @@ Device_DigitalOutWrite(void *arg, long period)
 
 			// CHECK LED PINS
 			pDigital = &pboard->port[portnum].io[23];//one before what we want to check
-			for (i = 0;i < 2;i++)
+			for (unsigned int i = 0; i < 2; i++)
 				{
-			 		mask=1<<(31-i);
+			 		mask = (unsigned int) 1 << (31-i);
 					pDigital++;
 				
-					if ( *(pDigital->pValue) ==0 ) {	pins |= mask;	    }	
+					if ( *(pDigital->pValue) == 0 ) {	pins |= mask;	    }	
 				}
 			// Write digital I/O register.
 			writel(pins,pboard->base + (offset));
-			portnum ++;
+			portnum++;
 			offset=DATA_WRITE_OFFSET_1; // set to port1 offset
    		 }
 }


### PR DESCRIPTION
These patches eliminate an error found by cppcheck:
src/hal/drivers/opto_ac5.c:432:13: error: Signed integer overflow for expression '1<<(31-i)'. [integerOverflow]
      mask=1<<(31-i);

This is just a pilot PR to test my thought to have cppcheck integral to the continuous integration (https://github.com/LinuxCNC/linuxcnc/issues/1574).

Many thanks!
Steffen