### PR TITLE
Do not use ax_python_devel for version checking

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1003,7 +1003,7 @@ AC_SUBST(YAPPS)
 AX_BOOST_BASE(,,AC_MSG_ERROR([libboost not found]))
 AX_PYTHON
 AC_PATH_PROG(PYTHON,[$PYTHON_BIN])
-AX_PYTHON_DEVEL([>='3.6'],,AC_MSG_ERROR([python-dev not found]))
+AX_PYTHON_DEVEL(,,AC_MSG_ERROR([python-dev not found]))
 AX_BOOST_PYTHON(,,AC_MSG_ERROR([libboost-python not found]))
 
 AC_MSG_CHECKING([whether to build documentation])


### PR DESCRIPTION
Disable checking version for python development package
using ax_python_devel.m4 as it does not support any
newer version then 3.9 of python.
Upstream version of this file seems to be unmaintained.

Fixes the following checking error for python >=3.10:
 checking for python build information...
 checking for python3.10... python3.10
 checking for main in -lpython3.10... yes
 <string>:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
 <string>:1: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
   results of the Python check:
     Binary:      python3.10
     Library:     python3.10
     Include Dir: /usr/include/python3.10
 checking for python3.10... /usr/bin/python3.10
 checking for python... (cached) /usr/bin/python3.10
 checking for a version of Python >= '2.1.0'... yes
 checking for a version of Python >='3.6'... no
 configure: error: this package requires Python >='3.6'.
 If you have it installed, but it isn't the default Python
 interpreter in your system path, please pass the PYTHON_VERSION
 variable to configure. See ``configure --help'' for reference.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>