### PR TITLE
 cppcheck pointed to an uninitialized variable

### DIFF
--- a/src/emc/kinematics/genhexkins.c
+++ b/src/emc/kinematics/genhexkins.c
@@ -541,7 +541,7 @@ int genhexKinematicsSetup(const  int   comp_id,
                           const  char* coordinates,
                           kparms*      kp)
 {
-    int i,res;
+    int i,res=0;
 
     haldata = hal_malloc(sizeof(struct haldata));
     if (!haldata) {

--- a/src/emc/kinematics/tripodkins.c
+++ b/src/emc/kinematics/tripodkins.c
@@ -233,7 +233,7 @@ int main(int argc, char *argv[])
   char buffer[BUFFERLEN];
   char cmd[BUFFERLEN];
   EmcPose pos, vel;
-  double joints[3], jointvels[3];
+  double joints[3]={0.0,0.0,0.0}, jointvels[3]={0.0,0.0,0.0};
   char inverse;
   char flags;
   KINEMATICS_FORWARD_FLAGS fflags;


### PR DESCRIPTION
Two uninilialised variables.

The "res" one may be more important than the second. Both issues were found by cppcheck.