### PR TITLE
cppcheck warned about a comparison of pointers from different objects

### DIFF
--- a/src/emc/nml_intf/interpl.cc
+++ b/src/emc/nml_intf/interpl.cc
@@ -85,8 +85,8 @@ int NML_INTERP_LIST::append(NMLmsg * nml_msg_ptr)
 #ifdef DEBUG_INTERPL
     if (sizeof(temp_node) < MAX_NML_COMMAND_SIZE + 4 ||
 	sizeof(temp_node) > MAX_NML_COMMAND_SIZE + 16 ||
-	((void *) &temp_node.line_number) >
-	((void *) &temp_node.command.commandbuf)) {
+	((uintptr_t) &temp_node.line_number) >
+	((uintptr_t) &temp_node.command.commandbuf)) {
 	rcs_print_error
 	    ("NML_INTERP_LIST::append : assumptions about NML_INTERP_LIST_NODE have been violated.");
 	return -1;


### PR DESCRIPTION
This may not be overly dramatical since hidden in a #debug conditional, but for the sake of clarity and to add src/emc/nml_intf to the whitelisted set of directories proposed in #1581, this change may be fine.

```
interpl.cc:88:36: error: Comparing pointers that point to different objects [comparePointers]
 ((void *) &temp_node.line_number) >
                                   ^
interpl.hh:26:9: note: Variable declared here.
    int line_number;  // line number it was on
        ^
interpl.cc:88:12: note: Address of variable taken here.
 ((void *) &temp_node.line_number) >
           ^
interpl.hh:37:7: note: Variable declared here.
 char commandbuf[MAX_NML_COMMAND_SIZE]; // the NML command;
      ^
interpl.cc:89:12: note: Address of variable taken here.
 ((void *) &temp_node.command.commandbuf)) {
           ^
interpl.cc:88:36: note: Comparing pointers that point to different objects
 ((void *) &temp_node.line_number) >
```