### PR TITLE
Fix misleading/wrong info in build doc.

### DIFF
--- a/docs/src/code/building-linuxcnc.adoc
+++ b/docs/src/code/building-linuxcnc.adoc
@@ -143,14 +143,11 @@ The most commonly used arguments are:
 
 `--with-realtime=uspace`::
 
-    Build for any realtime platform, or for non-realtime.
+    Build for Preempt-RT realtime platform, or for non-realtime.
     The resulting LinuxCNC executables will run on both a Linux kernel
     with Preempt-RT patches (providing realtime machine control) and
     on a vanilla (un-patched) Linux kernel (providing G-code simulation
-    but no realtime machine control).  If development files are installed
-    for Xenomai (typically from package libxenomai-dev) or RTAI (typically
-    from a package with a name starting "rtai-modules"), support for
-    these real-time kernels will also be enabled.
+    but no realtime machine control).
 
 `--with-realtime=/usr/realtime-$VERSION`::
 

--- a/docs/src/code/building-linuxcnc_es.adoc
+++ b/docs/src/code/building-linuxcnc_es.adoc
@@ -146,10 +146,7 @@ Los argumentos más utilizados son:
     Los ejecutables LinuxCNC resultantes se ejecutarán tanto en un kernel de Linux
     con parches Preempt-RT (que proporcionan control de la máquina en tiempo real) o
     en un núcleo Linux original (sin parches) (que proporciona simulación de código G
-    pero sin control de máquina en tiempo real). Si los archivos de desarrollo están instalados
-    para Xenomai (típicamente del paquete libxenomai-dev) o RTAI (típicamente
-    desde un paquete con un nombre que comienza por "rtai-modules"), también estarán habilitado
-    soporte para estos núcleos en tiempo real.
+    pero sin control de máquina en tiempo real).
 
 `--with-realtime=/usr/realtime-$VERSION`::
 
@@ -287,7 +284,7 @@ Los valores normales para este argumento son:
 `$KERNEL_VERSION`::
 
     Configura el paquete debian para la versión de kernel RTAI especificada
-    (por ejemplo, "3.4.9-rtai-686-pae"). Los encabezados del kernel 
+    (por ejemplo, "3.4.9-rtai-686-pae"). Los encabezados del kernel
     del paquete debian coincidente debe estar instalado en su máquina de compilación (por ejemplo
     "linux-headers-3.4.9-rtai-686-pae"). Tenga en cuenta que puede _construir_
     LinuxCNC en esta configuración, pero si no está ejecutando el


### PR DESCRIPTION
'./configure --with-realtime=uspace' does look for (and finds)
any installed rtai kernels, but the build itself does NOT build
support for these. Kernel modules are not built alongside the
uspace libraries; neither is uspace builds usable for checking
that code changes build on rtai systems.

I don't know about xenomai, but the (few and old) sources I've
found on building LinuxCNC with xenomai support seems to use
something like '--with-kernel=/boot/config-3.2.27-xenomai+'
rather than '--with-realtime=uspace'.

I don't speak Spanish so I could not fully fix the Spanish
version of the doc.