### PR TITLE
Disable Always on top by default (fixes #1589)

### DIFF
--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -45,7 +45,7 @@ set x [expr ($xmax - $masterwidth )  / 2 ]
 set y [expr ($ymax - $masterheight )  / 2]
 wm geometry . "${masterwidth}x${masterheight}+$x+$y"
 wm minsize . [int [expr $masterwidth*0.3]] [int [expr $masterheight*0.5]]
-wm attributes . -topmost yes
+wm attributes . -topmost no
 
 # trap mouse click on window manager delete and ask to save
 wm protocol . WM_DELETE_WINDOW askKill
@@ -709,7 +709,7 @@ proc entrybox {defVal buttonText label} {
         set ypos "[ expr {[winfo rooty [winfo parent $wn]]+ \
             ([winfo height [winfo parent $wn]]-[winfo reqheight $wn])/2}]"
         wm geometry $wn "+$xpos+$ypos"
-        wm attributes $wn -topmost yes
+        wm attributes $wn -topmost no
         variable entryVal
         set entryVal $defVal
         label .top.lbl -text $label


### PR DESCRIPTION
It looks that depending on the DE being used
enabling "Always on top" by default prevents other
windows to be also 'Always on top' - which, in fact,
makes sense.

So, let the user to conciously enable this option.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>