### PR TITLE
debian/copyright did not point out GFPD license for docs

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -148,10 +148,14 @@ Copyright: 2004-2022 The LinuxCNC Developers and notably
  rtapi:
            2009-2013 Michael Büsch <m AT bues DOT CH>
  .
- docs:
-  A list of authors that worked on the project Ordered alphabetically
-  by the SF/Github username:
-  .
+ Please inspect the logs of the git repository to learn about the >230 (11/2021) committers.
+License: GPL-2+
+ 
+Files: docs/*
+Copyright:
+ A list of authors that worked on the project Ordered alphabetically
+ by the SF/Github username:
+ .
       alex_joni      Alex Joni 
       andypugh       Andy Pugh 
       awallin        Anders Wallin 
@@ -186,8 +190,18 @@ Copyright: 2004-2022 The LinuxCNC Developers and notably
                      B. Stultiens
                      W. Martinjak
                      Trần Ngọc Quân
- Please inspect the logs of the git repository to learn about the >230 (11/2021) committers.
-License: GPL-2+
+License: GFDL-1.1+
+ Permission is granted to copy, distribute and/or modify this document
+ under the terms of the GNU Free Documentation License, Version 1.1
+ or any later version published by the Free Software Foundation;
+ with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
+ A copy of the license is included in the section entitled "GNU
+ Free Documentation License".
+ .
+ The complete license is an integral part of the documentation.
+ On Debian systems, the later versions of the GFDL can be found in
+ "/usr/share/common-licenses/GFDL-1.2" and
+ "/usr/share/common-licenses/GFDL-1.3".
 
 Files:
  src/emc/nml_intf/*

--- a/debian/copyright
+++ b/debian/copyright
@@ -204,6 +204,14 @@ License: GFDL-1.1+
  "/usr/share/common-licenses/GFDL-1.3".
 
 Files:
+ docs/src/hal/images/stepgen-type5-10.svg
+ docs/src/hal/images/stepgen-type2-4.svg
+ docs/src/hal/images/stepgen-type0.svg
+ docs/src/hal/images/stepgen-type11-14.svg
+Copyright: 2011 LinuxCNC.org
+License: GPL-3+
+
+Files:
  src/emc/nml_intf/*
  src/emc/kinematics/*
  src/emc/motion/*


### PR DESCRIPTION
This PR is a reaction on the rejection we got from the Debian FTPmasters on the missing reflection of the documentation that has the GFPD as its license. I am not so sure that everyone is aware of that, for instance I just found some SVGs that are GPLed not GFPD'. Any idea for anything more to check?

Maybe we use this PR also to discuss if the next submission should wait for any particular feature to be added/fixed. There still is a problem with Python on Bullseye that comes to mind. Something else? Just another pre-release maybe?

```
LINUXCNC - 2.9.0~pre0
Machine configuration directory is '/home/moeller/linuxcnc/configs/sim.axis'
Machine configuration file is 'axis_mm.ini'
Starting LinuxCNC...
Found file(lib): /usr/share/linuxcnc/hallib/core_sim.hal
Note: Using POSIX non-realtime
Found file(lib): /usr/share/linuxcnc/hallib/sim_spindle_encoder.hal
Found file(lib): /usr/share/linuxcnc/hallib/axis_manualtoolchange.hal
Found file(lib): /usr/share/linuxcnc/hallib/simulated_home.hal
PYTHON: exception during 'this' export:
TypeError: 'Boost.Python.class' object is not iterable


The above exception was the direct cause of the following exception:


Traceback (most recent call last):

  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load

  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked

  File "<frozen importlib._bootstrap>", line 666, in _load_unlocked

  File "<frozen importlib._bootstrap>", line 565, in module_from_spec

  File "<frozen importlib._bootstrap>", line 763, in create_module

SystemError: _PyEval_EvalFrameDefault returned a result with an error set


note: MAXV     max: 53.340 units/sec 3200.400 units/min
note: LJOG     max: 53.340 units/sec 3200.400 units/min
note: LJOG default: 30.480 units/sec 1828.800 units/min
note: jog_order='XYZ'
note: jog_invert=set()
PYTHON: exception during 'this' export:
TypeError: No Python class registered for C++ class Interp


Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/OpenGL/latebind.py", line 43, in __call__
    return self._finalCall( *args, **named )
TypeError: 'NoneType' object is not callable

During handling of the above exception, another exception occurred:
```