### PR TITLE
cppcheck: Memleak realloc, clarifying false positive

### DIFF
--- a/src/libnml/nml/nml_srv.cc
+++ b/src/libnml/nml/nml_srv.cc
@@ -252,8 +252,8 @@ REMOTE_READ_REPLY *NML_SERVER_LOCAL_PORT::blocking_read(REMOTE_READ_REQUEST *
 	    orig_bytes_moved);
 	nml->cms->first_diag_store = cmscopy->first_diag_store;
     }
-    breq->_nml = NULL;
-    delete nmlcopy;
+    delete breq->_nml;
+    breq->_nml=nmlcopy=NULL;
 
     /* Reply structure contains the latest shared memory info-- now return it 
        to cms_dispatch for return to caller */


### PR DESCRIPTION
The details are in commit messages. 
The first patch is the important one. It fixes a (rare, low-mem) memleak with realloc, and with malloc a surprising real one - at least this is how I read the code.

The second one is just, well, I think it is correct and just easier to understand - for humans and cppcheck alike.