### PR TITLE
halshow: remember window geometry and watchlist

### DIFF
--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -960,9 +960,11 @@ proc watchReset {del} {
                 set ::watchlist [lreplace $::watchlist $place $place]
                 set watchlist_copy $::watchlist
                 set ::watchlist ""
+                set scrollbar_pos [lindex [$::cisp yview] 0]
                 foreach var $watchlist_copy {
                     watchHAL $var
                 }
+                $::cisp yview moveto [expr $scrollbar_pos * (1 + 1/double([llength $watchlist_copy]))]
                 setStatusbar "'$del' [msgcat::mc "removed from list"]"
             } else {            
                 watchHAL zzz
@@ -973,8 +975,10 @@ proc watchReset {del} {
 
 proc reloadWatch {} {
     set watchlist_copy $::watchlist
+    set scrollbar_pos [lindex [$::cisp yview] 0]
     watchReset all
     foreach item $watchlist_copy { watchHAL $item }
+    $::cisp yview moveto $scrollbar_pos
 }
 
 # proc switches the insert and removal of upper right text

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -61,10 +61,17 @@ proc saveIni {} {
             # write file
             puts $fc "# Halshow settings"
             puts $fc "# This file is generated automatically."
-            puts $fc [list wm geometry . [wm geometry .]]
-            puts $fc [list placeFrames $::ratio]
-            puts $fc [list set ::ratio $::ratio]
-            puts $fc [list set ::old_w_leftf $::old_w_leftf]
+            puts $fc "wm geometry . [wm geometry .]"
+            puts $fc "placeFrames $::ratio"
+            puts $fc "set ::ratio $::ratio"
+            puts $fc "set ::old_w_leftf $::old_w_leftf"            
+            puts $fc "set ::watchlist {"
+            foreach elem $::watchlist {
+                puts $fc "    $elem"
+            }
+            puts $fc "}"
+            puts $fc "set ::workmode $::workmode"
+            puts $fc "set ::last_watchfile_tail $::last_watchfile_tail"
             close $fc
         }
     }
@@ -89,8 +96,8 @@ wm minsize . 230 240
 wm attributes . -topmost no
 
 # save settings after switching to another window
-bind . <FocusOut> {checkSizeChanged %W}
-# save settings after resize
+bind . <FocusOut> {saveIni}
+# save settings after resize (occurs also after start)
 bind . <FocusIn> {checkSizeChanged %W}
 
 # trap mouse click on window manager delete and ask to save
@@ -327,13 +334,6 @@ scrollbar $str -orient vert -command "$::treew yview"
 pack $str -side right -fill y
 pack $::treew -side right -fill both -expand yes
 $::treew bindText <Button-1> {workMode   }
-
-# Loading the settings from the file.
-# This overrides the default settings above.
-readIni
-if {$::ratio == 0} {
-    hideListview false
-}
 
 #----------tree widget handlers----------
 # a global var -- ::treenodes -- holds the names of existing nodes
@@ -982,6 +982,7 @@ proc savewatchlist { {fmt oneline} } {
   close $f
   set ::last_watchfile_tail [file tail    $sfile]
   set ::last_watchfile_dir  [file dirname $sfile]
+  wm title . "$::last_watchfile_tail - $::titlename"
 }
 
 #----------start up the displays----------
@@ -1041,5 +1042,14 @@ if {[llength $::argv] > 0} {
    }
 }
 
+# Loading the settings from the file.
+# This overrides the default settings above.
+readIni
+if {$::ratio == 0} {
+    hideListview false
+}
+if {$::workmode == "watchhal"} {
+    $::nb raise pw  
+}
 tkwait visibility .
 set ::initPhase false

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -94,7 +94,7 @@ proc saveIni {} {
 
 #----------start toplevel----------
 #
-set ::titlename [msgcat::mc "HAL Show"]
+set ::titlename [msgcat::mc "Halshow"]
 wm title . $::titlename
 wm protocol . WM_DELETE_WINDOW tk_
 image create photo applicationIcon -file [file join [file dirname [info script]] halshow_icon.png]
@@ -232,8 +232,6 @@ set watchmenu [menu $menubar.watch -tearoff 1]
         $watchmenu add command -label [msgcat::mc "Add parameter"] \
             -command {addToWatch param [msgcat::mc "Parameter"]}
         $watchmenu add separator
-        $watchmenu add command -label [msgcat::mc "Set Watch interval"] \
-            -command {setWatchInterval}
         $watchmenu add command -label [msgcat::mc "Reload Watch"] \
             -command {reloadWatch}
         $watchmenu add command -label [msgcat::mc "Erase Watch"] \

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -569,6 +569,8 @@ proc makeSettings {} {
         -justify left]  -anchor w -pady 2 -padx 2
     addTextSetting $f1 ::ffmts "    [msgcat::mc "Float"]"
     addTextSetting $f1 ::ifmts "    [msgcat::mc "Integer"]"
+    set ::ffmt_setting $f1.::ffmts
+    set ::ifmt_setting $f1.::ifmts
     addBoolSetting $f1 ::alwaysOnTop [msgcat::mc "Always on top\n(Note: May not\
         working with all desktop environments)"]
     addBoolSetting $f1 ::autoSaveWatchlist [msgcat::mc "Remember watchlist"]
@@ -1085,10 +1087,14 @@ if {[llength $::argv] > 0} {
        "--iformat" {incr idx;
                     set ::ifmt [lindex $::argv $idx]
                     incr idx
+                    $::ifmt_setting.label configure -text "    [msgcat::mc "Integer (disabled by \"--iformat\" argument)"]"
+                    $::ifmt_setting.entry configure -state disabled
                    }
        "--fformat" {incr idx;
                     set ::ffmt [lindex $::argv $idx]
                     incr idx
+                    $::ffmt_setting.label configure -text "    [msgcat::mc "Float (disabled by \"--fformat\" argument)"]"
+                    $::ffmt_setting.entry configure -state disabled
                    }
        default { set watchfile [lindex $::argv $idx]
                  if [file readable $watchfile] {

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -540,8 +540,8 @@ proc copySelection {clear} {
 proc makeWatch {} {
     set ::cisp [canvas $::watchhal.c -yscrollcommand [list $::watchhal.s set]]
     scrollbar $::watchhal.s -command [list $::cisp yview] -orient v
-    pack $::cisp -side left -fill both -expand yes
-    pack $::watchhal.s -side left -fill y -expand no
+    pack $::watchhal.s -side right -fill y -expand no
+    pack $::cisp -side right -fill both -expand yes  
     bind $::cisp <Configure> {
         set ::canvaswidth %w
         reloadWatch

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -29,6 +29,47 @@ foreach class { Button Checkbutton Entry Label Listbox Menu Menubutton \
     option add *$class.borderWidth 1  100
 }
 
+ if {[info exists ::env(CONFIG_DIR)]} {
+    set ::INIFILE "$::env(CONFIG_DIR)/halshow.preferences"
+ } else {
+    set ::INIFILE "~/.halshow_preferences"
+ }
+# puts stderr "Halshow inifile: $::INIFILE"
+
+
+proc readIni {} {
+    # check that the file is readable
+    if { ![file readable $::INIFILE]} {
+        # puts stderr "\[halshow\] Settings file not found, using defaults"
+        return -1
+    } elseif { [catch {source $::INIFILE}] } { 
+        puts stderr "\[halshow\] Error in settings file $::INIFILE, using defaults.\n" 
+        return -1
+    } else {
+        return 0
+    }
+}
+
+set ::initPhase true
+proc saveIni {} {
+    # The flag 'initPhase' prevents saving on the first FocusIn event
+    if {!$::initPhase} {
+        # open the file for writin0g (truncates if file exists)
+        if { [catch {set fc [open $::INIFILE w]}] } {
+            puts stder "\[halshow\] Unable to save settings to \"$INIFILE\"."
+        } else {
+            # write file
+            puts $fc "# Halshow settings"
+            puts $fc "# This file is generated automatically."
+            puts $fc [list wm geometry . [wm geometry .]]
+            puts $fc [list placeFrames $::ratio]
+            puts $fc [list set ::ratio $::ratio]
+            puts $fc [list set ::old_w_leftf $::old_w_leftf]
+            close $fc
+        }
+    }
+}
+
 #----------start toplevel----------
 #
 set ::titlename [msgcat::mc "HAL Show"]
@@ -43,13 +84,19 @@ set xmax [winfo screenwidth .]
 set ymax [winfo screenheight .]
 set x [expr ($xmax - $masterwidth )  / 2 ]
 set y [expr ($ymax - $masterheight )  / 2]
-wm geometry . "${masterwidth}x${masterheight}+$x+$y"
-wm minsize . [int [expr $masterwidth*0.3]] [int [expr $masterheight*0.5]]
+wm geometry . "${masterwidth}x${masterheight}+$x+$y" 
+wm minsize . 230 240
 wm attributes . -topmost no
+
+# save settings after switching to another window
+bind . <FocusOut> {checkSizeChanged %W}
+# save settings after resize
+bind . <FocusIn> {checkSizeChanged %W}
 
 # trap mouse click on window manager delete and ask to save
 wm protocol . WM_DELETE_WINDOW askKill
 proc askKill {} {
+    saveIni
     killHalConfig
 }
 
@@ -85,6 +132,28 @@ proc placeFrames {ratio} {
 }
 
 placeFrames 0.3
+
+set ::geometryOld [wm geometry .]
+proc checkSizeChanged {w} {
+    if {$w == "." || $w == ".f2.show.grip"} {
+        if {[wm geometry .] == $::geometryOld} {
+            return
+        }
+    } elseif {$w == "force"} {
+    } else {
+        return
+    }
+    saveIni
+    set ::geometryOld [wm geometry .]
+}
+
+set ::ratioOld $::ratio
+proc checkRatioChanged {} {
+    if {$::ratio != $::ratioOld} {
+        saveIni
+    }
+    set ::ratioOld $::ratio
+}
 
 # slider process is used for several widgets
 proc sSlide {f a b} {
@@ -167,27 +236,34 @@ set gripf [frame $::leftf.grip -borderwidth 3 -width 8 -cursor sb_h_double_arrow
 pack $gripf -side right -fill y
 pack $::tf -fill both -expand yes
 
-# grip symbol
+# grip symbol for changing the ratio of left and right frame
 set grip [frame $gripf.grip -relief groove -borderwidth 2 -width 2 -height 20]
-pack [frame $gripf.topfill] -side top -expand y ;# add frames to center grip
+pack [frame $gripf.topfill] -side top -expand y ; # add frames to center grip
 pack $grip
 pack [frame $gripf.bottomfill] -side bottom -expand y
 set ::grip_clicked false
 bind $gripf <Motion> [list scaleFrames]
 bind $gripf <ButtonPress-1> {set ::grip_clicked true}
-bind $gripf <ButtonRelease-1> {set ::grip_clicked false}
+bind $gripf <ButtonRelease-1> {
+    set ::grip_clicked false
+    checkRatioChanged
+}
 bind $grip <Motion> [list scaleFrames]
 bind $grip <ButtonPress-1> {set ::grip_clicked true}
-bind $grip <ButtonRelease-1> {set ::grip_clicked false}
+bind $grip <ButtonRelease-1> {
+    set ::grip_clicked false
+    checkRatioChanged
+}
 
 # frame to hide tree
 set fh [frame $::tf.fh -borderwidth 0 -relief raised]
 pack $fh -fill x
-set tlbl [label $fh.tlbl -text [msgcat::mc "Tree View"]]
-pack $tlbl -side left
+
 set bh [button $fh.bh -borderwidth 0 -text » -padx 6 -pady 1]
 pack $bh -side right
-bind $bh <Button-1> [list hideListview]
+set tlbl [label $fh.tlbl -text [msgcat::mc "Tree View"]]
+pack $tlbl -side left
+bind $bh <Button-1> [list hideListview true]
 
 # frame to show tree
 set ::fs [frame $::rightf.fs -borderwidth 1 -relief raised -width 24]
@@ -199,19 +275,24 @@ set clbl [canvas $::fs.clbl -width 20]
 pack $clbl
 $clbl create text 10 5 -angle 90 -anchor e -text [msgcat::mc "Tree View"] -font [list "" 10]
 
-proc hideListview {} {
+proc hideListview {resizeWindow} {
     place $::fs -width 24 -relheight 1.0
     pack forget $::nb
     place $::nb -anchor ne -relx 1.0 -relwidth 1.0 -width -33 -relheight 1.0
-    placeFrames 0 
-    set ::old_w_leftf [winfo width $::leftf]
-    set new_w [expr [winfo width $::nb] + [$::fs cget -width] + 9 + 2* [.main cget -padx]]
-    set new_x [int [expr [winfo x .] + [winfo width .] - $new_w - 3]]
-    # offset added here because [winfo geometry .] differs from [wm geometry .]    
-    set y [expr [winfo y .] - 61]
-    wm geometry . "${new_w}x[winfo height .]+$new_x+$y"
+    placeFrames 0
+    if {$resizeWindow} {
+        set ::old_w_leftf [winfo width $::leftf]
+        set new_w [expr [winfo width $::nb] + [$::fs cget -width] + 9 + 2* [.main cget -padx]]
+        set new_x [int [expr [winfo x .] + [winfo width .] - $new_w - 3]]
+        # offset added here because [winfo geometry .] differs from [wm geometry .]    
+        set y [expr [winfo y .] - 61]
+        wm geometry . "${new_w}x[winfo height .]+$new_x+$y"
+        tkwait visibility $::fs
+        saveIni
+   }
 }
 
+set ::old_w_leftf 160
 proc showListview {} {
     place forget $::fs
     place configure $::nb -relwidth 1.0 -width 0
@@ -223,8 +304,11 @@ proc showListview {} {
     # offset added here because [winfo geometry .] differs from [wm geometry .]
     set y [expr [winfo y .] - 61]
     wm geometry . "${new_w}x[winfo height .]+$new_x+$y"
+    tkwait visibility $::tf
+    saveIni
 }
 
+# scale left and right frame while dragging
 proc scaleFrames {} {
     if {$::grip_clicked} {
         set xpos [expr {[winfo pointerx .] - [winfo x .]}]
@@ -235,14 +319,21 @@ proc scaleFrames {} {
         }
     }
 }
-# build the tree widgets left side
 
+# build the tree widgets left side
 set ::treew [Tree $::tf.t  -width 10 -yscrollcommand "sSlide $::tf" ]
 set str $::tf.sc
 scrollbar $str -orient vert -command "$::treew yview"
 pack $str -side right -fill y
 pack $::treew -side right -fill both -expand yes
 $::treew bindText <Button-1> {workMode   }
+
+# Loading the settings from the file.
+# This overrides the default settings above.
+readIni
+if {$::ratio == 0} {
+    hideListview false
+}
 
 #----------tree widget handlers----------
 # a global var -- ::treenodes -- holds the names of existing nodes
@@ -422,6 +513,7 @@ proc makeShow {} {
 
     bind $::disp <Button-3> {popupmenu_text %X %Y}
     bind . <Control-KeyPress-c> {copySelection 0}
+    bind $f2.show.grip <ButtonRelease-1> {checkSizeChanged %W}
 }
 
 proc copySelection {clear} {
@@ -949,3 +1041,5 @@ if {[llength $::argv] > 0} {
    }
 }
 
+tkwait visibility .
+set ::initPhase false


### PR DESCRIPTION
**Saves the window geometry after resizing, changing the tree view width, moving the window, show/hide tree and exit.**

If started from a GUI then the `CONFIG_DIR` can be read ans the settings file is written to this path.
If started from the bash, this environmental variable cannot is not set, so the file is placed in the home directory.
Do you agree with that behaviour or should it be always written to the home directory? (Axis is doing in the same way)
But I thought it would be better to have a own settings file for each configuration.
Maybe there is a possibility to obtain the config dir  even when started from the bash?