### PR TITLE
Introducing destructor to os_intf/inetnull.cc

### DIFF
--- a/src/libnml/os_intf/inetnull.cc
+++ b/src/libnml/os_intf/inetnull.cc
@@ -58,6 +58,7 @@ int inet_file_close(INET_FILE * inet_file)
     if (NULL != inet_file) {
 	if (inet_file->fp) {
 	    fclose(inet_file->fp);
+	    inet_file->fp = NULL;
 	}
 	delete inet_file;
     }
@@ -95,4 +96,5 @@ int inet_file_rewind(INET_FILE * ifp)
 
 ~INET_FILE() {
     if (fp) fclose(fp);
+    fp = NULL;
 }

--- a/src/libnml/os_intf/inetnull.cc
+++ b/src/libnml/os_intf/inetnull.cc
@@ -20,6 +20,7 @@
 class INET_FILE {
   public:
     FILE * fp;
+    ~INET_FILE();
 };
 
 int inet_file_init(const char *agent_name, char *agent_version, int debug)
@@ -55,7 +56,9 @@ char *inet_file_gets(char *str, int maxlen, INET_FILE * inet_file)
 int inet_file_close(INET_FILE * inet_file)
 {
     if (NULL != inet_file) {
-	fclose(inet_file->fp);
+	if (inet_file->fp) {
+	    fclose(inet_file->fp);
+	}
 	delete inet_file;
     }
     return 0;
@@ -66,7 +69,11 @@ int inet_file_eof(INET_FILE * inet_file)
     if (NULL == inet_file) {
 	return 1;
     }
-    return feof(inet_file->fp);
+    if (inet_file->fp) {
+        return feof(inet_file->fp);
+    } else {
+	return 1; // or raise an error
+    }
 }
 
 int inet_file_exit()
@@ -79,9 +86,13 @@ int inet_file_rewind(INET_FILE * ifp)
     if (NULL == ifp) {
 	return -1;
     }
-    if (ifp->fp != NULL) {
+    if (ifp->fp) {
 	rewind(ifp->fp);
 	return 0;
     }
     return 0;
+}
+
+~INET_FILE() {
+    if (fp) fclose(fp);
 }


### PR DESCRIPTION
I am a bit uncertain about this one. Please discuss if this kind of hardening is indeed beneficial. And some good soul should bring this to the attention of the cppcheck devs.

Looked into this because of this error message, which is a false
positive that should be reported to cppcheck:

os_intf/inetnull.cc:45:5: error: Resource leak: fp [resourceLeak]
    return inet_file;