### PR TITLE
motmod refactoring: Remove joint and axis internal data from shared mem

### DIFF
--- a/src/emc/motion-logger/motion-logger.c
+++ b/src/emc/motion-logger/motion-logger.c
@@ -52,14 +52,12 @@ struct emcmot_error_t *emcmotError = 0;
 
 int mot_comp_id;
 
-emcmot_joint_t joint_array[EMCMOT_MAX_JOINTS];
+emcmot_joint_t joints[EMCMOT_MAX_JOINTS];
 int num_joints = EMCMOT_MAX_JOINTS;
-emcmot_joint_t *joints = 0;
 int num_spindles = EMCMOT_MAX_SPINDLES;
 
-emcmot_axis_t axis_array[EMCMOT_MAX_AXIS];
+emcmot_axis_t axes[EMCMOT_MAX_AXIS];
 int num_axes = EMCMOT_MAX_AXIS;
-emcmot_axis_t *axes = 0;
 
 void emcmot_config_change(void) {
     if (emcmotConfig->head == emcmotConfig->tail) {
@@ -130,9 +128,6 @@ static int init_comm_buffers(void) {
 
     emcmot_config_change();
 
-    /* init pointer to joint structs */
-    joints = joint_array;
-
     /* init per-joint stuff */
     for (joint_num = 0; joint_num < num_joints; joint_num++) {
 	/* point to structure for this joint */
@@ -172,9 +167,6 @@ static int init_comm_buffers(void) {
 
 	SET_JOINT_INPOS_FLAG(joint, 1);
     }
-
-    /* init pointer to axes structs */
-    axes = axis_array;
 
     /* init per-axis stuff */
     for (axis_num = 0; axis_num < num_axes; axis_num++) {

--- a/src/emc/motion-logger/motion-logger.c
+++ b/src/emc/motion-logger/motion-logger.c
@@ -121,7 +121,7 @@ static int init_comm_buffers(void) {
     emcmotStatus->rapid_scale = 1.0;
     for (int n = 0; n < EMCMOT_MAX_SPINDLES; n++) emcmotStatus->spindle_status[n].scale = 1.0;
     emcmotStatus->net_feed_scale = 1.0;
-    /* adaptive feed is off by default, feed override, spindle 
+    /* adaptive feed is off by default, feed override, spindle
        override, and feed hold are on */
     emcmotStatus->enables_new = FS_ENABLED | SS_ENABLED | FH_ENABLED;
     emcmotStatus->enables_queued = emcmotStatus->enables_new;

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -231,10 +231,10 @@ extern emcmot_hal_data_t *emcmot_hal_data;
 /* pointer to array of joint structs with all joint data */
 /* the actual array may be in shared memory or in kernel space, as
    determined by the init code in motion.c */
-extern emcmot_joint_t *joints;
+extern emcmot_joint_t joints[EMCMOT_MAX_JOINTS];
 
 /* pointer to array of axis structs with all axis data */
-extern emcmot_axis_t *axes;
+extern emcmot_axis_t axes[EMCMOT_MAX_AXIS];
 
 /* Variable defs */
 extern KINEMATICS_FORWARD_FLAGS fflags;

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -2,10 +2,10 @@
 * Description: mot_priv.h
 *   Macros and declarations local to the realtime sources.
 *
-* Author: 
+* Author:
 * License: GPL Version 2
 * System: Linux
-*    
+*
 * Copyright (c) 2004 All rights reserved.
 ********************************************************************/
 #ifndef MOT_PRIV_H
@@ -175,7 +175,7 @@ typedef struct {
     hal_float_t debug_float_3;	/* RPA: generic param, for debugging */
     hal_s32_t debug_s32_0;	/* RPA: generic param, for debugging */
     hal_s32_t debug_s32_1;	/* RPA: generic param, for debugging */
-    
+
     hal_bit_t *synch_do[EMCMOT_MAX_DIO]; /* WPI array: output pins for motion synched IO */
     hal_bit_t *synch_di[EMCMOT_MAX_DIO]; /* RPI array: input pins for motion synched IO */
     hal_float_t *analog_input[EMCMOT_MAX_AIO]; /* RPI array: input pins for analog Inputs */

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -86,11 +86,10 @@ RTAPI_MP_INT(unlock_joints_mask, "mask to select joints for unlock pins");
 /* pointer to emcmot_hal_data_t struct in HAL shmem, with all HAL data */
 emcmot_hal_data_t *emcmot_hal_data = 0;
 
-/* pointer to joint data */
-emcmot_joint_t *joints = 0;
-
-/* pointer to axis data */
-emcmot_axis_t *axes = 0;
+/* allocate array for joint data */
+emcmot_joint_t joints[EMCMOT_MAX_JOINTS];
+/* allocate array for axis data */
+emcmot_axis_t axes[EMCMOT_MAX_AXIS];
 
 /*
   Principles of communication:
@@ -244,6 +243,7 @@ static int module_intfc() {
 
     tpMotData(emcmotStatus
              ,emcmotConfig
+             ,axes
              );
     return 0;
 }
@@ -963,10 +963,6 @@ static int init_comm_buffers(void)
     /* record the kinematics type of the machine */
     emcmotConfig->kinType = kinematicsType();
     emcmot_config_change();
-
-    /* init pointer to joints and axes structs */
-    joints = &(emcmotStatus->joints[0]);
-    axes   = &(emcmotStatus->axes[0]);
 
     for (spindle_num = 0; spindle_num < EMCMOT_MAX_SPINDLES; spindle_num++){
         emcmotStatus->spindle_status[spindle_num].scale = 1.0;

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -337,7 +337,7 @@ int rtapi_app_main(void)
   else if(!num_aio){
     num_aio = DEFAULT_AIO;
   }
-    
+
     if (( num_aio < 1 ) || ( num_aio > EMCMOT_MAX_AIO )) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    _("MOTION: num_aio is %d, must be between 1 and %d\n"), num_aio, EMCMOT_MAX_AIO);
@@ -379,7 +379,7 @@ int rtapi_app_main(void)
 	hal_exit(mot_comp_id);
 	return -1;
     }
-    
+
     if (module_intfc()) {
 	rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: module_intfc() failed\n"));
 	return -1;
@@ -616,7 +616,7 @@ static int init_hal_io(void)
     /* default value of enable is TRUE, so simple machines
        can leave it disconnected */
     *(emcmot_hal_data->enable) = 1;
-    
+
     /* motion synched dio, init to not enabled */
     for (n = 0; n < num_dio; n++) {
 	 *(emcmot_hal_data->synch_do[n]) = 0;
@@ -949,7 +949,7 @@ static int init_comm_buffers(void)
     emcmotStatus->feed_scale = 1.0;
     emcmotStatus->rapid_scale = 1.0;
     emcmotStatus->net_feed_scale = 1.0;
-    /* adaptive feed is off by default, feed override, spindle 
+    /* adaptive feed is off by default, feed override, spindle
        override, and feed hold are on */
     emcmotStatus->enables_new = FS_ENABLED | SS_ENABLED | FH_ENABLED;
     emcmotStatus->enables_queued = emcmotStatus->enables_new;
@@ -1090,14 +1090,14 @@ static int init_threads(void)
 	return -1;
     }
     /* export realtime functions that do the real work */
-    retval = hal_export_funct("motion-controller", emcmotController, 0	/* arg 
+    retval = hal_export_funct("motion-controller", emcmotController, 0	/* arg
 	 */ , 1 /* uses_fp */ , 0 /* reentrant */ , mot_comp_id);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "MOTION: failed to export controller function\n");
 	return -1;
     }
-    retval = hal_export_funct("motion-command-handler", emcmotCommandHandler, 0	/* arg 
+    retval = hal_export_funct("motion-command-handler", emcmotCommandHandler, 0	/* arg
 	 */ , 1 /* uses_fp */ , 0 /* reentrant */ , mot_comp_id);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
@@ -1108,7 +1108,7 @@ static int init_threads(void)
 #if 0
     /*! \todo FIXME - currently the traj planner is called from the controller */
     /* eventually it will be a separate function */
-    retval = hal_export_funct("motion-traj-planner", emcmotTrajPlanner, 0	/* arg 
+    retval = hal_export_funct("motion-traj-planner", emcmotTrajPlanner, 0	/* arg
 	 */ , 1 /* uses_fp */ ,
 	0 /* reentrant */ , mot_comp_id);
     if (retval < 0) {

--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -635,7 +635,7 @@ Suggestion: Split this in to an Error and a Status flag register..
 	EmcPose probedPos;	/* Axis positions stored as soon as possible
 				   after last probeTripped */
 
-	
+
 	int synch_di[EMCMOT_MAX_DIO]; /* inputs to the motion controller, queried by G-code */
 	int synch_do[EMCMOT_MAX_DIO]; /* outputs to the motion controller, queried by G-code */
 	double analog_input[EMCMOT_MAX_AIO]; /* inputs to the motion controller, queried by G-code */

--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -594,8 +594,6 @@ Suggestion: Split this in to an Error and a Status flag register..
 */
 
     typedef struct emcmot_status_t {
-	emcmot_joint_t joints[EMCMOT_MAX_JOINTS];	/* joint data */
-	emcmot_axis_t  axes[EMCMOT_MAX_AXIS];	    /* axis data */
 	unsigned char head;	/* flag count for mutex detect */
 	/* these three are updated only when a new command is handled */
 	cmd_code_t commandEcho;	/* echo of input command */

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -311,8 +311,8 @@ STATIC inline double tpGetRealFinalVel(TP_STRUCT const * const tp,
 
     if (emcmotStatus->stepping || tc->term_cond != TC_TERM_COND_TANGENT || tp->reverse_run) {
         return 0.0;
-    } 
-    
+    }
+
     // Get target velocities for this segment and next segment
     double v_target_this = tpGetRealTargetVel(tp, tc);
     double v_target_next = 0.0;
@@ -405,7 +405,7 @@ int tpCreate(TP_STRUCT * const tp, int _queueSize,int id)
     if (-1 == tcqCreate(&tp->queue, tp->queueSize, tcSpace)) {
         return TP_ERR_FAIL;
     }
-    
+
 #ifdef MAKE_TP_HAL_PINS // {
     if (-1 == makepins(id)) {
         return TP_ERR_FAIL;
@@ -807,7 +807,7 @@ STATIC int tpInitBlendArcFromPrev(TP_STRUCT const * const tp,
 
     // Copy over state data from TP
     tcSetupState(blend_tc, tp);
-    
+
     // Set kinematics parameters from blend calculations
     tcSetupMotion(blend_tc,
             vel,
@@ -939,7 +939,7 @@ STATIC tp_err_t tpCreateLineArcBlend(TP_STRUCT * const tp, TC_STRUCT * const pre
     tp_debug_print("-- Starting LineArc blend arc --\n");
 
     PmCartesian acc_bound, vel_bound;
-    
+
     //Get machine limits
     tpGetMachineAccelBounds(&acc_bound);
     tpGetMachineVelBounds(&vel_bound);
@@ -975,10 +975,10 @@ STATIC tp_err_t tpCreateLineArcBlend(TP_STRUCT * const tp, TC_STRUCT * const pre
     int res_param = blendComputeParameters(&param);
 
     int res_points = blendFindPoints3(&points_approx, &geom, &param);
-    
+
     int res_post = blendLineArcPostProcess(&points_exact,
             &points_approx,
-            &param, 
+            &param,
             &geom, &prev_tc->coords.line.xyz,
             &tc->coords.circle.xyz);
 
@@ -991,7 +991,7 @@ STATIC tp_err_t tpCreateLineArcBlend(TP_STRUCT * const tp, TC_STRUCT * const pre
                 res_post);
         return TP_ERR_FAIL;
     }
-    
+
     /* If blend calculations were successful, then we're ready to create the
      * blend arc.
      */
@@ -1097,7 +1097,7 @@ STATIC tp_err_t tpCreateArcLineBlend(TP_STRUCT * const tp, TC_STRUCT * const pre
 
     tp_debug_print("-- Starting ArcLine blend arc --\n");
     PmCartesian acc_bound, vel_bound;
-    
+
     //Get machine limits
     tpGetMachineAccelBounds(&acc_bound);
     tpGetMachineVelBounds(&vel_bound);
@@ -1133,10 +1133,10 @@ STATIC tp_err_t tpCreateArcLineBlend(TP_STRUCT * const tp, TC_STRUCT * const pre
     int res_param = blendComputeParameters(&param);
 
     int res_points = blendFindPoints3(&points_approx, &geom, &param);
-    
+
     int res_post = blendArcLinePostProcess(&points_exact,
             &points_approx,
-            &param, 
+            &param,
             &geom, &prev_tc->coords.circle.xyz,
             &tc->coords.line.xyz);
 
@@ -1149,7 +1149,7 @@ STATIC tp_err_t tpCreateArcLineBlend(TP_STRUCT * const tp, TC_STRUCT * const pre
                 res_post);
         return TP_ERR_FAIL;
     }
-    
+
     blendCheckConsume(&param, &points_exact, prev_tc, emcmotConfig->arcBlendGapCycles);
 
     /* If blend calculations were successful, then we're ready to create the
@@ -1247,7 +1247,7 @@ STATIC tp_err_t tpCreateArcArcBlend(TP_STRUCT * const tp, TC_STRUCT * const prev
     }
 
     PmCartesian acc_bound, vel_bound;
-    
+
     //Get machine limits
     tpGetMachineAccelBounds(&acc_bound);
     tpGetMachineVelBounds(&vel_bound);
@@ -1290,10 +1290,10 @@ STATIC tp_err_t tpCreateArcArcBlend(TP_STRUCT * const tp, TC_STRUCT * const prev
 
     int res_param = blendComputeParameters(&param);
     int res_points = blendFindPoints3(&points_approx, &geom, &param);
-    
+
     int res_post = blendArcArcPostProcess(&points_exact,
             &points_approx,
-            &param, 
+            &param,
             &geom, &prev_tc->coords.circle.xyz,
             &tc->coords.circle.xyz);
 
@@ -1309,7 +1309,7 @@ STATIC tp_err_t tpCreateArcArcBlend(TP_STRUCT * const tp, TC_STRUCT * const prev
     }
 
     blendCheckConsume(&param, &points_exact, prev_tc, emcmotConfig->arcBlendGapCycles);
-    
+
     /* If blend calculations were successful, then we're ready to create the
      * blend arc. Begin work on temp copies of each circle here:
      */
@@ -1408,11 +1408,11 @@ STATIC tp_err_t tpCreateLineLineBlend(TP_STRUCT * const tp, TC_STRUCT * const pr
 
     tp_debug_print("-- Starting LineLine blend arc --\n");
     PmCartesian acc_bound, vel_bound;
-    
+
     //Get machine limits
     tpGetMachineAccelBounds(&acc_bound);
     tpGetMachineVelBounds(&vel_bound);
-    
+
     // Setup blend data structures
     BlendGeom3 geom;
     BlendParameters param;
@@ -2597,7 +2597,7 @@ STATIC int tpUpdateMovementStatus(TP_STRUCT * const tp, TC_STRUCT const * const 
         emcmotStatus->requested_vel = 0;
         emcmotStatus->current_vel = 0;
         emcmotStatus->spindleSync = 0;
-        
+
         emcPoseZero(&emcmotStatus->dtg);
 
         tp->motionType = 0;
@@ -3078,7 +3078,7 @@ STATIC int tpUpdateCycle(TP_STRUCT * const tp,
     // Run cycle update with stored cycle time
     int res_accel = 1;
     double acc=0, vel_desired=0;
-    
+
     // If the slowdown is not too great, use velocity ramping instead of trapezoidal velocity
     // Also, don't ramp up for parabolic blends
     if (tc->accel_mode && tc->term_cond == TC_TERM_COND_TANGENT) {

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -56,6 +56,7 @@
 
 static emcmot_status_t *emcmotStatus;
 static emcmot_config_t *emcmotConfig;
+static emcmot_axis_t *emcmotAxis;
 
 //==========================================================
 // tp module interface
@@ -79,10 +80,12 @@ void tpMotFunctions(void(*pDioWrite)(int,char)
 
 void tpMotData(emcmot_status_t *pstatus
               ,emcmot_config_t *pconfig
+              ,emcmot_axis_t *paxis
               )
 {
     emcmotStatus = pstatus;
     emcmotConfig = pconfig;
+    emcmotAxis = paxis;
 }
 //=========================================================
 
@@ -171,9 +174,9 @@ STATIC int tpGetMachineAccelBounds(PmCartesian  * const acc_bound) {
         return TP_ERR_FAIL;
     }
 
-    acc_bound->x = emcmotStatus->axes[0].acc_limit; //0==>x
-    acc_bound->y = emcmotStatus->axes[1].acc_limit; //1==>y
-    acc_bound->z = emcmotStatus->axes[2].acc_limit; //2==>z
+    acc_bound->x = emcmotAxis[0].acc_limit; //0==>x
+    acc_bound->y = emcmotAxis[1].acc_limit; //1==>y
+    acc_bound->z = emcmotAxis[2].acc_limit; //2==>z
     return TP_ERR_OK;
 }
 
@@ -183,9 +186,9 @@ STATIC int tpGetMachineVelBounds(PmCartesian  * const vel_bound) {
         return TP_ERR_FAIL;
     }
 
-    vel_bound->x = emcmotStatus->axes[0].vel_limit; //0==>x
-    vel_bound->y = emcmotStatus->axes[1].vel_limit; //1==>y
-    vel_bound->z = emcmotStatus->axes[2].vel_limit; //2==>z
+    vel_bound->x = emcmotAxis[0].vel_limit; //0==>x
+    vel_bound->y = emcmotAxis[1].vel_limit; //1==>y
+    vel_bound->z = emcmotAxis[2].vel_limit; //2==>z
     return TP_ERR_OK;
 }
 

--- a/src/emc/tp/tp.h
+++ b/src/emc/tp/tp.h
@@ -82,6 +82,7 @@ void tpMotFunctions(void(*pDioWrite)(int,char)
 
 void tpMotData(emcmot_status_t *
               ,emcmot_config_t *
+              ,emcmot_axis_t *
               );
 //---------------------------------------------------------------------
 


### PR DESCRIPTION
This patch takes a first step in reducing the scope of internal data of motmod by making joints' and axes' internal data inaccessible from "the rest of the world".

Rationale: Reducing the scope of data makes the code easier to maintain and extend. (Specifically, this is part of preparation for adding jerk limited jog planning in the future.)