### PR TITLE
Fix various typos

### DIFF
--- a/configs/by_interface/parport/nist-lathe/nist-lathe.hal
+++ b/configs/by_interface/parport/nist-lathe/nist-lathe.hal
@@ -111,7 +111,7 @@ net spindle-forward => pwmgen.0.enable
 # PID is not used to give closed-loop spindle speed control, because at the
 # highest speeds the software-based counter cannot keep up (note: with 'counter',
 # it can)
-# Instead, this offset and scale have been determined emperically
+# Instead, this offset and scale have been determined empirically
 # -- if these numbers are accurate, then top speed at this gearing is about
 # 1200 rpm
 #

--- a/configs/common/configurable_options/pyvcp/xyzjog.xml
+++ b/configs/common/configurable_options/pyvcp/xyzjog.xml
@@ -133,7 +133,7 @@
         <label>
                 <width>1</width>
         </label>
-        <labelframe text="MDI comands"> 
+        <labelframe text="MDI commands"> 
        <font>("Helvetica",20)</font>
 		<hbox>
                      <button>

--- a/configs/sim/axis/db_demo/README
+++ b/configs/sim/axis/db_demo/README
@@ -18,7 +18,7 @@ F2 --------- Machine On
 Ctrl-Home -- Home All
 R ---------- Run program
 
-You can also experiment with MDI for the releveant
+You can also experiment with MDI for the relevant
 commands (TnM6, T0M6, G10L0, G10L1, G10L10, M61)
 
 The default program runs a loop that a) loads tool
@@ -30,7 +30,7 @@ The display will show different zoffsets at each
 tool change since the tool data includes several
 tools with the same diameter but different
 zoffsets and the applied database rule selects the
-tool with the minimun time usage.  Since the pause
+tool with the minimum time usage.  Since the pause
 time is nominally the same for each tool offered,
 the database will select different tools for T10
 with each reload.

--- a/docs/man/es/man1/mitsub_vfd.1
+++ b/docs/man/es/man1/mitsub_vfd.1
@@ -39,7 +39,7 @@ Fr-A700 F700 E700 D700 technical manual for the 700 series
 .br
 The inverter must be set manually for communication
 .br
-( you may have to set PR 77 to 1 to unlock PR modifcation )
+( you may have to set PR 77 to 1 to unlock PR modification )
 .br
 You must power cycle the inverter for some of these. (eg 79)
 

--- a/docs/man/es/man1/xhc-whb04b-6.1
+++ b/docs/man/es/man1/xhc-whb04b-6.1
@@ -819,7 +819,7 @@ net pdnt\&.macro\-6                          whb\&.button\&.macro\-6            
 net pdnt\&.macro\-7                          whb\&.button\&.macro\-7                    halui\&.mdi\-command\-07             # use MDI command from main\&.ini
 net pdnt\&.reserved\&.for\&.spindle\&.dir         whb\&.button\&.macro\-8                                                     # Harcoded for spindle direction inside pendant
 net pdnt\&.macro\-9                          whb\&.button\&.macro\-9                    halui\&.mdi\-command\-09             # use MDI command from main\&.ini
-net pdnt\&.reserved\&.for\&.ABS\-REL             whb\&.button\&.macro\-10                                                    # Hardcoded for swap Dro  Relative/Absolue
+net pdnt\&.reserved\&.for\&.ABS\-REL             whb\&.button\&.macro\-10                                                    # Hardcoded for swap Dro  Relative/Absolute
 net pdnt\&.macro\-14                         whb\&.button\&.macro\-14                   halui\&.mdi\-command\-14             # use MDI command from main\&.ini
 net pdnt\&.reserved\&.for\&.flood               whb\&.button\&.macro\-15                                                    # Harcoded for halui\&.flood on/off
 net pdnt\&.reserved\&.for\&.mist                whb\&.button\&.macro\-16                                                    # Harcoded for halui\&.mist on/off
@@ -877,7 +877,7 @@ net pdnt\&.spindle\&.forward                  whb\&.halui\&.spindle\&.forward   
 net pdnt\&.spindle\&.reverse                  whb\&.halui\&.spindle\&.reverse             halui\&.spindle\&.0\&.reverse
 net pdnt\&.spindle\&.increase                 whb\&.halui\&.spindle\&.increase            halui\&.spindle\&.0\&.increase         # reserved whb\&.button\&.macro\-3
 net pdnt\&.spindle\&.decrease                 whb\&.halui\&.spindle\&.decrease            halui\&.spindle\&.0\&.decrease         # reserved whb\&.button\&.macro\-4
-net pdnt\&.spindle\-speed\-abs                whb\&.halui\&.spindle\-speed\-cmd           spindle\&.0\&.speed\-out\-abs          # speed cmd from motion in rpm absolue
+net pdnt\&.spindle\-speed\-abs                whb\&.halui\&.spindle\-speed\-cmd           spindle\&.0\&.speed\-out\-abs          # speed cmd from motion in rpm absolute
 
 
 # spindle speed override signals

--- a/docs/man/es/man9/sserial.9
+++ b/docs/man/es/man9/sserial.9
@@ -16,7 +16,7 @@ Mesa Anything-IO cards and a range of subsidiary devices termed "smart-serial
 remotes".
 The remote cards perform a variety of functions, but typically they combine 
 various classes of IO. 
-The remot cards are self-configuring, in that they tell the main LinuxCNC 
+The remote cards are self-configuring, in that they tell the main LinuxCNC 
 Hostmot2 driver what their pin functions are and what they should be named. 
 
 Many sserial remotes offer different pinouts depending on the mode they are 

--- a/docs/man/man9/hm2_rpspi.9
+++ b/docs/man/man9/hm2_rpspi.9
@@ -86,7 +86,7 @@ combinations of SPI and CE should be probed:
 
 The probe is performed exactly in above order. Any boards found will be
 numbered 0...4 in the order found. See also
-.BR INTERFACE\ CONFGURATION
+.BR INTERFACE\ CONFIGURATION
 below.
 
 It is an error if a probe fails and the driver will abort.  The SPI0/SPI1

--- a/docs/man/man9/sserial.9
+++ b/docs/man/man9/sserial.9
@@ -16,7 +16,7 @@ Mesa Anything-IO cards and a range of subsidiary devices termed "smart-serial
 remotes".
 The remote cards perform a variety of functions, but typically they combine 
 various classes of IO. 
-The remot cards are self-configuring, in that they tell the main LinuxCNC 
+The remote cards are self-configuring, in that they tell the main LinuxCNC 
 Hostmot2 driver what their pin functions are and what they should be named. 
 
 Many sserial remotes offer different pinouts depending on the mode they are 

--- a/docs/src/code/code-notes.adoc
+++ b/docs/src/code/code-notes.adoc
@@ -109,7 +109,7 @@ modules for some implementations (RTAI):
 
 * 'motmod' - processes NML commands and controls hardware via hal
 
-* 'kinematics module' - performs foward (joints-->coordinates) and
+* 'kinematics module' - performs forward (joints-->coordinates) and
 inverse (coordinates->joints) kinematics calculations
 
 LinuxCNC is started by a *linuxcnc* script which reads a

--- a/docs/src/gui/gladevcp.adoc
+++ b/docs/src/gui/gladevcp.adoc
@@ -1712,7 +1712,7 @@ The widget will emit the following signals:
         It will return the buttonname and the new state. Buttonname is one of "btn_home", "btn_dir_up", "btn_sel_prev",
         "btn_sel_next", "btn_jump_to" or "btn_select". State is a boolean and will be True or False.
     exit
-        This signal is Emmit, when the exit button has been pressed to close the IconView
+        This signal is emitted, when the exit button has been pressed to close the IconView
         mostly needed if the application is started as stand alone.
 
 

--- a/docs/src/gui/qtdragon.adoc
+++ b/docs/src/gui/qtdragon.adoc
@@ -429,7 +429,7 @@ Tool Measurement in QtDragon is done with the following steps:
 * Go to auto mode and start your program
 
 [NOTE]
-When fist setting up auto tool measurement, please use caution untill you confirm +
+When fist setting up auto tool measurement, please use caution until you confirm +
 tool change and probe locations - it's easy to break a tool/probe. Abort will be honoured +
 while the probe is in motion.
 

--- a/docs/src/gui/qtvcp_libraries.adoc
+++ b/docs/src/gui/qtvcp_libraries.adoc
@@ -519,7 +519,7 @@ KEYBIND = Keylookup()
 === adding key bndings
 Note keybindings require code under the _processed_key_event_ function +
 to call _KEYBIND.call()_ - most handler file already have this code. +
-In the handler file, under the _initialed_ function use this general syntaxt: +
+In the handler file, under the _initialed_ function use this general syntax: +
  +
 KEYBINDING.add_call("DEFINED_KEY","FUNCTION TO CALL", USER DATA) +
  +

--- a/docs/src/man/man1/xhc-whb04b-6.1.adoc
+++ b/docs/src/man/man1/xhc-whb04b-6.1.adoc
@@ -501,7 +501,7 @@ net pdnt.macro-6                          whb.button.macro-6                    
 net pdnt.macro-7                          whb.button.macro-7                    halui.mdi-command-07             # use MDI command from main.ini
 net pdnt.reserved.for.spindle.dir         whb.button.macro-8                                                     # Hardcoded for spindle direction inside pendant
 net pdnt.macro-9                          whb.button.macro-9                    halui.mdi-command-09             # use MDI command from main.ini
-net pdnt.reserved.for.ABS-REL             whb.button.macro-10                                                    # Hardcoded for swap Dro  Relative/Absolue
+net pdnt.reserved.for.ABS-REL             whb.button.macro-10                                                    # Hardcoded for swap Dro  Relative/Absolute
 net pdnt.macro-14                         whb.button.macro-14                   halui.mdi-command-14             # use MDI command from main.ini
 net pdnt.reserved.for.flood               whb.button.macro-15                                                    # Hardcoded for halui.flood on/off
 net pdnt.reserved.for.mist                whb.button.macro-16                                                    # Hardcoded for halui.mist on/off
@@ -559,7 +559,7 @@ net pdnt.spindle.forward                  whb.halui.spindle.forward             
 net pdnt.spindle.reverse                  whb.halui.spindle.reverse             halui.spindle.0.reverse
 net pdnt.spindle.increase                 whb.halui.spindle.increase            halui.spindle.0.increase         # reserved whb.button.macro-3
 net pdnt.spindle.decrease                 whb.halui.spindle.decrease            halui.spindle.0.decrease         # reserved whb.button.macro-4
-net pdnt.spindle-speed-abs                whb.halui.spindle-speed-cmd           spindle.0.speed-out-abs          # speed cmd from motion in rpm absolue
+net pdnt.spindle-speed-abs                whb.halui.spindle-speed-cmd           spindle.0.speed-out-abs          # speed cmd from motion in rpm absolute
 
 
 # spindle speed override signals

--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -1293,7 +1293,7 @@ If the user intends to place the material randomly on the table then the user mu
 
 === Cut Feed Rate
 
-QtPlasmaC is able to read a material file to load all the required cut paramaters. To enable to G-Code file to use the cut feed rate setting from the cut parameters use the following code in the G-Code file:
+QtPlasmaC is able to read a material file to load all the required cut parameters. To enable to G-Code file to use the cut feed rate setting from the cut parameters use the following code in the G-Code file:
 
 ----
 F#<_hal[plasmac.cut-feed-rate]>

--- a/docs/src/tooldatabase/tooldatabase.adoc
+++ b/docs/src/tooldatabase/tooldatabase.adoc
@@ -83,10 +83,10 @@ The commands issued for tool data changes are:
     The tool data line will include all elements of a tool table
     text line.
 
-  * "'l'" spindle_load (TnM6). The tool data line inclues only the 'T' and
+  * "'l'" spindle_load (TnM6). The tool data line includes only the 'T' and
     'P' items identifying the relevant tool number and pocket number.
 
-  * "'u'" spindle_unload (T0M6).  The tool data line inclues only the 'T'
+  * "'u'" spindle_unload (T0M6).  The tool data line includes only the 'T'
     and 'P' items identifying the relevant tool number and pocket number
 
 [NOTE]

--- a/lib/hallib/qtplasmac_comp.hal
+++ b/lib/hallib/qtplasmac_comp.hal
@@ -1,7 +1,7 @@
 
 # ***** plasmac component connections for a QtPlasmaC configuration *****
 
-# do not make any changes to this file, it may be overwitten by future updates
+# do not make any changes to this file, it may be overwritten by future updates
 # make all customizations in custom.hal or custom_postgui.hal
 
 # ---PLASMAC COMPONENT INPUTS---

--- a/lib/python/gladevcp/combi_dro.py
+++ b/lib/python/gladevcp/combi_dro.py
@@ -86,7 +86,7 @@ class Combi_DRO(Gtk.VBox):
                         GObject.ParamFlags.READWRITE),
         'font_size' : (GObject.TYPE_INT, 'Font Size', 'The font size of the big numbers, the small ones will be 2.5 times smaller',
                     8, 96, 25, GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT),
-        'toggle_readout' : (GObject.TYPE_BOOLEAN, 'Enable toggling readout with click', 'The DRO will toggle between Absolute , Relativ and DTG with each mouse click.',
+        'toggle_readout' : (GObject.TYPE_BOOLEAN, 'Enable toggling readout with click', 'The DRO will toggle between Absolute, Relative and DTG with each mouse click.',
                     True, GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT),
         'cycle_time' : (GObject.TYPE_INT, 'Cycle Time', 'Time, in milliseconds, that display will sleep between polls',
                     100, 1000, 150, GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT),

--- a/lib/python/gladevcp/jogwheel.py
+++ b/lib/python/gladevcp/jogwheel.py
@@ -126,7 +126,7 @@ class JogWheel(Gtk.DrawingArea, _HalJogWheelBase):
         self.dot_pitch_radius = self.inner_radius - self.dot_radius
 
         # create the cairo window
-        # I do not know why this workes without importing cairo
+        # I do not know why this works without importing cairo
         self.cr = widget.get_property('window').cairo_create()
 
         # the area of reactions

--- a/lib/python/gladevcp/offsetpage_widget.py
+++ b/lib/python/gladevcp/offsetpage_widget.py
@@ -264,7 +264,7 @@ class OffsetPage(Gtk.VBox):
         except:
             return None, None, None, None, None, None, None, None, None
 
-    # This allows hiding or showing columns from a text string of columnns
+    # This allows hiding or showing columns from a text string of columns
     # eg list ='ab'
     # default, all the columns are shown
     def set_col_visible(self, list, bool):

--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -385,7 +385,7 @@ class ToolEdit(Gtk.VBox):
     def set_visible(self,list,bool):
         self.set_col_visible(list, bool, tab= '1')
 
-    # This allows hiding or showing columns from a text string of columnns
+    # This allows hiding or showing columns from a text string of columns
     # eg list ='xyz'
     # tab= selects what tabs to apply it to
     def set_col_visible(self, list, bool= False, tab= '1'):

--- a/lib/python/qtvcp/widgets/dialog_widget.py
+++ b/lib/python/qtvcp/widgets/dialog_widget.py
@@ -226,7 +226,7 @@ class LcncDialog(QMessageBox, GeometryMixin):
 
     # This actually builds and displays the dialog.
     # there are three ways to get results:
-    # - through a return by status mesage   (return_callback = None, use_exec = False)
+    # - through a return by status message  (return_callback = None, use_exec = False)
     # - callback return                     (return_callback = function_name)
     # - by direct return statement          (use_exec = True)
     def showdialog(self, messagetext, more_info=None, details=None, display_type='OK',

--- a/lib/python/qtvcp/widgets/gcode_graphics.py
+++ b/lib/python/qtvcp/widgets/gcode_graphics.py
@@ -71,7 +71,7 @@ class  GCodeGraphics(Lcnc_3dGraphics, _HalWidgetBase):
         self.inhibit_selection = False
         self._block_line_selected = False
 
-        # stop respons to external STATUS signals
+        # stop response to external STATUS signals
         self._disable_STATUS_signals = False
         self._block_autoLoad = None
         self._block_reLoad = None

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -1562,14 +1562,14 @@ class GlCanonDraw:
 
     # N.B. no conversion here because joint positions are unitless
     #      joint_mode and display_joint
-    # Note: this is overriden in other guis (then AXIS) for different dro behavior
+    # Note: this is overridden in other guis (then AXIS) for different dro behavior
     def joint_dro_format(self,s,spd,num_of_joints,limit, homed):
         posstrs = ["  %s:% 9.4f" % i for i in
             zip(list(range(num_of_joints)), s.joint_actual_position)]
         droposstrs = posstrs
         return limit, homed, posstrs, droposstrs
 
-    # Note: this is overriden in other guis (then AXIS) for different dro behavior
+    # Note: this is overridden in other guis (then AXIS) for different dro behavior
     def dro_format(self,s,spd,dtg,limit,homed,positions,axisdtg,g5x_offset,g92_offset,tlo_offset):
             if self.get_show_metric():
                 format = "% 6s:" + self.dro_mm

--- a/share/qtvcp/screens/woodpecker/images/QTvcp Widgets_files/asciidoc.css
+++ b/share/qtvcp/screens/woodpecker/images/QTvcp Widgets_files/asciidoc.css
@@ -427,7 +427,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }

--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -458,8 +458,8 @@ Suggestion: Split this in to an Error and a Status flag register..
 	EMCMOT_JOINT_FLAG flag;	/* see above for bit details */
 	double coarse_pos;	/* trajectory point, before interp */
 	double pos_cmd;		/* commanded joint position */
-	double vel_cmd;		/* comanded joint velocity */
-	double acc_cmd;		/* comanded joint acceleration */
+	double vel_cmd;		/* commanded joint velocity */
+	double acc_cmd;		/* commanded joint acceleration */
 	double backlash_corr;	/* correction for backlash */
 	double backlash_filt;	/* filtered backlash correction */
 	double backlash_vel;	/* backlash velocity variable */
@@ -552,7 +552,7 @@ Suggestion: Split this in to an Error and a Status flag register..
 
     typedef struct {
 	double pos_cmd;		/* commanded axis position */
-	double teleop_vel_cmd;		/* comanded axis velocity */
+	double teleop_vel_cmd;		/* commanded axis velocity */
 	double max_pos_limit;	/* upper soft limit on axis pos */
 	double min_pos_limit;	/* lower soft limit on axis pos */
 	double vel_limit;	/* upper limit of axis speed */
@@ -571,7 +571,7 @@ Suggestion: Split this in to an Error and a Status flag register..
     } emcmot_axis_t;
 
     typedef struct {
-	double teleop_vel_cmd;		/* comanded axis velocity */
+	double teleop_vel_cmd;		/* commanded axis velocity */
 	double max_pos_limit;	/* upper soft limit on axis pos */
 	double min_pos_limit;	/* lower soft limit on axis pos */
     } emcmot_axis_status_t;

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -48,7 +48,7 @@
 #undef  MAKE_TP_HAL_PINS
 
 // api for tpCreate() inherits a component id  provision to include hal pins:
-// (not used by the this default tp implemenation but may
+// (not used by the this default tp implementation but may
 //  be used in alternate user-built implementations)
 #ifdef  MAKE_TP_HAL_PINS // {
 #include "hal.h"

--- a/src/emc/usr_intf/emcsh.cc
+++ b/src/emc/usr_intf/emcsh.cc
@@ -2549,7 +2549,7 @@ static int emc_user_angular_units(ClientData clientdata,
 	return TCL_OK;
     }
 
-    /* else it's an abitrary number, so just return it */
+    /* else it's an arbitrary number, so just return it */
     setresult(interp,"custom");
     return TCL_OK;
 }

--- a/src/emc/usr_intf/pncconf/tests.py
+++ b/src/emc/usr_intf/pncconf/tests.py
@@ -604,7 +604,7 @@ But there is not one in the machine-named folder.."""),True)
         halrun.write("addf simple-tp.0.update servo-thread \n")
         halrun.write("addf pid.0.do-pid-calcs servo-thread \n")
         halrun.write("addf scale_to_rpm servo-thread \n")
-        # do I/O write comands
+        # do I/O write commands
         for i in write:
             halrun.write('%s\n'%i)
         halrun.write( "newsig estop-out bit\n")

--- a/src/hal/classicladder/sequential.h
+++ b/src/hal/classicladder/sequential.h
@@ -77,7 +77,7 @@ typedef struct StrTransition
 	/* number of the steps to activate if condition true
 	   >1 if start of 'AND' */
 	short int NumStepToActiv[ NBR_SWITCHS_MAX ];
-	/* number of the steps to desactivate if condition true
+	/* number of the steps to deactivate if condition true
 	   >1 if end of 'AND' */
 	short int NumStepToDesactiv[ NBR_SWITCHS_MAX ];
 	/* if start of 'OR' */

--- a/src/hal/drivers/bcm2835.h
+++ b/src/hal/drivers/bcm2835.h
@@ -81,7 +81,7 @@
 /// as well as power and ground pins. Not all GPIO pins on the BCM 2835 are available on the
 /// IDE header.
 ///
-/// The functions in this librray are designed to be passed the BCM 2835 GPIO pin number and _not_
+/// The functions in this library are designed to be passed the BCM 2835 GPIO pin number and _not_
 /// the RPi pin number. There are symbolic definitions for each of the available pins
 /// that you should use for convenience. See \ref RPiGPIOPin.
 ///

--- a/src/hal/drivers/hal_vti.c
+++ b/src/hal/drivers/hal_vti.c
@@ -200,7 +200,7 @@ typedef struct {
 
 /* dio data */
     io_pin port[MAX_IO_PORTS][PINS_PER_PORT];	/* Holds MAX_IO_PORTS X PINS_PER_PORT
-						   number of discreet I/O points */
+						   number of discrete I/O points */
     unsigned char dir_bits[MAX_IO_PORTS * 2];	/* remembers config (which port is input which is output) */
 
     unsigned char model;

--- a/src/hal/user_comps/xhc-whb04b-6/example-configuration.md
+++ b/src/hal/user_comps/xhc-whb04b-6/example-configuration.md
@@ -103,7 +103,7 @@ net pdnt.macro-6                          whb.button.macro-6                    
 net pdnt.macro-7                          whb.button.macro-7                    halui.mdi-command-07             # use MDI command from main.ini
 net pdnt.reserved.for.spindle.dir         whb.button.macro-8                                                     # Hardcoded for spindle direction inside pendant
 net pdnt.macro-9                          whb.button.macro-9                    halui.mdi-command-09             # use MDI command from main.ini
-net pdnt.reserved.for.ABS-REL             whb.button.macro-10                                                    # Hardcoded for swap Dro  Relative/Absolue
+net pdnt.reserved.for.ABS-REL             whb.button.macro-10                                                    # Hardcoded for swap Dro  Relative/Absolute
 net pdnt.macro-14                         whb.button.macro-14                   halui.mdi-command-14             # use MDI command from main.ini
 net pdnt.reserved.for.flood               whb.button.macro-15                                                    # Hardcoded for halui.flood on/off
 net pdnt.reserved.for.mist                whb.button.macro-16                                                    # Hardcoded for halui.mist on/off
@@ -161,7 +161,7 @@ net pdnt.spindle.forward                  whb.halui.spindle.forward             
 net pdnt.spindle.reverse                  whb.halui.spindle.reverse             halui.spindle.0.reverse
 net pdnt.spindle.increase                 whb.halui.spindle.increase            halui.spindle.0.increase         # reserved whb.button.macro-3
 net pdnt.spindle.decrease                 whb.halui.spindle.decrease            halui.spindle.0.decrease         # reserved whb.button.macro-4
-net pdnt.spindle-speed-abs                whb.halui.spindle-speed-cmd           spindle.0.speed-out-abs          # speed cmd from motion in rpm absolue
+net pdnt.spindle-speed-abs                whb.halui.spindle-speed-cmd           spindle.0.speed-out-abs          # speed cmd from motion in rpm absolute
 
 
 # spindle speed override signals

--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -1269,7 +1269,7 @@ void Hal::setMacro9(bool enabled)
 // ----------------------------------------------------------------------
 void Hal::setMacro10(bool enabled)
 {
-    setPin(enabled, KeyCodes::Buttons.macro10.text);                        // Hardcoded Absolue/relative Dro
+    setPin(enabled, KeyCodes::Buttons.macro10.text);                        // Hardcoded Absolute/relative Dro
 }
 // ----------------------------------------------------------------------
 void Hal::setMacro11(bool enabled)

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -523,7 +523,7 @@ public:
     void setMacro9(bool enabled);
     //! \sa setMacro9(bool, size_t)
     void setMacro10(bool enabled);
-    //! \sa setMacro10(bool, size_t)        // Hardcoded Absolue/relative Dro
+    //! \sa setMacro10(bool, size_t)        // Hardcoded Absolute/relative Dro
     void setMacro11(bool enabled);
     //! \sa setMacro11(bool, size_t)
     void setMacro12(bool enabled);

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.cc
@@ -1056,7 +1056,7 @@ bool Pendant::onButtonPressedEvent(const MetaButtonCodes& metaButton)
     }
     else if (metaButton == KeyCodes::Meta.macro10)
     {
-        mHal.setMacro10(true);                         // Hardcoded Absolue/relative Dro
+        mHal.setMacro10(true);                         // Hardcoded Absolute/relative Dro
         isHandled = true;
     }
     else if (metaButton == KeyCodes::Meta.continuous)
@@ -1228,7 +1228,7 @@ bool Pendant::onButtonReleasedEvent(const MetaButtonCodes& metaButton)
     }
     else if (metaButton == KeyCodes::Meta.macro10)
     {
-        mHal.setMacro10(false);                        // Hardcoded Absolue/relative Dro
+        mHal.setMacro10(false);                        // Hardcoded Absolute/relative Dro
         isHandled = true;
     }
     else if (metaButton == KeyCodes::Meta.continuous)

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.h
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.h
@@ -314,7 +314,7 @@ public:
     const MetaButtonCodes function;
     const MetaButtonCodes probe_z;
     const MetaButtonCodes macro9;
-    const MetaButtonCodes macro10;        // Hardcoded Absolue/relative Dro
+    const MetaButtonCodes macro10;        // Hardcoded Absolute/relative Dro
     const MetaButtonCodes macro14;
     const MetaButtonCodes continuous;
     const MetaButtonCodes macro15;

--- a/src/rtapi/examples/timer/timertask.c
+++ b/src/rtapi/examples/timer/timertask.c
@@ -276,8 +276,8 @@ int rtapi_app_main(void)
     timer_prio = rtapi_prio_next_higher(rtapi_prio_lowest());
 
     /* create the timer task */
-    /* the second arg is an abitrary int that is passed to the timer task on
-       the first iterration */
+    /* the second arg is an arbitrary int that is passed to the timer task on
+       the first iteration */
     timer_task = rtapi_task_new(timer_code, 0 /* arg */ , timer_prio, module,
 	TIMER_STACKSIZE, RTAPI_NO_FP);
     if (timer_task < 0) {

--- a/src/rtapi/rtapi.h
+++ b/src/rtapi/rtapi.h
@@ -341,7 +341,7 @@ RTAPI_BEGIN_DECLS
     for all subsequent calls that need to act on the task.  On failure,
     returns a negative error code as listed above.  'taskcode' is the
     name of a function taking one int and returning void, which contains
-    the task code.  'arg' will be passed to 'taskcode' as an abitrary
+    the task code.  'arg' will be passed to 'taskcode' as an arbitrary
     void pointer when the task is started, and can be used to pass
     any amount of data to the task (by pointing to a struct, or other
     such tricks).

--- a/tests/limit3/constraints/test.hal
+++ b/tests/limit3/constraints/test.hal
@@ -2,7 +2,7 @@ setexact_for_test_suite_only
 
 
 #
-# This siggen produces test patters for limit3 to try to follow.
+# This siggen produces test patterns for limit3 to try to follow.
 #
 
 loadrt siggen


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.ts,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es -L ans,ba,bulle,componentes,doubleclick,dout,dum,fo,halp,ihs,inout,parm,parms,ro,ser,te,ue,wille,wont`