### PR TITLE
Emcmodule - Renaming status.id

### DIFF
--- a/lib/python/qtvcp/widgets/fake_status.py
+++ b/lib/python/qtvcp/widgets/fake_status.py
@@ -63,7 +63,7 @@ class fakeStatus():
         self.g92_offset = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
         self.gcodes = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         self.homed = (0, 0, 0, 0, 0, 0, 0, 0, 0)
-        self.id = 0
+        self.motion_id = 0
         self.inpos = False
         self.input_timeout = False
         self.interp_state = 0

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -362,7 +362,7 @@ static PyMemberDef Stat_members[] = {
     {(char*)"queue", T_INT, O(motion.traj.queue), READONLY},
     {(char*)"active_queue", T_INT, O(motion.traj.activeQueue), READONLY},
     {(char*)"queue_full", T_BOOL, O(motion.traj.queueFull), READONLY},
-    {(char*)"id", T_INT, O(motion.traj.id), READONLY},
+    {(char*)"motion_id", T_INT, O(motion.traj.id), READONLY},
     {(char*)"paused", T_BOOL, O(motion.traj.paused), READONLY},
     {(char*)"feedrate", T_DOUBLE, O(motion.traj.scale), READONLY},
     {(char*)"rapidrate", T_DOUBLE, O(motion.traj.rapid_scale), READONLY},

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -813,7 +813,7 @@ class LivePlotter:
 
         self.after = self.win.after(update_ms, self.update)
 
-        self.win.set_current_line(self.stat.id or self.stat.motion_line)
+        self.win.set_current_line(self.stat.motion_id or self.stat.motion_line)
 
         speed = self.stat.current_vel
 

--- a/src/emc/usr_intf/touchy/emc_interface.py
+++ b/src/emc/usr_intf/touchy/emc_interface.py
@@ -408,7 +408,7 @@ class emc_status:
                 set_text(self.status['file'], self.emcstat.file)
                 set_text(self.status['file_lines'], "%d" % len(self.listing.program))
                 set_text(self.status['line'], "%d" % self.emcstat.current_line)
-                set_text(self.status['id'], "%d" % self.emcstat.id)
+                set_text(self.status['id'], "%d" % self.emcstat.motion_id)
                 set_text(self.status['dtg'], "%.4f" % self.emcstat.distance_to_go)
                 set_text(self.status['velocity'], "%.4f" % (self.emcstat.current_vel * 60.0))
                 set_text(self.status['delay'], "%.2f" % self.emcstat.delay_left)
@@ -507,12 +507,12 @@ class emc_status:
                 set_active(self.blockdel['off'], not self.emcstat.block_delete)
                 
 
-                if self.emcstat.id == 0 and (self.emcstat.interp_state == self.emc.INTERP_PAUSED or self.emcstat.exec_state == self.emc.EXEC_WAITING_FOR_DELAY):
+                if self.emcstat.motion_id == 0 and (self.emcstat.interp_state == self.emc.INTERP_PAUSED or self.emcstat.exec_state == self.emc.EXEC_WAITING_FOR_DELAY):
                         self.listing.highlight_line(self.emcstat.current_line)
-                elif self.emcstat.id == 0:
+                elif self.emcstat.motion_id == 0:
                         self.listing.highlight_line(self.emcstat.motion_line)
                 else:
-                        self.listing.highlight_line(self.emcstat.id or self.emcstat.motion_line)
+                        self.listing.highlight_line(self.emcstat.motion_id or self.emcstat.motion_line)
 
                 e = self.emcerror.poll()
                 if e:

--- a/tests/startup-state/test-ui.py
+++ b/tests/startup-state/test-ui.py
@@ -55,7 +55,7 @@ def print_status(status):
     print("g92_offset: {}".format(status.g92_offset))
     print("gcodes: {}".format(status.gcodes))
     print("homed: {}".format(status.homed))
-    print("id: {}".format(status.id))
+    print("id: {}".format(status.motion_id))
     print("inpos: {}".format(status.inpos))
     print("input_timeout: {}".format(status.input_timeout))
     print("interp_state: {}".format(status.interp_state))

--- a/tests/startup-state/test-ui.py
+++ b/tests/startup-state/test-ui.py
@@ -245,7 +245,7 @@ assert(s.g92_offset[3:] == (0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
 assert(s.gcodes == (0, 800, -1, 170, 400, 200, 900, 940, 540, 490, 990, 640, -1, 970, 911, 80, 923))
 
 assert(not (1 in s.homed))
-assert(s.id == 0)
+assert(s.motion_id == 0)
 assert(s.inpos == True)
 assert(s.input_timeout == False)
 assert(s.interp_state == linuxcnc.INTERP_IDLE)


### PR DESCRIPTION
#1616 
Id shadows built-in command from python. 

The naming implication is ambiguous as id actually corresponds to the currently executing motion id; not the status id which would be the memory of address of status.