### PR TITLE
Avoiding crash of https://github.com/LinuxCNC/linuxcnc/issues/1599

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -36,7 +36,7 @@ DEV_PACKAGE_NAME=@MAIN_PACKAGE_NAME@-dev
 
 %:
 	# With debhelper 10 the --parallel becomes the default
-	dh $@ --parallel
+	dh $@
 
 override_dh_auto_configure:
 	cd src && ./autogen.sh
@@ -45,7 +45,8 @@ override_dh_auto_configure:
 	    --mandir=/usr/share/man \
 	    $(configure_realtime_arg) \
             $(enable_build_documentation) \
-	    --disable-check-runtime-deps
+	    --disable-check-runtime-deps \
+	    --with-boost-python=39
 
 override_dh_auto_build-arch:
 	$(MAKE) PYTHON=/usr/bin/python3 -C src

--- a/src/m4/ax_python.m4
+++ b/src/m4/ax_python.m4
@@ -55,7 +55,7 @@
 AC_DEFUN([AX_PYTHON],
 [AC_MSG_CHECKING(for python build information)
 AC_MSG_RESULT([])
-for python in python3.10 python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
+for python in python3 python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
 AC_CHECK_PROGS(PYTHON_BIN, [$python])
 ax_python_bin=$PYTHON_BIN
 if test x$ax_python_bin != x; then


### PR DESCRIPTION
I admit to be just slightly curious if this now builds on github - it should. I admit not to be the ultimate fan of this solution, since the test should be what python3's version is. The pragmatic side of mine has won for now, if you have a better idea - please go for it. Whatever we come up with to upload to Debian, it needs to run on unstable and bookworm. This patch was tested on unstable and if this now also builds on on the build server then I consider it just fine.