### PR TITLE
Motmod refactoring: Encapsulate emcmot_axis_t and axis_hal_t into axis.c

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1138,6 +1138,7 @@ obj-m += 5axiskins.o
 
 obj-$(CONFIG_MOTMOD) += motmod.o
 motmod-objs := emc/kinematics/cubic.o
+motmod-objs += emc/motion/axis.o
 motmod-objs += emc/motion/motion.o
 motmod-objs += emc/motion/command.o
 motmod-objs += emc/motion/control.o
@@ -1157,6 +1158,8 @@ tpmod-objs += emc/tp/tcq.o
 tpmod-objs += emc/tp/tp.o
 tpmod-objs += emc/tp/spherical_arc.o
 tpmod-objs += emc/tp/blendmath.o
+tpmod-objs += emc/motion/simple_tp.o
+tpmod-objs += emc/motion/axis.o
 tpmod-objs += emc/nml_intf/emcpose.o
 tpmod-objs += libnml/posemath/_posemath.o
 tpmod-objs += libnml/posemath/sincos.o $(MATHSTUB)

--- a/src/emc/motion-logger/Submakefile
+++ b/src/emc/motion-logger/Submakefile
@@ -1,9 +1,13 @@
 TARGETS += ../bin/motion-logger
 
-MOTION_LOGGER_SRCS := $(addprefix emc/motion-logger/, motion-logger.c)
+MOTION_LOGGER_SRCS := \
+	$(addprefix emc/motion-logger/, motion-logger.c) \
+	emc/motion/axis.c \
+	emc/motion/simple_tp.c
+
 USERSRCS += $(MOTION_LOGGER_SRCS)
 
 ../bin/motion-logger: $(call TOOBJS, $(MOTION_LOGGER_SRCS)) ../lib/libnml.so.0 ../lib/liblinuxcnchal.so.0
 	$(ECHO) Linking $(notdir $@)
-	$(Q)$(CC) $(LDFLAGS) -o $@ $^
+	$(Q)$(CC) $(LDFLAGS) -o $@ $^ -lm
 

--- a/src/emc/motion/axis.c
+++ b/src/emc/motion/axis.c
@@ -1,0 +1,706 @@
+
+#include "axis.h"
+#include "emcmotcfg.h"      // EMCMOT_MAX_AXIS
+#include "rtapi.h"
+#include "rtapi_math.h"
+#include "simple_tp.h"
+
+typedef struct {
+    double pos_cmd;                 /* commanded axis position */
+    double teleop_vel_cmd;          /* comanded axis velocity */
+    double max_pos_limit;           /* upper soft limit on axis pos */
+    double min_pos_limit;           /* lower soft limit on axis pos */
+    double vel_limit;               /* upper limit of axis speed */
+    double acc_limit;               /* upper limit of axis accel */
+    simple_tp_t teleop_tp;          /* planner for teleop mode motion */
+
+    int old_ajog_counts;            /* prior value, used for deltas */
+    int kb_ajog_active;             /* non-zero during a keyboard jog */
+    int wheel_ajog_active;          /* non-zero during a wheel jog */
+    int locking_joint;              /* locking_joint number, -1 ==> notused */
+
+    double ext_offset_vel_limit;    /* upper limit of axis speed for ext offset */
+    double ext_offset_acc_limit;    /* upper limit of axis accel for ext offset */
+    int old_eoffset_counts;
+    simple_tp_t ext_offset_tp;      /* planner for external coordinate offsets*/
+} emcmot_axis_t;
+
+typedef struct {
+    hal_float_t *pos_cmd;           /* RPI: commanded position */
+    hal_float_t *teleop_vel_cmd;    /* RPI: commanded velocity */
+    hal_float_t *teleop_pos_cmd;    /* RPI: teleop traj planner pos cmd */
+    hal_float_t *teleop_vel_lim;    /* RPI: teleop traj planner vel limit */
+    hal_bit_t   *teleop_tp_enable;  /* RPI: teleop traj planner is running */
+
+    hal_s32_t   *ajog_counts;       /* WPI: jogwheel position input */
+    hal_bit_t   *ajog_enable;       /* RPI: enable jogwheel */
+    hal_float_t *ajog_scale;        /* RPI: distance to jog on each count */
+    hal_float_t *ajog_accel_fraction;  /* RPI: to limit wheel jog accel */
+    hal_bit_t   *ajog_vel_mode;     /* RPI: true for "velocity mode" jogwheel */
+    hal_bit_t   *kb_ajog_active;    /* RPI: executing keyboard jog */
+    hal_bit_t   *wheel_ajog_active; /* RPI: executing handwheel jog */
+
+    hal_bit_t   *eoffset_enable;
+    hal_bit_t   *eoffset_clear;
+    hal_s32_t   *eoffset_counts;
+    hal_float_t *eoffset_scale;
+    hal_float_t *external_offset;
+    hal_float_t *external_offset_requested;
+} axis_hal_t;
+
+
+typedef struct {
+    axis_hal_t axis[EMCMOT_MAX_AXIS];   /* data for each axis */
+} axis_hal_data_t;
+
+static emcmot_axis_t axis_array[EMCMOT_MAX_AXIS];
+static axis_hal_data_t *hal_data = NULL;
+
+
+// Mark strings for translation, but defer translation to userspace
+#define _(s) (s)
+
+void axis_init_all(void)
+{
+    int n;
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        emcmot_axis_t *axis = &axis_array[n];
+        axis->locking_joint = -1;
+    }
+}
+
+void axis_initialize_external_offsets(void)
+{
+    int n;
+    axis_hal_t *axis_data;
+
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        axis_data = &hal_data->axis[n];
+
+        *(axis_data->external_offset) = 0;
+        *(axis_data->external_offset_requested) = 0;
+        axis_array[n].ext_offset_tp.pos_cmd  = 0;
+        axis_array[n].ext_offset_tp.curr_pos = 0;
+        axis_array[n].ext_offset_tp.curr_vel = 0;
+    }
+}
+
+#define CALL_CHECK(expr) do {           \
+        int _retval;                    \
+        _retval = expr;                 \
+        if (_retval) return _retval;    \
+    } while (0);
+
+static int export_axis(int mot_comp_id, char c, axis_hal_t * addr)
+{
+    int msg;
+
+    msg = rtapi_get_msg_level();
+    rtapi_set_msg_level(RTAPI_MSG_WARN);
+
+    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(addr->ajog_enable), mot_comp_id,"axis.%c.jog-enable", c));
+    CALL_CHECK(hal_pin_float_newf(HAL_IN, &(addr->ajog_scale), mot_comp_id,"axis.%c.jog-scale", c));
+    CALL_CHECK(hal_pin_s32_newf(HAL_IN, &(addr->ajog_counts), mot_comp_id,"axis.%c.jog-counts", c));
+    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(addr->ajog_vel_mode), mot_comp_id,"axis.%c.jog-vel-mode", c));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(addr->kb_ajog_active), mot_comp_id,"axis.%c.kb-jog-active", c));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(addr->wheel_ajog_active), mot_comp_id,"axis.%c.wheel-jog-active", c));
+
+    CALL_CHECK(hal_pin_float_newf(HAL_IN,&(addr->ajog_accel_fraction), mot_comp_id,"axis.%c.jog-accel-fraction", c));
+    *addr->ajog_accel_fraction = 1.0; // fraction of accel for wheel ajogs
+
+    rtapi_set_msg_level(msg);
+    return 0;
+}
+
+int axis_init_hal_io(int mot_comp_id)
+{
+    int n, retval;
+
+    hal_data = hal_malloc(sizeof(axis_hal_data_t));
+    if (!hal_data) {
+        rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: axis_hal_data hal_malloc() failed\n"));
+        return -1;
+    }
+
+    // export axis pins and parameters
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        char c = "xyzabcuvw"[n];
+        axis_hal_t *axis_data = &(hal_data->axis[n]);
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->pos_cmd, mot_comp_id, "axis.%c.pos-cmd", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->teleop_vel_cmd, mot_comp_id, "axis.%c.teleop-vel-cmd", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->teleop_pos_cmd, mot_comp_id, "axis.%c.teleop-pos-cmd", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->teleop_vel_lim, mot_comp_id, "axis.%c.teleop-vel-lim", c));
+        CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &axis_data->teleop_tp_enable, mot_comp_id, "axis.%c.teleop-tp-enable",c));
+        CALL_CHECK(hal_pin_bit_newf(HAL_IN, &axis_data->eoffset_enable, mot_comp_id, "axis.%c.eoffset-enable", c));
+        CALL_CHECK(hal_pin_bit_newf(HAL_IN, &axis_data->eoffset_clear, mot_comp_id, "axis.%c.eoffset-clear", c));
+        CALL_CHECK(hal_pin_s32_newf(HAL_IN, &axis_data->eoffset_counts, mot_comp_id, "axis.%c.eoffset-counts", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_IN, &axis_data->eoffset_scale, mot_comp_id, "axis.%c.eoffset-scale", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->external_offset, mot_comp_id, "axis.%c.eoffset", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &axis_data->external_offset_requested,
+           mot_comp_id, "axis.%c.eoffset-request", c));
+
+        retval = export_axis(mot_comp_id, c, axis_data);
+        if (retval) {
+            rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: axis %c pin/param export failed\n"), c);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+void axis_output_to_hal(double *pcmd_p[])
+{
+    int n;
+
+    // output axis info to HAL for scoping, etc
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        emcmot_axis_t *axis = &axis_array[n];
+        axis_hal_t *axis_data = &hal_data->axis[n];
+        *(axis_data->teleop_vel_cmd)    = axis->teleop_vel_cmd;
+        *(axis_data->teleop_pos_cmd)    = axis->teleop_tp.pos_cmd;
+        *(axis_data->teleop_vel_lim)    = axis->teleop_tp.max_vel;
+        *(axis_data->teleop_tp_enable)  = axis->teleop_tp.enable;
+        *(axis_data->kb_ajog_active)    = axis->kb_ajog_active;
+        *(axis_data->wheel_ajog_active) = axis->wheel_ajog_active;
+
+        // hal pins: axis.L.pos-cmd reported without applied offsets:
+        *(axis_data->pos_cmd) = *pcmd_p[n]
+                              - axis->ext_offset_tp.curr_pos;
+     }
+}
+
+void axis_set_max_pos_limit(int axis_num, double maxLimit)
+{
+    axis_array[axis_num].max_pos_limit = maxLimit;
+}
+
+void axis_set_min_pos_limit(int axis_num, double minLimit)
+{
+    axis_array[axis_num].min_pos_limit = minLimit;
+}
+
+void axis_set_vel_limit(int axis_num, double vel)
+{
+    axis_array[axis_num].vel_limit = vel;
+}
+
+void axis_set_acc_limit(int axis_num, double acc)
+{
+    axis_array[axis_num].acc_limit = acc;
+}
+
+void axis_set_ext_offset_vel_limit(int axis_num, double vel)
+{
+    axis_array[axis_num].ext_offset_vel_limit = vel;
+}
+
+void axis_set_ext_offset_acc_limit(int axis_num, double acc)
+{
+    axis_array[axis_num].ext_offset_acc_limit = acc;
+}
+
+void axis_set_locking_joint(int axis_num, int joint)
+{
+    axis_array[axis_num].locking_joint = joint;
+}
+
+
+double axis_get_min_pos_limit(int axis_num)
+{
+    return axis_array[axis_num].min_pos_limit;
+}
+
+double axis_get_max_pos_limit(int axis_num)
+{
+    return axis_array[axis_num].max_pos_limit;
+}
+
+double axis_get_vel_limit(int axis_num)
+{
+    return axis_array[axis_num].vel_limit;
+}
+
+double axis_get_acc_limit(int axis_num)
+{
+    return axis_array[axis_num].acc_limit;
+}
+
+double axis_get_teleop_vel_cmd(int axis_num)
+{
+    return axis_array[axis_num].teleop_vel_cmd;
+}
+
+int axis_get_locking_joint(int axis_num)
+{
+    return axis_array[axis_num].locking_joint;
+}
+
+double axis_get_compound_velocity(void)
+{
+    double v2 = 0.0;
+    int n;
+
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        emcmot_axis_t *axis = &axis_array[n];
+        if (axis->teleop_tp.active) {
+            v2 += axis->teleop_vel_cmd * axis->teleop_vel_cmd;
+        }
+    }
+
+    if (v2 > 0.0)
+        return sqrt(v2);
+    return 0.0;
+}
+
+double axis_get_ext_offset_curr_pos(int axis_num)
+{
+    return axis_array[axis_num].ext_offset_tp.curr_pos;
+}
+
+
+void axis_jog_cont(int axis_num, double vel, long servo_period)
+{
+    emcmot_axis_t *axis = &axis_array[axis_num];
+
+    if (vel > 0.0) {
+        axis->teleop_tp.pos_cmd = axis->max_pos_limit;
+    } else {
+        axis->teleop_tp.pos_cmd = axis->min_pos_limit;
+    }
+
+    axis->teleop_tp.max_vel = fabs(vel);
+    axis->teleop_tp.max_acc = axis->acc_limit;
+    axis->kb_ajog_active = 1;
+    axis->teleop_tp.enable = 1;
+}
+
+void axis_jog_incr(int axis_num, double offset, double vel, long servo_period)
+{
+    emcmot_axis_t *axis = &axis_array[axis_num];
+    double tmp1;
+
+    if (vel > 0.0) {
+        tmp1 = axis->teleop_tp.pos_cmd + offset;
+    } else {
+        tmp1 = axis->teleop_tp.pos_cmd - offset;
+    }
+
+    if (tmp1 > axis->max_pos_limit) { return; }
+    if (tmp1 < axis->min_pos_limit) { return; }
+
+    axis->teleop_tp.pos_cmd = tmp1;
+    axis->teleop_tp.max_vel = fabs(vel);
+    axis->teleop_tp.max_acc = axis->acc_limit;
+    axis->kb_ajog_active = 1;
+    axis->teleop_tp.enable = 1;
+}
+
+void axis_jog_abs(int axis_num, double offset, double vel)
+{
+    emcmot_axis_t *axis = &axis_array[axis_num];
+    double tmp1;
+
+    axis->kb_ajog_active = 1;
+    if (axis->wheel_ajog_active) { return; }
+    if (vel > 0.0) {
+        tmp1 = axis->teleop_tp.pos_cmd + offset;
+    } else {
+        tmp1 = axis->teleop_tp.pos_cmd - offset;
+    }
+    if (tmp1 > axis->max_pos_limit) { return; }
+    if (tmp1 < axis->min_pos_limit) { return; }
+    axis->teleop_tp.pos_cmd = tmp1;
+    axis->teleop_tp.max_vel = fabs(vel);
+    axis->teleop_tp.max_acc = axis->acc_limit;
+    axis->kb_ajog_active = 1;
+    axis->teleop_tp.enable = 1;
+}
+
+void axis_jog_abort(int axis_num)
+{
+    emcmot_axis_t *axis = &axis_array[axis_num];
+    axis->teleop_tp.enable = 0;
+}
+
+void axis_jog_abort_all(void)
+{
+    int n;
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        axis_jog_abort(n);
+    }
+}
+
+bool axis_jog_immediate_stop_all(void)
+{
+    int n;
+    bool aborted = false;
+
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        emcmot_axis_t *axis = &axis_array[n];
+        if (axis->teleop_tp.enable) {
+            aborted = true;
+        }
+        axis->teleop_tp.enable = 0;
+        axis->teleop_tp.curr_vel = 0.0;
+    }
+    return aborted;
+}
+
+void axis_jog_inhibit_all(void)
+{
+    int n;
+    emcmot_axis_t *axis;
+
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        axis = &axis_array[n];
+        if (axis->kb_ajog_active || axis->wheel_ajog_active) {
+            axis->teleop_tp.enable = 0;
+            axis->teleop_tp.curr_vel = 0.0;
+            axis->kb_ajog_active = 0;
+            axis->wheel_ajog_active = 0;
+        }
+    }
+}
+
+bool axis_jog_is_active(void)
+{
+    int n;
+    emcmot_axis_t *axis;
+
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        axis = &axis_array[n];
+        if (axis->kb_ajog_active || axis->wheel_ajog_active) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void axis_handle_jogwheels(bool motion_teleop_flag, bool motion_enable_flag, bool homing_is_active)
+{
+    int axis_num;
+    emcmot_axis_t *axis;
+    axis_hal_t *axis_data;
+    int new_ajog_counts, delta;
+    double distance, pos, stop_dist;
+    static int first_pass = 1;	/* used to set initial conditions */
+
+    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
+        double aaccel_limit;
+        axis = &axis_array[axis_num];
+        axis_data = &hal_data->axis[axis_num];
+
+        // disallow accel bogus fractions
+        if (   (*(axis_data->ajog_accel_fraction) > 1)
+            || (*(axis_data->ajog_accel_fraction) < 0) ) {
+            aaccel_limit = axis->acc_limit;
+        } else {
+            aaccel_limit = *(axis_data->ajog_accel_fraction) * axis->acc_limit;
+        }
+
+        new_ajog_counts = *(axis_data->ajog_counts);
+        delta = new_ajog_counts - axis->old_ajog_counts;
+        axis->old_ajog_counts = new_ajog_counts;
+        if ( first_pass ) { continue; }
+        if ( delta == 0 ) {
+            //just update counts
+            continue;
+        }
+        if (!motion_teleop_flag) {
+            axis->teleop_tp.enable = 0;
+            return;
+        }
+        if (!motion_enable_flag)              { continue; }
+        if ( *(axis_data->ajog_enable) == 0 ) { continue; }
+        if (homing_is_active)                 { continue; }
+        if (axis->kb_ajog_active)             { continue; }
+
+        if (axis->locking_joint >= 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR,
+            "Cannot wheel jog a locking indexer AXIS_%c\n",
+            "XYZABCUVW"[axis_num]);
+            continue;
+        }
+
+        distance = delta * *(axis_data->ajog_scale);
+        pos = axis->teleop_tp.pos_cmd + distance;
+        if ( *(axis_data->ajog_vel_mode) ) {
+            double v = axis->vel_limit;
+            /* compute stopping distance at max speed */
+            stop_dist = v * v / ( 2 * aaccel_limit);
+            /* if commanded position leads the actual position by more
+               than stopping distance, discard excess command */
+            if ( pos > axis->pos_cmd + stop_dist ) {
+                pos = axis->pos_cmd + stop_dist;
+            } else if ( pos < axis->pos_cmd - stop_dist ) {
+                pos = axis->pos_cmd - stop_dist;
+            }
+        }
+        if (pos > axis->max_pos_limit) { break; }
+        if (pos < axis->min_pos_limit) { break; }
+        axis->teleop_tp.pos_cmd = pos;
+        axis->teleop_tp.max_vel = axis->vel_limit;
+        axis->teleop_tp.max_acc = aaccel_limit;
+        axis->wheel_ajog_active = 1;
+        axis->teleop_tp.enable  = 1;
+    }
+    first_pass = 0;
+}
+
+void axis_sync_teleop_tp_to_carte_pos(int extfactor, double *pcmd_p[])
+{
+    int n;
+    // expect extfactor =  -1 || 0 || +1
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        axis_array[n].teleop_tp.curr_pos = *pcmd_p[n]
+                            + extfactor * axis_array[n].ext_offset_tp.curr_pos;
+    }
+}
+
+void axis_sync_carte_pos_to_teleop_tp(int extfactor, double *pcmd_p[])
+{
+    int n;
+    // expect extfactor =  -1 || 0 || +1
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        *pcmd_p[n] = axis_array[n].teleop_tp.curr_pos
+                            + extfactor * axis_array[n].ext_offset_tp.curr_pos;
+    }
+}
+
+void axis_apply_ext_offsets_to_carte_pos(int extfactor, double *pcmd_p[])
+{
+    int n;
+    // expect extfactor =  -1 || 0 || +1
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        *pcmd_p[n] = *pcmd_p[n]
+                            + extfactor * axis_array[n].ext_offset_tp.curr_pos;
+    }
+}
+
+hal_bit_t axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bool all_homed)
+{
+    static int first_pass = 1;
+    int n;
+    emcmot_axis_t *axis;
+    axis_hal_t *axis_data;
+    int new_eoffset_counts, delta;
+    static int last_eoffset_enable[EMCMOT_MAX_AXIS];
+    double ext_offset_epsilon;
+    hal_bit_t eoffset_active;
+
+    eoffset_active = 0;
+
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        axis = &axis_array[n];
+        // coord,teleop updates done in get_pos_cmds()
+        axis->ext_offset_tp.max_vel = axis->ext_offset_vel_limit;
+        axis->ext_offset_tp.max_acc = axis->ext_offset_acc_limit;
+
+        axis_data = &hal_data->axis[n];
+
+        new_eoffset_counts       = *(axis_data->eoffset_counts);
+        delta                    = new_eoffset_counts - axis->old_eoffset_counts;
+        axis->old_eoffset_counts = new_eoffset_counts;
+
+        *(axis_data->external_offset)  = axis->ext_offset_tp.curr_pos;
+        axis->ext_offset_tp.enable = 1;
+        if ( first_pass ) {
+            *(axis_data->external_offset) = 0;
+            continue;
+        }
+
+        // Use stopping criterion of simple_tp.c:
+        ext_offset_epsilon = TINY_DP(axis->ext_offset_tp.max_acc, servo_period);
+        if (fabs(*(axis_data->external_offset)) > ext_offset_epsilon) {
+            eoffset_active = 1;
+        }
+        if ( !*(axis_data->eoffset_enable) ) {
+            axis->ext_offset_tp.enable = 0;
+            // Detect disabling of eoffsets:
+            //   At very high accel, simple planner may terminate with
+            //   a larger position value than occurs at more realistic accels.
+            if (last_eoffset_enable[n]
+                && (fabs(*(axis_data->external_offset)) > ext_offset_epsilon)
+                && motion_enable_flag
+                && axis->ext_offset_tp.enable) {
+                // to stdout only:
+                rtapi_print_msg(RTAPI_MSG_NONE,
+                           "*** Axis_%c External Offset=%.4g eps=%.4g\n"
+                           "*** External Offset disabled while NON-zero\n"
+                           "*** To clear: re-enable & zero or use Machine-Off\n",
+                           "XYZABCUVW"[n],
+                           *(axis_data->external_offset),
+                           ext_offset_epsilon);
+            }
+            last_eoffset_enable[n] = 0;
+            continue; // Note: if   not eoffset_enable
+                      //       then planner disabled and no pos_cmd updates
+                      //       useful for eoffset_pid hold
+        }
+        last_eoffset_enable[n] = 1;
+        if (*(axis_data->eoffset_clear)) {
+            axis->ext_offset_tp.pos_cmd             = 0;
+            *(axis_data->external_offset_requested) = 0;
+            continue;
+        }
+        if (delta == 0)           { continue; }
+        if (!all_homed)           { continue; }
+        if (!motion_enable_flag)  { continue; }
+
+        axis->ext_offset_tp.pos_cmd   += delta *  *(axis_data->eoffset_scale);
+        *(axis_data->external_offset_requested) = axis->ext_offset_tp.pos_cmd;
+    } // for n
+    first_pass = 0;
+
+    return eoffset_active;
+}
+
+/* For each axis, return -1 if over negative limit, 1 if over positive limit,
+   or 0 if in range */
+void axis_check_constraints(double pos[], int failing_axes[])
+{
+    int axis_num;
+    double eps = 1e-308;
+
+    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num += 1) {
+        double nl = axis_array[axis_num].min_pos_limit;
+        double pl = axis_array[axis_num].max_pos_limit;
+        failing_axes[axis_num] = 0;
+
+        if (   (fabs(pos[axis_num]) < eps)
+            && (fabs(axis_array[axis_num].min_pos_limit) < eps)
+            && (fabs(axis_array[axis_num].max_pos_limit) < eps) ) {
+            continue;
+        }
+
+        if (pos[axis_num] < (nl - 0.000000000001)) { // see pull request #1047
+            failing_axes[axis_num] = -1;
+        }
+
+        if (pos[axis_num] > (pl + 0.000000000001)) { // see pull request #1047
+            failing_axes[axis_num] = 1;
+        }
+    }
+}
+
+int axis_update_coord_with_bound(double *pcmd_p[], double servo_period)
+{
+    int n;
+    int ans = 0;
+    emcmot_axis_t *axis;
+    double save_pos_cmd[EMCMOT_MAX_AXIS];
+    double save_offset_cmd[EMCMOT_MAX_AXIS];
+
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        axis = &axis_array[n];
+        save_pos_cmd[n]     = *pcmd_p[n];
+        save_offset_cmd[n]  = axis->ext_offset_tp.pos_cmd;
+        simple_tp_update(&(axis->ext_offset_tp), servo_period);
+    }
+    axis_apply_ext_offsets_to_carte_pos(+1, pcmd_p); // add external offsets
+
+    for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
+        axis = &axis_array[n];
+        //workaround: axis letters not in [TRAJ]COORDINATES
+        //            have min_pos_limit == max_pos_lim == 0
+        if ( (0 == axis->max_pos_limit) && (0 == axis->min_pos_limit) ) {
+            continue;
+        }
+        if (axis->ext_offset_tp.curr_pos == 0) {
+           continue; // don't claim violation if no offset
+        }
+
+        if (*pcmd_p[n] >= axis->max_pos_limit) {
+            // hold carte_pos_cmd at the limit:
+            *pcmd_p[n]  = axis->max_pos_limit;
+            // stop growth of offsetting position:
+            axis->ext_offset_tp.curr_pos = axis->max_pos_limit
+                                         - save_pos_cmd[n];
+            if (axis->ext_offset_tp.pos_cmd > save_offset_cmd[n]) {
+                axis->ext_offset_tp.pos_cmd = save_offset_cmd[n];
+            }
+            axis->ext_offset_tp.curr_vel = 0;
+            ans++;
+            continue;
+        }
+        if (*pcmd_p[n] <= axis->min_pos_limit) {
+            *pcmd_p[n]  = axis->min_pos_limit;
+            axis->ext_offset_tp.curr_pos = axis->min_pos_limit
+                                         - save_pos_cmd[n];
+            if (axis->ext_offset_tp.pos_cmd < save_offset_cmd[n]) {
+                axis->ext_offset_tp.pos_cmd = save_offset_cmd[n];
+            }
+            axis->ext_offset_tp.curr_vel = 0;
+            ans++;
+        }
+    }
+    if (ans > 0) { return 1; }
+    return 0;
+}
+
+static int update_teleop_with_check(int axis_num, simple_tp_t *the_tp, double servo_period)
+{
+    // 'the_tp' is the planner to update
+    // the tests herein apply to the sum of the offsets for both
+    // planners (teleop_tp and ext_offset_tp)
+    double save_curr_pos;
+    emcmot_axis_t *axis = &axis_array[axis_num];
+
+    save_curr_pos = the_tp->curr_pos;
+    simple_tp_update(the_tp, servo_period);
+
+    //workaround: axis letters not in [TRAJ]COORDINATES
+    //            have min_pos_limit == max_pos_lim == 0
+    if  ( (0 == axis->max_pos_limit) && (0 == axis->min_pos_limit) ) {
+        return 0;
+    }
+    if  ( (axis->ext_offset_tp.curr_pos + axis->teleop_tp.curr_pos)
+          >= axis->max_pos_limit) {
+        // positive error, restore save_curr_pos
+        the_tp->curr_pos = save_curr_pos;
+        the_tp->curr_vel = 0;
+        return 1;
+    }
+    if  ( (axis->ext_offset_tp.curr_pos + axis->teleop_tp.curr_pos)
+           <= axis->min_pos_limit) {
+        // negative error, restore save_curr_pos
+        the_tp->curr_pos = save_curr_pos;
+        the_tp->curr_vel = 0;
+        return 1;
+    }
+    return 0;
+}
+
+int axis_calc_motion(double servo_period)
+{
+    int axis_num;
+    int violated_teleop_limit = 0;
+    emcmot_axis_t *axis;
+
+    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
+        axis = &axis_array[axis_num];
+        // teleop_tp.max_vel is always positive
+        if (axis->teleop_tp.max_vel > axis->vel_limit) {
+            axis->teleop_tp.max_vel = axis->vel_limit;
+        }
+        if (update_teleop_with_check(axis_num, &(axis->teleop_tp), servo_period)) {
+            violated_teleop_limit = 1;
+        } else {
+            axis->teleop_vel_cmd = axis->teleop_tp.curr_vel;
+            axis->pos_cmd = axis->teleop_tp.curr_pos;
+        }
+
+        if (!axis->teleop_tp.active) {
+            axis->kb_ajog_active = 0;
+            axis->wheel_ajog_active = 0;
+        }
+
+        if (axis->ext_offset_tp.enable) {
+            if (update_teleop_with_check(axis_num, &(axis->ext_offset_tp), servo_period)) {
+                violated_teleop_limit = 1;
+            }
+        }
+    }
+    return violated_teleop_limit;
+}

--- a/src/emc/motion/axis.h
+++ b/src/emc/motion/axis.h
@@ -1,0 +1,61 @@
+
+#ifndef AXIS_H
+#define AXIS_H
+
+#include "rtapi_bool.h"
+#include "hal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void axis_init_all(void);
+void axis_initialize_external_offsets(void);
+int axis_init_hal_io(int mot_comp_id);
+
+void axis_handle_jogwheels(bool motion_teleop_flag, bool motion_enable_flag, bool homing_is_active);
+hal_bit_t axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bool all_homed);
+void axis_check_constraints(double pos[], int failing_axes[]);
+
+void axis_jog_cont(int axis_num, double vel, long servo_period);
+void axis_jog_incr(int axis_num, double offset, double vel, long servo_period);
+void axis_jog_abs(int axis_num, double offset, double vel);
+void axis_jog_abort_all(void);
+void axis_jog_abort(int axis_num);
+bool axis_jog_immediate_stop_all(void);
+void axis_jog_inhibit_all(void);
+bool axis_jog_is_active(void);
+
+void axis_output_to_hal(double *pcmd_p[]);
+
+void axis_set_max_pos_limit(int axis_num, double maxLimit);
+void axis_set_min_pos_limit(int axis_num, double minLimit);
+void axis_set_vel_limit(int axis_num, double vel);
+void axis_set_acc_limit(int axis_num, double acc);
+void axis_set_ext_offset_vel_limit(int axis_num, double ext_offset_vel);
+void axis_set_ext_offset_acc_limit(int axis_num, double ext_offset_acc);
+void axis_set_locking_joint(int axis_num, int joint);
+
+double axis_get_min_pos_limit(int axis_num);
+double axis_get_max_pos_limit(int axis_num);
+double axis_get_vel_limit(int axis_num);
+double axis_get_acc_limit(int axis_num);
+int axis_get_locking_joint(int axis_num);
+double axis_get_compound_velocity(void);
+double axis_get_ext_offset_curr_pos(int axis_num);
+
+double axis_get_teleop_vel_cmd(int axis_num);
+
+void axis_sync_teleop_tp_to_carte_pos(int extfactor, double *pcmd_p[]);
+void axis_sync_carte_pos_to_teleop_tp(int extfactor, double *pcmd_p[]);
+void axis_apply_ext_offsets_to_carte_pos(int extfactor, double *pcmd_p[]);
+
+int axis_update_coord_with_bound(double *pcmd_p[], double servo_period);
+
+int axis_calc_motion(double servo_period);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* AXIS_H */

--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -64,6 +64,7 @@
 #include "rtapi_math.h"
 #include "motion_types.h"
 #include "homing.h"
+#include "axis.h"
 
 #include "tp_debug.h"
 
@@ -181,32 +182,6 @@ void apply_spindle_limits(spindle_status_t *s){
     }
 }
 
-
-void axis_check_constraints(double pos[], int failing_axes[])
-{
-    int axis_num;
-    double eps = 1e-308;
-
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num += 1) {
-        double nl = axes[axis_num].min_pos_limit;
-        double pl = axes[axis_num].max_pos_limit;
-        failing_axes[axis_num] = 0;
-
-        if (   (fabs(pos[axis_num]) < eps)
-            && (fabs(axes[axis_num].min_pos_limit) < eps)
-            && (fabs(axes[axis_num].max_pos_limit) < eps) ) {
-            continue;
-        }
-
-        if (pos[axis_num] < (nl - 0.000000000001)) { // see pull request #1047
-            failing_axes[axis_num] = -1;
-        }
-
-        if (pos[axis_num] > (pl + 0.000000000001)) { // see pull request #1047
-            failing_axes[axis_num] = 1;
-        }
-    }
-}
 
 /* inRange() returns non-zero if the position lies within the joint
    limits, or 0 if not.  It also reports an error for each joint limit
@@ -405,10 +380,9 @@ STATIC int is_feed_type(int motion_type)
   */
 void emcmotCommandHandler(void *arg, long servo_period)
 {
-    int joint_num, axis_num, spindle_num;
+    int joint_num, spindle_num;
     int n,s0,s1;
     emcmot_joint_t *joint;
-    emcmot_axis_t *axis;
     double tmp1;
     emcmot_comp_entry_t *comp_entry;
     char issue_atspeed = 0;
@@ -435,9 +409,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	/* ...and process command */
 
         joint = 0;
-        axis  = 0;
         joint_num = emcmotCommand->joint;
-        axis_num  = emcmotCommand->axis;
 
 //-----------------------------------------------------------------------------
 // joints_axes test for unexpected conditions
@@ -447,7 +419,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
             || emcmotCommand->command == EMCMOT_JOG_INCR
             || emcmotCommand->command == EMCMOT_JOG_ABS
            ) {
-           if (GET_MOTION_TELEOP_FLAG() && axis_num < 0) {
+           if (GET_MOTION_TELEOP_FLAG() && (emcmotCommand->axis < 0)) {
                emsg = "command.com teleop: unexpected negative axis_num";
                if (joint_num >= 0) {
                    emsg = "Mode is TELEOP, cannot jog joint";
@@ -456,7 +428,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
            }
            if (!GET_MOTION_TELEOP_FLAG() && joint_num < 0) {
                emsg = "command.com !teleop: unexpected negative joint_num";
-               if (axis_num >= 0) {
+               if (emcmotCommand->axis >= 0) {
                    emsg = "Mode is NOT TELEOP, cannot jog axis coordinate";
                }
                abort = 1;
@@ -470,11 +442,10 @@ void emcmotCommandHandler(void *arg, long servo_period)
                return;
            }
            if (GET_MOTION_TELEOP_FLAG()) {
-                axis = &axes[axis_num];
-                if ( (axis_num >= 0) && (axis->locking_joint >= 0) ) {
+                if ( (emcmotCommand->axis >= 0) && (axis_get_locking_joint(emcmotCommand->axis) >= 0) ) {
                     rtapi_print_msg(RTAPI_MSG_ERR,
                     "Cannot jog a locking indexer AXIS_%c,joint_num=%d\n",
-                    "XYZABCUVW"[axis_num],axis->locking_joint);
+                    "XYZABCUVW"[emcmotCommand->axis], axis_get_locking_joint(emcmotCommand->axis));
                     return;
                 }
            }
@@ -518,9 +489,6 @@ void emcmotCommandHandler(void *arg, long servo_period)
                   return;
             }
         }
-        if (axis_num >= 0 && axis_num < EMCMOT_MAX_AXIS) {
-            axis = &axes[axis_num];
-        }
 	switch (emcmotCommand->command) {
 	case EMCMOT_ABORT:
 	    /* abort motion */
@@ -535,12 +503,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", joint_num);
 	    /* check for coord or free space motion active */
 	    if (GET_MOTION_TELEOP_FLAG()) {
-		for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-		    /* point to joint struct */
-		    axis = &axes[axis_num];
-		    /* tell teleop planner to stop */
-		    axis->teleop_tp.enable = 0;
-                }
+                axis_jog_abort_all();
 	    } else if (GET_MOTION_COORD_FLAG()) {
 		tpAbort(&emcmotInternal->coord_tp);
 	    } else {
@@ -574,8 +537,9 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", joint_num);
 	    if (GET_MOTION_TELEOP_FLAG()) {
 		/* tell teleop planner to stop */
-		if (axis != 0) axis->teleop_tp.enable = 0;
-		/* do nothing in teleop mode */
+		if ((emcmotCommand->axis >= 0) && (emcmotCommand->axis < EMCMOT_MAX_AXIS)) {
+                    axis_jog_abort(emcmotCommand->axis);
+                }
 	    } else if (GET_MOTION_COORD_FLAG()) {
 		/* do nothing in coord mode */
 	    } else {
@@ -593,10 +557,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	    break;
 
 	case EMCMOT_FREE:
-            for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-              axis = &axes[axis_num];
-              if (axis != 0) { axis->teleop_tp.enable = 0; }
-            }
+            axis_jog_abort_all();
 	    /* change the mode to free mode motion (joint mode) */
 	    /* can be done at any time */
 	    /* this code doesn't actually make the transition, it merely
@@ -859,10 +820,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	        joint->kb_jjog_active = 1;
 	        /* and let it go */
 	        joint->free_tp.enable = 1;
-                for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-                    axis = &axes[axis_num];
-                    if (axis != 0) { axis->teleop_tp.enable = 0; }
-                }
+                axis_jog_abort_all();
 	        /*! \todo FIXME - should we really be clearing errors here? */
 	        SET_JOINT_ERROR_FLAG(joint, 0);
 	        /* clear joints homed flag(s) if we don't have forward kins.
@@ -873,20 +831,11 @@ void emcmotCommandHandler(void *arg, long servo_period)
             } else {
                 // TELEOP  JOG_CONT
                 if (GET_MOTION_ERROR_FLAG()) { break; }
-                if (emcmotCommand->vel > 0.0) {
-                    axis->teleop_tp.pos_cmd = axis->max_pos_limit;
-                } else {
-                    axis->teleop_tp.pos_cmd = axis->min_pos_limit;
-                }
-
-	        axis->teleop_tp.max_vel = fabs(emcmotCommand->vel);
-	        axis->teleop_tp.max_acc = axis->acc_limit;
-	        axis->kb_ajog_active = 1;
                 for (joint_num = 0; joint_num < ALL_JOINTS; joint_num++) {
                     joint = &joints[joint_num];
                     if (joint != 0) { joint->free_tp.enable = 0; }
                 }
-	        axis->teleop_tp.enable = 1;
+                axis_jog_cont(emcmotCommand->axis, emcmotCommand->vel, servo_period);
             }
 	    break;
 
@@ -948,10 +897,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	        joint->kb_jjog_active = 1;
 	        /* and let it go */
 	        joint->free_tp.enable = 1;
-                for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-                    axis = &axes[axis_num];
-                    if (axis != 0) { axis->teleop_tp.enable = 0; }
-                }
+                axis_jog_abort_all();
 	        SET_JOINT_ERROR_FLAG(joint, 0);
 	        /* clear joint homed flag(s) if we don't have forward kins.
 	           Otherwise, a transition into coordinated mode will incorrectly
@@ -961,19 +907,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
             } else {
                 // TELEOP JOG_INCR
                 if (GET_MOTION_ERROR_FLAG()) { break; }
-	        if (emcmotCommand->vel > 0.0) {
-		    tmp1 = axis->teleop_tp.pos_cmd + emcmotCommand->offset;
-	        } else {
-		    tmp1 = axis->teleop_tp.pos_cmd - emcmotCommand->offset;
-	        }
-                if (tmp1 > axis->max_pos_limit) { break; }
-                if (tmp1 < axis->min_pos_limit) { break; }
-
-	        axis->teleop_tp.pos_cmd = tmp1;
-	        axis->teleop_tp.max_vel = fabs(emcmotCommand->vel);
-	        axis->teleop_tp.max_acc = axis->acc_limit;
-	        axis->kb_ajog_active = 1;
-	        axis->teleop_tp.enable = 1;
+                axis_jog_incr(emcmotCommand->axis, emcmotCommand->offset, emcmotCommand->vel, servo_period);
                 for (joint_num = 0; joint_num < ALL_JOINTS; joint_num++) {
                     joint = &joints[joint_num];
                     if (joint != 0) { joint->free_tp.enable = 0; }
@@ -1039,21 +973,8 @@ void emcmotCommandHandler(void *arg, long servo_period)
                    since homing, otherwise just do this one */
                 clearHomes(joint_num);
             } else {
-                axis->kb_ajog_active = 1;
                 // TELEOP JOG_ABS
-                if (axis->wheel_ajog_active) { break; }
-	        if (emcmotCommand->vel > 0.0) {
-		    tmp1 = axis->teleop_tp.pos_cmd + emcmotCommand->offset;
-	        } else {
-		    tmp1 = axis->teleop_tp.pos_cmd - emcmotCommand->offset;
-	        }
-	        if (tmp1 > axis->max_pos_limit) { break; }
-	        if (tmp1 < axis->min_pos_limit) { break; }
-                axis->teleop_tp.pos_cmd = tmp1;
-                axis->teleop_tp.max_vel = fabs(emcmotCommand->vel);
-                axis->teleop_tp.max_acc = axis->acc_limit;
-                axis->kb_ajog_active = 1;
-                axis->teleop_tp.enable = 1;
+                axis_jog_abs(emcmotCommand->axis, emcmotCommand->offset, emcmotCommand->vel);
                 for (joint_num = 0; joint_num < ALL_JOINTS; joint_num++) {
                    joint = &joints[joint_num];
                    if (joint != 0) { joint->free_tp.enable = 0; }
@@ -2010,49 +1931,49 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	    /* set the position limits for axis */
 	    /* can be done at any time */
 	    rtapi_print_msg(RTAPI_MSG_DBG, "SET_AXIS_POSITION_LIMITS");
-	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", axis_num);
+	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", emcmotCommand->axis);
 	    emcmot_config_change();
-	    if (axis == 0) {
-		break;
-	    }
-	    axis->min_pos_limit = emcmotCommand->minLimit;
-	    axis->max_pos_limit = emcmotCommand->maxLimit;
+            if ((emcmotCommand->axis < 0) || (emcmotCommand->axis >= EMCMOT_MAX_AXIS)) {
+                break;
+            }
+            axis_set_min_pos_limit(emcmotCommand->axis, emcmotCommand->minLimit);
+            axis_set_max_pos_limit(emcmotCommand->axis, emcmotCommand->maxLimit);
 	    break;
 
         case EMCMOT_SET_AXIS_VEL_LIMIT:
 	    /* set the max axis vel */
 	    /* can be done at any time */
 	    rtapi_print_msg(RTAPI_MSG_DBG, "SET_AXIS_VEL_LIMITS");
-	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", axis_num);
+	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", emcmotCommand->axis);
 	    emcmot_config_change();
-	    if (axis == 0) {
-		break;
-	    }
-	    axis->vel_limit = emcmotCommand->vel;
-	    axis->ext_offset_vel_limit = emcmotCommand->ext_offset_vel;
+            if ((emcmotCommand->axis < 0) || (emcmotCommand->axis >= EMCMOT_MAX_AXIS)) {
+                break;
+            }
+            axis_set_vel_limit(emcmotCommand->axis, emcmotCommand->vel);
+            axis_set_ext_offset_vel_limit(emcmotCommand->axis, emcmotCommand->ext_offset_vel);
             break;
 
         case EMCMOT_SET_AXIS_ACC_LIMIT:
  	    /* set the max axis acc */
 	    /* can be done at any time */
 	    rtapi_print_msg(RTAPI_MSG_DBG, "SET_AXIS_ACC_LIMITS");
-	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", axis_num);
+	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", emcmotCommand->axis);
 	    emcmot_config_change();
-	    if (axis == 0) {
-		break;
-	    }
-	    axis->acc_limit = emcmotCommand->acc;
-	    axis->ext_offset_acc_limit = emcmotCommand->ext_offset_acc;
+            if ((emcmotCommand->axis < 0) || (emcmotCommand->axis >= EMCMOT_MAX_AXIS)) {
+                break;
+            }
+            axis_set_acc_limit(emcmotCommand->axis, emcmotCommand->acc);
+            axis_set_ext_offset_acc_limit(emcmotCommand->axis, emcmotCommand->ext_offset_acc);
             break;
 
         case EMCMOT_SET_AXIS_LOCKING_JOINT:
 	    rtapi_print_msg(RTAPI_MSG_DBG, "SET_AXIS_ACC_LOCKING_JOINT");
-	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", axis_num);
+	    rtapi_print_msg(RTAPI_MSG_DBG, " %d", emcmotCommand->axis);
 	    emcmot_config_change();
-	    if (axis == 0) {
-		break;
-	    }
-	    axis->locking_joint = joint_num;
+            if ((emcmotCommand->axis < 0) || (emcmotCommand->axis >= EMCMOT_MAX_AXIS)) {
+                break;
+            }
+            axis_set_locking_joint(emcmotCommand->axis, joint_num);
             break;
 
 	default:

--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -218,23 +218,23 @@ STATIC int inRange(EmcPose pos, int id, char *move_type)
     emcmot_joint_t *joint;
     int in_range = 1;
 
-    if(check_axis_constraint(pos.tran.x, id, move_type, 0, 'X') == 0) 
+    if(check_axis_constraint(pos.tran.x, id, move_type, 0, 'X') == 0)
         in_range = 0;
-    if(check_axis_constraint(pos.tran.y, id, move_type, 1, 'Y') == 0) 
+    if(check_axis_constraint(pos.tran.y, id, move_type, 1, 'Y') == 0)
         in_range = 0;
-    if(check_axis_constraint(pos.tran.z, id, move_type, 2, 'Z') == 0) 
+    if(check_axis_constraint(pos.tran.z, id, move_type, 2, 'Z') == 0)
         in_range = 0;
-    if(check_axis_constraint(pos.a, id, move_type, 3, 'A') == 0) 
+    if(check_axis_constraint(pos.a, id, move_type, 3, 'A') == 0)
         in_range = 0;
-    if(check_axis_constraint(pos.b, id, move_type, 4, 'B') == 0) 
+    if(check_axis_constraint(pos.b, id, move_type, 4, 'B') == 0)
         in_range = 0;
-    if(check_axis_constraint(pos.c, id, move_type, 5, 'C') == 0) 
+    if(check_axis_constraint(pos.c, id, move_type, 5, 'C') == 0)
         in_range = 0;
-    if(check_axis_constraint(pos.u, id, move_type, 6, 'U') == 0) 
+    if(check_axis_constraint(pos.u, id, move_type, 6, 'U') == 0)
         in_range = 0;
-    if(check_axis_constraint(pos.v, id, move_type, 7, 'V') == 0) 
+    if(check_axis_constraint(pos.v, id, move_type, 7, 'V') == 0)
         in_range = 0;
-    if(check_axis_constraint(pos.w, id, move_type, 8, 'W') == 0) 
+    if(check_axis_constraint(pos.w, id, move_type, 8, 'W') == 0)
         in_range = 0;
 
     /* Now, check that the endpoint puts the joints within their limits too */
@@ -336,11 +336,11 @@ int emcmotGetRotaryIsUnlocked(int jnum) {
 
 /*! \function emcmotDioWrite()
 
-  sets or clears a HAL DIO pin, 
+  sets or clears a HAL DIO pin,
   pins get exported at runtime
-  
+
   index is valid from 0 to emcmotConfig->num_dio <= EMCMOT_MAX_DIO, defined in emcmotcfg.h
-  
+
 */
 void emcmotDioWrite(int index, char value)
 {
@@ -357,11 +357,11 @@ void emcmotDioWrite(int index, char value)
 
 /*! \function emcmotAioWrite()
 
-  sets or clears a HAL AIO pin, 
+  sets or clears a HAL AIO pin,
   pins get exported at runtime
-  
+
   index is valid from 0 to emcmotConfig->num_aio <= EMCMOT_MAX_AIO, defined in emcmotcfg.h
-  
+
 */
 void emcmotAioWrite(int index, double value)
 {
@@ -395,7 +395,7 @@ STATIC int is_feed_type(int motion_type)
 void emcmotCommandHandler(void *arg, long servo_period)
 {
     int joint_num, axis_num, spindle_num;
-    int n,s0,s1; 
+    int n,s0,s1;
     emcmot_joint_t *joint;
     emcmot_axis_t *axis;
     double tmp1;
@@ -420,7 +420,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
 
 	/* clear status value by default */
 	emcmotStatus->commandStatus = EMCMOT_COMMAND_OK;
-	
+
 	/* ...and process command */
 
         joint = 0;
@@ -1097,9 +1097,9 @@ void emcmotCommandHandler(void *arg, long servo_period)
 	    tpSetId(&emcmotInternal->coord_tp, emcmotCommand->id);
 	    int res_addline = tpAddLine(&emcmotInternal->coord_tp,
 					emcmotCommand->pos,
-					emcmotCommand->motion_type, 
+					emcmotCommand->motion_type,
 					emcmotCommand->vel,
-					emcmotCommand->ini_maxvel, 
+					emcmotCommand->ini_maxvel,
 					emcmotCommand->acc,
 					emcmotStatus->enables_new,
 					issue_atspeed,
@@ -1492,7 +1492,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
             /* unhome the specified joint, or all joints if -1 */
             rtapi_print_msg(RTAPI_MSG_DBG, "JOINT_UNHOME");
             rtapi_print_msg(RTAPI_MSG_DBG, " %d", joint_num);
-            
+
             if (   (emcmotStatus->motion_state != EMCMOT_MOTION_FREE)
                 && (emcmotStatus->motion_state != EMCMOT_MOTION_DISABLED)) {
                 reportError(_("must be in joint mode or disabled to unhome"));
@@ -1604,7 +1604,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
 
                 if (probeval != probe_whenclears) {
                     // the probe is already in the state we're seeking.
-                    if(probe_whenclears) 
+                    if(probe_whenclears)
                         reportError(_("Probe is already clear when starting G38.4 or G38.5 move"));
                     else
                         reportError(_("Probe is already tripped when starting G38.2 or G38.3 move"));
@@ -1675,7 +1675,7 @@ void emcmotCommandHandler(void *arg, long servo_period)
                                     emcmotCommand->ini_maxvel,
                                     emcmotCommand->acc,
                                     emcmotStatus->enables_new,
-                                    emcmotCommand->scale, 
+                                    emcmotCommand->scale,
                                     emcmotCommand->tag);
         if (res_addtap < 0) {
             emcmotStatus->atspeed_next_feed = 0; /* rigid tap always waits for spindle to be at-speed */

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -80,7 +80,7 @@ static double *pcmd_p[EMCMOT_MAX_AXIS];
 /* 'process_inputs()' is responsible for reading hardware input
    signals (from the HAL) and doing basic processing on them.  In
    the case of position feedback, that means removing backlash or
-   screw error comp and calculating the following error.  For 
+   screw error comp and calculating the following error.  For
    switches, it means debouncing them and setting flags in the
    emcmotStatus structure.
 */
@@ -675,21 +675,21 @@ static void process_probe_inputs(void)
 
     // trigger when the probe clears, instead of the usual case of triggering when it trips
     char probe_whenclears = !!(probe_type & 2);
-    
+
     /* read probe input */
     emcmotStatus->probeVal = !!*(emcmot_hal_data->probe_input);
     if (emcmotStatus->probing) {
         /* check if the probe has been tripped */
         if (emcmotStatus->probeVal ^ probe_whenclears) {
             /* remember the current position */
-            emcmotStatus->probedPos = emcmotStatus->carte_pos_fb; 
+            emcmotStatus->probedPos = emcmotStatus->carte_pos_fb;
             /* stop! */
             emcmotStatus->probing = 0;
             emcmotStatus->probeTripped = 1;
             tpAbort(&emcmotInternal->coord_tp);
         /* check if the probe hasn't tripped, but the move finished */
         } else if (GET_MOTION_INPOS_FLAG() && tpQueueDepth(&emcmotInternal->coord_tp) == 0) {
-            /* we are already stopped, but we need to remember the current 
+            /* we are already stopped, but we need to remember the current
                position here, because it will still be queried */
             emcmotStatus->probedPos = emcmotStatus->carte_pos_fb;
             emcmotStatus->probing = 0;
@@ -1046,7 +1046,7 @@ static void handle_jjogwheels(void)
 	}
 
         // disallow accel bogus fractions
-        if (    (*(joint_data->jjog_accel_fraction) > 1) 
+        if (    (*(joint_data->jjog_accel_fraction) > 1)
              || (*(joint_data->jjog_accel_fraction) < 0) ) {
             jaccel_limit = joint->acc_limit;
         } else {
@@ -1561,7 +1561,7 @@ static void get_pos_cmds(long period)
 	    joint->vel_cmd = 0.0;
 	    joint->acc_cmd = 0.0;
 	}
-	
+
 	break;
     default:
 	break;
@@ -1569,7 +1569,7 @@ static void get_pos_cmds(long period)
     /* check command against soft limits */
     /* This is a backup check, it should be impossible to command
 	a move outside the soft limits.  However there is at least
-	two cases that isn't caught upstream: 
+	two cases that isn't caught upstream:
 	1) if an arc has both endpoints inside the limits, but the curve extends outside,
 	2) if homing params are wrong then after homing joint pos_cmd are outside,
 	the upstream checks will pass it.
@@ -1608,7 +1608,7 @@ static void get_pos_cmds(long period)
         ** Guis may not provide a means to recover for identity kins except
         ** by unhoming/jogging/rehoming.  (For trivkins, using kinstype=both
         ** can be used as a workaround).
-        ** 
+        **
         */
 	    for (joint_num = 0; joint_num < emcmotConfig->numJoints; joint_num++) {
 	        if (joint_limit[joint_num][0] == 1) {
@@ -1776,7 +1776,7 @@ static void compute_screw_comp(void)
 	    dpos = joint->pos_cmd - comp->entry->nominal;
 	    if (joint->vel_cmd > 0.0) {
 	        /* moving "up". apply forward screw comp */
-		joint->backlash_corr = comp->entry->fwd_trim + 
+		joint->backlash_corr = comp->entry->fwd_trim +
 					comp->entry->fwd_slope * dpos;
 	    } else if (joint->vel_cmd < 0.0) {
 	        /* moving "down". apply reverse screw comp */
@@ -1789,7 +1789,7 @@ static void compute_screw_comp(void)
 	    /* no compensation data, just use +/- 1/2 of backlash */
 	    /** FIXME: this can actually be removed - if the user space code
 		sends a single compensation entry with any nominal value,
-		and with fwd_trim = +0.5 times the backlash value, and 
+		and with fwd_trim = +0.5 times the backlash value, and
 		rev_trim = -0.5 times backlash, the above screw comp code
 		will give exactly the same result as this code. */
 	    /* determine which way the compensation should be applied */
@@ -1815,7 +1815,7 @@ static void compute_screw_comp(void)
      *   At the end, the speed is ramped dowm using the same acceleration.
      *   The algorithm keeps looking ahead. Depending on the distance to go,
      *   the speed is increased, kept constant or decreased.
-     *   
+     *
      * Limitations:
      *   Since the compensation adds up to the normal movement, total
      *   acceleration and total velocity may exceed maximum settings!
@@ -1836,7 +1836,7 @@ static void compute_screw_comp(void)
 	 * The TP and backlash shouldn't use more than 100%
 	 * (together) but this requires some interaction that
 	 * isn't implemented yet.
-	 */ 
+	 */
         v_max = 0.5 * joint->vel_limit * emcmotStatus->net_feed_scale;
         a_max = 0.5 * joint->acc_limit;
         v = joint->backlash_vel;

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "motion_types.h"
 #include "homing.h"
+#include "axis.h"
 #include "kinematics.h"  //for kinematicsSwitchable()
 
 // Mark strings for translation, but defer translation to userspace
@@ -38,7 +39,6 @@
 
 static int    ext_offset_teleop_limit = 0;
 static int    ext_offset_coord_limit  = 0;
-static double ext_offset_epsilon;
 static bool   coord_cubic_active = 0;
 static int    switchkins_type = 0;
 /* kinematics flags */
@@ -124,7 +124,6 @@ static void set_operating_mode(void);
    when the jogwheel(s) turn.
 */
 static void handle_jjogwheels(void);
-static void handle_ajogwheels(void);
 
 /* 'do_homing_sequence()' decides what, if anything, needs to be done
     related to multi-joint homing.
@@ -180,13 +179,6 @@ static void output_to_hal(void);
 */
 static void update_status(void);
 
-static void initialize_external_offsets(void);
-static void plan_external_offsets(void);
-static void sync_teleop_tp_to_carte_pos(int);
-static void sync_carte_pos_to_teleop_tp(int);
-static void apply_ext_offsets_to_carte_pos(int);
-static int  update_coord_with_bound(void);
-static int  update_teleop_with_check(int,simple_tp_t*);
 static void handle_kinematicsSwitch(void);
 
 /***********************************************************************
@@ -252,7 +244,9 @@ void emcmotController(void *arg, long period)
     check_for_faults();
     set_operating_mode();
     handle_jjogwheels();
-    handle_ajogwheels();
+    if (!emcmotStatus->on_soft_limit) {  // change from teleop to move off joint soft limit
+        axis_handle_jogwheels(GET_MOTION_TELEOP_FLAG(), GET_MOTION_ENABLE_FLAG(), get_homing_is_active());
+    }
     do_homing_sequence();
     if (   (emcmotStatus->motion_state == EMCMOT_MOTION_FREE)
         && do_homing()) {
@@ -261,7 +255,7 @@ void emcmotController(void *arg, long period)
 
     get_pos_cmds(period);
     compute_screw_comp();
-    plan_external_offsets();
+    *(emcmot_hal_data->eoffset_active) = axis_plan_external_offsets(servo_period, GET_MOTION_ENABLE_FLAG(), get_allhomed());
     output_to_hal();
     write_homing_out_pins(ALL_JOINTS);
     update_status();
@@ -335,7 +329,6 @@ static void process_inputs(void)
     double abs_ferror, scale;
     joint_hal_t *joint_data;
     emcmot_joint_t *joint;
-    emcmot_axis_t *axis;
     unsigned char enables;
     /* read spindle angle (for threading, etc) */
     for (spindle_num = 0; spindle_num < emcmotConfig->numSpindles; spindle_num++){
@@ -528,7 +521,7 @@ static void process_inputs(void)
     // if jog in progress
     if (enables & *(emcmot_hal_data->jog_inhibit) && *(emcmot_hal_data->jog_is_active)) {
         // stop any joint jog
-        int jNum,aNum;
+        int jNum;
         for (jNum = 0; jNum < NO_OF_KINS_JOINTS; jNum++) {
             joint = &joints[jNum];
             if (joint->kb_jjog_active || joint->wheel_jjog_active) {
@@ -539,15 +532,8 @@ static void process_inputs(void)
             }
         }
         // stop any axis jog
-        for (aNum = 0; aNum < EMCMOT_MAX_AXIS; aNum++) {
-            axis = &axes[aNum];
-            if (axis->kb_ajog_active || axis->wheel_ajog_active) {
-                axis->teleop_tp.enable = 0;
-                axis->teleop_tp.curr_vel = 0.0;
-                axis->kb_ajog_active = 0;
-                axis->wheel_ajog_active = 0;
-            }
-        }
+        axis_jog_inhibit_all();
+
         *(emcmot_hal_data->jog_is_active) = 0;
         reportError("Jog aborted by jog-inhibit");
     }
@@ -670,7 +656,6 @@ static void process_probe_inputs(void)
 
     // don't error
     char probe_suppress = probe_type & 1;
-    int axis_num;
 
     // trigger when the probe clears, instead of the usual case of triggering when it trips
     char probe_whenclears = !!(probe_type & 2);
@@ -737,15 +722,8 @@ static void process_probe_inputs(void)
                 if(!aborted) aborted=2;
             }
         }
-        for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-            emcmot_axis_t *axis;
-            axis = &axes[axis_num];
-            // abort any coordinate jogs
-            if (axis->teleop_tp.enable) {
-                axis->teleop_tp.enable = 0;
-                axis->teleop_tp.curr_vel = 0.0;
-                aborted = 3;
-            }
+        if (axis_jog_immediate_stop_all()) {
+            aborted = 3;
         }
 
         if(aborted == 1) {
@@ -844,9 +822,8 @@ static void check_for_faults(void)
 
 static void set_operating_mode(void)
 {
-    int joint_num, axis_num;
+    int joint_num;
     emcmot_joint_t *joint;
-    emcmot_axis_t *axis;
     double positions[EMCMOT_MAX_JOINTS];
 
     /* check for disabling */
@@ -871,13 +848,7 @@ static void set_operating_mode(void)
 	       we just went into disabled state */
 	}
 
-	for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-	    /* point to axis data */
-	    axis = &axes[axis_num];
-	    /* disable teleop mode planner */
-	    axis->teleop_tp.enable = 0;
-	    axis->teleop_tp.curr_vel = 0.0;
-        }
+    axis_jog_immediate_stop_all();
 
 	SET_MOTION_ENABLE_FLAG(0);
 	/* don't clear the motion error flag, since that may signify why we
@@ -891,7 +862,7 @@ static void set_operating_mode(void)
                         "soft limit with active external offsets");
             *(emcmot_hal_data->eoffset_limited) = 0;
         }
-        initialize_external_offsets();
+        axis_initialize_external_offsets();
         tpSetPos(&emcmotInternal->coord_tp, &emcmotStatus->carte_pos_cmd);
 	for (joint_num = 0; joint_num < ALL_JOINTS; joint_num++) {
 	    /* point to joint data */
@@ -908,7 +879,7 @@ static void set_operating_mode(void)
 	}
 	if ( !GET_MOTION_ENABLE_FLAG() ) {
             if (GET_MOTION_TELEOP_FLAG()) {
-                sync_teleop_tp_to_carte_pos(0);
+                axis_sync_teleop_tp_to_carte_pos(0, pcmd_p);
             }
 	}
 	SET_MOTION_ENABLE_FLAG(1);
@@ -945,7 +916,7 @@ static void set_operating_mode(void)
 
             kinematicsForward(positions, &emcmotStatus->carte_pos_cmd, &fflags, &iflags);
             // entering teleop (INPOS), remove ext offsets
-            sync_teleop_tp_to_carte_pos(-1);
+            axis_sync_teleop_tp_to_carte_pos(-1, pcmd_p);
 	} else {
 	    /* not in position-- don't honor mode change */
 	    emcmotInternal->teleoperating = 0;
@@ -970,7 +941,8 @@ static void set_operating_mode(void)
 	    if (GET_MOTION_INPOS_FLAG()) {
 		/* preset traj planner to current position */
 
-                apply_ext_offsets_to_carte_pos(-1); // subtract at coord mode start
+                // subtract at coord mode start
+                axis_apply_ext_offsets_to_carte_pos(-1, pcmd_p);
 
 		tpSetPos(&emcmotInternal->coord_tp, &emcmotStatus->carte_pos_cmd);
 		/* drain the cubics so they'll synch up */
@@ -1167,86 +1139,10 @@ static void handle_jjogwheels(void)
     first_pass = 0;
 }
 
-static void handle_ajogwheels(void)
-{
-    int axis_num;
-    emcmot_axis_t *axis;
-    axis_hal_t *axis_data;
-    int new_ajog_counts, delta;
-    double distance, pos, stop_dist;
-    static int first_pass = 1;	/* used to set initial conditions */
-
-    // change from teleop to move off joint soft limit
-    if ( emcmotStatus->on_soft_limit ) { return; }
-
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-        double aaccel_limit;
-        axis = &axes[axis_num];
-        axis_data = &(emcmot_hal_data->axis[axis_num]);
-
-        // disallow accel bogus fractions
-        if (   (*(axis_data->ajog_accel_fraction) > 1)
-            || (*(axis_data->ajog_accel_fraction) < 0) ) {
-            aaccel_limit = axis->acc_limit;
-        } else {
-            aaccel_limit = *(axis_data->ajog_accel_fraction) * axis->acc_limit;
-        }
-
-	new_ajog_counts = *(axis_data->ajog_counts);
-	delta = new_ajog_counts - axis->old_ajog_counts;
-	axis->old_ajog_counts = new_ajog_counts;
-	if ( first_pass ) { continue; }
-	if ( delta == 0 ) {
-            //just update counts
-            continue;
-        }
-        if (!GET_MOTION_TELEOP_FLAG()) {
-            axis->teleop_tp.enable = 0;
-            return;
-        }
-	if (!GET_MOTION_TELEOP_FLAG())        { continue; }
-	if (!GET_MOTION_ENABLE_FLAG())        { continue; }
-	if ( *(axis_data->ajog_enable) == 0 ) { continue; }
-	if (get_homing_is_active()   )        { continue; }
-	if (axis->kb_ajog_active)             { continue; }
-
-	if (axis->locking_joint >= 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR,
-        "Cannot wheel jog a locking indexer AXIS_%c\n",
-        "XYZABCUVW"[axis_num]);
-	continue;
-	}
-
-	distance = delta * *(axis_data->ajog_scale);
-	pos = axis->teleop_tp.pos_cmd + distance;
-	if ( *(axis_data->ajog_vel_mode) ) {
-            double v = axis->vel_limit;
-	    /* compute stopping distance at max speed */
-	    stop_dist = v * v / ( 2 * aaccel_limit);
-	    /* if commanded position leads the actual position by more
-	       than stopping distance, discard excess command */
-	    if ( pos > axis->pos_cmd + stop_dist ) {
-		pos = axis->pos_cmd + stop_dist;
-	    } else if ( pos < axis->pos_cmd - stop_dist ) {
-		pos = axis->pos_cmd - stop_dist;
-	    }
-	}
-	if (pos > axis->max_pos_limit) { break; }
-	if (pos < axis->min_pos_limit) { break; }
-        axis->teleop_tp.pos_cmd = pos;
-        axis->teleop_tp.max_vel = axis->vel_limit;
-        axis->teleop_tp.max_acc = aaccel_limit;
- 	axis->wheel_ajog_active = 1;
-        axis->teleop_tp.enable  = 1;
-    }
-    first_pass = 0;
-}
-
 static void get_pos_cmds(long period)
 {
-    int joint_num, axis_num, result;
+    int joint_num, result;
     emcmot_joint_t *joint;
-    emcmot_axis_t *axis;
     double positions[EMCMOT_MAX_JOINTS];
     double vel_lim;
 
@@ -1398,11 +1294,7 @@ static void get_pos_cmds(long period)
 	break;
 
     case EMCMOT_MOTION_COORD:
-	for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-	    axis = &axes[axis_num];
-	    axis->teleop_tp.enable = 0;
-	    axis->teleop_tp.curr_vel = 0.0;
-        } // for(axis_num)
+        axis_jog_immediate_stop_all();
 
 	/* check joint 0 to see if the interpolators are empty */
 	coord_cubic_active = 1;
@@ -1414,7 +1306,7 @@ static void get_pos_cmds(long period)
             /* get new commanded traj pos */
             tpGetPos(&emcmotInternal->coord_tp, &emcmotStatus->carte_pos_cmd);
 
-            if ( update_coord_with_bound() ) {
+            if (axis_update_coord_with_bound(pcmd_p, servo_period)) {
                 ext_offset_coord_limit = 1;
             } else {
                 ext_offset_coord_limit = 0;
@@ -1470,36 +1362,12 @@ static void get_pos_cmds(long period)
 	break;
 
     case EMCMOT_MOTION_TELEOP:
-        ext_offset_teleop_limit = 0;
-        for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-            axis = &axes[axis_num];
-            // teleop_tp.max_vel is always positive
-            if(axis->teleop_tp.max_vel > axis->vel_limit) {
-                axis->teleop_tp.max_vel = axis->vel_limit;
-            }
-            if (update_teleop_with_check(axis_num,&(axis->teleop_tp) )) {
-                ext_offset_teleop_limit = 1;
-            } else {
-                axis->teleop_vel_cmd = axis->teleop_tp.curr_vel;
-                axis->pos_cmd = axis->teleop_tp.curr_pos;
-            }
-
-            if(!axis->teleop_tp.active) {
-                axis->kb_ajog_active = 0;
-                axis->wheel_ajog_active = 0;
-            }
-
-            if (axis->ext_offset_tp.enable) {
-                if (update_teleop_with_check(axis_num,&(axis->ext_offset_tp)) ) {
-                    ext_offset_teleop_limit = 1;
-                }
-            }
-        }
+        ext_offset_teleop_limit = axis_calc_motion(servo_period);
         if (!ext_offset_teleop_limit) {
             ext_offset_coord_limit = 0; //in case was set in prior coord motion
         }
 
-        sync_carte_pos_to_teleop_tp(+1); // teleop
+        axis_sync_carte_pos_to_teleop_tp(+1, pcmd_p); // teleop
 
 	/* the next position then gets run through the inverse kins,
 	    to compute the next positions of the joints */
@@ -1637,11 +1505,7 @@ static void get_pos_cmds(long period)
         && GET_MOTION_TELEOP_FLAG()
         && emcmotStatus->on_soft_limit ) {
         SET_MOTION_ERROR_FLAG(1);
-        for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-            axis = &axes[axis_num];
-            axis->teleop_tp.enable = 0;
-            axis->teleop_tp.curr_vel = 0.0;
-        }
+        axis_jog_immediate_stop_all();
     }
     if (ext_offset_teleop_limit || ext_offset_coord_limit) {
         *(emcmot_hal_data->eoffset_limited) = 1;
@@ -1933,12 +1797,10 @@ static void compute_screw_comp(void)
 
 static void output_to_hal(void)
 {
-    int joint_num, axis_num, spindle_num;
+    int joint_num, spindle_num;
     double inch_mult;
     emcmot_joint_t *joint;
-    emcmot_axis_t *axis;
     joint_hal_t *joint_data;
-    axis_hal_t *axis_data;
     static int old_motion_index[EMCMOT_MAX_SPINDLES] = {0};
     static int old_hal_index[EMCMOT_MAX_SPINDLES] = {0};
     bool activeJog = 0;
@@ -2032,15 +1894,7 @@ static void output_to_hal(void)
         *(emcmot_hal_data->current_vel) = emcmotStatus->current_vel;
         *(emcmot_hal_data->requested_vel) = emcmotStatus->requested_vel;
     } else if (GET_MOTION_TELEOP_FLAG()) {
-        int i;
-        double v2 = 0.0;
-        for(i=0; i < EMCMOT_MAX_AXIS; i++)
-            if(axes[i].teleop_tp.active)
-                v2 += axes[i].teleop_vel_cmd * axes[i].teleop_vel_cmd;
-        if(v2 > 0.0)
-            emcmotStatus->current_vel = (*emcmot_hal_data->current_vel) = sqrt(v2);
-        else
-            emcmotStatus->current_vel = (*emcmot_hal_data->current_vel) = 0.0;
+        emcmotStatus->current_vel = (*emcmot_hal_data->current_vel) = axis_get_compound_velocity();
         *(emcmot_hal_data->requested_vel) = 0.0;
     } else {
         int i;
@@ -2159,27 +2013,9 @@ static void output_to_hal(void)
         }
     } // for joint_num
 
-    /* output axis info to HAL for scoping, etc */
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-        /* point to axis struct */
-        axis = &axes[axis_num];
-        /* point to HAL data */
-        axis_data = &(emcmot_hal_data->axis[axis_num]);
-        /* write to HAL pins */
-        *(axis_data->teleop_vel_cmd)    = axis->teleop_vel_cmd;
-        *(axis_data->teleop_pos_cmd)    = axis->teleop_tp.pos_cmd;
-        *(axis_data->teleop_vel_lim)    = axis->teleop_tp.max_vel;
-        *(axis_data->teleop_tp_enable)  = axis->teleop_tp.enable;
-        *(axis_data->kb_ajog_active)    = axis->kb_ajog_active;
-        *(axis_data->wheel_ajog_active) = axis->wheel_ajog_active;
-
-        // hal pins: axis.L.pos-cmd reported without applied offsets:
-        *(axis_data->pos_cmd) = *pcmd_p[axis_num]
-                              - axis->ext_offset_tp.curr_pos;
-        // axis jog is in progress
-        if (axis->kb_ajog_active || axis->wheel_ajog_active) {
-                activeJog = 1;
-        }
+    axis_output_to_hal(pcmd_p);
+    if (axis_jog_is_active()) {
+        activeJog = 1;
     }
     *(emcmot_hal_data->jog_is_active) = activeJog;
 }
@@ -2189,7 +2025,6 @@ static void update_status(void)
     int joint_num, axis_num, dio, aio, misc_error;
     emcmot_joint_t *joint;
     emcmot_joint_status_t *joint_status;
-    emcmot_axis_t *axis;
     emcmot_axis_status_t *axis_status;
 #ifdef WATCH_FLAGS
     static int old_joint_flags[8];
@@ -2228,24 +2063,22 @@ static void update_status(void)
     }
 
     for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-	/* point to axis data */
-	axis = &axes[axis_num];
-	/* point to axis status */
-	axis_status = &(emcmotStatus->axis_status[axis_num]);
+        /* point to axis status */
+        axis_status = &(emcmotStatus->axis_status[axis_num]);
 
-	axis_status->teleop_vel_cmd = axis->teleop_vel_cmd;
-	axis_status->max_pos_limit = axis->max_pos_limit;
-	axis_status->min_pos_limit = axis->min_pos_limit;
+        axis_status->teleop_vel_cmd = axis_get_teleop_vel_cmd(axis_num);
+        axis_status->max_pos_limit = axis_get_max_pos_limit(axis_num);
+        axis_status->min_pos_limit = axis_get_min_pos_limit(axis_num);
     }
-    emcmotStatus->eoffset_pose.tran.x = (&axes[0])->ext_offset_tp.curr_pos;
-    emcmotStatus->eoffset_pose.tran.y = (&axes[1])->ext_offset_tp.curr_pos;
-    emcmotStatus->eoffset_pose.tran.z = (&axes[2])->ext_offset_tp.curr_pos;
-    emcmotStatus->eoffset_pose.a      = (&axes[3])->ext_offset_tp.curr_pos;
-    emcmotStatus->eoffset_pose.b      = (&axes[4])->ext_offset_tp.curr_pos;
-    emcmotStatus->eoffset_pose.c      = (&axes[5])->ext_offset_tp.curr_pos;
-    emcmotStatus->eoffset_pose.u      = (&axes[6])->ext_offset_tp.curr_pos;
-    emcmotStatus->eoffset_pose.v      = (&axes[7])->ext_offset_tp.curr_pos;
-    emcmotStatus->eoffset_pose.w      = (&axes[8])->ext_offset_tp.curr_pos;
+    emcmotStatus->eoffset_pose.tran.x = axis_get_ext_offset_curr_pos(0);
+    emcmotStatus->eoffset_pose.tran.y = axis_get_ext_offset_curr_pos(1);
+    emcmotStatus->eoffset_pose.tran.z = axis_get_ext_offset_curr_pos(2);
+    emcmotStatus->eoffset_pose.a      = axis_get_ext_offset_curr_pos(3);
+    emcmotStatus->eoffset_pose.b      = axis_get_ext_offset_curr_pos(4);
+    emcmotStatus->eoffset_pose.c      = axis_get_ext_offset_curr_pos(5);
+    emcmotStatus->eoffset_pose.u      = axis_get_ext_offset_curr_pos(6);
+    emcmotStatus->eoffset_pose.v      = axis_get_ext_offset_curr_pos(7);
+    emcmotStatus->eoffset_pose.w      = axis_get_ext_offset_curr_pos(8);
 
     emcmotStatus->external_offsets_applied = *(emcmot_hal_data->eoffset_active);
 
@@ -2294,222 +2127,3 @@ static void update_status(void)
     }
 #endif
 }
-
-static void sync_teleop_tp_to_carte_pos(int extfactor)
-{
-    int axis_num;
-    emcmot_axis_t *axis;
-
-    // expect extfactor =  -1 || 0 || +1
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-        axis = &axes[axis_num];
-        axis->teleop_tp.curr_pos = *pcmd_p[axis_num]
-                                 + extfactor * axis->ext_offset_tp.curr_pos;
-    }
-} //sync_teleop_tp_to_carte_pos()
-
-static void sync_carte_pos_to_teleop_tp(int extfactor)
-{
-    int axis_num;
-    emcmot_axis_t *axis;
-
-    // expect extfactor =  -1 || 0 || +1
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-        axis = &axes[axis_num];
-        *pcmd_p[axis_num] = axis->teleop_tp.curr_pos
-                          + extfactor * axis->ext_offset_tp.curr_pos;
-    }
-} // sync_carte_pos_to_teleop_tp()
-
-static void apply_ext_offsets_to_carte_pos(int extfactor)
-{
-    int axis_num;
-    emcmot_axis_t *axis;
-
-    // expect extfactor =  -1 || 0 || +1
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-        axis = &axes[axis_num];
-        *pcmd_p[axis_num] = *pcmd_p[axis_num]
-                          + extfactor * axis->ext_offset_tp.curr_pos;
-    }
-} // apply_ext_offsets_to_carte_pos()
-
-static void initialize_external_offsets()
-{
-    int axis_num;
-    emcmot_axis_t *axis;
-    axis_hal_t *axis_data;
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-        axis = &axes[axis_num];
-        axis_data = &(emcmot_hal_data->axis[axis_num]);
-
-        *(axis_data->external_offset) = 0;
-        *(axis_data->external_offset_requested) = 0;
-        axis->ext_offset_tp.pos_cmd  = 0;
-        axis->ext_offset_tp.curr_pos = 0;
-        axis->ext_offset_tp.curr_vel = 0;
-    }
-} // initialize_external_offsets()
-
-static void plan_external_offsets(void)
-{
-    static int first_pass = 1;
-    int axis_num;
-    emcmot_axis_t *axis;
-    axis_hal_t *axis_data;
-    int new_eoffset_counts, delta;
-    static int last_eoffset_enable[EMCMOT_MAX_AXIS];
-
-    *(emcmot_hal_data->eoffset_active) = 0; //set if any enabled
-
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-        axis = &axes[axis_num];
-        // coord,teleop updates done in get_pos_cmds()
-        axis->ext_offset_tp.max_vel = axis->ext_offset_vel_limit;
-        axis->ext_offset_tp.max_acc = axis->ext_offset_acc_limit;
-
-        axis_data = &(emcmot_hal_data->axis[axis_num]);
-
-        new_eoffset_counts       = *(axis_data->eoffset_counts);
-        delta                    = new_eoffset_counts - axis->old_eoffset_counts;
-        axis->old_eoffset_counts = new_eoffset_counts;
-
-        *(axis_data->external_offset)  = axis->ext_offset_tp.curr_pos;
-        axis->ext_offset_tp.enable = 1;
-        if ( first_pass ) {
-            *(axis_data->external_offset) = 0;
-            continue;
-        }
-
-        // Use stopping criterion of simple_tp.c:
-        ext_offset_epsilon = TINY_DP(axis->ext_offset_tp.max_acc,servo_period);
-        if (fabs(*(axis_data->external_offset)) > ext_offset_epsilon) {
-           *(emcmot_hal_data->eoffset_active) = 1;
-        }
-        if ( !*(axis_data->eoffset_enable) ) {
-            axis->ext_offset_tp.enable = 0;
-            // Detect disabling of eoffsets:
-            //   At very high accel, simple planner may terminate with
-            //   a larger position value than occurs at more realistic accels.
-            if (   last_eoffset_enable[axis_num]
-                && (fabs(*(axis_data->external_offset)) > ext_offset_epsilon)
-                && GET_MOTION_ENABLE_FLAG()
-                && axis->ext_offset_tp.enable
-               ) {
-               // to stdout only:
-               rtapi_print_msg(RTAPI_MSG_NONE,
-                           "*** Axis_%c External Offset=%.4g eps=%.4g\n"
-                           "*** External Offset disabled while NON-zero\n"
-                           "*** To clear: re-enable & zero or use Machine-Off\n",
-                           "XYZABCUVW"[axis_num],
-                           *(axis_data->external_offset),
-                           ext_offset_epsilon);
-            }
-            last_eoffset_enable[axis_num] = 0;
-            continue; // Note: if   not eoffset_enable
-                      //       then planner disabled and no pos_cmd updates
-                      //       useful for eoffset_pid hold
-        }
-        last_eoffset_enable[axis_num] = 1;
-        if (*(axis_data->eoffset_clear)) {
-            axis->ext_offset_tp.pos_cmd             = 0;
-            *(axis_data->external_offset_requested) = 0;
-            continue;
-        }
-        if ( delta == 0 )                { continue; }
-        if ( !get_allhomed() )           { continue; }
-        if ( !GET_MOTION_ENABLE_FLAG() ) { continue; }
-
-        axis->ext_offset_tp.pos_cmd   += delta *  *(axis_data->eoffset_scale);
-        *(axis_data->external_offset_requested) = axis->ext_offset_tp.pos_cmd;
-    } // for axis_num
-    first_pass = 0;
-} // plan_external_offsets()
-
-static int update_teleop_with_check(int axis_num,simple_tp_t *the_tp)
-{
-    // 'the_tp' is the planner to update
-    // the tests herein apply to the sum of the offsets for both
-    // planners (teleop_tp and ext_offset_tp)
-    double save_curr_pos;
-    emcmot_axis_t *axis = &axes[axis_num];
-
-    save_curr_pos = the_tp->curr_pos;
-    simple_tp_update(the_tp, servo_period );
-
-    //workaround: axis letters not in [TRAJ]COORDINATES
-    //            have min_pos_limit == max_pos_lim == 0
-    if  ( (0 == axis->max_pos_limit) && (0 == axis->min_pos_limit) ) {
-        return 0;
-    }
-    if  ( (axis->ext_offset_tp.curr_pos + axis->teleop_tp.curr_pos)
-          >= axis->max_pos_limit) {
-        // positive error, restore save_curr_pos
-        the_tp->curr_pos = save_curr_pos;
-        the_tp->curr_vel = 0;
-        return 1;
-    }
-    if  ( (axis->ext_offset_tp.curr_pos + axis->teleop_tp.curr_pos)
-           <= axis->min_pos_limit) {
-        // negative error, restore save_curr_pos
-        the_tp->curr_pos = save_curr_pos;
-        the_tp->curr_vel = 0;
-        return 1;
-    }
-    return 0;
-} // update_teleop_with_check()
-
-static int update_coord_with_bound(void)
-{
-    int axis_num;
-    int ans = 0;
-    emcmot_axis_t *axis;
-    double save_pos_cmd[EMCMOT_MAX_AXIS];
-    double save_offset_cmd[EMCMOT_MAX_AXIS];
-
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-        axis = &axes[axis_num];
-        save_pos_cmd[axis_num]     = *pcmd_p[axis_num];
-        save_offset_cmd[axis_num]  = axis->ext_offset_tp.pos_cmd;
-        simple_tp_update(&(axis->ext_offset_tp), servo_period );
-    }
-    apply_ext_offsets_to_carte_pos(+1); // add external offsets
-
-    for (axis_num = 0; axis_num < EMCMOT_MAX_AXIS; axis_num++) {
-        axis = &axes[axis_num];
-        //workaround: axis letters not in [TRAJ]COORDINATES
-        //            have min_pos_limit == max_pos_lim == 0
-        if ( (0 == axis->max_pos_limit) && (0 == axis->min_pos_limit) ) {
-            continue;
-        }
-        if (axis->ext_offset_tp.curr_pos == 0) {
-           continue; // don't claim violation if no offset
-        }
-
-        if (*pcmd_p[axis_num] >= axis->max_pos_limit) {
-            // hold carte_pos_cmd at the limit:
-            *pcmd_p[axis_num]  = axis->max_pos_limit;
-            // stop growth of offsetting position:
-            axis->ext_offset_tp.curr_pos = axis->max_pos_limit
-                                         - save_pos_cmd[axis_num];
-            if (axis->ext_offset_tp.pos_cmd > save_offset_cmd[axis_num]) {
-                axis->ext_offset_tp.pos_cmd = save_offset_cmd[axis_num];
-            }
-            axis->ext_offset_tp.curr_vel = 0;
-            ans++;
-            continue;
-        }
-        if (*pcmd_p[axis_num] <= axis->min_pos_limit) {
-            *pcmd_p[axis_num]  = axis->min_pos_limit;
-            axis->ext_offset_tp.curr_pos = axis->min_pos_limit
-                                         - save_pos_cmd[axis_num];
-            if (axis->ext_offset_tp.pos_cmd < save_offset_cmd[axis_num]) {
-                axis->ext_offset_tp.pos_cmd = save_offset_cmd[axis_num];
-            }
-            axis->ext_offset_tp.curr_vel = 0;
-            ans++;
-        }
-    }
-    if (ans > 0) { return 1; }
-    return 0;
-} // update_coord_with_bound()

--- a/src/emc/motion/mot_priv.h
+++ b/src/emc/motion/mot_priv.h
@@ -119,29 +119,6 @@ typedef struct {
     hal_float_t *posthome_cmd; //  IN pin extrajoint
 } extrajoint_hal_t;
 
-typedef struct {
-    hal_float_t *pos_cmd;        /* RPI: commanded position */
-    hal_float_t *teleop_vel_cmd; /* RPI: commanded velocity */
-    hal_float_t *teleop_pos_cmd; /* RPI: teleop traj planner pos cmd */
-    hal_float_t *teleop_vel_lim; /* RPI: teleop traj planner vel limit */
-    hal_bit_t   *teleop_tp_enable; /* RPI: teleop traj planner is running */
-
-    hal_s32_t   *ajog_counts;	/* WPI: jogwheel position input */
-    hal_bit_t   *ajog_enable;	/* RPI: enable jogwheel */
-    hal_float_t *ajog_scale;	/* RPI: distance to jog on each count */
-    hal_float_t *ajog_accel_fraction;	/* RPI: to limit wheel jog accel */
-    hal_bit_t   *ajog_vel_mode;	/* RPI: true for "velocity mode" jogwheel */
-    hal_bit_t   *kb_ajog_active;   /* RPI: executing keyboard jog */
-    hal_bit_t   *wheel_ajog_active;/* RPI: executing handwheel jog */
-
-    hal_bit_t   *eoffset_enable;
-    hal_bit_t   *eoffset_clear;
-    hal_s32_t   *eoffset_counts;
-    hal_float_t *eoffset_scale;
-    hal_float_t *external_offset;
-    hal_float_t *external_offset_requested;
-} axis_hal_t;
-
 /* machine data */
 
 typedef struct {
@@ -207,7 +184,6 @@ typedef struct {
     spindle_hal_t spindle[EMCMOT_MAX_SPINDLES];     /*spindle data */
     joint_hal_t joint[EMCMOT_MAX_JOINTS];	/* data for each joint */
     extrajoint_hal_t ejoint[EMCMOT_MAX_EXTRAJOINTS]; /* data for each extrajoint */
-    axis_hal_t axis[EMCMOT_MAX_AXIS];	        /* data for each axis */
 
     hal_bit_t   *eoffset_active; /* ext offsets active */
     hal_bit_t   *eoffset_limited; /* ext offsets exceed limit */
@@ -232,9 +208,6 @@ extern emcmot_hal_data_t *emcmot_hal_data;
 /* the actual array may be in shared memory or in kernel space, as
    determined by the init code in motion.c */
 extern emcmot_joint_t joints[EMCMOT_MAX_JOINTS];
-
-/* pointer to array of axis structs with all axis data */
-extern emcmot_axis_t axes[EMCMOT_MAX_AXIS];
 
 /* Variable defs */
 extern KINEMATICS_FORWARD_FLAGS fflags;

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -444,6 +444,12 @@ void rtapi_app_exit(void)
 *                         LOCAL FUNCTION CODE                          *
 ************************************************************************/
 
+#define CALL_CHECK(expr) do {           \
+        int _retval;                    \
+        _retval = expr;                 \
+        if (_retval) return _retval;    \
+    } while (0);
+
 /* init_hal_io() exports HAL pins and parameters making data from
    the realtime control module visible and usable by the world
 */
@@ -464,146 +470,140 @@ static int init_hal_io(void)
     }
 
     /* export machine wide hal pins */
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->probe_input), mot_comp_id, "motion.probe-input")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->adaptive_feed), mot_comp_id, "motion.adaptive-feed")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->feed_hold), mot_comp_id, "motion.feed-hold")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->feed_inhibit), mot_comp_id, "motion.feed-inhibit")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->homing_inhibit), mot_comp_id, "motion.homing-inhibit")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->jog_inhibit), mot_comp_id, "motion.jog-inhibit")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->tp_reverse), mot_comp_id, "motion.tp-reverse")) < 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->enable), mot_comp_id, "motion.enable")) != 0) goto error;
+    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->probe_input), mot_comp_id, "motion.probe-input"));
+    CALL_CHECK(hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->adaptive_feed), mot_comp_id, "motion.adaptive-feed"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->feed_hold), mot_comp_id, "motion.feed-hold"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->feed_inhibit), mot_comp_id, "motion.feed-inhibit"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->homing_inhibit), mot_comp_id, "motion.homing-inhibit"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->jog_inhibit), mot_comp_id, "motion.jog-inhibit"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->tp_reverse), mot_comp_id, "motion.tp-reverse"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->enable), mot_comp_id, "motion.enable"));
 
     /* state tags pins */
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_upm), mot_comp_id, "motion.feed-upm")) < 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_inches_per_minute), mot_comp_id, "motion.feed-inches-per-minute")) < 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_inches_per_second), mot_comp_id, "motion.feed-inches-per-second")) < 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_mm_per_minute), mot_comp_id, "motion.feed-mm-per-minute")) < 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_mm_per_second), mot_comp_id, "motion.feed-mm-per-second")) < 0) goto error;
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_upm), mot_comp_id, "motion.feed-upm"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_inches_per_minute), mot_comp_id, "motion.feed-inches-per-minute"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_inches_per_second), mot_comp_id, "motion.feed-inches-per-second"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_mm_per_minute), mot_comp_id, "motion.feed-mm-per-minute"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->feed_mm_per_second), mot_comp_id, "motion.feed-mm-per-second"));
 
     /* export motion-synched digital output pins */
     /* export motion digital input pins */
-    if(names_din[0]){
-      for (n = 0; n < num_dio; n++) {
-        if(names_din[n] == NULL || (*names_din[n] == 0)){break;}
-        if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_di[n]), mot_comp_id, "motion.din-%s", names_din[n])) != 0) goto error;
-      }
-    }
-    else{
-      for (n = 0; n < num_dio; n++) {
-        if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_di[n]), mot_comp_id, "motion.digital-in-%02d", n)) != 0)
-          goto error;
-      }
+    if (names_din[0]){
+        for (n = 0; n < num_dio; n++) {
+            if (names_din[n] == NULL || (*names_din[n] == 0)) {break;}
+            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_di[n]), mot_comp_id, "motion.din-%s", names_din[n]));
+        }
+    } else {
+        for (n = 0; n < num_dio; n++) {
+            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_di[n]), mot_comp_id, "motion.digital-in-%02d", n));
+        }
     }
 
-    if(names_dout[0]){
-      for (n = 0; n < num_dio; n++) {
-        if(names_dout[n] == NULL || (*names_dout[n] == 0)){break;}
-        if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.dout-%s", names_dout[n])) != 0) goto error;
-      }
-    }
-    else{
-      for (n = 0; n < num_dio; n++) {
-        if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.digital-out-%02d",n)) != 0) goto error;
-      }
+    if (names_dout[0]){
+        for (n = 0; n < num_dio; n++) {
+            if (names_dout[n] == NULL || (*names_dout[n] == 0)) {break;}
+            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.dout-%s", names_dout[n]));
+        }
+    } else {
+        for (n = 0; n < num_dio; n++) {
+            CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.digital-out-%02d",n));
+        }
     }
 
-  /* export motion-synched analog output pins */
-  /* export motion analog input pins */
-  if(names_ain[0]){
-    for (n = 0; n < num_aio; n++) {
-      if(names_ain[n] == NULL || (*names_ain[n] == 0)){break;}
-      if ((retval = hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->analog_input[n]), mot_comp_id, "motion.ain-%s", names_ain[n])) != 0) goto error;
+    /* export motion-synched analog output pins */
+    /* export motion analog input pins */
+    if (names_ain[0]) {
+        for (n = 0; n < num_aio; n++) {
+            if (names_ain[n] == NULL || (*names_ain[n] == 0)) {break;}
+            CALL_CHECK(hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->analog_input[n]), mot_comp_id, "motion.ain-%s", names_ain[n]));
+        }
+    } else {
+        for (n = 0; n < num_aio; n++) {
+            CALL_CHECK(hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->analog_input[n]), mot_comp_id, "motion.analog-in-%02d", n));
+        }
     }
-  }
-  else{
-    for (n = 0; n < num_aio; n++) {
-    if ((retval = hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->analog_input[n]), mot_comp_id, "motion.analog-in-%02d", n)) != 0) goto error;
+    if (names_aout[0]) {
+        for (n = 0; n < num_aio; n++) {
+            if (names_aout[n] == NULL || (*names_aout[n] == 0)) {break;}
+            CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->analog_output[n]), mot_comp_id, "motion.aout-%s", names_aout[n]));
+        }
+    } else {
+        for (n = 0; n < num_aio; n++) {
+            CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->analog_output[n]), mot_comp_id, "motion.analog-out-%02d", n));
+        }
     }
-  }
-  if(names_aout[0]){
-    for (n = 0; n < num_aio; n++) {
-      if(names_aout[n] == NULL || (*names_aout[n] == 0)){break;}
-      if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->analog_output[n]), mot_comp_id, "motion.aout-%s", names_aout[n])) != 0) goto error;
-    }
-  }
-  else{
-    for (n = 0; n < num_aio; n++) {
-  if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->analog_output[n]), mot_comp_id, "motion.analog-out-%02d", n)) != 0) goto error;
-    }
-  }
 
-  if(names_misc_errors[0]){
-    for (n = 0; n < num_misc_error; n++) {
-      if(names_misc_errors[n] == NULL || (*names_misc_errors[n] == 0)){break;}
-      if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->misc_error[n]), mot_comp_id, "motion.err-%s", names_misc_errors[n])) != 0) goto error;
+    if (names_misc_errors[0]) {
+        for (n = 0; n < num_misc_error; n++) {
+            if (names_misc_errors[n] == NULL || (*names_misc_errors[n] == 0)) {break;}
+            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->misc_error[n]), mot_comp_id, "motion.err-%s", names_misc_errors[n]));
+        }
+    } else {
+        /* export misc error input pins */
+        for (n = 0; n < num_misc_error; n++) {
+            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->misc_error[n]), mot_comp_id, "motion.misc-error-%02d", n));
+        }
     }
-  }
-  else {
-    /* export misc error input pins */
-    for (n = 0; n < num_misc_error; n++) {
-  if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->misc_error[n]), mot_comp_id, "motion.misc-error-%02d", n)) != 0) goto error;
-    }
-  }
 
-  /* export machine wide hal pins */
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->motion_enabled), mot_comp_id, "motion.motion-enabled")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->in_position), mot_comp_id, "motion.in-position")) != 0) goto error;
-    if ((retval = hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->motion_type), mot_comp_id, "motion.motion-type")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->coord_mode), mot_comp_id, "motion.coord-mode")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->teleop_mode), mot_comp_id, "motion.teleop-mode")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->coord_error), mot_comp_id, "motion.coord-error")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->on_soft_limit), mot_comp_id, "motion.on-soft-limit")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->current_vel), mot_comp_id, "motion.current-vel")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->requested_vel), mot_comp_id, "motion.requested-vel")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->distance_to_go), mot_comp_id, "motion.distance-to-go")) != 0) goto error;
-    if ((retval = hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->program_line), mot_comp_id, "motion.program-line")) != 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->jog_is_active), mot_comp_id, "motion.jog-is-active")) != 0) goto error;
+    /* export machine wide hal pins */
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->motion_enabled), mot_comp_id, "motion.motion-enabled"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->in_position), mot_comp_id, "motion.in-position"));
+    CALL_CHECK(hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->motion_type), mot_comp_id, "motion.motion-type"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->coord_mode), mot_comp_id, "motion.coord-mode"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->teleop_mode), mot_comp_id, "motion.teleop-mode"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->coord_error), mot_comp_id, "motion.coord-error"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->on_soft_limit), mot_comp_id, "motion.on-soft-limit"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->current_vel), mot_comp_id, "motion.current-vel"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->requested_vel), mot_comp_id, "motion.requested-vel"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->distance_to_go), mot_comp_id, "motion.distance-to-go"));
+    CALL_CHECK(hal_pin_s32_newf(HAL_OUT, &(emcmot_hal_data->program_line), mot_comp_id, "motion.program-line"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->jog_is_active), mot_comp_id, "motion.jog-is-active"));
 
     /* export debug parameters */
     /* these can be used to view any internal variable, simply change a line
        in control.c:output_to_hal() and recompile */
-    if ((retval = hal_param_bit_newf(HAL_RO, &(emcmot_hal_data->debug_bit_0), mot_comp_id, "motion.debug-bit-0")) != 0) goto error;
-    if ((retval = hal_param_bit_newf(HAL_RO, &(emcmot_hal_data->debug_bit_1), mot_comp_id, "motion.debug-bit-1")) != 0) goto error;
-    if ((retval = hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_0), mot_comp_id, "motion.debug-float-0")) != 0) goto error;
-    if ((retval = hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_1), mot_comp_id, "motion.debug-float-1")) != 0) goto error;
-    if ((retval = hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_2), mot_comp_id, "motion.debug-float-2")) != 0) goto error;
-    if ((retval = hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_3), mot_comp_id, "motion.debug-float-3")) != 0) goto error;
-    if ((retval = hal_param_s32_newf(HAL_RO, &(emcmot_hal_data->debug_s32_0), mot_comp_id, "motion.debug-s32-0")) != 0) goto error;
-    if ((retval = hal_param_s32_newf(HAL_RO, &(emcmot_hal_data->debug_s32_1), mot_comp_id, "motion.debug-s32-1")) != 0) goto error;
+    CALL_CHECK(hal_param_bit_newf(HAL_RO, &(emcmot_hal_data->debug_bit_0), mot_comp_id, "motion.debug-bit-0"));
+    CALL_CHECK(hal_param_bit_newf(HAL_RO, &(emcmot_hal_data->debug_bit_1), mot_comp_id, "motion.debug-bit-1"));
+    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_0), mot_comp_id, "motion.debug-float-0"));
+    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_1), mot_comp_id, "motion.debug-float-1"));
+    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_2), mot_comp_id, "motion.debug-float-2"));
+    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->debug_float_3), mot_comp_id, "motion.debug-float-3"));
+    CALL_CHECK(hal_param_s32_newf(HAL_RO, &(emcmot_hal_data->debug_s32_0), mot_comp_id, "motion.debug-s32-0"));
+    CALL_CHECK(hal_param_s32_newf(HAL_RO, &(emcmot_hal_data->debug_s32_1), mot_comp_id, "motion.debug-s32-1"));
 
     // FIXME - debug only, remove later
     // export HAL parameters for some trajectory planner internal variables
     // so they can be scoped
-    if ((retval = hal_param_float_newf(HAL_RO, &(emcmot_hal_data->traj_pos_out), mot_comp_id, "traj.pos_out")) != 0) goto error;
-    if ((retval = hal_param_float_newf(HAL_RO, &(emcmot_hal_data->traj_vel_out), mot_comp_id, "traj.vel_out")) != 0) goto error;
-    if ((retval = hal_param_u32_newf(HAL_RO, &(emcmot_hal_data->traj_active_tc), mot_comp_id, "traj.active_tc")) != 0) goto error;
+    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->traj_pos_out), mot_comp_id, "traj.pos_out"));
+    CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->traj_vel_out), mot_comp_id, "traj.vel_out"));
+    CALL_CHECK(hal_param_u32_newf(HAL_RO, &(emcmot_hal_data->traj_active_tc), mot_comp_id, "traj.active_tc"));
 
-    for ( n = 0 ; n < 4 ; n++ ) {
-        if ((retval = hal_param_float_newf(HAL_RO, &(emcmot_hal_data->tc_pos[n]), mot_comp_id, "tc.%d.pos", n)) != 0) goto error;
-        if ((retval = hal_param_float_newf(HAL_RO, &(emcmot_hal_data->tc_vel[n]), mot_comp_id, "tc.%d.vel", n)) != 0) goto error;
-        if ((retval = hal_param_float_newf(HAL_RO, &(emcmot_hal_data->tc_acc[n]), mot_comp_id, "tc.%d.acc", n)) != 0) goto error;
+    for (n = 0; n < 4; n++) {
+        CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->tc_pos[n]), mot_comp_id, "tc.%d.pos", n));
+        CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->tc_vel[n]), mot_comp_id, "tc.%d.vel", n));
+        CALL_CHECK(hal_param_float_newf(HAL_RO, &(emcmot_hal_data->tc_acc[n]), mot_comp_id, "tc.%d.acc", n));
     }
     // end of exporting trajectory planner internals
 
     // export timing related HAL pins so they can be scoped and/or connected
-    if ((retval = hal_pin_u32_newf(HAL_OUT, &(emcmot_hal_data->last_period), mot_comp_id, "motion.servo.last-period")) != 0) goto error;
+    CALL_CHECK(hal_pin_u32_newf(HAL_OUT, &(emcmot_hal_data->last_period), mot_comp_id, "motion.servo.last-period"));
 #ifdef HAVE_CPU_KHZ
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->last_period_ns), mot_comp_id, "motion.servo.last-period-ns")) != 0) goto error;
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->last_period_ns), mot_comp_id, "motion.servo.last-period-ns"));
 #endif
 
     // export timing related HAL pins so they can be scoped
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_x), mot_comp_id, "motion.tooloffset.x")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_y), mot_comp_id, "motion.tooloffset.y")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_z), mot_comp_id, "motion.tooloffset.z")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_a), mot_comp_id, "motion.tooloffset.a")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_b), mot_comp_id, "motion.tooloffset.b")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_c), mot_comp_id, "motion.tooloffset.c")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_u), mot_comp_id, "motion.tooloffset.u")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_v), mot_comp_id, "motion.tooloffset.v")) != 0) goto error;
-    if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_w), mot_comp_id, "motion.tooloffset.w")) != 0) goto error;
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_x), mot_comp_id, "motion.tooloffset.x"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_y), mot_comp_id, "motion.tooloffset.y"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_z), mot_comp_id, "motion.tooloffset.z"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_a), mot_comp_id, "motion.tooloffset.a"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_b), mot_comp_id, "motion.tooloffset.b"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_c), mot_comp_id, "motion.tooloffset.c"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_u), mot_comp_id, "motion.tooloffset.u"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_v), mot_comp_id, "motion.tooloffset.v"));
+    CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->tooloffset_w), mot_comp_id, "motion.tooloffset.w"));
 
     if (kinematicsSwitchable()) {
-        if ((retval = hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->switchkins_type), mot_comp_id, "motion.switchkins-type")) != 0) return retval;
+        CALL_CHECK(hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->switchkins_type), mot_comp_id, "motion.switchkins-type"));
     }
     /* initialize machine wide pins and parameters */
     *(emcmot_hal_data->adaptive_feed) = 1.0;
@@ -619,17 +619,17 @@ static int init_hal_io(void)
 
     /* motion synched dio, init to not enabled */
     for (n = 0; n < num_dio; n++) {
-	 *(emcmot_hal_data->synch_do[n]) = 0;
-	 *(emcmot_hal_data->synch_di[n]) = 0;
+        *(emcmot_hal_data->synch_do[n]) = 0;
+        *(emcmot_hal_data->synch_di[n]) = 0;
     }
 
     for (n = 0; n < num_aio; n++) {
-	 *(emcmot_hal_data->analog_output[n]) = 0.0;
-	 *(emcmot_hal_data->analog_input[n]) = 0.0;
+        *(emcmot_hal_data->analog_output[n]) = 0.0;
+        *(emcmot_hal_data->analog_input[n]) = 0.0;
     }
 
     for (n = 0; n < num_misc_error; n++) {
-      *(emcmot_hal_data->misc_error[n]) = 0;
+        *(emcmot_hal_data->misc_error[n]) = 0;
     }
 
     /*! \todo FIXME - these don't really need initialized, since they are written
@@ -653,7 +653,7 @@ static int init_hal_io(void)
     *(emcmot_hal_data->last_period) = 0;
 
     /* export spindle pins and params */
-    for (n=0; n < num_spindles; n++) {
+    for (n = 0; n < num_spindles; n++) {
         retval = export_spindle(n, &(emcmot_hal_data->spindle[n]));
         if (retval != 0){
             rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: spindle %d pin export failed"), n);
@@ -662,17 +662,17 @@ static int init_hal_io(void)
     }
     /* export joint pins and parameters */
     for (n = 0; n < num_joints; n++) {
-	joint_data = &(emcmot_hal_data->joint[n]);
-	/* export all vars */
+        joint_data = &(emcmot_hal_data->joint[n]);
+        /* export all vars */
         retval = export_joint(n, joint_data);
-	if (retval != 0) {
-	    rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: joint %d pin/param export failed\n"), n);
-	    return -1;
-	}
-	*(joint_data->amp_enable) = 0;
+        if (retval != 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: joint %d pin/param export failed\n"), n);
+            return -1;
+        }
+        *(joint_data->amp_enable) = 0;
 
-	/* We'll init the index model to EXT_ENCODER_INDEX_MODEL_RAW for now,
-	   because it is always supported. */
+        /* We'll init the index model to EXT_ENCODER_INDEX_MODEL_RAW for now,
+           because it is always supported. */
     }
     /* export joint pins and parameters */
     for (n = 0; n < num_extrajoints; n++) {
@@ -688,50 +688,32 @@ static int init_hal_io(void)
     for (n = 0; n < EMCMOT_MAX_AXIS; n++) {
         char c = "xyzabcuvw"[n];
         axis_data = &(emcmot_hal_data->axis[n]);
-        if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].pos_cmd),
-           mot_comp_id, "axis.%c.pos-cmd",         c)) != 0) goto error;
-        if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].teleop_vel_cmd),
-           mot_comp_id, "axis.%c.teleop-vel-cmd",         c)) != 0) goto error;
-        if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].teleop_pos_cmd),
-           mot_comp_id, "axis.%c.teleop-pos-cmd",  c)) != 0) goto error;
-        if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].teleop_vel_lim),
-           mot_comp_id, "axis.%c.teleop-vel-lim",  c)) != 0) goto error;
-        if ((retval = hal_pin_bit_newf(HAL_OUT,   &(emcmot_hal_data->axis[n].teleop_tp_enable),
-           mot_comp_id, "axis.%c.teleop-tp-enable",c)) != 0) goto error;
-        if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->axis[n].eoffset_enable),
-           mot_comp_id, "axis.%c.eoffset-enable", c)) != 0) return retval;
-        if ((retval = hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->axis[n].eoffset_clear),
-           mot_comp_id, "axis.%c.eoffset-clear", c)) != 0) return retval;
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].pos_cmd), mot_comp_id, "axis.%c.pos-cmd", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].teleop_vel_cmd), mot_comp_id, "axis.%c.teleop-vel-cmd", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].teleop_pos_cmd), mot_comp_id, "axis.%c.teleop-pos-cmd", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].teleop_vel_lim), mot_comp_id, "axis.%c.teleop-vel-lim", c));
+        CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->axis[n].teleop_tp_enable), mot_comp_id, "axis.%c.teleop-tp-enable",c));
+        CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->axis[n].eoffset_enable), mot_comp_id, "axis.%c.eoffset-enable", c));
+        CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->axis[n].eoffset_clear), mot_comp_id, "axis.%c.eoffset-clear", c));
 
-        if ((retval = hal_pin_s32_newf(HAL_IN, &(emcmot_hal_data->axis[n].eoffset_counts),
-           mot_comp_id, "axis.%c.eoffset-counts", c)) != 0) return retval;
-        if ((retval = hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->axis[n].eoffset_scale),
-           mot_comp_id, "axis.%c.eoffset-scale", c)) != 0) return retval;
+        CALL_CHECK(hal_pin_s32_newf(HAL_IN, &(emcmot_hal_data->axis[n].eoffset_counts), mot_comp_id, "axis.%c.eoffset-counts", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_IN, &(emcmot_hal_data->axis[n].eoffset_scale), mot_comp_id, "axis.%c.eoffset-scale", c));
 
-        if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].external_offset),
-           mot_comp_id, "axis.%c.eoffset", c)) != 0) return retval;
-        if ((retval = hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].external_offset_requested),
-           mot_comp_id, "axis.%c.eoffset-request", c)) != 0) return retval;
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].external_offset), mot_comp_id, "axis.%c.eoffset", c));
+        CALL_CHECK(hal_pin_float_newf(HAL_OUT, &(emcmot_hal_data->axis[n].external_offset_requested), mot_comp_id, "axis.%c.eoffset-request", c));
 
         retval = export_axis(c, axis_data);
-	if (retval != 0) {
-	    rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: axis %c pin/param export failed\n"), c);
-	    return -1;
-	}
+        if (retval != 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: axis %c pin/param export failed\n"), c);
+            return -1;
+        }
     }
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->eoffset_limited), mot_comp_id,
-                  "motion.eoffset-limited")) < 0) goto error;
-    if ((retval = hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->eoffset_active), mot_comp_id,
-                  "motion.eoffset-active")) < 0) goto error;
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->eoffset_limited), mot_comp_id, "motion.eoffset-limited"));
+    CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->eoffset_active), mot_comp_id, "motion.eoffset-active"));
 
     /* Done! */
-    rtapi_print_msg(RTAPI_MSG_INFO,
-	"MOTION: init_hal_io() complete, %d axes.\n", n);
+    rtapi_print_msg(RTAPI_MSG_INFO,	"MOTION: init_hal_io() complete, %d axes.\n", n);
     return 0;
-
-    error:
-	return retval;
-
 }
 
 static int export_spindle(int num, spindle_hal_t * addr){

--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -551,26 +551,6 @@ Suggestion: Split this in to an Error and a Status flag register..
     } spindle_status_t;
 
     typedef struct {
-	double pos_cmd;		/* commanded axis position */
-	double teleop_vel_cmd;		/* commanded axis velocity */
-	double max_pos_limit;	/* upper soft limit on axis pos */
-	double min_pos_limit;	/* lower soft limit on axis pos */
-	double vel_limit;	/* upper limit of axis speed */
-	double acc_limit;	/* upper limit of axis accel */
-	simple_tp_t teleop_tp;	/* planner for teleop mode motion */
-
-	int old_ajog_counts;	/* prior value, used for deltas */
-	int kb_ajog_active;	/* non-zero during a keyboard jog */
-	int wheel_ajog_active;	/* non-zero during a wheel jog */
-	int locking_joint;	/* locking_joint number, -1 ==> notused*/
-
-	double      ext_offset_vel_limit;	/* upper limit of axis speed for ext offset */
-	double      ext_offset_acc_limit;	/* upper limit of axis accel for ext offset */
-	int         old_eoffset_counts;
-	simple_tp_t ext_offset_tp;/* planner for external coordinate offsets*/
-    } emcmot_axis_t;
-
-    typedef struct {
 	double teleop_vel_cmd;		/* commanded axis velocity */
 	double max_pos_limit;	/* upper soft limit on axis pos */
 	double min_pos_limit;	/* lower soft limit on axis pos */

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -20,6 +20,7 @@
 #include "motion_types.h"
 #include "spherical_arc.h"
 #include "blendmath.h"
+#include "axis.h"
 //KLUDGE Don't include all of emc.hh here, just hand-copy the TERM COND
 //definitions until we can break the emc constants out into a separate file.
 //#include "emc.hh"
@@ -56,7 +57,6 @@
 
 static emcmot_status_t *emcmotStatus;
 static emcmot_config_t *emcmotConfig;
-static emcmot_axis_t *emcmotAxis;
 
 //==========================================================
 // tp module interface
@@ -80,12 +80,10 @@ void tpMotFunctions(void(*pDioWrite)(int,char)
 
 void tpMotData(emcmot_status_t *pstatus
               ,emcmot_config_t *pconfig
-              ,emcmot_axis_t *paxis
               )
 {
     emcmotStatus = pstatus;
     emcmotConfig = pconfig;
-    emcmotAxis = paxis;
 }
 //=========================================================
 
@@ -174,9 +172,9 @@ STATIC int tpGetMachineAccelBounds(PmCartesian  * const acc_bound) {
         return TP_ERR_FAIL;
     }
 
-    acc_bound->x = emcmotAxis[0].acc_limit; //0==>x
-    acc_bound->y = emcmotAxis[1].acc_limit; //1==>y
-    acc_bound->z = emcmotAxis[2].acc_limit; //2==>z
+    acc_bound->x = axis_get_acc_limit(0); //0==>x
+    acc_bound->y = axis_get_acc_limit(1); //1==>y
+    acc_bound->z = axis_get_acc_limit(2); //2==>z
     return TP_ERR_OK;
 }
 
@@ -186,9 +184,9 @@ STATIC int tpGetMachineVelBounds(PmCartesian  * const vel_bound) {
         return TP_ERR_FAIL;
     }
 
-    vel_bound->x = emcmotAxis[0].vel_limit; //0==>x
-    vel_bound->y = emcmotAxis[1].vel_limit; //1==>y
-    vel_bound->z = emcmotAxis[2].vel_limit; //2==>z
+    vel_bound->x = axis_get_vel_limit(0); //0==>x
+    vel_bound->y = axis_get_vel_limit(1); //1==>y
+    vel_bound->z = axis_get_vel_limit(2); //2==>z
     return TP_ERR_OK;
 }
 

--- a/src/emc/tp/tp.h
+++ b/src/emc/tp/tp.h
@@ -82,7 +82,6 @@ void tpMotFunctions(void(*pDioWrite)(int,char)
 
 void tpMotData(emcmot_status_t *
               ,emcmot_config_t *
-              ,emcmot_axis_t *
               );
 //---------------------------------------------------------------------
 


### PR DESCRIPTION
This continues my refactoring work of reducing the scope of data structures in motmod. The idea is to reduce code duplication, improve readability and maintainability, and to make it easier to add new features.

No functional changes are intended.

The code builds on uspace and rtai (configured --with-realtime=/usr/realtime-4.19.195-rtai-amd64). runtests passes on uspace (no testing done on rtai).