### PR TITLE
Readme incorrectly stated XYZY when it should be XYYZ. Reported as #1…

### DIFF
--- a/configs/sim/axis/gantry/README
+++ b/configs/sim/axis/gantry/README
@@ -1,10 +1,11 @@
 Axis gui sim configs for gantry applications
-using 2 joints for the Y coordinate
+using 2 joints for the Y coordinate.
 
-Use trivkins coordinates=XYZY kinstype=BOTH
+Use trivkins coordinates=XYYZ kinstype=BOTH
+
 X: joint0
-Y: joint1 and joint3
-Z: joint2
+Y: joint1 and joint2
+Z: joint3
 
 gantry.ini    basic gantry demo (in)
 gantry_mm.ini basic gantry demo (mm)

--- a/configs/sim/axis/gantry/README_es
+++ b/configs/sim/axis/gantry/README_es
@@ -1,10 +1,10 @@
 Configuración Sim gui Axis para porticos
 usando 2 articulaciones en Y
 
-Usar trivkins coordinates=XYZY kinstype=BOTH
+Usar trivkins coordinates=XYYZ kinstype=BOTH
 X: joint0
-Y: joint1 y joint3
-Z: joint2
+Y: joint1 y joint2
+Z: joint3
 
 gantry.ini    Demo de portico básico (in)
 gantry_mm.ini Demo de portico basico (mm)


### PR DESCRIPTION
Minor update to Readme files. Gantry setup is XYYZ.