### PR TITLE
gladevcp: fix color in VCP elements

### DIFF
--- a/lib/python/gladevcp/hal_bar.py
+++ b/lib/python/gladevcp/hal_bar.py
@@ -85,11 +85,11 @@ class HAL_Bar(Gtk.DrawingArea, _HalWidgetBase):
     def __init__(self):
         super(HAL_Bar, self).__init__()
 
-        self.bg_color = Gdk.Color.parse('gray')
-        self.z0_color = Gdk.Color.parse('green')
-        self.z1_color = Gdk.Color.parse('yellow')
-        self.z2_color = Gdk.Color.parse('red')
-        self.target_color = Gdk.Color.parse('purple')
+        self.bg_color = Gdk.Color.parse('gray')[1]
+        self.z0_color = Gdk.Color.parse('green')[1]
+        self.z1_color = Gdk.Color.parse('yellow')[1]
+        self.z2_color = Gdk.Color.parse('red')[1]
+        self.target_color = Gdk.Color.parse('purple')[1]
         self.target_width = 2
         self.force_width = self._size_request[0]
         self.force_height = self._size_request[1]

--- a/lib/python/gladevcp/hal_dial.py
+++ b/lib/python/gladevcp/hal_dial.py
@@ -75,7 +75,7 @@ class Hal_Dial(Gtk.DrawingArea, _HalJogWheelBase):
         self.scale = 1.0
         self.scale_adjustable = True
         self.count_type_shown=1
-        self.center_color = Gdk.Color.parse('#bdefbdefbdef') # gray
+        self.center_color = Gdk.Color.parse('#bdefbdefbdef')[1] # gray
         # private
         self._minute_offset = 0 # the offset of the pointer hand
         self._last_offset = 0

--- a/lib/python/gladevcp/hal_graph.py
+++ b/lib/python/gladevcp/hal_graph.py
@@ -90,8 +90,8 @@ class HAL_Graph(Gtk.DrawingArea, _HalWidgetBase):
     def __init__(self):
         super(HAL_Graph, self).__init__()
 
-        self.bg_color = Gdk.Color.parse('white')
-        self.fg_color = Gdk.Color.parse('red')
+        self.bg_color = Gdk.Color.parse('white')[1]
+        self.fg_color = Gdk.Color.parse('red')[1]
 
         self.force_radius = None
         self.ticks = deque()

--- a/lib/python/gladevcp/hal_lightbutton.py
+++ b/lib/python/gladevcp/hal_lightbutton.py
@@ -106,8 +106,8 @@ class HAL_LightButton(Gtk.DrawingArea, _HalWidgetBase):
         
         self.dual_color = False
         self.use_bitmaps = False  #this feature is not implemented yet
-        self.light_on_color = Gdk.Color.parse('green')
-        self.light_off_color = Gdk.Color.parse('gray')
+        self.light_on_color = Gdk.Color.parse('green')[1]
+        self.light_off_color = Gdk.Color.parse('gray')[1]
         self.border_width = 6
         self.corner_radius = 4
         self.button_text = 'Button'
@@ -115,8 +115,8 @@ class HAL_LightButton(Gtk.DrawingArea, _HalWidgetBase):
         self.font_face = 'Sans'
         self.font_bold = False
         self.font_size = 10
-        self.font_on_color = Gdk.Color.parse('black')
-        self.font_off_color = Gdk.Color.parse('black')
+        self.font_on_color = Gdk.Color.parse('black')[1]
+        self.font_off_color = Gdk.Color.parse('black')[1]
         self.create_enable_pin = False
         
         self.active = False

--- a/lib/python/gladevcp/hal_widgets.py
+++ b/lib/python/gladevcp/hal_widgets.py
@@ -281,7 +281,7 @@ class HAL_ProgressBar(Gtk.ProgressBar, _HalWidgetBase):
         self.hal_pin_scale = self.hal.newpin(self.hal_name+".scale", hal.HAL_FLOAT, hal.HAL_IN)
         if self.yellow_limit or self.red_limit:
             self.set_fraction(0)
-            self.modify_bg(Gtk.STATE_PRELIGHT, Gdk.Color.parse('#0f0'))
+            self.modify_bg(Gtk.STATE_PRELIGHT, Gdk.Color.parse('#0f0')[1])
         if self.text_template:
             self.set_text(self.text_template % {'value':0})
 


### PR DESCRIPTION
In several VCP elements it should be
`color = Gdk.Color.parse('colorstring')[1]` 
instead of 
`color = Gdk.Color.parse('colorstring')` 
because `Gdk.Color.parse()` returns `(bool, Gdk.Color)`

fixes  #1596