### PR TITLE
docs: HAL Component List - generate unlisted components automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ build-stamp
 .tmp*
 # Ignore generated html files, 
 /docs/src/*/*.html
+docs/src/hal/components_gen1.adoc
+docs/src/hal/components_gen9.adoc
 # docs/html/.gitignore is for the html directory
 debian/*.debhelper.log
 rtlib/Module.symvers

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,7 @@ build-stamp
 .tmp*
 # Ignore generated html files, 
 /docs/src/*/*.html
-docs/src/hal/components_gen1.adoc
-docs/src/hal/components_gen9.adoc
+docs/src/hal/components_gen.adoc
 # docs/html/.gitignore is for the html directory
 debian/*.debhelper.log
 rtlib/Module.symvers

--- a/docs/po4a.cfg
+++ b/docs/po4a.cfg
@@ -111,6 +111,7 @@
 [type: AsciiDoc_def] src/hal/canonical-devices.adoc $lang:src/$lang/hal/canonical-devices.adoc
 [type: AsciiDoc_def] src/hal/comp.adoc $lang:src/$lang/hal/comp.adoc
 [type: AsciiDoc_def] src/hal/components.adoc $lang:src/$lang/hal/components.adoc
+[type: AsciiDoc_def] src/hal/components_gen.adoc $lang:src/$lang/hal/components_gen.adoc
 [type: AsciiDoc_def] src/hal/general-ref.adoc $lang:src/$lang/hal/general-ref.adoc
 [type: AsciiDoc_def] src/hal/hal-examples.adoc $lang:src/$lang/hal/hal-examples.adoc
 [type: AsciiDoc_def] src/hal/halmodule.adoc $lang:src/$lang/hal/halmodule.adoc

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -336,7 +336,6 @@ DOTFILES=$(shell find . -name "*.dot") $(shell find ../docs/src/ -name "*.dot")
 .PHONY: svgs_made_from_dots
 svgs_made_from_dots: $(DOTFILES:.dot=.svg)
 
-docs: gen_complist
 ifeq ($(BUILD_DOCS_PDF),yes)
 docs: pdfdocs
 install-doc: install-doc-pdf

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -336,6 +336,7 @@ DOTFILES=$(shell find . -name "*.dot") $(shell find ../docs/src/ -name "*.dot")
 .PHONY: svgs_made_from_dots
 svgs_made_from_dots: $(DOTFILES:.dot=.svg)
 
+docs: gen_complist
 ifeq ($(BUILD_DOCS_PDF),yes)
 docs: pdfdocs
 install-doc: install-doc-pdf
@@ -353,17 +354,17 @@ htmldocs: svgs_made_from_dots .htmldoc-stamp checkref_en
 .htmldoc-stamp: copy_asciidoc_files gen_complist $(HTML_TARGETS) .images-stamp .include-stamp
 	touch $@
 
-.PHONY: copy_asciidoc_files
+.PHONY: copy_asciidoc_files gen_complist gen_complist_links
 copy_asciidoc_files:
 	cp -f /etc/asciidoc/stylesheets/*.css $(DOC_DIR)/html
 	cp -f /etc/asciidoc/javascripts/*.js $(DOC_DIR)/html
 
 gen_complist:
-	python3 $(DOC_SRCDIR)/gen_complist.py
+	python3 $(DOC_SRCDIR)/gen_complist.py $(DOC_SRCDIR)/hal/components.adoc
 	touch $(DOC_SRCDIR)/hal/components.adoc
 
-.PHONY gen_complist_links:
-	python3 $(DOC_SRCDIR)/gen_complist.py links
+gen_complist_links:
+	python3 $(DOC_SRCDIR)/gen_complist.py $(DOC_SRCDIR)/hal/components.adoc links
 
 checkref: checkref_en checkref_de checkref_es checkref_fr checkref_hu checkref_nb checkref_vi checkref_zh_CN
 

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -353,17 +353,12 @@ htmldocs: svgs_made_from_dots .htmldoc-stamp checkref_en
 .htmldoc-stamp: copy_asciidoc_files gen_complist $(HTML_TARGETS) .images-stamp .include-stamp
 	touch $@
 
-.PHONY: copy_asciidoc_files gen_complist gen_complist_links
-copy_asciidoc_files:
-	cp -f /etc/asciidoc/stylesheets/*.css $(DOC_DIR)/html
-	cp -f /etc/asciidoc/javascripts/*.js $(DOC_DIR)/html
+copy_asciidoc_files: $(wildcard /etc/asciidoc/stylesheets/*.css) $(wildcard /etc/asciidoc/javascripts/*.js)
+	cp -f $^ $(DOC_DIR)/html
 
-gen_complist:
+gen_complist: $(DOC_SRCDIR)/gen_complist.py $(DOC_SRCDIR)/hal/components.adoc $(MAN_HTML_TARGETS)
+	mkdir -p $(DOC_DIR)/html/hal
 	python3 $(DOC_SRCDIR)/gen_complist.py $(DOC_SRCDIR)/hal/components.adoc
-	touch $(DOC_SRCDIR)/hal/components.adoc
-
-gen_complist_links:
-	python3 $(DOC_SRCDIR)/gen_complist.py $(DOC_SRCDIR)/hal/components.adoc links
 
 checkref: checkref_en checkref_de checkref_es checkref_fr checkref_hu checkref_nb checkref_vi checkref_zh_CN
 

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -360,6 +360,10 @@ copy_asciidoc_files:
 
 gen_complist:
 	python3 $(DOC_SRCDIR)/gen_complist.py
+	touch $(DOC_SRCDIR)/hal/components.adoc
+
+.PHONY gen_complist_links:
+	python3 $(DOC_SRCDIR)/gen_complist.py links
 
 checkref: checkref_en checkref_de checkref_es checkref_fr checkref_hu checkref_nb checkref_vi checkref_zh_CN
 

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -350,13 +350,16 @@ pdfdocs: svgs_made_from_dots $(PDF_TARGETS)
 
 htmldocs: svgs_made_from_dots .htmldoc-stamp checkref_en
 
-.htmldoc-stamp: copy_asciidoc_files $(HTML_TARGETS) .images-stamp .include-stamp
+.htmldoc-stamp: copy_asciidoc_files gen_complist $(HTML_TARGETS) .images-stamp .include-stamp
 	touch $@
 
 .PHONY: copy_asciidoc_files
 copy_asciidoc_files:
 	cp -f /etc/asciidoc/stylesheets/*.css $(DOC_DIR)/html
 	cp -f /etc/asciidoc/javascripts/*.js $(DOC_DIR)/html
+
+gen_complist:
+	python3 $(DOC_SRCDIR)/gen_complist.py
 
 checkref: checkref_en checkref_de checkref_es checkref_fr checkref_hu checkref_nb checkref_vi checkref_zh_CN
 

--- a/docs/src/asciideps
+++ b/docs/src/asciideps
@@ -9,6 +9,12 @@ includes () {
 	DIR=`dirname "$1"`
 
 	for f in `sed -ne "s|^include::\(.*\)\[\]$|$DIR/\1|p" "$1"`; do
+		# components_gen.adoc will contain only generated content
+		case "$f" in
+			*/components_gen*.adoc)
+			touch "$f"
+			;;
+		esac
 		echo "$f"
 		includes "$f"
 	done

--- a/docs/src/asciideps
+++ b/docs/src/asciideps
@@ -11,7 +11,7 @@ includes () {
 	for f in `sed -ne "s|^include::\(.*\)\[\]$|$DIR/\1|p" "$1"`; do
 		# components_gen.adoc will contain only generated content
 		case "$f" in
-			*/components_gen*.adoc)
+			*/components_gen.adoc)
 			touch "$f"
 			;;
 		esac

--- a/docs/src/gen_complist.py
+++ b/docs/src/gen_complist.py
@@ -50,7 +50,7 @@ def generate_complist(complist_path):
             file2.write('| ' + i + ' |||\n')
         file2.write('|=======================\n')
     if len(obs1) > 0:
-        file2.write('\n=== Obsolete (auto generated)\n')
+        file2.write('\n=== Without man page (auto generated)\n')
         file2.write('[{tab_options}]\n|=======================\n')
         for i in sorted(obs1):
             file2.write('| ' + i + ' |||\n')
@@ -65,7 +65,7 @@ def generate_complist(complist_path):
             file3.write('| ' + i + ' |||\n')
         file3.write('|=======================\n')
     if len(obs9) > 0:
-        file3.write('\n=== Obsolete (auto generated)\n')
+        file3.write('\n=== Without man page (auto generated)\n')
         file3.write('[{tab_options}]\n|=======================\n')
         for i in sorted(obs9):
             file3.write('| ' + i + ' |||\n')
@@ -102,7 +102,7 @@ def generate_links(filename, manpage='1', create_backup=True, add_descr=False):
                     if add_descr:
                         splitted = line.split('|')
                         splitted[2] = extract_descr('../docs/man/man'+manpage+'/'+comp+'.'+manpage)\
-                        .replace(comp, '',1).strip('\n -')
+                        .replace(comp + ' ', ' ',1).strip('\n -')
                         line = '|'.join(splitted)
         file_links.append(line)
 

--- a/docs/src/gen_complist.py
+++ b/docs/src/gen_complist.py
@@ -33,7 +33,7 @@ def generate_complist(complist_path):
                         print('gen_complist: Broken link:', link, file=sys.stderr)
                         miss_in_man.add(comp_man.split(".")[0])
                 else:
-                    print("gen_complist: Component", splitted[1], "without link")
+                    print("gen_complist: Component \"" + splitted[1].strip() + "\" without link")
                     miss_in_man.add(splitted[1])
     file1.close()
     miss_in_list = man_files.difference(complist_doc)
@@ -55,7 +55,7 @@ def generate_complist(complist_path):
     file2.close()
 
     generate_links(gen_filename, False, True)
-    print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list'.format(len(miss_in_list), len(miss_in_man)))
+    print('gen_complist: Added {} uncategorized and {} potentially obsolete entrie(s) to hal component list'.format(len(miss_in_list), len(miss_in_man)))
 
 
 def generate_links(filename, create_backup=True, add_descr=False):
@@ -69,7 +69,7 @@ def generate_links(filename, create_backup=True, add_descr=False):
             if 'link:' in splitted[1]:
                 link = re.search('(?<=link:).*(?=\[)', splitted[1]).group()
                 if not os.path.isfile(os.path.join('../docs/html/hal',link)):
-                    print('gen_complist_link: Broken link:', link)
+                    print('gen_complist: Broken link:', link)
             else:
                 comp_man = splitted[1].strip(' ')
                 if comp_man in man_files:
@@ -91,7 +91,7 @@ def generate_links(filename, create_backup=True, add_descr=False):
         for line in file_links:
             file.write(line)
         file.close()
-        print('gen_complist_links: Added {} link(s) to {}'.format(links_added, filename))
+        print('gen_complist: Added {} link(s) to {}'.format(links_added, filename))
 
 
 def extract_descr(filename):

--- a/docs/src/gen_complist.py
+++ b/docs/src/gen_complist.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # generate_complist()
-#       Compares the entries in the component list (components.adoc) with the 
+#       Compares the entries in the component list (components.adoc) with the
 #       available man pages and adds tables for missing components.
 # generate_links()
 #       Generates a copy of components.adoc with added links to the man pages for the components.
@@ -10,83 +10,59 @@ import re
 import sys
 
 man1_path = '../docs/man/man1'
-man1_files = {f.replace('.1', '') for f in os.listdir(man1_path) if os.path.isfile(os.path.join(man1_path, f))}
+man1_files = {f for f in os.listdir(man1_path) if os.path.isfile(os.path.join(man1_path, f))}
 man9_path = '../docs/man/man9'
-man9_files = {f.replace('.9', '') for f in os.listdir(man9_path) if os.path.isfile(os.path.join(man9_path, f))}
-man = {'1':man1_files, '9':man9_files}
-doc1 = set()
-doc9 = set()
-components = {'1':doc1, '9':doc9}
-section_switch = '[[sec:realtime-components]]'
+man9_files = {f for f in os.listdir(man9_path) if os.path.isfile(os.path.join(man9_path, f))}
+man_files = man1_files.union(man9_files)
+complist_doc = set()
+miss_in_man = set()
 # complist_path = '../docs/src/hal/components.adoc'
 
 def generate_complist(complist_path):
     file1 = open(complist_path, 'r')
-    manpage = '1'
     for line in file1:
-        if section_switch in line:
-            manpage = '9'
-        
         if line[0] == '|' and line[1] != '=':
             splitted = line.split('|')
             if splitted[1].strip() != '':
                 if 'link:' in splitted[1]:
-                    comp = re.search('\[.*\]', splitted[1]).group()
+                    link = re.search('(?<=link:).*(?=\\[)', splitted[1]).group()
+                    comp_man = re.search("[a-zA-Z0-9-_\\.]+(?=\\.html)", link).group()
+                    if os.path.isfile(os.path.join('../docs/html/hal',link)):
+                        complist_doc.add(comp_man)
+                    else:
+                        print('gen_complist: Broken link:', link, file=sys.stderr)
+                        miss_in_man.add(comp_man.split(".")[0])
                 else:
-                    comp = splitted[1]
-                components[manpage].add(comp.strip('[] '))
-
+                    print("gen_complist: Component", splitted[1], "without link")
+                    miss_in_man.add(splitted[1])
     file1.close()
-    miss1 = man1_files.difference(doc1)
-    obs1 = doc1.difference(man1_files)
-    miss9 = man9_files.difference(doc9)
-    obs9 = doc9.difference(man9_files)
-    gen1_filename = '../docs/src/hal/components_gen1.adoc'
-    file2 = open(gen1_filename, 'w')
-    if len(miss1) > 0:
-        file2.write('=== Not categorized (auto generated)\n')
+    miss_in_list = man_files.difference(complist_doc)
+
+    gen_filename = '../docs/src/hal/components_gen.adoc'
+    file2 = open(gen_filename, 'w')
+    if len(miss_in_list) > 0:
+        file2.write('=== Not categorized (auto generated from man pages)\n')
         file2.write('[{tab_options}]\n|=======================\n')
-        for i in sorted(miss1):
+        for i in sorted(miss_in_list):
             file2.write('| ' + i + ' |||\n')
         file2.write('|=======================\n')
-    if len(obs1) > 0:
-        file2.write('\n=== Without man page (auto generated)\n')
+    if len(miss_in_man) > 0:
+        file2.write('\n=== Without man page or broken link (auto generated from component list)\n')
         file2.write('[{tab_options}]\n|=======================\n')
-        for i in sorted(obs1):
+        for i in sorted(miss_in_man):
             file2.write('| ' + i + ' |||\n')
         file2.write('|=======================\n')
     file2.close()
-    gen9_filename = '../docs/src/hal/components_gen9.adoc'
-    file3 = open(gen9_filename, 'w')
-    if len(miss9) > 0:
-        file3.write('=== Not categorized (auto generated)\n')
-        file3.write('[{tab_options}]\n|=======================\n')
-        for i in sorted(miss9):
-            file3.write('| ' + i + ' |||\n')
-        file3.write('|=======================\n')
-    if len(obs9) > 0:
-        file3.write('\n=== Without man page (auto generated)\n')
-        file3.write('[{tab_options}]\n|=======================\n')
-        for i in sorted(obs9):
-            file3.write('| ' + i + ' |||\n')
-        file3.write('|=======================\n')
-    file3.close()
 
-    generate_links(gen1_filename, '1', False, True)
-    generate_links(gen9_filename, '9', False, True)
-
-    print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man1)'.format(len(miss1), len(obs1)))
-    print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man9)'.format(len(miss9), len(obs9)))
+    generate_links(gen_filename, False, True)
+    print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list'.format(len(miss_in_list), len(miss_in_man)))
 
 
-def generate_links(filename, manpage='1', create_backup=True, add_descr=False):
+def generate_links(filename, create_backup=True, add_descr=False):
     file = open(filename, 'r')
     file_links = []
     links_added = 0
     for line in file:
-        if section_switch in line:
-            manpage = '9'
-        
         if line[0] == '|' and line[1] != '=':
             splitted = line.split('|')
 
@@ -95,22 +71,22 @@ def generate_links(filename, manpage='1', create_backup=True, add_descr=False):
                 if not os.path.isfile(os.path.join('../docs/html/hal',link)):
                     print('gen_complist_link: Broken link:', link)
             else:
-                comp = splitted[1].strip(' ')
-                if comp in man[manpage]:
-                    line = line.replace(comp, 'link:../man/man'+manpage+'/'+comp+'.'+manpage+'.html['+comp+']', 1)
+                comp_man = splitted[1].strip(' ')
+                if comp_man in man_files:
+                    comp, man = comp_man.split(".")
+                    line = line.replace(comp_man, 'link:../man/man'+man+'/'+comp_man+'.html['+comp+']', 1)
                     links_added += 1
                     if add_descr:
                         splitted = line.split('|')
-                        splitted[2] = extract_descr('../docs/man/man'+manpage+'/'+comp+'.'+manpage)\
+                        splitted[2] = extract_descr('../docs/man/man'+man+'/'+comp_man)\
                         .replace(comp + ' ', ' ',1).strip('\n -')
                         line = '|'.join(splitted)
         file_links.append(line)
-
     file.close()
 
     if links_added:
         if create_backup:
-            os.rename(filename, filename+'~')        
+            os.rename(filename, filename+'~')
         file = open(filename, 'w')
         for line in file_links:
             file.write(line)
@@ -122,7 +98,7 @@ def extract_descr(filename):
     file = open(filename, 'r')
     descr = ''
     in_descr = False
-    
+
     for line in file:
         if '.SH NAME' in line or '.SH "NAME' in line:
             in_descr = True

--- a/docs/src/gen_complist.py
+++ b/docs/src/gen_complist.py
@@ -1,67 +1,114 @@
 #!/usr/bin/env python3
-# This file compares the entries in the component list (components.adoc) with the 
-# available man pages and adds a tables for missing components.
+# generate_complist()
+#       Compares the entries in the component list (components.adoc) with the 
+#       available man pages and adds tables for missing components.
+# generate_links()
+#       Generates a copy of components.adoc with added links to the man pages for the components.
 
 from os import listdir
 from os.path import isfile, join
+import re
+import sys
 
 man1_path = '../docs/html/man/man1'
 man1_files = {f.replace('.1.html', '') for f in listdir(man1_path) if isfile(join(man1_path, f))}
 man9_path = '../docs/html/man/man9'
 man9_files = {f.replace('.9.html', '') for f in listdir(man9_path) if isfile(join(man9_path, f))}
-
-file1 = open('../docs/src/hal/components.adoc', 'r')
-section_switch = '[[sec:realtime-components]]'
+man = [man1_files,man9_files]
 doc1 = set()
 doc9 = set()
 components = [doc1,doc9]
-comp_index = 0
-for line in file1:
-    if section_switch in line:
-        comp_index = 1
-    
-    if line[0] == '|' and line[1] != '=':
-        line = line.split('|')
-        if line[1].strip() != '':
-            components[comp_index].add(line[1].strip())
-            #print(line[1].strip(), "-->", comp_index)
+section_switch = '[[sec:realtime-components]]'
+complist_path = '../docs/src/hal/components.adoc'
 
-file1.close()
+def generate_complist():
+    file1 = open(complist_path, 'r')
+    comp_index = 0
+    for line in file1:
+        if section_switch in line:
+            comp_index = 1
+        
+        if line[0] == '|' and line[1] != '=':
+            splitted = line.split('|')
+            if splitted[1].strip() != '':
+                if 'link:' in splitted[1]:
+                    comp = re.search('\[.*\]', splitted[1]).group()
+                else:
+                    comp = splitted[1]
+                components[comp_index].add(comp.strip('[] '))
 
-miss1 = man1_files.difference(doc1)
-obs1 = doc1.difference(man1_files)
-miss9 = man9_files.difference(doc9)
-obs9 = doc9.difference(man9_files)
+    file1.close()
+    miss1 = man1_files.difference(doc1)
+    obs1 = doc1.difference(man1_files)
+    miss9 = man9_files.difference(doc9)
+    obs9 = doc9.difference(man9_files)
 
-file2 = open('../docs/src/hal/components_gen1.adoc', 'w')
-if len(miss1) > 0:
-    file2.write('=== Not categorized (auto generated)\n')
-    file2.write('[{tab_options}]\n|=======================\n')
-    for i in sorted(miss1):
-        file2.write('| ' + i + ' |||\n')
-    file2.write('|=======================\n')
-if len(obs1) > 0:
-    file2.write('\n=== Obsolete (auto generated)\n')
-    file2.write('[{tab_options}]\n|=======================\n')
-    for i in sorted(obs1):
-        file2.write('| ' + i + ' |||\n')
-    file2.write('|=======================\n')
-file2.close()
+    file2 = open('../docs/src/hal/components_gen1.adoc', 'w')
+    if len(miss1) > 0:
+        file2.write('=== Not categorized (auto generated)\n')
+        file2.write('[{tab_options}]\n|=======================\n')
+        for i in sorted(miss1):
+            file2.write('| ' + i + ' |||\n')
+        file2.write('|=======================\n')
+    if len(obs1) > 0:
+        file2.write('\n=== Obsolete (auto generated)\n')
+        file2.write('[{tab_options}]\n|=======================\n')
+        for i in sorted(obs1):
+            file2.write('| ' + i + ' |||\n')
+        file2.write('|=======================\n')
+    file2.close()
 
-file3 = open('../docs/src/hal/components_gen9.adoc', 'w')
-if len(miss9) > 0:
-    file3.write('=== Not categorized (auto generated)\n')
-    file3.write('[{tab_options}]\n|=======================\n')
-    for i in sorted(miss9):
-        file3.write('| ' + i + ' |||\n')
-    file3.write('|=======================\n')
-if len(obs9) > 0:
-    file3.write('\n=== Obsolete (auto generated)\n')
-    file3.write('[{tab_options}]\n|=======================\n')
-    for i in sorted(obs9):
-        file3.write('| ' + i + ' |||\n')
-    file3.write('|=======================\n')
-file3.close()
+    file3 = open('../docs/src/hal/components_gen9.adoc', 'w')
+    if len(miss9) > 0:
+        file3.write('=== Not categorized (auto generated)\n')
+        file3.write('[{tab_options}]\n|=======================\n')
+        for i in sorted(miss9):
+            file3.write('| ' + i + ' |||\n')
+        file3.write('|=======================\n')
+    if len(obs9) > 0:
+        file3.write('\n=== Obsolete (auto generated)\n')
+        file3.write('[{tab_options}]\n|=======================\n')
+        for i in sorted(obs9):
+            file3.write('| ' + i + ' |||\n')
+        file3.write('|=======================\n')
+    file3.close()
 
-print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man1)'.format(len(miss1), len(obs1)))
-print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man9)'.format(len(miss9), len(obs9)))
+    print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man1)'.format(len(miss1), len(obs1)))
+    print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man9)'.format(len(miss9), len(obs9)))
+
+
+def generate_links():
+    file1 = open(complist_path, 'r')
+    file1_links = open('../docs/src/hal/components_links.adoc', 'w')
+    comp_index = 0
+    manpage = '1'
+    for line in file1:
+        if section_switch in line:
+            comp_index = 1
+            manpage = '9'
+        
+        if line[0] == '|' and line[1] != '=':
+            splitted = line.split('|')
+
+            if 'link:' in splitted[1]:
+                link = re.search('(?<=link:).*(?=\[)', splitted[1]).group()
+                if not isfile(join('../docs/html/hal',link)):
+                    print('broken link:', link)
+            else:
+                comp = splitted[1].strip(' ')
+                if comp in man[comp_index]:
+                    line = line.replace(comp, 'link:../man/man'+manpage+'/'+comp+'.'+manpage+'.html['+comp+']', 1)
+
+        file1_links.write(line)
+
+    file1.close()
+    file1_links.close()
+
+if __name__ == "__main__":
+
+    if len(sys.argv) > 1:
+        if sys.argv[1] == 'links':
+            generate_links()
+
+    else:
+        generate_complist()

--- a/docs/src/gen_complist.py
+++ b/docs/src/gen_complist.py
@@ -72,14 +72,14 @@ def generate_complist(complist_path):
         file3.write('|=======================\n')
     file3.close()
 
-    generate_links(gen1_filename, '1', False)
-    generate_links(gen9_filename, '9', False)
+    generate_links(gen1_filename, '1', False, True)
+    generate_links(gen9_filename, '9', False, True)
 
     print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man1)'.format(len(miss1), len(obs1)))
     print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man9)'.format(len(miss9), len(obs9)))
 
 
-def generate_links(filename, manpage='1', create_backup=True):
+def generate_links(filename, manpage='1', create_backup=True, add_descr=False):
     file = open(filename, 'r')
     file_links = []
     links_added = 0
@@ -99,7 +99,11 @@ def generate_links(filename, manpage='1', create_backup=True):
                 if comp in man[manpage]:
                     line = line.replace(comp, 'link:../man/man'+manpage+'/'+comp+'.'+manpage+'.html['+comp+']', 1)
                     links_added += 1
-
+                    if add_descr:
+                        splitted = line.split('|')
+                        splitted[2] = extract_descr('../docs/man/man'+manpage+'/'+comp+'.'+manpage)\
+                        .replace(comp, '',1).strip('\n -')
+                        line = '|'.join(splitted)
         file_links.append(line)
 
     file.close()
@@ -114,11 +118,25 @@ def generate_links(filename, manpage='1', create_backup=True):
         print('gen_complist_links: Added {} link(s) to {}'.format(links_added, filename))
 
 
+def extract_descr(filename):
+    file = open(filename, 'r')
+    descr = ''
+    in_descr = False
+    
+    for line in file:
+        if '.SH NAME' in line or '.SH "NAME' in line:
+            in_descr = True
+        elif '.SH' in line:
+            break
+        elif in_descr:
+            descr += line
+    file.close()
+    return re.sub(r'\\fB|\\fR|\\fI|\\', '', descr)
+
 if __name__ == "__main__":
 
     if len(sys.argv) > 1:
-        if len(sys.argv) > 2:
-            if sys.argv[2] == 'links':
-                generate_links(sys.argv[1])
+        if 'links' in sys.argv:
+            generate_links(sys.argv[1])
         else:
             generate_complist(sys.argv[1])

--- a/docs/src/gen_complist.py
+++ b/docs/src/gen_complist.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# This file compares the entries in the component list (components.adoc) with the 
+# available man pages and adds a tables for missing components.
+
+from os import listdir
+from os.path import isfile, join
+
+man1_path = '../docs/html/man/man1'
+man1_files = {f.replace('.1.html', '') for f in listdir(man1_path) if isfile(join(man1_path, f))}
+man9_path = '../docs/html/man/man9'
+man9_files = {f.replace('.9.html', '') for f in listdir(man9_path) if isfile(join(man9_path, f))}
+
+file1 = open('../docs/src/hal/components.adoc', 'r')
+section_switch = '[[sec:realtime-components]]'
+doc1 = set()
+doc9 = set()
+components = [doc1,doc9]
+comp_index = 0
+for line in file1:
+    if section_switch in line:
+        comp_index = 1
+    
+    if line[0] == '|' and line[1] != '=':
+        line = line.split('|')
+        if line[1].strip() != '':
+            components[comp_index].add(line[1].strip())
+            #print(line[1].strip(), "-->", comp_index)
+
+file1.close()
+
+miss1 = man1_files.difference(doc1)
+obs1 = doc1.difference(man1_files)
+miss9 = man9_files.difference(doc9)
+obs9 = doc9.difference(man9_files)
+
+file2 = open('../docs/src/hal/components_gen1.adoc', 'w')
+if len(miss1) > 0:
+    file2.write('=== Not categorized (auto generated)\n')
+    file2.write('[{tab_options}]\n|=======================\n')
+    for i in sorted(miss1):
+        file2.write('| ' + i + ' |||\n')
+    file2.write('|=======================\n')
+if len(obs1) > 0:
+    file2.write('\n=== Obsolete (auto generated)\n')
+    file2.write('[{tab_options}]\n|=======================\n')
+    for i in sorted(obs1):
+        file2.write('| ' + i + ' |||\n')
+    file2.write('|=======================\n')
+file2.close()
+
+file3 = open('../docs/src/hal/components_gen9.adoc', 'w')
+if len(miss9) > 0:
+    file3.write('=== Not categorized (auto generated)\n')
+    file3.write('[{tab_options}]\n|=======================\n')
+    for i in sorted(miss9):
+        file3.write('| ' + i + ' |||\n')
+    file3.write('|=======================\n')
+if len(obs9) > 0:
+    file3.write('\n=== Obsolete (auto generated)\n')
+    file3.write('[{tab_options}]\n|=======================\n')
+    for i in sorted(obs9):
+        file3.write('| ' + i + ' |||\n')
+    file3.write('|=======================\n')
+file3.close()
+
+print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man1)'.format(len(miss1), len(obs1)))
+print('gen_complist: Added {} uncategorized and {} obsolete entries to hal component list (man9)'.format(len(miss9), len(obs9)))

--- a/docs/src/hal/basic-hal.adoc
+++ b/docs/src/hal/basic-hal.adoc
@@ -377,7 +377,7 @@ follow a 'Truth Table' that states what the output is for any given
 input. Typically these are bit manipulators and follow electrical logic
 gate truth tables.
 
-For further components see <<sec:realtime-components,Realtime Components List>>
+For further components see <<sec:hal-components,HAL Components List>>
 or the man pages.
 
 [[sub:hal-and2]]

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -1,5 +1,5 @@
 [[cha:hal-components]]
-:tab_options: cols="20s,80,0,0", frame="none", grid="none"
+:tab_options: cols="15s,85,0,0", frame="none", grid="none"
 
 [[cha:hal-components]]
 = HAL Component List((("HAL Component List")))
@@ -17,29 +17,55 @@ man axis (or perhaps 'man 1 axis' if your system requires it.)
 ----
 
 
+=== User interface
+
 [{tab_options}]
 |=======================
 | axis | AXIS LinuxCNC (The Enhanced Machine Controller) Graphical User Interface. ||
 | axis-remote | AXIS Remote Interface. ||
-| comp | Build, compile and install LinuxCNC HAL components. ||
 | gladevcp | Virtual Control Panel for LinuxCNC based on Glade, Gtk and HAL widgets. ||
+| gladevcp | Displays Virtual Control Panels built with GTK/Glade. ||
+| halui | Observe HAL pins and command LinuxCNC through NML. ||
+| pyvcp | Virtual Control Panel for LinuxCNC. ||
+
+|=======================
+
+=== Hardware Drivers
+
+[{tab_options}]
+|=======================
 | gs2 | HAL userspace component for Automation Direct GS2 VFD's. ||
+| mb2hal | ||
+|=======================
+
+=== Diagnostic and Configuration Tools
+
+[{tab_options}]
+|=======================
+| halmeter | Observe HAL pins, signals, and parameters. ||
+| halshow |||
+| halscope |||
+|=======================
+
+=== Other
+
+[{tab_options}]
+|=======================
+| comp | Build, compile and install LinuxCNC HAL components. ||
 | halcmd | Manipulate the Enhanced Machine Controller HAL from the command line. ||
 | hal_input | Control HAL pins with any Linux input device, including USB HID devices. ||
-| halmeter | Observe HAL pins, signals, and parameters. ||
 | halrun | Manipulate the Enhanced Machine Controller HAL from the command line. ||
 | halsampler | Sample data from HAL in realtime. ||
 | halstreamer | Stream file data into HAL in real time. ||
-| halui | Observe HAL pins and command LinuxCNC through NML. ||
 | io | Accepts NML I/O commands, interacts with HAL in userspace. ||
 | iocontrol | Accepts NML I/O commands, interacts with HAL in userspace. ||
 | linuxcnc | LinuxCNC (The Enhanced Machine Controller). ||
-| pyvcp | Virtual Control Panel for LinuxCNC. ||
 | shuttle | control HAL pins with the ShuttleXpress and ShuttlePRO devices made by Contour Design. ||
 |=======================
 
 [[sec:realtime-components]]
-== Realtime Components List
+
+== Realtime Components
 
 Some of these will have expanded descriptions from the man pages.
 Some will have limited descriptions. All of the components have man pages.
@@ -52,35 +78,17 @@ man motion
 man 9 motion
 ----
 
-[NOTE]
-If component requires a thread with a float, it is usually the slowest,
-thus _servo-thread_.
+See also the 'Man Pages' section of the link:../index.html[docs main page] or the
+link:../man/man9/[directory listing of man9].
 
-[NOTE]
-See also the 'Man Pages' section of the link:../index.html[docs main page]
-or the link:../man/man9/[directory listing of man9].
-
-[[sec:core-realtime-components]]
-=== Core LinuxCNC components
-[{tab_options}]
-|=======================
-| motion | Accepts NML motion commands, interacts with HAL in realtime. ||
-| axis | Accepts NML motion commands, interacts with HAL in realtime. ||
-| classicladder | Realtime software PLC based on ladder logic.
-See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
-| gladevcp | Displays Virtual Control Panels built with GTK/Glade. ||
-| threads | Creates hard realtime HAL threads. ||
-|=======================
-
-[[sec:Realtime-Components-logic]]
 === Logic and Bitwise components
 
-[{tab_options}]
+[cols="15s,85,0,0", frame="none", grid="none"]
 |=======================
-|and2|Two-input AND gate. For out to be true both inputs must be true. |link:../man/man9/and2.9.html[and2] |
-|not|Inverter|link:../man/man9/not.9.html[not] |
-|or2|Two-input OR gate|link:../man/man9/or2.9.html[or2] |
-|xor2|Two-input XOR (exclusive OR) gate|link:../man/man9/xor2.9.html[xor2] |
+| and2 | Two-input AND gate. For out to be true both inputs must be true. (link:../man/man9/and2.9.html[and2]) ||
+| not  | Inverter ||
+| or2  | Two-input OR gate ||
+| xor2 | Two-input XOR (exclusive OR) gate ||
 | dbounce | Filter noisy digital inputs. link:../man/man9/dbounce.9.html[Details].                                   | |
 | debounce | Filter noisy digital inputs. link:../man/man9/debounce.9.html[Details]. <<sec:debounce, Description>>  | |
 | edge | Edge detector. | |
@@ -95,6 +103,7 @@ See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
 
 [[sec:Realtime-Components-flottant]]
 === Arithmetic and float-components
+
 [{tab_options}]
 |=======================
 | abs | Compute the absolute value and sign of the input signal.                                  | |
@@ -149,7 +158,6 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 [[sec:Realtime-Components-pilotes]]
 === Hardware Drivers
 
-
 [{tab_options}]
 |=======================
 | hal_ppmc | Pico Systems <<cha:pico-drivers,driver>> for analog servo, PWM and Stepper controller. ||
@@ -165,6 +173,7 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 
 [[sec:Realtime-Components-cinematiques]]
 === Kinematics
+
 [{tab_options}]
 |=======================
 | kins | kinematics definitions for LinuxCNC. ||
@@ -192,6 +201,7 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 |=======================
 
 === BLDC and 3-phase motor control
+
 [{tab_options}]
 |=======================
 | bldc_hall3 | 3-wire Bipolar trapezoidal commutation BLDC motor driver using Hall sensors. ||

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -1,3 +1,4 @@
+:lang: en
 [[cha:hal-components]]
 :tab_options: cols="15s,85,0,0", frame="none", grid="none"
 
@@ -21,12 +22,12 @@ man axis (or perhaps 'man 1 axis' if your system requires it.)
 
 [{tab_options}]
 |=======================
-| link:../man/man1/axis.1.html[axis] | AXIS LinuxCNC (The Enhanced Machine Controller) Graphical User Interface. ||
-| link:../man/man1/axis-remote.1.html[axis-remote] | AXIS Remote Interface. ||
-| link:../man/man1/gladevcp.1.html[gladevcp] | Virtual Control Panel for LinuxCNC based on Glade, Gtk and HAL widgets. ||
-| link:../man/man1/gladevcp.1.html[gladevcp] | Displays Virtual Control Panels built with GTK/Glade. ||
-| link:../man/man1/halui.1.html[halui] | Observe HAL pins and command LinuxCNC through NML. ||
-| link:../man/man1/pyvcp.1.html[pyvcp] | Virtual Control Panel for LinuxCNC. ||
+| axis | AXIS LinuxCNC (The Enhanced Machine Controller) Graphical User Interface. ||
+| axis-remote | AXIS Remote Interface. ||
+| gladevcp | Virtual Control Panel for LinuxCNC based on Glade, Gtk and HAL widgets. ||
+| gladevcp | Displays Virtual Control Panels built with GTK/Glade. ||
+| halui | Observe HAL pins and command LinuxCNC through NML. ||
+| pyvcp | Virtual Control Panel for LinuxCNC. ||
 
 |=======================
 
@@ -34,34 +35,34 @@ man axis (or perhaps 'man 1 axis' if your system requires it.)
 
 [{tab_options}]
 |=======================
-| link:../man/man1/mb2hal.1.html[mb2hal] | MB2HAL is a generic userspace HAL component to communicate with one or more Modbus devices. Modbus RTU and Modbus TCP is supported.||
+| gs2 | HAL userspace component for Automation Direct GS2 VFD's. ||
+| mb2hal | ||
 |=======================
 
 === Diagnostic and Configuration Tools
 
 [{tab_options}]
 |=======================
-| link:../man/man1/halmeter.1.html[halmeter] | Observe HAL pins, signals, and parameters. ||
-| link:../man/man1/halshow.1.html[halshow]  | Show HAL parameters, pins and signals ||
-| link:../man/man1/halscope.1.html[halscope] | Software oscilloscope for viewing real time waveforms of HAL pins and signals ||
+| halmeter | Observe HAL pins, signals, and parameters. ||
+| halshow |||
+| halscope |||
 |=======================
 
 === Other
 
 [{tab_options}]
 |=======================
-| link:../man/man1/halcmd.1.html[halcmd] | Manipulate the Enhanced Machine Controller HAL from the command line. ||
-| link:../man/man1/hal_input.1.html[hal_input] | Control HAL pins with any Linux input device, including USB HID devices. ||
-| link:../man/man1/halrun.1.html[halrun] | Manipulate the Enhanced Machine Controller HAL from the command line. ||
-| link:../man/man1/halsampler.1.html[halsampler] | Sample data from HAL in realtime. ||
-| link:../man/man1/halstreamer.1.html[halstreamer] | Stream file data into HAL in real time. ||
-| link:../man/man1/io.1.html[io] | Accepts NML I/O commands, interacts with HAL in userspace. ||
-| link:../man/man1/iocontrol.1.html[iocontrol] | Accepts NML I/O commands, interacts with HAL in userspace. ||
-| link:../man/man1/linuxcnc.1.html[linuxcnc] | LinuxCNC (The Enhanced Machine Controller). ||
-| link:../man/man1/shuttle.1.html[shuttle] | control HAL pins with the ShuttleXpress and ShuttlePRO devices made by Contour Design. ||
+| comp | Build, compile and install LinuxCNC HAL components. ||
+| halcmd | Manipulate the Enhanced Machine Controller HAL from the command line. ||
+| hal_input | Control HAL pins with any Linux input device, including USB HID devices. ||
+| halrun | Manipulate the Enhanced Machine Controller HAL from the command line. ||
+| halsampler | Sample data from HAL in realtime. ||
+| halstreamer | Stream file data into HAL in real time. ||
+| io | Accepts NML I/O commands, interacts with HAL in userspace. ||
+| iocontrol | Accepts NML I/O commands, interacts with HAL in userspace. ||
+| linuxcnc | LinuxCNC (The Enhanced Machine Controller). ||
+| shuttle | control HAL pins with the ShuttleXpress and ShuttlePRO devices made by Contour Design. ||
 |=======================
-
-include::components_gen1.adoc[]
 
 [[sec:realtime-components]]
 
@@ -82,22 +83,35 @@ See also the 'Man Pages' section of the link:../index.html[docs main page] or th
 link:../man/man9/[directory listing of man9].
 
 === Logic and Bitwise components
-
-[cols="15s,85,0,0", frame="none", grid="none"]
+[{tab_options}]
 |=======================
 | link:../man/man9/and2.9.html[and2] | Two-input AND gate. For out to be true both inputs must be true. (link:../man/man9/and2.9.html[and2]) ||
-| link:../man/man9/not.9.html[not]  | Inverter ||
-| link:../man/man9/or2.9.html[or2]  | Two-input OR gate ||
-| link:../man/man9/xor2.9.html[xor2] | Two-input XOR (exclusive OR) gate ||
+| link:../man/man9/bitwise.9.html[bitwise] |Computes various bitwise operations on the two input values||
 | link:../man/man9/dbounce.9.html[dbounce] | Filter noisy digital inputs. link:../man/man9/dbounce.9.html[Details].                                   | |
 | link:../man/man9/debounce.9.html[debounce] | Filter noisy digital inputs. link:../man/man9/debounce.9.html[Details]. <<sec:debounce, Description>>  | |
+| link:../man/man9/demux.9.html[demux] |Select one of several output pins by integer and/or or individual bits.||
 | link:../man/man9/edge.9.html[edge] | Edge detector. | |
+| link:../man/man9/estop_latch.9.html[estop_latch] | ESTOP latch. ||
 | link:../man/man9/flipflop.9.html[flipflop] | D type flip-flop. | |
-| link:../man/man9/oneshot.9.html[oneshot] | One-shot pulse generator. | |
 | link:../man/man9/logic.9.html[logic] | General logic function component. | |
 | link:../man/man9/lut5.9.html[lut5] | A 5-input logic function based on a look-up table. <<sec:lut5,Description>> | |
 | link:../man/man9/match8.9.html[match8] | 8-bit binary match detector. | |
+| link:../man/man9/multiclick.9.html[multiclick] |Single-, double-, triple-, and quadruple-click detector||
+| link:../man/man9/multiswitch.9.html[multiswitch] |This component toggles between a specified number of output bits||
+| link:../man/man9/mux_generic.9.html[mux_generic] |choose one from several input values||
+| link:../man/man9/not.9.html[not]  | Inverter ||
+| link:../man/man9/oneshot.9.html[oneshot] | One-shot pulse generator. | |
+| link:../man/man9/or2.9.html[or2]  | Two-input OR gate ||
 | link:../man/man9/select8.9.html[select8] | 8-bit binary match detector. | |
+| link:../man/man9/tof.9.html[tof] |IEC TOF timer - delay falling edge on a signal||
+| link:../man/man9/toggle.9.html[toggle] | Push-on, push-off from momentary pushbuttons. ||
+| link:../man/man9/toggle2nist.9.html[toggle2nist] | Toggle button to nist logic. ||
+| link:../man/man9/ton.9.html[ton] |IEC TON timer - delay rising edge on a signal||
+| link:../man/man9/tp.9.html[tp] |IEC TP timer - generate a high pulse of defined duration on rising edge||
+| link:../man/man9/tristate_bit.9.html[tristate_bit] | Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics. ||
+| link:../man/man9/tristate_float.9.html[tristate_float] | Place a signal on an I/O pin only when enabled, similar to a tristatebuffer in electronics. ||
+| link:../man/man9/xor2.9.html[xor2] | Two-input XOR (exclusive OR) gate ||
+| link:../man/man9/xhc_hb04_util.9.html[xhc_hb04_util] |xhc-hb04 convenience utility||
 |=======================
 
 
@@ -106,43 +120,45 @@ link:../man/man9/[directory listing of man9].
 
 [{tab_options}]
 |=======================
-| link:../man/man9/abs.9.html[abs] | Compute the absolute value and sign of the input signal.                                  | |
-| link:../man/man9/blend.9.html[blend] | Perform linear interpolation between two values. | |
-| link:../man/man9/comp.9.html[comp] | Two input comparator with hysteresis. | |
-| link:../man/man9/constant.9.html[constant] | Use a parameter to set the value of a pin. | |
-| link:../man/man9/sum2.9.html[sum2] | Sum of two inputs (each with a gain) and an offset. | |
-| link:../man/man9/counter.9.html[counter] | Counts input pulses (deprecated). Use the <<sec:encoder, encoder>> component.  | |
-| link:../man/man9/updown.9.html[updown] | Counts up or down, with optional limits and wraparound behavior. | |
-| link:../man/man9/ddt.9.html[ddt] | Compute the derivative of the input function. | |
-| link:../man/man9/deadzone.9.html[deadzone] | Return the center if within the threshold. | |
-| link:../man/man9/hypot.9.html[hypot] | Three-input hypotenuse (Euclidean distance) calculator. | |
-| link:../man/man9/mult2.9.html[mult2] | Product of two inputs. | |
-| link:../man/man9/mux16.9.html[mux16] | Select from one of sixteen input values. | |
-| link:../man/man9/mux2.9.html[mux2] | Select from one of two input values. | |
-| link:../man/man9/mux4.9.html[mux4] | Select from one of four input values. | |
-| link:../man/man9/mux8.9.html[mux8] | Select from one of eight input values. | |
-| link:../man/man9/near.9.html[near] | Determine whether two values are roughly equal. | |
-| link:../man/man9/offset.9.html[offset] | Adds an offset to an input, and subtracts it from the feedback value. | |
-| link:../man/man9/integ.9.html[integ] | Integrator. | |
-| link:../man/man9/invert.9.html[invert] | Compute the inverse of the input signal. | |
-| link:../man/man9/wcomp.9.html[wcomp] | Window comparator. | |
-| link:../man/man9/weighted_sum.9.html[weighted_sum] | Convert a group of bits to an integer. | |
-| link:../man/man9/biquad.9.html[biquad] | Biquad IIR filter | |
-| link:../man/man9/lowpass.9.html[lowpass] | Low-pass filter | |
-| link:../man/man9/limit1.9.html[limit1] | Limit the output signal to fall between min and max. footnote:[When the input is a position, this means that the 'position' is limited.] | |
-| link:../man/man9/limit2.9.html[limit2] | Limit the output signal to fall between min and max.  Limit its slew rate to less than maxv per second. 
+| abs | Compute the absolute value and sign of the input signal.                                  | |
+| blend | Perform linear interpolation between two values. | |
+| comp | Two input comparator with hysteresis. | |
+| constant | Use a parameter to set the value of a pin. | |
+| sum2 | Sum of two inputs (each with a gain) and an offset. | |
+| counter | Counts input pulses (deprecated). Use the <<sec:encoder, encoder>> component.  | |
+| updown | Counts up or down, with optional limits and wraparound behavior. | |
+| ddt | Compute the derivative of the input function. | |
+| deadzone | Return the center if within the threshold. | |
+| hypot | Three-input hypotenuse (Euclidean distance) calculator. | |
+| mult2 | Product of two inputs. | |
+| mux16 | Select from one of sixteen input values. | |
+| mux2 | Select from one of two input values. | |
+| mux4 | Select from one of four input values. | |
+| mux8 | Select from one of eight input values. | |
+| near | Determine whether two values are roughly equal. | |
+| offset | Adds an offset to an input, and subtracts it from the feedback value. | |
+| integ | Integrator. | |
+| invert | Compute the inverse of the input signal. | |
+| wcomp | Window comparator. | |
+| weighted_sum | Convert a group of bits to an integer. | |
+| biquad | Biquad IIR filter | |
+| lowpass | Low-pass filter | |
+| limit1 | Limit the output signal to fall between min and max. footnote:[When the input is a position, this means that the 'position' is limited.] | |
+| limit2 | Limit the output signal to fall between min and max.  Limit its slew rate to less than maxv per second. 
 footnote:[When the input is a position, this means that 'position' and 'velocity' are limited.]  | |
-| link:../man/man9/limit3.9.html[limit3] | Limit the output signal to fall between min and max. 
+| limit3 | Limit the output signal to fall between min and max. 
 Limit its slew rate to less than maxv per second. Limit its second derivative to less than MaxA per second squared. footnote:[When
  the input is a position, this means that the 'position', 'velocity', and 'acceleration' are limited.] | |
-| link:../man/man9/maj3.9.html[maj3] | Compute the majority of 3 inputs. | |
-| link:../man/man9/scale.9.html[scale] | Applies a scale and offset to its input. | |
+| maj3 | Compute the majority of 3 inputs. | |
+| scale | Applies a scale and offset to its input. | |
 |=======================
 
 === Type conversion
-
 [{tab_options}]
 |=======================
+| link:../man/man9/bin2gray.9.html[bin2gray] |Convert a number to the gray-code representation||
+| link:../man/man9/bitslice.9.html[bitslice] |Convert an unsigned-32 input into individual bits||
+| link:../man/man9/conv_bit_float.9.html[conv_bit_float] |Convert a value from bit to float||
 | link:../man/man9/conv_bit_s32.9.html[conv_bit_s32] | Convert a value from bit to s32.     ||
 | link:../man/man9/conv_bit_u32.9.html[conv_bit_u32] | Convert a value from bit to u32.     ||
 | link:../man/man9/conv_float_s32.9.html[conv_float_s32] | Convert a value from float to s32. ||
@@ -153,6 +169,7 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 | link:../man/man9/conv_u32_bit.9.html[conv_u32_bit] | Convert a value from u32 to bit.     ||
 | link:../man/man9/conv_u32_float.9.html[conv_u32_float] | Convert a value from u32 to float. ||
 | link:../man/man9/conv_u32_s32.9.html[conv_u32_s32] | Convert a value from u32 to s32.     ||
+| link:../man/man9/gray2bin.9.html[gray2bin] |Convert a gray-code input to binary||
 |=======================
 
 [[sec:Realtime-Components-pilotes]]
@@ -160,45 +177,34 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 
 [{tab_options}]
 |=======================
-| gs2 | HAL userspace component for Automation Direct GS2 VFD's. ||
 | hal_ppmc | Pico Systems <<cha:pico-drivers,driver>> for analog servo, PWM and Stepper controller. ||
-| link:../man/man9/hm2_7i43.9.html[hm2_7i43] | Mesa Electronics driver for the 7i43 EPP Anything IO board with HostMot2. (See the man page for more information) ||
-| link:../man/man9/hm2_pci.9.html[hm2_pci] | Mesa Electronics driver for the 5i20, 5i22, 5i23, 4i65, and 4i68 Anything I/O boards, with HostMot2 firmware. (See the man page for more information) ||
-| link:../man/man9/hostmot2.9.html[hostmot2] | Mesa Electronics <<cha:mesa-hostmot2-driver,driver>> for the HostMot2 firmware. ||
-| link:../man/man9/mesa_7i65.9.html[mesa_7i65] | Mesa Electronics driver for the 7i65 eight-axis servo card. (See the man page for more information) ||
+| hm2_7i43 | Mesa Electronics driver for the 7i43 EPP Anything IO board with HostMot2. (See the man page for more information) ||
+| hm2_pci | Mesa Electronics driver for the 5i20, 5i22, 5i23, 4i65, and 4i68 Anything I/O boards, with HostMot2 firmware. (See the man page for more information) ||
+| hostmot2 | Mesa Electronics <<cha:mesa-hostmot2-driver,driver>> for the HostMot2 firmware. ||
+| mesa_7i65 | Mesa Electronics driver for the 7i65 eight-axis servo card. (See the man page for more information) ||
 | pluto_servo | Pluto-P <<cha:pluto-p-driver,driver>> and firmware for the parallel port FPGA, for servos. ||
 | pluto_step | Pluto-P <<cha:pluto-p-driver,driver>> for the parallel port FPGA, for steppers. ||
-| link:../man/man9/thc.9.html[thc] | Torch Height Control using a Mesa THC card or any analog to velocity input ||
-| link:../man/man9/serport.9.html[serport] | Hardware driver for the digital I/O bits of the 8250 and 16550 serial port. ||
+| thc | Torch Height Control using a Mesa THC card or any analog to velocity input ||
+| serport | Hardware driver for the digital I/O bits of the 8250 and 16550 serial port. ||
 |=======================
+
 
 [[sec:Realtime-Components-cinematiques]]
 === Kinematics
 
 [{tab_options}]
 |=======================
-| link:../man/man9/kins.9.html[kins] | kinematics definitions for LinuxCNC. ||
-| link:../man/man9/gantrykins.9.html[gantrykins] | A kinematics module that maps one axis to multiple joints. ||
-| link:../man/man9/genhexkins.9.html[genhexkins] | Gives six degrees of freedom in position and orientation (XYZABC). The location of the motors is defined at compile time. ||
-| link:../man/man9/genserkins.9.html[genserkins] | Kinematics that can model a general serial-link manipulator with up to 6 angular joints. ||
-| link:../man/man9/maxkins.9.html[maxkins] | Kinematics for a tabletop 5 axis mill named 'max' with tilting head (B axis) and horizontal rotary mounted to the table (C axis).
+| kins | kinematics definitions for LinuxCNC. ||
+| gantrykins | A kinematics module that maps one axis to multiple joints. ||
+| genhexkins | Gives six degrees of freedom in position and orientation (XYZABC). The location of the motors is defined at compile time. ||
+| genserkins | Kinematics that can model a general serial-link manipulator with up to 6 angular joints. ||
+| maxkins | Kinematics for a tabletop 5 axis mill named 'max' with tilting head (B axis) and horizontal rotary mounted to the table (C axis).
  Provides UVW motion in the rotated coordinate system. The source file, maxkins.c, may be a useful starting point for other 5-axis systems. ||
-| link:../man/man9/tripodkins.9.html[tripodkins] | The joints represent the distance of the controlled point from three predefined locations (the motors), giving three degrees of freedom in position (XYZ). ||
-| link:../man/man9/trivkins.9.html[trivkins] | There is a 1:1 correspondence between joints and axes. Most standard milling machines and lathes use the trivial kinematics module. ||
-| link:../man/man9/pumakins.9.html[pumakins] | Kinematics for PUMA-style robots. ||
-| link:../man/man9/rotatekins.9.html[rotatekins] | The X and Y axes are rotated 45 degrees compared to the joints 0 and 1. ||
-| link:../man/man9/scarakins.9.html[scarakins] | Kinematics for SCARA-type robots. ||
-|=======================
-
-=== Motor control
-
-[{tab_options}]
-|=======================
-| link:../man/man9/at_pid.9.html[at_pid] | Proportional/integral/derivative controller with auto tuning. ||
-| link:../man/man9/pid.9.html[pid] | Proportional/integral/derivative controller. <<sec:pid,Description>> ||
-| link:../man/man9/pwmgen.9.html[pwmgen] | Software PWM/PDM generation. <<sec:pwmgen,Description>> ||
-| link:../man/man9/encoder.9.html[encoder] | Software counting of quadrature encoder signals. <<sec:encoder,Description>>. ||
-| link:../man/man9/stepgen.9.html[stepgen] | Software step pulse generation. <<sec:stepgen,Description>>. ||
+| tripodkins | The joints represent the distance of the controlled point from three predefined locations (the motors), giving three degrees of freedom in position (XYZ). ||
+| trivkins | There is a 1:1 correspondence between joints and axes. Most standard milling machines and lathes use the trivial kinematics module. ||
+| pumakins | Kinematics for PUMA-style robots. ||
+| rotatekins | The X and Y axes are rotated 45 degrees compared to the joints 0 and 1. ||
+| scarakins | Kinematics for SCARA-type robots. ||
 |=======================
 
 === BLDC and 3-phase motor control
@@ -206,39 +212,26 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 [{tab_options}]
 |=======================
 | bldc_hall3 | 3-wire Bipolar trapezoidal commutation BLDC motor driver using Hall sensors. ||
-| link:../man/man9/clarke2.9.html[clarke2] | Two input version of Clarke transform. ||
-| link:../man/man9/clarke3.9.html[clarke3] | Clarke (3 phase to cartesian) transform. ||
-| link:../man/man9/clarkeinv.9.html[clarkeinv] | Inverse Clarke transform. ||
+| clarke2 | Two input version of Clarke transform. ||
+| clarke3 | Clarke (3 phase to cartesian) transform. ||
+| clarkeinv | Inverse Clarke transform. ||
 |=======================
 
-clarkeinv:: (((clarkeinv))) Inverse Clarke transform.
-
+=== Other
 [{tab_options}]
 |=======================
 | link:../man/man9/comp.9.html[comp] | Build, compile and install LinuxCNC HAL components. ||
-|link:../man/man9/motion.9.html[motion] | Accepts NML motion commands, interacts with HAL in realtime. ||
-|link:../man/man9/classicladder.9.html[classicladder] | Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
-|link:../man/man9/threads.9.html[threads] | Creates hard realtime HAL threads. ||
+| link:../man/man9/motion.9.html[motion] | Accepts NML motion commands, interacts with HAL in realtime. ||
+| link:../man/man9/classicladder.9.html[classicladder] | Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
+| link:../man/man9/threads.9.html[threads] | Creates hard realtime HAL threads. ||
 | link:../man/man9/charge_pump.9.html[charge_pump] | Creates a square-wave for the 'charge pump' input of some controller boards.
 The 'Charge Pump' should be added to the base thread function. When enabled the output is on for one period and off for one period. 
 To calculate the frequency of the output 1/(period time in seconds x 2) = hz. For example if you have a base period of 100,000ns that 
 is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 hz or 5 Khz. ||
 | link:../man/man9/encoder_ratio.9.html[encoder_ratio] | An electronic gear to synchronize two axes. ||
-| link:../man/man9/estop_latch.9.html[estop_latch] | ESTOP latch. ||
 | link:../man/man9/feedcomp.9.html[feedcomp] | Multiply the input by the ratio of current velocity to the feed rate. ||
 | link:../man/man9/gearchange.9.html[gearchange] | Select from one of two speed ranges. ||
-| link:../man/man9/ilowpass.9.html[ilowpass] | While it may find other applications,
-this component was written to create smoother motion while jogging with an MPG.
-In a machine with high acceleration, a short jog can behave almost like a step
-function. By putting the ilowpass component between the MPG encoder counts
-output and the axis jog-counts input, this can be smoothed.
-Choose scale conservatively so that during a single session there will never
-be more than about 2e9/scale pulses seen on the MPG. Choose gain according
-to the smoothing level desired. Divide the axis.N.jog-scale values by scale. ||
 | link:../man/man9/joyhandle.9.html[joyhandle] | Sets nonlinear joypad movements, deadbands and scales. ||
-| link:../man/man9/knob2float.9.html[knob2float] | Convert counts (probably from an encoder) to a float value. ||
-| link:../man/man9/minmax.9.html[minmax] | Track the minimum and maximum values of the input to the outputs. ||
-| link:../man/man9/sample_hold.9.html[sample_hold] | Sample and Hold. ||
 | link:../man/man9/sampler.9.html[sampler] | Sample data from HAL in real time. ||
 | link:../man/man9/siggen.9.html[siggen] | Signal generator. <<sec:siggen,Description>>. ||
 | link:../man/man9/sim_encoder.9.html[sim_encoder] | Simulated quadrature encoder. <<sec:simulated-encoder,Description>>. ||
@@ -248,12 +241,6 @@ to the smoothing level desired. Divide the axis.N.jog-scale values by scale. ||
 | link:../man/man9/supply.9.html[supply] | Set output pins with values from parameters (deprecated). ||
 | link:../man/man9/threadtest.9.html[threadtest] | Component for testing thread behavior. ||
 | link:../man/man9/time.9.html[time] | Accumulated run-time timer counts HH:MM:SS of 'active' input. ||
-| link:../man/man9/timedelay.9.html[timedelay] | The equivalent of a time-delay relay. ||
-| link:../man/man9/timedelta.9.html[timedelta] | Component that measures thread scheduling timing behavior. ||
-| link:../man/man9/toggle2nist.9.html[toggle2nist] | Toggle button to nist logic. ||
-| link:../man/man9/toggle.9.html[toggle] | Push-on, push-off from momentary pushbuttons. ||
-| link:../man/man9/tristate_bit.9.html[tristate_bit] | Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics. ||
-| link:../man/man9/tristate_float.9.html[tristate_float] | Place a signal on an I/O pin only when enabled, similar to a tristatebuffer in electronics. ||
 | link:../man/man9/watchdog.9.html[watchdog] | Monitor one to thirty-two inputs for a 'heartbeat'. ||
 |=======================
 

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -224,11 +224,11 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 | link:../man/man9/maj3.9.html[maj3] | Compute the majority of 3 inputs. | |
 | link:../man/man9/minmax.9.html[minmax] | Track the minimum and maximum values of the input to the outputs. ||
 | link:../man/man9/mult2.9.html[mult2] | Product of two inputs. | |
-| link:../man/man9/mux16.9.html[mux16] | Select from one of sixteen input values. | |
-| link:../man/man9/mux2.9.html[mux2] | Select from one of two input values. | |
-| link:../man/man9/mux4.9.html[mux4] | Select from one of four input values. | |
-| link:../man/man9/mux8.9.html[mux8] | Select from one of eight input values. | |
-| link:../man/man9/mux_generic.9.html[mux_generic] |choose one from several input values||
+| link:../man/man9/mux16.9.html[mux16] | Select from one of 16 input values (multiplexer). | |
+| link:../man/man9/mux2.9.html[mux2] | Select from one of two input values (multiplexer). | |
+| link:../man/man9/mux4.9.html[mux4] | Select from one of four input values (multiplexer). | |
+| link:../man/man9/mux8.9.html[mux8] | Select from one of eight input values (multiplexer). | |
+| link:../man/man9/mux_generic.9.html[mux_generic] | Select one from several input values (multiplexer).||
 | link:../man/man9/near.9.html[near] | Determine whether two values are roughly equal. | |
 | link:../man/man9/offset.9.html[offset] | Adds an offset to an input, and subtracts it from the feedback value. | |
 | link:../man/man9/sample_hold.9.html[sample_hold] | Sample and Hold. ||
@@ -307,8 +307,8 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 | link:../man/man9/threads.9.html[threads] | Creates hard realtime HAL threads. ||
 | link:../man/man9/charge_pump.9.html[charge_pump] | Creates a square-wave for the 'charge pump' input of some controller boards.
 The 'Charge Pump' should be added to the base thread function. When enabled the output is on for one period and off for one period. 
-To calculate the frequency of the output 1/(period time in seconds x 2) = hz. For example if you have a base period of 100,000ns that 
-is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 hz or 5 Khz. ||
+To calculate the frequency of the output 1/(period time in seconds x 2) = Hz. For example if you have a base period of 100,000 ns that 
+is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 Hz or 5 kHz. ||
 | link:../man/man9/encoder_ratio.9.html[encoder_ratio] | An electronic gear to synchronize two axes. ||
 | link:../man/man9/feedcomp.9.html[feedcomp] | Multiply the input by the ratio of current velocity to the feed rate. ||
 | link:../man/man9/gladevcp.9.html[gladevcp (Realtime)] |displays Virtual control Panels built with GTK / GLADE||

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -1,38 +1,42 @@
-:lang: en
-:toc:
+[[cha:hal-components]]
+:tab_options: cols="20s,80,0,0", frame="none", grid="none"
 
 [[cha:hal-components]]
 = HAL Component List((("HAL Component List")))
 
 == Commands and Userspace Components
 
-All of the commands in the following list have man pages.
-Some will have expanded descriptions, some will have limited descriptions.
-Also, all of the components listed below have man pages.
-From this list you know what components exist, and you can use 'man n name' to get additional information.
-To view the information in the man page, in a terminal window type:
+All of the commands in the following list have man pages. 
+Some will have expanded descriptions, some will have limited descriptions. 
+From this list you know what components exist, 
+and you can use 'man n name' to get additional information. 
+To view the information in the man page, in a terminal window type: 
 
 ----
 man axis (or perhaps 'man 1 axis' if your system requires it.)
 ----
 
-axis:: AXIS LinuxCNC (The Enhanced Machine Controller) Graphical User Interface.
-axis-remote:: AXIS Remote Interface.
-comp:: Build, compile and install LinuxCNC HAL components.
-gladevcp:: Virtual Control Panel for LinuxCNC based on Glade, Gtk and HAL widgets.
-gs2:: HAL userspace component for Automation Direct GS2 VFD's.
-halcmd:: Manipulate the Enhanced Machine Controller HAL from the command line.
-hal_input:: Control HAL pins with any Linux input device, including USB HID devices.
-halmeter:: Observe HAL pins, signals, and parameters.
-halrun:: Manipulate the Enhanced Machine Controller HAL from the command line.
-halsampler:: Sample data from HAL in realtime.
-halstreamer:: Stream file data into HAL in real time.
-halui:: Observe HAL pins and command LinuxCNC through NML.
-io:: Accepts NML I/O commands, interacts with HAL in userspace.
-iocontrol:: Accepts NML I/O commands, interacts with HAL in userspace.
-linuxcnc:: LinuxCNC (The Enhanced Machine Controller).
-pyvcp:: Virtual Control Panel for LinuxCNC.
-shuttle:: control HAL pins with the ShuttleXpress and ShuttlePRO devices made by Contour Design.
+
+[{tab_options}]
+|=======================
+| axis | AXIS LinuxCNC (The Enhanced Machine Controller) Graphical User Interface. ||
+| axis-remote | AXIS Remote Interface. ||
+| comp | Build, compile and install LinuxCNC HAL components. ||
+| gladevcp | Virtual Control Panel for LinuxCNC based on Glade, Gtk and HAL widgets. ||
+| gs2 | HAL userspace component for Automation Direct GS2 VFD's. ||
+| halcmd | Manipulate the Enhanced Machine Controller HAL from the command line. ||
+| hal_input | Control HAL pins with any Linux input device, including USB HID devices. ||
+| halmeter | Observe HAL pins, signals, and parameters. ||
+| halrun | Manipulate the Enhanced Machine Controller HAL from the command line. ||
+| halsampler | Sample data from HAL in realtime. ||
+| halstreamer | Stream file data into HAL in real time. ||
+| halui | Observe HAL pins and command LinuxCNC through NML. ||
+| io | Accepts NML I/O commands, interacts with HAL in userspace. ||
+| iocontrol | Accepts NML I/O commands, interacts with HAL in userspace. ||
+| linuxcnc | LinuxCNC (The Enhanced Machine Controller). ||
+| pyvcp | Virtual Control Panel for LinuxCNC. ||
+| shuttle | control HAL pins with the ShuttleXpress and ShuttlePRO devices made by Contour Design. ||
+|=======================
 
 [[sec:realtime-components]]
 == Realtime Components List
@@ -58,282 +62,188 @@ or the link:../man/man9/[directory listing of man9].
 
 [[sec:core-realtime-components]]
 === Core LinuxCNC components
-
-This lists HAL components that are all written in lower case and should not be
-confused with other parts of LinuxCNC bearing the same name (AXIS, ClassicLadder,
-GladeVCP) that these components communicate with.
-
-motion:: (((motion))) Accepts NML motion commands, interacts with HAL in realtime.
-
-axis:: (((axis))) Accepts NML motion commands, interacts with HAL in realtime.
-
-classicladder:: (((ClassicLadder))) Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information.
-
-gladevcp:: (((gladevcp))) Displays Virtual Control Panels built with GTK/Glade.
-
-threads:: (((threads))) Creates hard realtime HAL threads.
+[{tab_options}]
+|=======================
+| motion | Accepts NML motion commands, interacts with HAL in realtime. ||
+| axis | Accepts NML motion commands, interacts with HAL in realtime. ||
+| classicladder | Realtime software PLC based on ladder logic.
+See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
+| gladevcp | Displays Virtual Control Panels built with GTK/Glade. ||
+| threads | Creates hard realtime HAL threads. ||
+|=======================
 
 [[sec:Realtime-Components-logic]]
 === Logic and Bitwise components
 
-and2:: (((and2))) Two-input AND gate. For out to be true both inputs must be true. link:../man/man9/and2.9.html[Details]
+[{tab_options}]
+|=======================
+|and2|Two-input AND gate. For out to be true both inputs must be true. |link:../man/man9/and2.9.html[and2] |
+|not|Inverter|link:../man/man9/not.9.html[not] |
+|or2|Two-input OR gate|link:../man/man9/or2.9.html[or2] |
+|xor2|Two-input XOR (exclusive OR) gate|link:../man/man9/xor2.9.html[xor2] |
+| dbounce | Filter noisy digital inputs. link:../man/man9/dbounce.9.html[Details].                                   | |
+| debounce | Filter noisy digital inputs. link:../man/man9/debounce.9.html[Details]. <<sec:debounce, Description>>  | |
+| edge | Edge detector. | |
+| flipflop | D type flip-flop. | |
+| oneshot | One-shot pulse generator. | |
+| logic | General logic function component. | |
+| lut5 | A 5-input logic function based on a look-up table. <<sec:lut5,Description>> | |
+| match8 | 8-bit binary match detector. | |
+| select8 | 8-bit binary match detector. | |
+|=======================
 
-not:: (((not))) Inverter. link:../man/man9/not.9.html[Details]
-
-or2:: (((or2))) Two-input OR gate. link:../man/man9/or2.9.html[Details]
-
-xor2:: (((xor2))) Two-input XOR (exclusive OR) gate. link:../man/man9/xor2.9.html[Details]
-
-dbounce:: (((dbounce))) Filter noisy digital inputs. link:../man/man9/dbounce.9.html[Details].
-
-debounce:: (((debounce))) Filter noisy digital inputs. link:../man/man9/debounce.9.html[Details]. <<sec:debounce, Description>>
-
-edge:: (((edge))) Edge detector.
-
-flipflop:: (((flipflop))) D type flip-flop.
-
-oneshot:: (((oneshot))) One-shot pulse generator.
-
-logic:: (((logic))) General logic function component.
-
-lut5:: (((lut5))) A 5-input logic function based on a look-up table. <<sec:lut5,Description>>
-
-match8:: (((match8))) 8-bit binary match detector.
-
-select8:: (((select8))) 8-bit binary match detector.
 
 [[sec:Realtime-Components-flottant]]
 === Arithmetic and float-components
-
-abs:: [[sub:abs]](((abs))) Compute the absolute value and sign of the input signal.
-
-blend:: (((blend))) Perform linear interpolation between two values.
-
-comp:: (((comp))) Two input comparator with hysteresis.
-
-constant:: (((constant))) Use a parameter to set the value of a pin.
-
-sum2:: (((sum2))) Sum of two inputs (each with a gain) and an offset.
-
-counter:: (((counter))) Counts input pulses (deprecated).
-+
-Use the _encoder_ component with _... counter-mode = TRUE_.
-See section <<sec:encoder,encoder>>.
-
-updown:: (((updown))) Counts up or down, with optional limits and wraparound behavior.
-
-ddt:: (((ddt))) Compute the derivative of the input function.
-
-deadzone:: (((deadzone))) Return the center if within the threshold.
-
-hypot:: (((hypot))) Three-input hypotenuse (Euclidean distance) calculator.
-
-mult2:: (((mult2))) Product of two inputs (multiplexing).
-
-mux16:: (((mux16))) Select from one of sixteen input values (multiplexing).
-
-mux2:: (((mux2))) Select from one of two input values (multiplexing).
-
-mux4:: (((mux4))) Select from one of four input values (multiplexing).
-
-mux8:: (((mux8))) Select from one of eight input values (multiplexing).
-
-near:: (((near))) Determine whether two values are roughly equal.
-
-offset:: (((offset))) Adds an offset to an input, and subtracts it from the feedback value.
-
-integ:: (((integ))) Integrator.
-
-invert:: (((invert))) Compute the inverse of the input signal.
-
-wcomp:: (((wcomp))) Window comparator.
-
-weighted_sum:: (((weighted_sum))) Convert a group of bits to an integer.
-
-biquad:: (((biquad))) Biquad IIR filter
-
-lowpass:: (((lowpass))) Low-pass filter
-
-limit1:: (((limit1))) Limit the output signal to fall between min and max.
-  footnote:[When the input is a position, this means that the 'position'
-  is limited.]
-
-limit2:: (((limit2))) Limit the output signal to fall between min and max.
-  Limit its slew rate to less than maxv per second. footnote:[When the input
-  is a position, this means that 'position' and 'velocity' are limited.]
-
-limit3:: (((limit3))) Limit the output signal to fall between min and max.
-  Limit its slew rate to less than maxv per second.
-  Limit its second derivative to less than MaxA per second squared.
-  footnote:[When the input is a position, this means that the 'position',
-  'velocity', and 'acceleration' are limited.]
-
-maj3:: (((maj3))) Compute the majority of 3 inputs.
-
-scale:: (((scale))) Applies a scale and offset to its input.
+[{tab_options}]
+|=======================
+| abs | Compute the absolute value and sign of the input signal.                                  | |
+| blend | Perform linear interpolation between two values. | |
+| comp | Two input comparator with hysteresis. | |
+| constant | Use a parameter to set the value of a pin. | |
+| sum2 | Sum of two inputs (each with a gain) and an offset. | |
+| counter | Counts input pulses (deprecated). Use the <<sec:encoder, encoder>> component.  | |
+| updown | Counts up or down, with optional limits and wraparound behavior. | |
+| ddt | Compute the derivative of the input function. | |
+| deadzone | Return the center if within the threshold. | |
+| hypot | Three-input hypotenuse (Euclidean distance) calculator. | |
+| mult2 | Product of two inputs. | |
+| mux16 | Select from one of sixteen input values. | |
+| mux2 | Select from one of two input values. | |
+| mux4 | Select from one of four input values. | |
+| mux8 | Select from one of eight input values. | |
+| near | Determine whether two values are roughly equal. | |
+| offset | Adds an offset to an input, and subtracts it from the feedback value. | |
+| integ | Integrator. | |
+| invert | Compute the inverse of the input signal. | |
+| wcomp | Window comparator. | |
+| weighted_sum | Convert a group of bits to an integer. | |
+| biquad | Biquad IIR filter | |
+| lowpass | Low-pass filter | |
+| limit1 | Limit the output signal to fall between min and max. footnote:[When the input is a position, this means that the 'position' is limited.] | |
+| limit2 | Limit the output signal to fall between min and max.  Limit its slew rate to less than maxv per second. 
+footnote:[When the input is a position, this means that 'position' and 'velocity' are limited.]  | |
+| limit3 | Limit the output signal to fall between min and max. 
+Limit its slew rate to less than maxv per second. Limit its second derivative to less than MaxA per second squared. footnote:[When
+ the input is a position, this means that the 'position', 'velocity', and 'acceleration' are limited.] | |
+| maj3 | Compute the majority of 3 inputs. | |
+| scale | Applies a scale and offset to its input. | |
+|=======================
 
 === Type conversion
 
-conv_bit_s32:: (((conv_bit_s32))) Convert a value from bit to s32.
-
-conv_bit_u32:: (((conv_bit_u32))) Convert a value from bit to u32.
-
-conv_float_s32:: (((conv_float_s32))) Convert a value from float to s32.
-
-conv_float_u32:: (((conv_float_u32))) Convert a value from float to u32.
-
-conv_s32_bit:: (((conv_s32_bit))) Convert a value from s32 to bit.
-
-conv_s32_float:: (((conv_s32_float))) Convert a value from s32 to float.
-
-conv_s32_u32:: (((conv_s32_u32))) Convert a value from s32 to u32.
-
-conv_u32_bit:: (((conv_u32_bit))) Convert a value from u32 to bit.
-
-conv_u32_float:: (((conv_u32_float))) Convert a value from u32 to float.
-
-conv_u32_s32:: (((conv_u32_s32))) Convert a value from u32 to s32.
+[{tab_options}]
+|=======================
+| conv_bit_s32 | Convert a value from bit to s32.     ||
+| conv_bit_u32 | Convert a value from bit to u32.     ||
+| conv_float_s32 | Convert a value from float to s32. ||
+| conv_float_u32 | Convert a value from float to u32. ||
+| conv_s32_bit | Convert a value from s32 to bit.     ||
+| conv_s32_float | Convert a value from s32 to float. ||
+| conv_s32_u32 | Convert a value from s32 to u32.     ||
+| conv_u32_bit | Convert a value from u32 to bit.     ||
+| conv_u32_float | Convert a value from u32 to float. ||
+| conv_u32_s32 | Convert a value from u32 to s32.     ||
+|=======================
 
 [[sec:Realtime-Components-pilotes]]
 === Hardware Drivers
 
-hal_ppmc:: (((hal_ppmc))) Pico Systems <<cha:pico-drivers,driver>> for analog servo, PWM and Stepper controller.
 
-hm2_7i43:: (((hm2_7i43))) Mesa Electronics driver for the 7i43 EPP Anything IO board with HostMot2. (See the man page for more information)
-
-hm2_pci:: (((hm2_pci))) Mesa Electronics driver for the 5i20, 5i22, 5i23, 4i65, and 4i68 Anything I/O boards, with HostMot2 firmware.  (See the man page for more information)
-
-hostmot2:: (((hostmot2))) Mesa Electronics <<cha:mesa-hostmot2-driver,driver>> for the HostMot2 firmware.
-
-mesa_7i65:: (((7i65))) Mesa Electronics driver for the 7i65 eight-axis servo card. (See the man page for more information)
-
-pluto_servo:: (((pluto_servo))) Pluto-P <<cha:pluto-p-driver,driver>> and firmware for the parallel port FPGA, for servos.
-
-pluto_step:: (((pluto_step))) Pluto-P <<cha:pluto-p-driver,driver>> for the parallel port FPGA, for steppers.
-
-thc:: (((torch height control))) Torch Height Control using a Mesa THC card or any analog to velocity input
-
-serport:: (((serport))) Hardware driver for the digital I/O bits of the 8250 and 16550 serial port.
+[{tab_options}]
+|=======================
+| hal_ppmc | Pico Systems <<cha:pico-drivers,driver>> for analog servo, PWM and Stepper controller. ||
+| hm2_7i43 | Mesa Electronics driver for the 7i43 EPP Anything IO board with HostMot2. (See the man page for more information) ||
+| hm2_pci | Mesa Electronics driver for the 5i20, 5i22, 5i23, 4i65, and 4i68 Anything I/O boards, with HostMot2 firmware. (See the man page for more information) ||
+| hostmot2 | Mesa Electronics <<cha:mesa-hostmot2-driver,driver>> for the HostMot2 firmware. ||
+| mesa_7i65 | Mesa Electronics driver for the 7i65 eight-axis servo card. (See the man page for more information) ||
+| pluto_servo | Pluto-P <<cha:pluto-p-driver,driver>> and firmware for the parallel port FPGA, for servos. ||
+| pluto_step | Pluto-P <<cha:pluto-p-driver,driver>> for the parallel port FPGA, for steppers. ||
+| thc | Torch Height Control using a Mesa THC card or any analog to velocity input ||
+| serport | Hardware driver for the digital I/O bits of the 8250 and 16550 serial port. ||
+|=======================
 
 [[sec:Realtime-Components-cinematiques]]
 === Kinematics
-
-kins:: (((kins))) kinematics definitions for LinuxCNC.
-
-gantrykins:: (((gantrykins))) A kinematics module that maps one axis to multiple joints.
-
-genhexkins:: (((genhexkins))) Gives six degrees of freedom in position and orientation (XYZABC).
-  The location of the motors is defined at compile time.
-
-genserkins:: (((genserkins))) Kinematics that can model a general serial-link manipulator with up to
-  6 angular joints.
-
-maxkins:: (((maxkins))) Kinematics for a tabletop 5 axis mill named 'max' with tilting head (B axis) and
-  horizontal rotary mounted to the table (C axis).
-  Provides UVW motion in the rotated coordinate system.
-  The source file, maxkins.c, may be a useful starting point for other 5-axis systems.
-
-tripodkins:: (((tripodkins))) The joints represent the distance of the controlled point from three
-  predefined locations (the motors), giving three degrees of freedom in
-  position (XYZ).
-
-trivkins:: (((trivkins))) There is a 1:1 correspondence between joints and axes. Most standard
-  milling machines and lathes use the trivial kinematics module.
-
-pumakins:: (((pumakins))) Kinematics for PUMA-style robots.
-
-rotatekins:: (((rotatekins))) The X and Y axes are rotated 45 degrees compared to the joints 0 and 1.
-
-scarakins:: (((scarakins))) Kinematics for SCARA-type robots.
+[{tab_options}]
+|=======================
+| kins | kinematics definitions for LinuxCNC. ||
+| gantrykins | A kinematics module that maps one axis to multiple joints. ||
+| genhexkins | Gives six degrees of freedom in position and orientation (XYZABC). The location of the motors is defined at compile time. ||
+| genserkins | Kinematics that can model a general serial-link manipulator with up to 6 angular joints. ||
+| maxkins | Kinematics for a tabletop 5 axis mill named 'max' with tilting head (B axis) and horizontal rotary mounted to the table (C axis).
+ Provides UVW motion in the rotated coordinate system. The source file, maxkins.c, may be a useful starting point for other 5-axis systems. ||
+| tripodkins | The joints represent the distance of the controlled point from three predefined locations (the motors), giving three degrees of freedom in position (XYZ). ||
+| trivkins | There is a 1:1 correspondence between joints and axes. Most standard milling machines and lathes use the trivial kinematics module. ||
+| pumakins | Kinematics for PUMA-style robots. ||
+| rotatekins | The X and Y axes are rotated 45 degrees compared to the joints 0 and 1. ||
+| scarakins | Kinematics for SCARA-type robots. ||
+|=======================
 
 === Motor control
 
-at_pid:: (((at_pid))) Proportional/integral/derivative controller with auto tuning.
-
-pid:: (((pid))) Proportional/integral/derivative controller. <<sec:pid,Description>>
-
-pwmgen:: (((pwmgen))) Software PWM/PDM generation. <<sec:pwmgen,Description>>
-
-encoder:: (((encoder))) Software counting of quadrature encoder signals. <<sec:encoder,Description>>.
-
-stepgen:: (((stepgen))) Software step pulse generation. <<sec:stepgen,Description>>.
+[{tab_options}]
+|=======================
+| at_pid | Proportional/integral/derivative controller with auto tuning. ||
+| pid | Proportional/integral/derivative controller. <<sec:pid,Description>> ||
+| pwmgen | Software PWM/PDM generation. <<sec:pwmgen,Description>> ||
+| encoder | Software counting of quadrature encoder signals. <<sec:encoder,Description>>. ||
+| stepgen | Software step pulse generation. <<sec:stepgen,Description>>. ||
+|=======================
 
 === BLDC and 3-phase motor control
-
-bldc_hall3:: (((bldc_hall3))) 3-wire Bipolar trapezoidal commutation BLDC motor driver using Hall sensors.
-
-clarke2:: (((clarke2))) Two input version of Clarke transform.
-
-clarke3:: (((clarke3))) Clarke (3 phase to cartesian) transform.
+[{tab_options}]
+|=======================
+| bldc_hall3 | 3-wire Bipolar trapezoidal commutation BLDC motor driver using Hall sensors. ||
+| clarke2 | Two input version of Clarke transform. ||
+| clarke3 | Clarke (3 phase to cartesian) transform. ||
+| clarkeinv | Inverse Clarke transform. ||
+|=======================
 
 clarkeinv:: (((clarkeinv))) Inverse Clarke transform.
 
-=== Other Components
-
-charge_pump:: (((charge_pump))) Creates a square-wave for the 'charge pump' input of some controller boards.
-  The 'Charge Pump' should be added to the base thread function. When enabled the output is on for one period and off for one period. To calculate the frequency of the output 1/(period time in seconds x 2) = Hz. For example if you have a base period of 100,000 ns that is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 Hz or 5 kHz.
-
-encoder_ratio:: (((encoder_ratio))) An electronic gear to synchronize two axes.
-
-estop_latch:: (((estop_latch))) ESTOP latch.
-
-feedcomp:: (((feedcomp))) Multiply the input by the ratio of current velocity to the feed rate.
-
-gearchange:: (((gearchange))) Select from one of two speed ranges.
-
-[[sec:ilowpass]]
-ilowpass:: (((ilowpass))) While it may find other applications,
-  this component was written to create smoother motion while jogging with an MPG.
-+
+[{tab_options}]
+|=======================
+|motion | Accepts NML motion commands, interacts with HAL in realtime. ||
+|classicladder | Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
+|threads | Creates hard realtime HAL threads. ||
+| charge_pump | Creates a square-wave for the 'charge pump' input of some controller boards.
+The 'Charge Pump' should be added to the base thread function. When enabled the output is on for one period and off for one period. 
+To calculate the frequency of the output 1/(period time in seconds x 2) = hz. For example if you have a base period of 100,000ns that 
+is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 hz or 5 Khz. ||
+| encoder_ratio | An electronic gear to synchronize two axes. ||
+| estop_latch | ESTOP latch. ||
+| feedcomp | Multiply the input by the ratio of current velocity to the feed rate. ||
+| gearchange | Select from one of two speed ranges. ||
+| ilowpass | While it may find other applications,
+this component was written to create smoother motion while jogging with an MPG.
 In a machine with high acceleration, a short jog can behave almost like a step
 function. By putting the ilowpass component between the MPG encoder counts
 output and the axis jog-counts input, this can be smoothed.
-+
 Choose scale conservatively so that during a single session there will never
 be more than about 2e9/scale pulses seen on the MPG. Choose gain according
-to the smoothing level desired. Divide the axis.N.jog-scale values by scale.
-
-joyhandle:: (((joyhandle))) Sets nonlinear joypad movements, deadbands and scales.
-
-knob2float:: (((knob2float))) Convert counts (probably from an encoder) to a float value.
-
-minmax:: (((minmax))) Track the minimum and maximum values of the input to the outputs.
-
-sample_hold:: (((sample_hold))) Sample and Hold.
-
-sampler:: (((sampler))) Sample data from HAL in real time.
-
-siggen:: (((siggen))) Signal generator. <<sec:siggen,Description>>.
-
-sim_encoder:: (((sim_encoder))) Simulated quadrature encoder. <<sec:simulated-encoder,Description>>.
-
-sphereprobe:: (((sphereprobe))) Probe a pretend hemisphere.
-
-steptest:: (((steptest))) Used by Stepconf to allow testing of acceleration and velocity values for an axis.
-
-streamer:: (((streamer))) Stream file data into HAL in real time.
-
-supply:: (((supply))) Set output pins with values from parameters (deprecated).
-
-threadtest:: (((threadtest))) Component for testing thread behavior.
-
-time:: (((time))) Accumulated run-time timer counts HH:MM:SS of 'active' input.
-
-timedelay:: (((timedelay))) The equivalent of a time-delay relay.
-
-timedelta:: (((timedelta))) Component that measures thread scheduling timing behavior.
-
-toggle2nist:: (((toggle2nist))) Toggle button to nist logic.
-
-toggle:: (((toggle))) Push-on, push-off from momentary pushbuttons.
-
-tristate_bit:: (((tristate_bit))) Place a signal on an I/O pin only when enabled, similar to a tristate
-  buffer in electronics.
-
-tristate_float:: (((tristate_float))) Place a signal on an I/O pin only when enabled, similar to a tristate
-  buffer in electronics.
-
-watchdog:: (((watchdog))) Monitor one to thirty-two inputs for a 'heartbeat'.
+to the smoothing level desired. Divide the axis.N.jog-scale values by scale. ||
+| joyhandle | Sets nonlinear joypad movements, deadbands and scales. ||
+| knob2float | Convert counts (probably from an encoder) to a float value. ||
+| minmax | Track the minimum and maximum values of the input to the outputs. ||
+| sample_hold | Sample and Hold. ||
+| sampler | Sample data from HAL in real time. ||
+| siggen | Signal generator. <<sec:siggen,Description>>. ||
+| sim_encoder | Simulated quadrature encoder. <<sec:simulated-encoder,Description>>. ||
+| sphereprobe | Probe a pretend hemisphere. ||
+| steptest | Used by Stepconf to allow testing of acceleration and velocity values for an axis. ||
+| streamer | Stream file data into HAL in real time. ||
+| supply | Set output pins with values from parameters (deprecated). ||
+| threadtest | Component for testing thread behavior. ||
+| time | Accumulated run-time timer counts HH:MM:SS of 'active' input. ||
+| timedelay | The equivalent of a time-delay relay. ||
+| timedelta | Component that measures thread scheduling timing behavior. ||
+| toggle2nist | Toggle button to nist logic. ||
+| toggle | Push-on, push-off from momentary pushbuttons. ||
+| tristate_bit | Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics. ||
+| tristate_float | Place a signal on an I/O pin only when enabled, similar to a tristatebuffer in electronics. ||
+| watchdog | Monitor one to thirty-two inputs for a 'heartbeat'. ||
+|=======================
 
 == HAL API calls
 

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -34,8 +34,7 @@ man axis (or perhaps 'man 1 axis' if your system requires it.)
 
 [{tab_options}]
 |=======================
-| gs2 | HAL userspace component for Automation Direct GS2 VFD's. ||
-| mb2hal | ||
+| mb2hal | MB2HAL is a generic userspace HAL component to communicate with one or more Modbus devices. Modbus RTU and Modbus TCP is supported.||
 |=======================
 
 === Diagnostic and Configuration Tools
@@ -43,15 +42,14 @@ man axis (or perhaps 'man 1 axis' if your system requires it.)
 [{tab_options}]
 |=======================
 | halmeter | Observe HAL pins, signals, and parameters. ||
-| halshow |||
-| halscope |||
+| halshow  | Show HAL parameters, pins and signals ||
+| halscope | Software oscilloscope for viewing real time waveforms of HAL pins and signals ||
 |=======================
 
 === Other
 
 [{tab_options}]
 |=======================
-| comp | Build, compile and install LinuxCNC HAL components. ||
 | halcmd | Manipulate the Enhanced Machine Controller HAL from the command line. ||
 | hal_input | Control HAL pins with any Linux input device, including USB HID devices. ||
 | halrun | Manipulate the Enhanced Machine Controller HAL from the command line. ||
@@ -62,6 +60,8 @@ man axis (or perhaps 'man 1 axis' if your system requires it.)
 | linuxcnc | LinuxCNC (The Enhanced Machine Controller). ||
 | shuttle | control HAL pins with the ShuttleXpress and ShuttlePRO devices made by Contour Design. ||
 |=======================
+
+include::components_gen1.adoc[]
 
 [[sec:realtime-components]]
 
@@ -160,6 +160,7 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 
 [{tab_options}]
 |=======================
+| gs2 | HAL userspace component for Automation Direct GS2 VFD's. ||
 | hal_ppmc | Pico Systems <<cha:pico-drivers,driver>> for analog servo, PWM and Stepper controller. ||
 | hm2_7i43 | Mesa Electronics driver for the 7i43 EPP Anything IO board with HostMot2. (See the man page for more information) ||
 | hm2_pci | Mesa Electronics driver for the 5i20, 5i22, 5i23, 4i65, and 4i68 Anything I/O boards, with HostMot2 firmware. (See the man page for more information) ||
@@ -214,6 +215,7 @@ clarkeinv:: (((clarkeinv))) Inverse Clarke transform.
 
 [{tab_options}]
 |=======================
+| comp | Build, compile and install LinuxCNC HAL components. ||
 |motion | Accepts NML motion commands, interacts with HAL in realtime. ||
 |classicladder | Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
 |threads | Creates hard realtime HAL threads. ||
@@ -254,6 +256,8 @@ to the smoothing level desired. Divide the axis.N.jog-scale values by scale. ||
 | tristate_float | Place a signal on an I/O pin only when enabled, similar to a tristatebuffer in electronics. ||
 | watchdog | Monitor one to thirty-two inputs for a 'heartbeat'. ||
 |=======================
+
+include::components_gen9.adoc[]
 
 == HAL API calls
 

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -18,9 +18,6 @@ To view the information in the man page, in a terminal window type:
 man axis (or perhaps 'man <n> axis' if your system requires it. n = 1 for userspace and 9 for realtime components)
 ----
 
-[[sec:realtime-components]]
-
-
 [NOTE]
 See also the 'Man Pages' section of the link:../index.html[docs main page] or the
 link:../man/[directory listing].
@@ -109,7 +106,6 @@ instance||
 | link:../man/man1/xhc-whb04b-6.1.html[xhc-whb04b-6] |Userspace jog dial HAL component for the wireless XHC WHB04B-6 USB device&.||
 |=======================
 
-[[sec:Realtime-Components-pilotes]]
 === Mesa and other I/O Cards (Realtime)
 [{tab_options}]
 |=======================
@@ -194,7 +190,6 @@ Smart-serial remote parameters can now be set in the HAL file in the normal way.
 | link:../man/man9/xor2.9.html[xor2] | Two-input XOR (exclusive OR) gate ||
 |=======================
 
-[[sec:Realtime-Components-flottant]]
 ==== Arithmetic and float
 [{tab_options}]
 |=======================
@@ -260,7 +255,6 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 | link:../man/man9/gray2bin.9.html[gray2bin] |Convert a gray-code input to binary||
 |=======================
 
-[[sec:Realtime-Components-cinematiques]]
 === Kinematics (Realtime)
 [{tab_options}]
 |=======================

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -21,12 +21,12 @@ man axis (or perhaps 'man 1 axis' if your system requires it.)
 
 [{tab_options}]
 |=======================
-| axis | AXIS LinuxCNC (The Enhanced Machine Controller) Graphical User Interface. ||
-| axis-remote | AXIS Remote Interface. ||
-| gladevcp | Virtual Control Panel for LinuxCNC based on Glade, Gtk and HAL widgets. ||
-| gladevcp | Displays Virtual Control Panels built with GTK/Glade. ||
-| halui | Observe HAL pins and command LinuxCNC through NML. ||
-| pyvcp | Virtual Control Panel for LinuxCNC. ||
+| link:../man/man1/axis.1.html[axis] | AXIS LinuxCNC (The Enhanced Machine Controller) Graphical User Interface. ||
+| link:../man/man1/axis-remote.1.html[axis-remote] | AXIS Remote Interface. ||
+| link:../man/man1/gladevcp.1.html[gladevcp] | Virtual Control Panel for LinuxCNC based on Glade, Gtk and HAL widgets. ||
+| link:../man/man1/gladevcp.1.html[gladevcp] | Displays Virtual Control Panels built with GTK/Glade. ||
+| link:../man/man1/halui.1.html[halui] | Observe HAL pins and command LinuxCNC through NML. ||
+| link:../man/man1/pyvcp.1.html[pyvcp] | Virtual Control Panel for LinuxCNC. ||
 
 |=======================
 
@@ -34,31 +34,31 @@ man axis (or perhaps 'man 1 axis' if your system requires it.)
 
 [{tab_options}]
 |=======================
-| mb2hal | MB2HAL is a generic userspace HAL component to communicate with one or more Modbus devices. Modbus RTU and Modbus TCP is supported.||
+| link:../man/man1/mb2hal.1.html[mb2hal] | MB2HAL is a generic userspace HAL component to communicate with one or more Modbus devices. Modbus RTU and Modbus TCP is supported.||
 |=======================
 
 === Diagnostic and Configuration Tools
 
 [{tab_options}]
 |=======================
-| halmeter | Observe HAL pins, signals, and parameters. ||
-| halshow  | Show HAL parameters, pins and signals ||
-| halscope | Software oscilloscope for viewing real time waveforms of HAL pins and signals ||
+| link:../man/man1/halmeter.1.html[halmeter] | Observe HAL pins, signals, and parameters. ||
+| link:../man/man1/halshow.1.html[halshow]  | Show HAL parameters, pins and signals ||
+| link:../man/man1/halscope.1.html[halscope] | Software oscilloscope for viewing real time waveforms of HAL pins and signals ||
 |=======================
 
 === Other
 
 [{tab_options}]
 |=======================
-| halcmd | Manipulate the Enhanced Machine Controller HAL from the command line. ||
-| hal_input | Control HAL pins with any Linux input device, including USB HID devices. ||
-| halrun | Manipulate the Enhanced Machine Controller HAL from the command line. ||
-| halsampler | Sample data from HAL in realtime. ||
-| halstreamer | Stream file data into HAL in real time. ||
-| io | Accepts NML I/O commands, interacts with HAL in userspace. ||
-| iocontrol | Accepts NML I/O commands, interacts with HAL in userspace. ||
-| linuxcnc | LinuxCNC (The Enhanced Machine Controller). ||
-| shuttle | control HAL pins with the ShuttleXpress and ShuttlePRO devices made by Contour Design. ||
+| link:../man/man1/halcmd.1.html[halcmd] | Manipulate the Enhanced Machine Controller HAL from the command line. ||
+| link:../man/man1/hal_input.1.html[hal_input] | Control HAL pins with any Linux input device, including USB HID devices. ||
+| link:../man/man1/halrun.1.html[halrun] | Manipulate the Enhanced Machine Controller HAL from the command line. ||
+| link:../man/man1/halsampler.1.html[halsampler] | Sample data from HAL in realtime. ||
+| link:../man/man1/halstreamer.1.html[halstreamer] | Stream file data into HAL in real time. ||
+| link:../man/man1/io.1.html[io] | Accepts NML I/O commands, interacts with HAL in userspace. ||
+| link:../man/man1/iocontrol.1.html[iocontrol] | Accepts NML I/O commands, interacts with HAL in userspace. ||
+| link:../man/man1/linuxcnc.1.html[linuxcnc] | LinuxCNC (The Enhanced Machine Controller). ||
+| link:../man/man1/shuttle.1.html[shuttle] | control HAL pins with the ShuttleXpress and ShuttlePRO devices made by Contour Design. ||
 |=======================
 
 include::components_gen1.adoc[]
@@ -85,19 +85,19 @@ link:../man/man9/[directory listing of man9].
 
 [cols="15s,85,0,0", frame="none", grid="none"]
 |=======================
-| and2 | Two-input AND gate. For out to be true both inputs must be true. (link:../man/man9/and2.9.html[and2]) ||
-| not  | Inverter ||
-| or2  | Two-input OR gate ||
-| xor2 | Two-input XOR (exclusive OR) gate ||
-| dbounce | Filter noisy digital inputs. link:../man/man9/dbounce.9.html[Details].                                   | |
-| debounce | Filter noisy digital inputs. link:../man/man9/debounce.9.html[Details]. <<sec:debounce, Description>>  | |
-| edge | Edge detector. | |
-| flipflop | D type flip-flop. | |
-| oneshot | One-shot pulse generator. | |
-| logic | General logic function component. | |
-| lut5 | A 5-input logic function based on a look-up table. <<sec:lut5,Description>> | |
-| match8 | 8-bit binary match detector. | |
-| select8 | 8-bit binary match detector. | |
+| link:../man/man9/and2.9.html[and2] | Two-input AND gate. For out to be true both inputs must be true. (link:../man/man9/and2.9.html[and2]) ||
+| link:../man/man9/not.9.html[not]  | Inverter ||
+| link:../man/man9/or2.9.html[or2]  | Two-input OR gate ||
+| link:../man/man9/xor2.9.html[xor2] | Two-input XOR (exclusive OR) gate ||
+| link:../man/man9/dbounce.9.html[dbounce] | Filter noisy digital inputs. link:../man/man9/dbounce.9.html[Details].                                   | |
+| link:../man/man9/debounce.9.html[debounce] | Filter noisy digital inputs. link:../man/man9/debounce.9.html[Details]. <<sec:debounce, Description>>  | |
+| link:../man/man9/edge.9.html[edge] | Edge detector. | |
+| link:../man/man9/flipflop.9.html[flipflop] | D type flip-flop. | |
+| link:../man/man9/oneshot.9.html[oneshot] | One-shot pulse generator. | |
+| link:../man/man9/logic.9.html[logic] | General logic function component. | |
+| link:../man/man9/lut5.9.html[lut5] | A 5-input logic function based on a look-up table. <<sec:lut5,Description>> | |
+| link:../man/man9/match8.9.html[match8] | 8-bit binary match detector. | |
+| link:../man/man9/select8.9.html[select8] | 8-bit binary match detector. | |
 |=======================
 
 
@@ -106,53 +106,53 @@ link:../man/man9/[directory listing of man9].
 
 [{tab_options}]
 |=======================
-| abs | Compute the absolute value and sign of the input signal.                                  | |
-| blend | Perform linear interpolation between two values. | |
-| comp | Two input comparator with hysteresis. | |
-| constant | Use a parameter to set the value of a pin. | |
-| sum2 | Sum of two inputs (each with a gain) and an offset. | |
-| counter | Counts input pulses (deprecated). Use the <<sec:encoder, encoder>> component.  | |
-| updown | Counts up or down, with optional limits and wraparound behavior. | |
-| ddt | Compute the derivative of the input function. | |
-| deadzone | Return the center if within the threshold. | |
-| hypot | Three-input hypotenuse (Euclidean distance) calculator. | |
-| mult2 | Product of two inputs. | |
-| mux16 | Select from one of sixteen input values. | |
-| mux2 | Select from one of two input values. | |
-| mux4 | Select from one of four input values. | |
-| mux8 | Select from one of eight input values. | |
-| near | Determine whether two values are roughly equal. | |
-| offset | Adds an offset to an input, and subtracts it from the feedback value. | |
-| integ | Integrator. | |
-| invert | Compute the inverse of the input signal. | |
-| wcomp | Window comparator. | |
-| weighted_sum | Convert a group of bits to an integer. | |
-| biquad | Biquad IIR filter | |
-| lowpass | Low-pass filter | |
-| limit1 | Limit the output signal to fall between min and max. footnote:[When the input is a position, this means that the 'position' is limited.] | |
-| limit2 | Limit the output signal to fall between min and max.  Limit its slew rate to less than maxv per second. 
+| link:../man/man9/abs.9.html[abs] | Compute the absolute value and sign of the input signal.                                  | |
+| link:../man/man9/blend.9.html[blend] | Perform linear interpolation between two values. | |
+| link:../man/man9/comp.9.html[comp] | Two input comparator with hysteresis. | |
+| link:../man/man9/constant.9.html[constant] | Use a parameter to set the value of a pin. | |
+| link:../man/man9/sum2.9.html[sum2] | Sum of two inputs (each with a gain) and an offset. | |
+| link:../man/man9/counter.9.html[counter] | Counts input pulses (deprecated). Use the <<sec:encoder, encoder>> component.  | |
+| link:../man/man9/updown.9.html[updown] | Counts up or down, with optional limits and wraparound behavior. | |
+| link:../man/man9/ddt.9.html[ddt] | Compute the derivative of the input function. | |
+| link:../man/man9/deadzone.9.html[deadzone] | Return the center if within the threshold. | |
+| link:../man/man9/hypot.9.html[hypot] | Three-input hypotenuse (Euclidean distance) calculator. | |
+| link:../man/man9/mult2.9.html[mult2] | Product of two inputs. | |
+| link:../man/man9/mux16.9.html[mux16] | Select from one of sixteen input values. | |
+| link:../man/man9/mux2.9.html[mux2] | Select from one of two input values. | |
+| link:../man/man9/mux4.9.html[mux4] | Select from one of four input values. | |
+| link:../man/man9/mux8.9.html[mux8] | Select from one of eight input values. | |
+| link:../man/man9/near.9.html[near] | Determine whether two values are roughly equal. | |
+| link:../man/man9/offset.9.html[offset] | Adds an offset to an input, and subtracts it from the feedback value. | |
+| link:../man/man9/integ.9.html[integ] | Integrator. | |
+| link:../man/man9/invert.9.html[invert] | Compute the inverse of the input signal. | |
+| link:../man/man9/wcomp.9.html[wcomp] | Window comparator. | |
+| link:../man/man9/weighted_sum.9.html[weighted_sum] | Convert a group of bits to an integer. | |
+| link:../man/man9/biquad.9.html[biquad] | Biquad IIR filter | |
+| link:../man/man9/lowpass.9.html[lowpass] | Low-pass filter | |
+| link:../man/man9/limit1.9.html[limit1] | Limit the output signal to fall between min and max. footnote:[When the input is a position, this means that the 'position' is limited.] | |
+| link:../man/man9/limit2.9.html[limit2] | Limit the output signal to fall between min and max.  Limit its slew rate to less than maxv per second. 
 footnote:[When the input is a position, this means that 'position' and 'velocity' are limited.]  | |
-| limit3 | Limit the output signal to fall between min and max. 
+| link:../man/man9/limit3.9.html[limit3] | Limit the output signal to fall between min and max. 
 Limit its slew rate to less than maxv per second. Limit its second derivative to less than MaxA per second squared. footnote:[When
  the input is a position, this means that the 'position', 'velocity', and 'acceleration' are limited.] | |
-| maj3 | Compute the majority of 3 inputs. | |
-| scale | Applies a scale and offset to its input. | |
+| link:../man/man9/maj3.9.html[maj3] | Compute the majority of 3 inputs. | |
+| link:../man/man9/scale.9.html[scale] | Applies a scale and offset to its input. | |
 |=======================
 
 === Type conversion
 
 [{tab_options}]
 |=======================
-| conv_bit_s32 | Convert a value from bit to s32.     ||
-| conv_bit_u32 | Convert a value from bit to u32.     ||
-| conv_float_s32 | Convert a value from float to s32. ||
-| conv_float_u32 | Convert a value from float to u32. ||
-| conv_s32_bit | Convert a value from s32 to bit.     ||
-| conv_s32_float | Convert a value from s32 to float. ||
-| conv_s32_u32 | Convert a value from s32 to u32.     ||
-| conv_u32_bit | Convert a value from u32 to bit.     ||
-| conv_u32_float | Convert a value from u32 to float. ||
-| conv_u32_s32 | Convert a value from u32 to s32.     ||
+| link:../man/man9/conv_bit_s32.9.html[conv_bit_s32] | Convert a value from bit to s32.     ||
+| link:../man/man9/conv_bit_u32.9.html[conv_bit_u32] | Convert a value from bit to u32.     ||
+| link:../man/man9/conv_float_s32.9.html[conv_float_s32] | Convert a value from float to s32. ||
+| link:../man/man9/conv_float_u32.9.html[conv_float_u32] | Convert a value from float to u32. ||
+| link:../man/man9/conv_s32_bit.9.html[conv_s32_bit] | Convert a value from s32 to bit.     ||
+| link:../man/man9/conv_s32_float.9.html[conv_s32_float] | Convert a value from s32 to float. ||
+| link:../man/man9/conv_s32_u32.9.html[conv_s32_u32] | Convert a value from s32 to u32.     ||
+| link:../man/man9/conv_u32_bit.9.html[conv_u32_bit] | Convert a value from u32 to bit.     ||
+| link:../man/man9/conv_u32_float.9.html[conv_u32_float] | Convert a value from u32 to float. ||
+| link:../man/man9/conv_u32_s32.9.html[conv_u32_s32] | Convert a value from u32 to s32.     ||
 |=======================
 
 [[sec:Realtime-Components-pilotes]]
@@ -162,14 +162,14 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 |=======================
 | gs2 | HAL userspace component for Automation Direct GS2 VFD's. ||
 | hal_ppmc | Pico Systems <<cha:pico-drivers,driver>> for analog servo, PWM and Stepper controller. ||
-| hm2_7i43 | Mesa Electronics driver for the 7i43 EPP Anything IO board with HostMot2. (See the man page for more information) ||
-| hm2_pci | Mesa Electronics driver for the 5i20, 5i22, 5i23, 4i65, and 4i68 Anything I/O boards, with HostMot2 firmware. (See the man page for more information) ||
-| hostmot2 | Mesa Electronics <<cha:mesa-hostmot2-driver,driver>> for the HostMot2 firmware. ||
-| mesa_7i65 | Mesa Electronics driver for the 7i65 eight-axis servo card. (See the man page for more information) ||
+| link:../man/man9/hm2_7i43.9.html[hm2_7i43] | Mesa Electronics driver for the 7i43 EPP Anything IO board with HostMot2. (See the man page for more information) ||
+| link:../man/man9/hm2_pci.9.html[hm2_pci] | Mesa Electronics driver for the 5i20, 5i22, 5i23, 4i65, and 4i68 Anything I/O boards, with HostMot2 firmware. (See the man page for more information) ||
+| link:../man/man9/hostmot2.9.html[hostmot2] | Mesa Electronics <<cha:mesa-hostmot2-driver,driver>> for the HostMot2 firmware. ||
+| link:../man/man9/mesa_7i65.9.html[mesa_7i65] | Mesa Electronics driver for the 7i65 eight-axis servo card. (See the man page for more information) ||
 | pluto_servo | Pluto-P <<cha:pluto-p-driver,driver>> and firmware for the parallel port FPGA, for servos. ||
 | pluto_step | Pluto-P <<cha:pluto-p-driver,driver>> for the parallel port FPGA, for steppers. ||
-| thc | Torch Height Control using a Mesa THC card or any analog to velocity input ||
-| serport | Hardware driver for the digital I/O bits of the 8250 and 16550 serial port. ||
+| link:../man/man9/thc.9.html[thc] | Torch Height Control using a Mesa THC card or any analog to velocity input ||
+| link:../man/man9/serport.9.html[serport] | Hardware driver for the digital I/O bits of the 8250 and 16550 serial port. ||
 |=======================
 
 [[sec:Realtime-Components-cinematiques]]
@@ -177,28 +177,28 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 
 [{tab_options}]
 |=======================
-| kins | kinematics definitions for LinuxCNC. ||
-| gantrykins | A kinematics module that maps one axis to multiple joints. ||
-| genhexkins | Gives six degrees of freedom in position and orientation (XYZABC). The location of the motors is defined at compile time. ||
-| genserkins | Kinematics that can model a general serial-link manipulator with up to 6 angular joints. ||
-| maxkins | Kinematics for a tabletop 5 axis mill named 'max' with tilting head (B axis) and horizontal rotary mounted to the table (C axis).
+| link:../man/man9/kins.9.html[kins] | kinematics definitions for LinuxCNC. ||
+| link:../man/man9/gantrykins.9.html[gantrykins] | A kinematics module that maps one axis to multiple joints. ||
+| link:../man/man9/genhexkins.9.html[genhexkins] | Gives six degrees of freedom in position and orientation (XYZABC). The location of the motors is defined at compile time. ||
+| link:../man/man9/genserkins.9.html[genserkins] | Kinematics that can model a general serial-link manipulator with up to 6 angular joints. ||
+| link:../man/man9/maxkins.9.html[maxkins] | Kinematics for a tabletop 5 axis mill named 'max' with tilting head (B axis) and horizontal rotary mounted to the table (C axis).
  Provides UVW motion in the rotated coordinate system. The source file, maxkins.c, may be a useful starting point for other 5-axis systems. ||
-| tripodkins | The joints represent the distance of the controlled point from three predefined locations (the motors), giving three degrees of freedom in position (XYZ). ||
-| trivkins | There is a 1:1 correspondence between joints and axes. Most standard milling machines and lathes use the trivial kinematics module. ||
-| pumakins | Kinematics for PUMA-style robots. ||
-| rotatekins | The X and Y axes are rotated 45 degrees compared to the joints 0 and 1. ||
-| scarakins | Kinematics for SCARA-type robots. ||
+| link:../man/man9/tripodkins.9.html[tripodkins] | The joints represent the distance of the controlled point from three predefined locations (the motors), giving three degrees of freedom in position (XYZ). ||
+| link:../man/man9/trivkins.9.html[trivkins] | There is a 1:1 correspondence between joints and axes. Most standard milling machines and lathes use the trivial kinematics module. ||
+| link:../man/man9/pumakins.9.html[pumakins] | Kinematics for PUMA-style robots. ||
+| link:../man/man9/rotatekins.9.html[rotatekins] | The X and Y axes are rotated 45 degrees compared to the joints 0 and 1. ||
+| link:../man/man9/scarakins.9.html[scarakins] | Kinematics for SCARA-type robots. ||
 |=======================
 
 === Motor control
 
 [{tab_options}]
 |=======================
-| at_pid | Proportional/integral/derivative controller with auto tuning. ||
-| pid | Proportional/integral/derivative controller. <<sec:pid,Description>> ||
-| pwmgen | Software PWM/PDM generation. <<sec:pwmgen,Description>> ||
-| encoder | Software counting of quadrature encoder signals. <<sec:encoder,Description>>. ||
-| stepgen | Software step pulse generation. <<sec:stepgen,Description>>. ||
+| link:../man/man9/at_pid.9.html[at_pid] | Proportional/integral/derivative controller with auto tuning. ||
+| link:../man/man9/pid.9.html[pid] | Proportional/integral/derivative controller. <<sec:pid,Description>> ||
+| link:../man/man9/pwmgen.9.html[pwmgen] | Software PWM/PDM generation. <<sec:pwmgen,Description>> ||
+| link:../man/man9/encoder.9.html[encoder] | Software counting of quadrature encoder signals. <<sec:encoder,Description>>. ||
+| link:../man/man9/stepgen.9.html[stepgen] | Software step pulse generation. <<sec:stepgen,Description>>. ||
 |=======================
 
 === BLDC and 3-phase motor control
@@ -206,28 +206,28 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 [{tab_options}]
 |=======================
 | bldc_hall3 | 3-wire Bipolar trapezoidal commutation BLDC motor driver using Hall sensors. ||
-| clarke2 | Two input version of Clarke transform. ||
-| clarke3 | Clarke (3 phase to cartesian) transform. ||
-| clarkeinv | Inverse Clarke transform. ||
+| link:../man/man9/clarke2.9.html[clarke2] | Two input version of Clarke transform. ||
+| link:../man/man9/clarke3.9.html[clarke3] | Clarke (3 phase to cartesian) transform. ||
+| link:../man/man9/clarkeinv.9.html[clarkeinv] | Inverse Clarke transform. ||
 |=======================
 
 clarkeinv:: (((clarkeinv))) Inverse Clarke transform.
 
 [{tab_options}]
 |=======================
-| comp | Build, compile and install LinuxCNC HAL components. ||
-|motion | Accepts NML motion commands, interacts with HAL in realtime. ||
-|classicladder | Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
-|threads | Creates hard realtime HAL threads. ||
-| charge_pump | Creates a square-wave for the 'charge pump' input of some controller boards.
+| link:../man/man9/comp.9.html[comp] | Build, compile and install LinuxCNC HAL components. ||
+|link:../man/man9/motion.9.html[motion] | Accepts NML motion commands, interacts with HAL in realtime. ||
+|link:../man/man9/classicladder.9.html[classicladder] | Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
+|link:../man/man9/threads.9.html[threads] | Creates hard realtime HAL threads. ||
+| link:../man/man9/charge_pump.9.html[charge_pump] | Creates a square-wave for the 'charge pump' input of some controller boards.
 The 'Charge Pump' should be added to the base thread function. When enabled the output is on for one period and off for one period. 
 To calculate the frequency of the output 1/(period time in seconds x 2) = hz. For example if you have a base period of 100,000ns that 
 is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 hz or 5 Khz. ||
-| encoder_ratio | An electronic gear to synchronize two axes. ||
-| estop_latch | ESTOP latch. ||
-| feedcomp | Multiply the input by the ratio of current velocity to the feed rate. ||
-| gearchange | Select from one of two speed ranges. ||
-| ilowpass | While it may find other applications,
+| link:../man/man9/encoder_ratio.9.html[encoder_ratio] | An electronic gear to synchronize two axes. ||
+| link:../man/man9/estop_latch.9.html[estop_latch] | ESTOP latch. ||
+| link:../man/man9/feedcomp.9.html[feedcomp] | Multiply the input by the ratio of current velocity to the feed rate. ||
+| link:../man/man9/gearchange.9.html[gearchange] | Select from one of two speed ranges. ||
+| link:../man/man9/ilowpass.9.html[ilowpass] | While it may find other applications,
 this component was written to create smoother motion while jogging with an MPG.
 In a machine with high acceleration, a short jog can behave almost like a step
 function. By putting the ilowpass component between the MPG encoder counts
@@ -235,26 +235,26 @@ output and the axis jog-counts input, this can be smoothed.
 Choose scale conservatively so that during a single session there will never
 be more than about 2e9/scale pulses seen on the MPG. Choose gain according
 to the smoothing level desired. Divide the axis.N.jog-scale values by scale. ||
-| joyhandle | Sets nonlinear joypad movements, deadbands and scales. ||
-| knob2float | Convert counts (probably from an encoder) to a float value. ||
-| minmax | Track the minimum and maximum values of the input to the outputs. ||
-| sample_hold | Sample and Hold. ||
-| sampler | Sample data from HAL in real time. ||
-| siggen | Signal generator. <<sec:siggen,Description>>. ||
-| sim_encoder | Simulated quadrature encoder. <<sec:simulated-encoder,Description>>. ||
-| sphereprobe | Probe a pretend hemisphere. ||
-| steptest | Used by Stepconf to allow testing of acceleration and velocity values for an axis. ||
-| streamer | Stream file data into HAL in real time. ||
-| supply | Set output pins with values from parameters (deprecated). ||
-| threadtest | Component for testing thread behavior. ||
-| time | Accumulated run-time timer counts HH:MM:SS of 'active' input. ||
-| timedelay | The equivalent of a time-delay relay. ||
-| timedelta | Component that measures thread scheduling timing behavior. ||
-| toggle2nist | Toggle button to nist logic. ||
-| toggle | Push-on, push-off from momentary pushbuttons. ||
-| tristate_bit | Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics. ||
-| tristate_float | Place a signal on an I/O pin only when enabled, similar to a tristatebuffer in electronics. ||
-| watchdog | Monitor one to thirty-two inputs for a 'heartbeat'. ||
+| link:../man/man9/joyhandle.9.html[joyhandle] | Sets nonlinear joypad movements, deadbands and scales. ||
+| link:../man/man9/knob2float.9.html[knob2float] | Convert counts (probably from an encoder) to a float value. ||
+| link:../man/man9/minmax.9.html[minmax] | Track the minimum and maximum values of the input to the outputs. ||
+| link:../man/man9/sample_hold.9.html[sample_hold] | Sample and Hold. ||
+| link:../man/man9/sampler.9.html[sampler] | Sample data from HAL in real time. ||
+| link:../man/man9/siggen.9.html[siggen] | Signal generator. <<sec:siggen,Description>>. ||
+| link:../man/man9/sim_encoder.9.html[sim_encoder] | Simulated quadrature encoder. <<sec:simulated-encoder,Description>>. ||
+| link:../man/man9/sphereprobe.9.html[sphereprobe] | Probe a pretend hemisphere. ||
+| link:../man/man9/steptest.9.html[steptest] | Used by Stepconf to allow testing of acceleration and velocity values for an axis. ||
+| link:../man/man9/streamer.9.html[streamer] | Stream file data into HAL in real time. ||
+| link:../man/man9/supply.9.html[supply] | Set output pins with values from parameters (deprecated). ||
+| link:../man/man9/threadtest.9.html[threadtest] | Component for testing thread behavior. ||
+| link:../man/man9/time.9.html[time] | Accumulated run-time timer counts HH:MM:SS of 'active' input. ||
+| link:../man/man9/timedelay.9.html[timedelay] | The equivalent of a time-delay relay. ||
+| link:../man/man9/timedelta.9.html[timedelta] | Component that measures thread scheduling timing behavior. ||
+| link:../man/man9/toggle2nist.9.html[toggle2nist] | Toggle button to nist logic. ||
+| link:../man/man9/toggle.9.html[toggle] | Push-on, push-off from momentary pushbuttons. ||
+| link:../man/man9/tristate_bit.9.html[tristate_bit] | Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics. ||
+| link:../man/man9/tristate_float.9.html[tristate_float] | Place a signal on an I/O pin only when enabled, similar to a tristatebuffer in electronics. ||
+| link:../man/man9/watchdog.9.html[watchdog] | Monitor one to thirty-two inputs for a 'heartbeat'. ||
 |=======================
 
 include::components_gen9.adoc[]

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -1,88 +1,169 @@
 :lang: en
-[[cha:hal-components]]
 :tab_options: cols="15s,85,0,0", frame="none", grid="none"
 
 [[cha:hal-components]]
 = HAL Component List((("HAL Component List")))
 
-== Commands and Userspace Components
+== Components
 
-All of the commands in the following list have man pages. 
+// < explanation of the difference between a real-time and a userspace component >
+
+Most of the commands in the following list have man pages. 
 Some will have expanded descriptions, some will have limited descriptions. 
 From this list you know what components exist, 
-and you can use 'man n name' to get additional information. 
+and you can use 'man name' to get additional information.
 To view the information in the man page, in a terminal window type: 
 
 ----
-man axis (or perhaps 'man 1 axis' if your system requires it.)
+man axis (or perhaps 'man <n> axis' if your system requires it. n = 1 for userspace and 9 for realtime components)
 ----
-
-
-=== User interface
-
-[{tab_options}]
-|=======================
-| axis | AXIS LinuxCNC (The Enhanced Machine Controller) Graphical User Interface. ||
-| axis-remote | AXIS Remote Interface. ||
-| gladevcp | Virtual Control Panel for LinuxCNC based on Glade, Gtk and HAL widgets. ||
-| gladevcp | Displays Virtual Control Panels built with GTK/Glade. ||
-| halui | Observe HAL pins and command LinuxCNC through NML. ||
-| pyvcp | Virtual Control Panel for LinuxCNC. ||
-
-|=======================
-
-=== Hardware Drivers
-
-[{tab_options}]
-|=======================
-| gs2 | HAL userspace component for Automation Direct GS2 VFD's. ||
-| mb2hal | ||
-|=======================
-
-=== Diagnostic and Configuration Tools
-
-[{tab_options}]
-|=======================
-| halmeter | Observe HAL pins, signals, and parameters. ||
-| halshow |||
-| halscope |||
-|=======================
-
-=== Other
-
-[{tab_options}]
-|=======================
-| comp | Build, compile and install LinuxCNC HAL components. ||
-| halcmd | Manipulate the Enhanced Machine Controller HAL from the command line. ||
-| hal_input | Control HAL pins with any Linux input device, including USB HID devices. ||
-| halrun | Manipulate the Enhanced Machine Controller HAL from the command line. ||
-| halsampler | Sample data from HAL in realtime. ||
-| halstreamer | Stream file data into HAL in real time. ||
-| io | Accepts NML I/O commands, interacts with HAL in userspace. ||
-| iocontrol | Accepts NML I/O commands, interacts with HAL in userspace. ||
-| linuxcnc | LinuxCNC (The Enhanced Machine Controller). ||
-| shuttle | control HAL pins with the ShuttleXpress and ShuttlePRO devices made by Contour Design. ||
-|=======================
 
 [[sec:realtime-components]]
 
-== Realtime Components
 
-Some of these will have expanded descriptions from the man pages.
-Some will have limited descriptions. All of the components have man pages.
-From this list you know what components exist and can use 'man n name' to get additional information.
-To view the information in the man page, in a terminal window type:
-
-----
-man motion
-# or
-man 9 motion
-----
-
+[NOTE]
 See also the 'Man Pages' section of the link:../index.html[docs main page] or the
-link:../man/man9/[directory listing of man9].
+link:../man/[directory listing].
 
-=== Logic and Bitwise components
+
+=== User Interfaces (Userspace)
+==== Machine Control
+[{tab_options}]
+|=======================
+| link:../man/man1/axis.1.html[axis] | AXIS LinuxCNC (The Enhanced Machine Controller) Graphical User Interface. ||
+| link:../man/man1/axis-remote.1.html[axis-remote] | AXIS Remote Interface. ||
+| link:../man/man1/gmoccapy.1.html[gmoccapy] |TOUCHY LinuxCNC Graphical User Interface||
+| link:../man/man1/gscreen.1.html[gscreen] |TOUCHY LinuxCNC Graphical User Interface||
+| link:../man/man1/halui.1.html[halui] | Observe HAL pins and command LinuxCNC through NML. ||
+| link:../man/man1/mdro.1.html[mdro] |manual only Digital Read Out (DRO)||
+| link:../man/man1/ngcgui.1.html[ngcgui] |a framework for conversational G-code generation on the controller||
+| link:../man/man1/panelui.1.html[panelui] |short description||
+| link:../man/man1/pyngcgui.1.html[pyngcgui] |python implementation of ngcgui||
+| link:../man/man1/touchy.1.html[touchy] |axis - TOUCHY LinuxCNC Graphical User Interface||
+|=======================
+
+==== Virtual Control Panels (VCP)
+[{tab_options}]
+|=======================
+| link:../man/man1/gladevcp.1.html[gladevcp] | Virtual Control Panel for LinuxCNC based on Glade, Gtk and HAL widgets. ||
+| link:../man/man1/gladevcp_demo.1.html[gladevcp_demo] |gladevcp - used by sample configs to deonstrate Glade Virtual_demo||
+| link:../man/man1/gremlin_view.1.html[gremlin_view] |G-code graphical preview||
+| link:../man/man1/moveoff_gui.1.html[moveoff_gui] |a gui for the moveoff component||
+| link:../man/man1/pyui.1.html[pyui] |utility for panelui||
+| link:../man/man1/pyvcp.1.html[pyvcp] | Virtual Control Panel for LinuxCNC. ||
+| link:../man/man1/pyvcp_demo.1.html[pyvcp_demo] |Python Virtual Control Panel demonstration component||
+| link:../man/man1/qtvcp.1.html[qtvcp] |QT based virtual control panels||
+|=======================
+
+==== Vismach Virtual Machines
+[{tab_options}]
+|=======================
+| link:../man/man1/5axisgui.1.html[5axisgui] |Vismach Virtual Machine GUI||
+| link:../man/man1/hbmgui.1.html[hbmgui] |Vismach Virtual Machine GUI||
+| link:../man/man1/hexagui.1.html[hexagui] |Vismach Virtual Machine GUI||
+| link:../man/man1/lineardelta.1.html[lineardelta] |Vismach Virtual Machine GUI||
+| link:../man/man1/maho600gui.1.html[maho600gui] |hexagui - Vismach Virtual Machine GUI||
+| link:../man/man1/max5gui.1.html[max5gui] |hexagui - Vismach Virtual Machine GUI||
+| link:../man/man1/puma560gui.1.html[puma560gui] |puma560agui - Vismach Virtual Machine GUI||
+| link:../man/man1/pumagui.1.html[pumagui] |Vismach Virtual Machine GUI||
+| link:../man/man1/rotarydelta.1.html[rotarydelta] |Vismach Virtual Machine GUI||
+| link:../man/man1/scaragui.1.html[scaragui] |Vismach Virtual Machine GUI||
+| link:../man/man1/xyzac-trt-gui.1.html[xyzac-trt-gui] |Vismach Virtual Machine GUI||
+| link:../man/man1/xyzbc-trt-gui.1.html[xyzbc-trt-gui] |Vismach Virtual Machine GUI||
+|=======================
+
+=== Motion (Userspace)
+[{tab_options}]
+|=======================
+| link:../man/man1/io.1.html[io] |iocontrol - interacts with HAL or G-code in userspace||
+| link:../man/man1/iocontrol.1.html[iocontrol] |interacts with HAL or G-code in userspace||
+| link:../man/man1/iov2.1.html[iov2] |interacts with HAL or G-code in userspace||
+| link:../man/man1/mdi.1.html[mdi] |Send G-code commands from the terminal to the running LinuxCNC
+instance||
+| link:../man/man1/milltask.1.html[milltask] |Userspace task controller for LinuxCNC||
+| link:../man/man9/motion.9.html[motion] | Accepts NML motion commands, interacts with HAL in realtime. ||
+|=======================
+
+=== Hardware Drivers
+==== VFD & Communication Interfaces (Userspace)
+[{tab_options}]
+|=======================
+| link:../man/man1/elbpcom.1.html[elbpcom] |Communicate with Mesa ethernet cards||
+| link:../man/man1/gs2_vfd.1.html[gs2_vfd] |HAL userspace component for Automation Direct GS2 VFD's||
+| link:../man/man1/hal_parport.1.html[hal_parport] |Realtime HAL component to communicate with one or more pc parallel ports.||
+| link:../man/man1/hy_gt_vfd.1.html[hy_gt_vfd] |HAL userspace component for Huanyang GT-series VFDs||
+| link:../man/man1/hy_vfd.1.html[hy_vfd] |HAL userspace component for Huanyang VFDs||
+| link:../man/man1/mb2hal.1.html[mb2hal] | MB2HAL is a generic userspace HAL component to communicate with one or more Modbus devices. Modbus RTU and Modbus TCP is supported.||
+| link:../man/man1/mitsub_vfd.1.html[mitsub_vfd] |HAL userspace component for Mitsubishi A500 F500 E500 A500 D700 E700 F700-series VFDs (others may work)||
+| link:../man/man1/monitor-xhc-hb04.1.html[monitor-xhc-hb04] |monitors the XHC-HB04 pendant and warns of disconnection||
+| link:../man/man1/pi500_vfd.1.html[pi500_vfd] |Powtran PI500 modbus driver||
+| link:../man/man1/pmx485.1.html[pmx485] |Modbus communications with a Powermax Plasma Cutter.||
+| link:../man/man1/pmx485-test.1.html[pmx485-test] |Modbus communications testing with a Powermax Plasma Cutter||
+| link:../man/man1/shuttle.1.html[shuttle] |control HAL pins with the ShuttleXpress, ShuttlePRO, and ShuttlePRO2 device made by Contour Design||
+| link:../man/man1/svd-ps_vfd.1.html[svd-ps_vfd] |HAL userspace component for SVD-P(S) VFDs||
+| link:../man/man1/vfdb_vfd.1.html[vfdb_vfd] |HAL userspace component for Delta VFD-B Variable Frequency Drives||
+| link:../man/man1/vfs11_vfd.1.html[vfs11_vfd] |HAL userspace component for Toshiba-Schneider VF-S11 Variable Frequency Drives||
+| link:../man/man1/wj200_vfd.1.html[wj200_vfd] |Hitachi wj200 modbus driver||
+| link:../man/man1/xhc-hb04.1.html[xhc-hb04] |User-space HAL component for the xhc-hb04 pendant.||
+| link:../man/man1/xhc-hb04-accels.1.html[xhc-hb04-accels] |Obsolete script for jogging wheel||
+| link:../man/man1/xhc-whb04b-6.1.html[xhc-whb04b-6] |Userspace jog dial HAL component for the wireless XHC WHB04B-6 USB device&.||
+|=======================
+
+[[sec:Realtime-Components-pilotes]]
+=== Mesa and other I/O Cards (Realtime)
+[{tab_options}]
+|=======================
+| hal_ppmc | Pico Systems <<cha:pico-drivers,driver>> for analog servo, PWM and Stepper controller. ||
+| link:../man/man9/hal_bb_gpio.9.html[hal_bb_gpio] |Driver for beaglebone GPIO pins||
+| link:../man/man9/hm2_7i43.9.html[hm2_7i43] | Mesa Electronics driver for the 7i43 EPP Anything IO board with HostMot2. (See the man page for more information) ||
+| link:../man/man9/hm2_7i90.9.html[hm2_7i90] |LinuxCNC HAL driver for the Mesa Electronics 7i90 EPP Anything IO board with HostMot2 firmware.||
+| link:../man/man9/hm2_eth.9.html[hm2_eth] |LinuxCNC HAL driver for the Mesa Electronics Ethernet Anything IO boards, with HostMot2 firmware.||
+| link:../man/man9/hm2_pci.9.html[hm2_pci] | Mesa Electronics driver for the 5i20, 5i22, 5i23, 4i65, and 4i68 Anything I/O boards, with HostMot2 firmware. (See the man page for more information) ||
+| link:../man/man9/hm2_rpspi.9.html[hm2_rpspi] |LinuxCNC HAL driver for the Mesa Electronics SPI Anything IO boards, with HostMot2 firmware.||
+| link:../man/man9/hm2_spi.9.html[hm2_spi] |LinuxCNC HAL driver for the Mesa Electronics SPI Anything IO boards, with HostMot2 firmware.||
+| link:../man/man9/hostmot2.9.html[hostmot2] | Mesa Electronics <<cha:mesa-hostmot2-driver,driver>> for the HostMot2 firmware. ||
+| link:../man/man9/max31855.9.html[max31855] |Support for the MAX31855 Thermocouple-to-Digital converter using bitbanged spi||
+| link:../man/man9/mesa_7i65.9.html[mesa_7i65] | Mesa Electronics driver for the 7i65 eight-axis servo card. (See the man page for more information) ||
+| link:../man/man9/mesa_pktgyro_test.9.html[mesa_pktgyro_test] |PktUART simple test with Microstrain 3DM-GX3-15 gyro||
+| link:../man/man9/opto_ac5.9.html[opto_ac5] |Realtime driver for opto22 PCI-AC5 cards||
+| pluto_servo | Pluto-P <<cha:pluto-p-driver,driver>> and firmware for the parallel port FPGA, for servos. ||
+| pluto_step | Pluto-P <<cha:pluto-p-driver,driver>> for the parallel port FPGA, for steppers. ||
+| link:../man/man9/serport.9.html[serport] | Hardware driver for the digital I/O bits of the 8250 and 16550 serial port. ||
+| link:../man/man9/sserial.9.html[sserial] |hostmot2 - Smart Serial LinuxCNC HAL driver for the Mesa Electronics HostMot2 Smart-Serial remote cards||
+| link:../man/man9/thc.9.html[thc] | Torch Height Control using a Mesa THC card or any analog to velocity input ||
+|=======================
+
+=== Utilities (Userspace)
+[{tab_options}]
+|=======================
+| link:../man/man1/hal-histogram.1.html[hal-histogram] |plots the value of a HAL pin as a histogram||
+| link:../man/man1/halcompile.1.html[halcompile] |Build, compile and install LinuxCNC HAL components||
+| link:../man/man1/halmeter.1.html[halmeter] | Observe HAL pins, signals, and parameters. ||
+| link:../man/man1/halcmd.1.html[halcmd] |manipulate the LinuxCNC HAL from the command line||
+| link:../man/man1/halcmd_twopass.1.html[halcmd_twopass] |short description||
+| link:../man/man1/halreport.1.html[halreport] |creates a report on the status of the HAL||
+| link:../man/man1/halrmt.1.html[halrmt] |short description||
+| link:../man/man1/halrun.1.html[halrun] |manipulate the LinuxCNC HAL from the command line||
+| link:../man/man1/halsampler.1.html[halsampler] |sample data from HAL in realtime||
+| link:../man/man1/halscope.1.html[halscope] | Software oscilloscope for viewing real time waveforms of HAL pins and signals ||
+| link:../man/man1/halshow.1.html[halshow]  | Show HAL parameters, pins and signals ||
+| link:../man/man1/halstreamer.1.html[halstreamer] |stream file data into HAL in real time||
+| link:../man/man1/haltcl.1.html[haltcl] |manipulate the LinuxCNC HAL from the command line using a tcl||
+| link:../man/man1/image-to-gcode.1.html[image-to-gcode] |converts bitmap images to G-code||
+| link:../man/man1/latency-histogram.1.html[latency-histogram] |plot a histogram of machine latency||
+| link:../man/man1/latency-plot.1.html[latency-plot] |another way to view latency numbers||
+| link:../man/man1/latency-test.1.html[latency-test] |test the realtime system latency||
+| link:../man/man1/pncconf.1.html[pncconf] |configuration wizard for Mesa cards||
+| link:../man/man9/setsserial.9.html[setsserial] |a utility for setting Smart Serial NVRAM parameters.
+NOTE: This rather clunky utility is no longer needed except for flashing new smart-serial remote firmware.
+Smart-serial remote parameters can now be set in the HAL file in the normal way.||
+| link:../man/man1/sim_pin.1.html[sim_pin] |gui for displaying and setting one or more Hal inputs||
+| link:../man/man1/stepconf.1.html[stepconf] |A configuration wizard for parallel-port based machines.||
+
+|=======================
+
+=== Signal processing (Realtime)
+==== Logic and Bitwise
 [{tab_options}]
 |=======================
 | link:../man/man9/and2.9.html[and2] | Two-input AND gate. For out to be true both inputs must be true. (link:../man/man9/and2.9.html[and2]) ||
@@ -98,7 +179,6 @@ link:../man/man9/[directory listing of man9].
 | link:../man/man9/match8.9.html[match8] | 8-bit binary match detector. | |
 | link:../man/man9/multiclick.9.html[multiclick] |Single-, double-, triple-, and quadruple-click detector||
 | link:../man/man9/multiswitch.9.html[multiswitch] |This component toggles between a specified number of output bits||
-| link:../man/man9/mux_generic.9.html[mux_generic] |choose one from several input values||
 | link:../man/man9/not.9.html[not]  | Inverter ||
 | link:../man/man9/oneshot.9.html[oneshot] | One-shot pulse generator. | |
 | link:../man/man9/or2.9.html[or2]  | Two-input OR gate ||
@@ -107,53 +187,61 @@ link:../man/man9/[directory listing of man9].
 | link:../man/man9/toggle.9.html[toggle] | Push-on, push-off from momentary pushbuttons. ||
 | link:../man/man9/toggle2nist.9.html[toggle2nist] | Toggle button to nist logic. ||
 | link:../man/man9/ton.9.html[ton] |IEC TON timer - delay rising edge on a signal||
+| link:../man/man9/timedelay.9.html[timedelay] | The equivalent of a time-delay relay. ||
 | link:../man/man9/tp.9.html[tp] |IEC TP timer - generate a high pulse of defined duration on rising edge||
 | link:../man/man9/tristate_bit.9.html[tristate_bit] | Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics. ||
 | link:../man/man9/tristate_float.9.html[tristate_float] | Place a signal on an I/O pin only when enabled, similar to a tristatebuffer in electronics. ||
 | link:../man/man9/xor2.9.html[xor2] | Two-input XOR (exclusive OR) gate ||
+|=======================
+
+[[sec:Realtime-Components-flottant]]
+==== Arithmetic and float
+[{tab_options}]
+|=======================
+| link:../man/man9/abs_s32.9.html[abs_s32] |Compute the absolute value and sign of the input signal||
+| link:../man/man9/abs.9.html[abs] | Compute the absolute value and sign of the input signal. | |
+| link:../man/man9/biquad.9.html[biquad] | Biquad IIR filter | |
+| link:../man/man9/blend.9.html[blend] | Perform linear interpolation between two values. | |
+| link:../man/man9/comp.9.html[comp] | Two input comparator with hysteresis. | |
+| link:../man/man9/constant.9.html[constant] | Use a parameter to set the value of a pin. | |
+| link:../man/man9/counter.9.html[counter] | Counts input pulses (deprecated). Use the <<sec:encoder, encoder>> component.  | |
+| link:../man/man9/ddt.9.html[ddt] | Compute the derivative of the input function. | |
+| link:../man/man9/deadzone.9.html[deadzone] | Return the center if within the threshold. | |
+| link:../man/man9/hypot.9.html[hypot] | Three-input hypotenuse (Euclidean distance) calculator. | |
+| link:../man/man9/ilowpass.9.html[ilowpass] |  Low-pass filter with integer inputs and outputs ||
+| link:../man/man9/integ.9.html[integ] | Integrator. | |
+| link:../man/man9/invert.9.html[invert] | Compute the inverse of the input signal. | |
+| link:../man/man9/filter_kalman.9.html[filter_kalman] |Unidimensional Kalman filter, also known as linear quadratic estimation (LQE)||
+| link:../man/man9/knob2float.9.html[knob2float] | Convert counts (probably from an encoder) to a float value. ||
+| link:../man/man9/lowpass.9.html[lowpass] | Low-pass filter | |
+| link:../man/man9/limit1.9.html[limit1] | Limit the output signal to fall between min and max. footnote:[When the input is a position, this means that the 'position' is limited.] | |
+| link:../man/man9/limit2.9.html[limit2] | Limit the output signal to fall between min and max.  Limit its slew rate to less than maxv per second. 
+footnote:[When the input is a position, this means that 'position' and 'velocity' are limited.]  | |
+| link:../man/man9/limit3.9.html[limit3] | Limit the output signal to fall between min and max. 
+Limit its slew rate to less than maxv per second. Limit its second derivative to less than MaxA per second squared. footnote:[When
+ the input is a position, this means that the 'position', 'velocity', and 'acceleration' are limited.] | |
+| link:../man/man9/lincurve.9.html[lincurve] |one-dimensional lookup table||
+| link:../man/man9/maj3.9.html[maj3] | Compute the majority of 3 inputs. | |
+| link:../man/man9/minmax.9.html[minmax] | Track the minimum and maximum values of the input to the outputs. ||
+| link:../man/man9/mult2.9.html[mult2] | Product of two inputs. | |
+| link:../man/man9/mux16.9.html[mux16] | Select from one of sixteen input values. | |
+| link:../man/man9/mux2.9.html[mux2] | Select from one of two input values. | |
+| link:../man/man9/mux4.9.html[mux4] | Select from one of four input values. | |
+| link:../man/man9/mux8.9.html[mux8] | Select from one of eight input values. | |
+| link:../man/man9/mux_generic.9.html[mux_generic] |choose one from several input values||
+| link:../man/man9/near.9.html[near] | Determine whether two values are roughly equal. | |
+| link:../man/man9/offset.9.html[offset] | Adds an offset to an input, and subtracts it from the feedback value. | |
+| link:../man/man9/sample_hold.9.html[sample_hold] | Sample and Hold. ||
+| link:../man/man9/scale.9.html[scale] | Applies a scale and offset to its input. | |
+| link:../man/man9/sum2.9.html[sum2] | Sum of two inputs (each with a gain) and an offset. | |
+| link:../man/man9/timedelta.9.html[timedelta] | Component that measures thread scheduling timing behavior. ||
+| link:../man/man9/updown.9.html[updown] | Counts up or down, with optional limits and wraparound behavior. | |
+| link:../man/man9/wcomp.9.html[wcomp] | Window comparator. | |
+| link:../man/man9/weighted_sum.9.html[weighted_sum] | Convert a group of bits to an integer. | |
 | link:../man/man9/xhc_hb04_util.9.html[xhc_hb04_util] |xhc-hb04 convenience utility||
 |=======================
 
-
-[[sec:Realtime-Components-flottant]]
-=== Arithmetic and float-components
-
-[{tab_options}]
-|=======================
-| abs | Compute the absolute value and sign of the input signal.                                  | |
-| blend | Perform linear interpolation between two values. | |
-| comp | Two input comparator with hysteresis. | |
-| constant | Use a parameter to set the value of a pin. | |
-| sum2 | Sum of two inputs (each with a gain) and an offset. | |
-| counter | Counts input pulses (deprecated). Use the <<sec:encoder, encoder>> component.  | |
-| updown | Counts up or down, with optional limits and wraparound behavior. | |
-| ddt | Compute the derivative of the input function. | |
-| deadzone | Return the center if within the threshold. | |
-| hypot | Three-input hypotenuse (Euclidean distance) calculator. | |
-| mult2 | Product of two inputs. | |
-| mux16 | Select from one of sixteen input values. | |
-| mux2 | Select from one of two input values. | |
-| mux4 | Select from one of four input values. | |
-| mux8 | Select from one of eight input values. | |
-| near | Determine whether two values are roughly equal. | |
-| offset | Adds an offset to an input, and subtracts it from the feedback value. | |
-| integ | Integrator. | |
-| invert | Compute the inverse of the input signal. | |
-| wcomp | Window comparator. | |
-| weighted_sum | Convert a group of bits to an integer. | |
-| biquad | Biquad IIR filter | |
-| lowpass | Low-pass filter | |
-| limit1 | Limit the output signal to fall between min and max. footnote:[When the input is a position, this means that the 'position' is limited.] | |
-| limit2 | Limit the output signal to fall between min and max.  Limit its slew rate to less than maxv per second. 
-footnote:[When the input is a position, this means that 'position' and 'velocity' are limited.]  | |
-| limit3 | Limit the output signal to fall between min and max. 
-Limit its slew rate to less than maxv per second. Limit its second derivative to less than MaxA per second squared. footnote:[When
- the input is a position, this means that the 'position', 'velocity', and 'acceleration' are limited.] | |
-| maj3 | Compute the majority of 3 inputs. | |
-| scale | Applies a scale and offset to its input. | |
-|=======================
-
-=== Type conversion
+==== Type conversion
 [{tab_options}]
 |=======================
 | link:../man/man9/bin2gray.9.html[bin2gray] |Convert a number to the gray-code representation||
@@ -172,56 +260,49 @@ Limit its slew rate to less than maxv per second. Limit its second derivative to
 | link:../man/man9/gray2bin.9.html[gray2bin] |Convert a gray-code input to binary||
 |=======================
 
-[[sec:Realtime-Components-pilotes]]
-=== Hardware Drivers
-
-[{tab_options}]
-|=======================
-| hal_ppmc | Pico Systems <<cha:pico-drivers,driver>> for analog servo, PWM and Stepper controller. ||
-| hm2_7i43 | Mesa Electronics driver for the 7i43 EPP Anything IO board with HostMot2. (See the man page for more information) ||
-| hm2_pci | Mesa Electronics driver for the 5i20, 5i22, 5i23, 4i65, and 4i68 Anything I/O boards, with HostMot2 firmware. (See the man page for more information) ||
-| hostmot2 | Mesa Electronics <<cha:mesa-hostmot2-driver,driver>> for the HostMot2 firmware. ||
-| mesa_7i65 | Mesa Electronics driver for the 7i65 eight-axis servo card. (See the man page for more information) ||
-| pluto_servo | Pluto-P <<cha:pluto-p-driver,driver>> and firmware for the parallel port FPGA, for servos. ||
-| pluto_step | Pluto-P <<cha:pluto-p-driver,driver>> for the parallel port FPGA, for steppers. ||
-| thc | Torch Height Control using a Mesa THC card or any analog to velocity input ||
-| serport | Hardware driver for the digital I/O bits of the 8250 and 16550 serial port. ||
-|=======================
-
-
 [[sec:Realtime-Components-cinematiques]]
-=== Kinematics
-
+=== Kinematics (Realtime)
 [{tab_options}]
 |=======================
-| kins | kinematics definitions for LinuxCNC. ||
-| gantrykins | A kinematics module that maps one axis to multiple joints. ||
-| genhexkins | Gives six degrees of freedom in position and orientation (XYZABC). The location of the motors is defined at compile time. ||
-| genserkins | Kinematics that can model a general serial-link manipulator with up to 6 angular joints. ||
-| maxkins | Kinematics for a tabletop 5 axis mill named 'max' with tilting head (B axis) and horizontal rotary mounted to the table (C axis).
- Provides UVW motion in the rotated coordinate system. The source file, maxkins.c, may be a useful starting point for other 5-axis systems. ||
-| tripodkins | The joints represent the distance of the controlled point from three predefined locations (the motors), giving three degrees of freedom in position (XYZ). ||
-| trivkins | There is a 1:1 correspondence between joints and axes. Most standard milling machines and lathes use the trivial kinematics module. ||
-| pumakins | Kinematics for PUMA-style robots. ||
-| rotatekins | The X and Y axes are rotated 45 degrees compared to the joints 0 and 1. ||
-| scarakins | Kinematics for SCARA-type robots. ||
+| link:../man/man9/corexy_by_hal.9.html[corexy_by_hal] |CoreXY kinematics||
+| link:../man/man9/differential.9.html[differential] |kinematics for a differential transmission||
+| link:../man/man9/gantry.9.html[gantry] |LinuxCNC HAL component for driving multiple joints from a single axis||
+| link:../man/man9/gantrykins.9.html[gantrykins] | A kinematics module that maps one axis to multiple joints. ||
+| link:../man/man9/genhexkins.9.html[genhexkins] | Gives six degrees of freedom in position and orientation (XYZABC). The location of the motors is defined at compile time. ||
+| link:../man/man9/genserkins.9.html[genserkins] | Kinematics that can model a general serial-link manipulator with up to 6 angular joints. ||
+| link:../man/man9/gentrivkins.9.html[gentrivkins] |See link:../man/man9/trivkins.9.html[trivkins]||
+| link:../man/man9/kins.9.html[kins] | kinematics definitions for LinuxCNC. ||
+| link:../man/man9/lineardeltakins.9.html[lineardeltakins] |Kinematics for a linear delta robot||
+| link:../man/man9/maxkins.9.html[maxkins] | Kinematics for a tabletop 5 axis mill named 'max' with tilting head (B axis) and horizontal rotary mounted to the table (C axis). Provides UVW motion in the rotated coordinate system. The source file, maxkins.c, may be a useful starting point for other 5-axis systems. ||
+| link:../man/man9/millturn.9.html[millturn] |Switchable kinematics for a mill-turn machine||
+| link:../man/man9/pentakins.9.html[pentakins] |||
+| link:../man/man9/pumakins.9.html[pumakins] | Kinematics for PUMA-style robots. ||
+| link:../man/man9/rosekins.9.html[rosekins] |Kinematics for a rose engine||
+| link:../man/man9/rotatekins.9.html[rotatekins] | The X and Y axes are rotated 45 degrees compared to the joints 0 and 1. ||
+| link:../man/man9/scarakins.9.html[scarakins] | Kinematics for SCARA-type robots. ||
+| link:../man/man9/tripodkins.9.html[tripodkins] | The joints represent the distance of the controlled point from three predefined locations (the motors), giving three degrees of freedom in position (XYZ). ||
+| link:../man/man9/trivkins.9.html[trivkins] | There is a 1:1 correspondence between joints and axes. Most standard milling machines and lathes use the trivial kinematics module. ||
+| link:../man/man9/userkins.9.html[userkins] |Template for user-built kinematics||
 |=======================
 
-=== BLDC and 3-phase motor control
-
+=== Motor control (Realtime)
 [{tab_options}]
 |=======================
-| bldc_hall3 | 3-wire Bipolar trapezoidal commutation BLDC motor driver using Hall sensors. ||
-| clarke2 | Two input version of Clarke transform. ||
-| clarke3 | Clarke (3 phase to cartesian) transform. ||
-| clarkeinv | Inverse Clarke transform. ||
+| link:../man/man9/at_pid.9.html[at_pid] | Proportional/integral/derivative controller with auto tuning. ||
+| link:../man/man9/bldc.9.html[bldc] |BLDC and AC-servo control component||
+| link:../man/man9/clarke2.9.html[clarke2] | Two input version of Clarke transform. ||
+| link:../man/man9/clarke3.9.html[clarke3] | Clarke (3 phase to cartesian) transform. ||
+| link:../man/man9/clarkeinv.9.html[clarkeinv] | Inverse Clarke transform. ||
+| link:../man/man9/encoder.9.html[encoder] | Software counting of quadrature encoder signals. <<sec:encoder,Description>>. ||
+| link:../man/man9/pid.9.html[pid] | Proportional/integral/derivative controller. <<sec:pid,Description>> ||
+| link:../man/man9/pwmgen.9.html[pwmgen] | Software PWM/PDM generation. <<sec:pwmgen,Description>> ||
+| link:../man/man9/stepgen.9.html[stepgen] | Software step pulse generation. <<sec:stepgen,Description>>. ||
 |=======================
 
-=== Other
+=== Other (Realtime)
 [{tab_options}]
 |=======================
 | link:../man/man9/comp.9.html[comp] | Build, compile and install LinuxCNC HAL components. ||
-| link:../man/man9/motion.9.html[motion] | Accepts NML motion commands, interacts with HAL in realtime. ||
 | link:../man/man9/classicladder.9.html[classicladder] | Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information. ||
 | link:../man/man9/threads.9.html[threads] | Creates hard realtime HAL threads. ||
 | link:../man/man9/charge_pump.9.html[charge_pump] | Creates a square-wave for the 'charge pump' input of some controller boards.
@@ -230,6 +311,7 @@ To calculate the frequency of the output 1/(period time in seconds x 2) = hz. Fo
 is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 hz or 5 Khz. ||
 | link:../man/man9/encoder_ratio.9.html[encoder_ratio] | An electronic gear to synchronize two axes. ||
 | link:../man/man9/feedcomp.9.html[feedcomp] | Multiply the input by the ratio of current velocity to the feed rate. ||
+| link:../man/man9/gladevcp.9.html[gladevcp (Realtime)] |displays Virtual control Panels built with GTK / GLADE||
 | link:../man/man9/gearchange.9.html[gearchange] | Select from one of two speed ranges. ||
 | link:../man/man9/joyhandle.9.html[joyhandle] | Sets nonlinear joypad movements, deadbands and scales. ||
 | link:../man/man9/sampler.9.html[sampler] | Sample data from HAL in real time. ||
@@ -244,11 +326,11 @@ is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 hz or 5 Khz. |
 | link:../man/man9/watchdog.9.html[watchdog] | Monitor one to thirty-two inputs for a 'heartbeat'. ||
 |=======================
 
-include::components_gen9.adoc[]
+
+include::components_gen.adoc[]
 
 == HAL API calls
-
-----
+....
 hal_add_funct_to_thread.3hal
 hal_bit_t.3hal
 hal_create_thread.3hal
@@ -291,11 +373,10 @@ hal_u32_t.3hal
 hal_unlink.3hal
 intro.3hal
 undocumented.3hal
-----
+....
 
 == RTAPI calls
-
-----
+....
 EXPORT_FUNCTION.3rtapi
 MODULE_AUTHOR.3rtapi
 MODULE_DESCRIPTION.3rtapi
@@ -348,6 +429,6 @@ rtapi_task_pause.3rtapi
 rtapi_task_resume.3rtapi
 rtapi_task_start.3rtapi
 rtapi_task_wait.3rtapi
-----
+....
 
 // vim: set syntax=asciidoc:

--- a/docs/src/hal/hal-examples.adoc
+++ b/docs/src/hal/hal-examples.adoc
@@ -114,7 +114,7 @@ net tool-prepare-loopback iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
 
 This example uses 'ddt', 'mult2' and 'abs' to compute the velocity of
 a single axis. For more information on the real time components see the
-man pages or the Realtime Components section (<<sec:realtime-components>>).
+man pages or the HAL Components List (<<sec:hal-components>>).
 
 The first thing is to check your configuration to make sure you are
 not using any of the real time components all ready. You can do this by

--- a/docs/src/hal/intro.adoc
+++ b/docs/src/hal/intro.adoc
@@ -277,7 +277,7 @@ driver.
 
 Each HAL component is a piece of software with well-defined inputs,
 outputs, and behavior, that can be installed and interconnected as
-needed. The section <<sec:realtime-components,Realtime Components List>>
+needed. The section <<sec:hal-components,HAL Components List>>
 lists all available components and a brief description of what each does.
 
 [[sec:hal-timing-issues]]


### PR DESCRIPTION
As discussed in #996 it would be great to have a list of all HAL components which is always up-to-date.

I decided to use the current list as it already covers a lot of components.
A script checks this list against the existing man pages and generates tables for those that are missing and for those that are too much. It writes those into two tables each that are included in the components.adoc.
Moreover it generates the links for the man pages for the missing entries AND extracts the descriptions of the man pages and writes them into the table.
So all what you see in the tables **Not categorized (auto generated)** and **Obsolete (auto generated)** in 
https://hansu.github.io/linuxcnc-doc/devel/html/hal/components.html is generated.
(The current page as reference: http://linuxcnc.org/docs/devel/html/hal/components.html)
This can now be manually sorted into suitable categories. And it ensures that components that are added are always in this list.

The script detects missing man pages for these components.
- bldc_hall3
- gs2
- hal_ppmc
- pluto_servo
- pluto_step

I guess `bldc_hall3` is now `bldc` and `gs` is renamed to `gs2_vfd`. And the other three - are they still available and just don't have a man page?

Another question: should we keep the list of
3. HAL API calls 
and
4. RTAPI calls
here? I think it they are not of great benefit here.

@andypugh I would appreciate your opinion here ;-)








Closes #996