### PR TITLE
Gmoccapy: fix gcode view issue (2.8)

### DIFF
--- a/lib/python/gladevcp/hal_sourceview.py
+++ b/lib/python/gladevcp/hal_sourceview.py
@@ -335,6 +335,9 @@ class EMC_Action_Save(_EMC_Action, _EMC_FileChooser):
 
 class EMC_Action_SaveAs(EMC_Action_Save):
     __gtype_name__ = 'EMC_Action_SaveAs'
+    __gsignals__ = {
+        'saved-as': (gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ()),
+    }
 
     def __init__(self, *a, **kw):
         _EMC_Action.__init__(self, *a, **kw)
@@ -357,3 +360,4 @@ class EMC_Action_SaveAs(EMC_Action_Save):
         if r == gtk.RESPONSE_OK:
             self.save(fn)
             self.currentfolder = os.path.dirname(fn)
+            self.emit('saved-as')

--- a/lib/python/gladevcp/hal_sourceview.py
+++ b/lib/python/gladevcp/hal_sourceview.py
@@ -46,6 +46,7 @@ class EMC_SourceView(gtksourceview.View, _EMC_ActionBase):
         self.buf = gtksourceview.Buffer()
         self.buf.set_max_undo_levels(20)
         self.buf.connect('changed', self.update_iter)
+        self.buf.connect('modified-changed', self.modified_changed)
         self.set_buffer(self.buf)
         self.lm = gtksourceview.LanguageManager()
         self.sm = gtksourceview.StyleSchemeManager()
@@ -206,6 +207,9 @@ class EMC_SourceView(gtksourceview.View, _EMC_ActionBase):
         self.match_start = self.match_end = None
         start, end = self.buf.get_bounds()
         self.buf.remove_tag(self.found_text_tag, start, end)
+
+    def modified_changed(self,widget):
+        self.update_iter()
         self.emit("changed")
 
     # This will search the buffer for a specified text string.

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -210,6 +210,7 @@ class gmoccapy(object):
         self.gcodeerror = ""   # we need this to avoid multiple messages of the same error
 
         self.file_changed = False
+        self.widgets.hal_action_saveas.connect("saved-as", self.saved_as)
 
         self.lathe_mode = None # we need this to check if we have a lathe config
         self.backtool_lathe = False
@@ -4760,6 +4761,9 @@ class gmoccapy(object):
             # self.command.program_open(tempfilename)
         self.widgets.gcode_view.grab_focus()
         self.widgets.btn_save.set_sensitive(False)
+
+    def saved_as(self, widget):
+        self.widgets.btn_save.set_sensitive(True)
 
     def on_tbtn_optional_blocks_toggled(self, widget, data=None):
         opt_blocks = widget.get_active()

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -4679,9 +4679,10 @@ class gmoccapy(object):
         self.gcodeerror = ""
         self.file_changed = False
 
-    def on_gcode_view_changed(self, state):
-        print("gcode view changed")
-        self.file_changed = True
+    def on_gcode_view_changed(self, widget):
+        buf_modified = self.widgets.gcode_view.buf.get_modified()
+        print("gcode view changed (modified: {})".format(buf_modified))
+        self.file_changed = buf_modified
 
     # Search and replace handling in edit mode
     # undo changes while in edit mode


### PR DESCRIPTION
Fixes these three issues according to
https://forum.linuxcnc.org/gmoccapy/43045-after-saving-ngc-file-ask-for-do-you-want-to-exit-without-saving-the-changes
1. When editing a G-code file, a change was detected even when only the cursor changed.
2. After saving the changes, a warning for unsaved changes appeared again.
3. After creating a new file and 'save as', the save button was disabled.
