### PR TITLE
gmoccapy: fix source typo

### DIFF
--- a/configs/sim/gmoccapy/gmoccapy_messages.ini
+++ b/configs/sim/gmoccapy/gmoccapy_messages.ini
@@ -47,10 +47,10 @@ INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm ,1.2345 in
 #       okdialog : Will hold focus on the message dialog and will activate a "-waiting" Hal_Pin OUT.
 #                  Closing the message will reset the waiting pin
 #       yesnodialog : Will hold focus on the message dialog and will activate a "-waiting" Hal_Pin bit OUT
-#                     it will also give access to an "-responce" Hal_Pin Bit Out, this pin will hold 1 if the
+#                     it will also give access to an "-response" Hal_Pin Bit Out, this pin will hold 1 if the
 #                     user clicks OK, and in all other states it will be 0
 #                     Closing the message will reset the waiting pin
-#                     The responce Hal Pin will remain 1 until the dialog is called again
+#                     The response Hal Pin will remain 1 until the dialog is called again
 # MESSAGE_PINNAME = is the name of the hal pin group to be created
 
 

--- a/configs/sim/gmoccapy/messages.ini
+++ b/configs/sim/gmoccapy/messages.ini
@@ -47,10 +47,10 @@ INCREMENTS = 1.000 mm, 0.100 mm, 0.010 mm, 0.001 mm ,1.2345 in
 #       okdialog : Will hold focus on the message dialog and will activate a "-waiting" Hal_Pin OUT.
 #                  Closing the message will reset the waiting pin
 #       yesnodialog : Will hold focus on the message dialog and will activate a "-waiting" Hal_Pin bit OUT
-#                     it will also give access to an "-responce" Hal_Pin Bit Out, this pin will hold 1 if the
+#                     it will also give access to an "-response" Hal_Pin Bit Out, this pin will hold 1 if the
 #                     user clicks OK, and in all other states it will be 0
 #                     Closing the message will reset the waiting pin
-#                     The responce Hal Pin will remain 1 until the dialog is called again
+#                     The response Hal Pin will remain 1 until the dialog is called again
 # MESSAGE_PINNAME = is the name of the hal pin group to be created
 
 

--- a/docs/src/gui/gmoccapy.adoc
+++ b/docs/src/gui/gmoccapy.adoc
@@ -834,7 +834,7 @@ All are HAL_BIT pin.
 
 * gmoccapy.messages.yesnodialog
 * gmoccapy.messages.yesnodialog-waiting
-* gmoccapy.messages.yesnodialog-responce
+* gmoccapy.messages.yesnodialog-response
 
 'Okdialog'
 

--- a/docs/src/gui/gmoccapy_hu.adoc
+++ b/docs/src/gui/gmoccapy_hu.adoc
@@ -542,7 +542,7 @@ Mind HAL_BIT lábak. +
 
 * gmoccapy.messages.yesnodialog
 * gmoccapy.messages.yesnodialog-waiting
-* gmoccapy.messages.yesnodialog-responce
+* gmoccapy.messages.yesnodialog-response
 
 'Okdialog'
 

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -2188,16 +2188,16 @@ class gmoccapy(object):
             if pin.get():
                 self.halcomp["messages." + message[2] + "-waiting"] = 1
                 title = "Pin " + message[2] + " message"
-                responce = self.dialogs.show_user_message(self, message[0], title)
+                response = self.dialogs.show_user_message(self, message[0], title)
                 self.halcomp["messages." + message[2] + "-waiting"] = 0
         elif message[1] == "yesnodialog":
             if pin.get():
                 self.halcomp["messages." + message[2] + "-waiting"] = 1
                 self.halcomp["messages." + message[2] + "-response"] = 0
                 title = "Pin " + message[2] + " message"
-                responce = self.dialogs.yesno_dialog(self, message[0], title)
+                response = self.dialogs.yesno_dialog(self, message[0], title)
                 self.halcomp["messages." + message[2] + "-waiting"] = 0
-                self.halcomp["messages." + message[2] + "-response"] = responce
+                self.halcomp["messages." + message[2] + "-response"] = response
             else:
                 self.halcomp["messages." + message[2] + "-waiting"] = 0
         else:


### PR DESCRIPTION
Fix source typo `responce` to `response`