### PR TITLE
fix for full circle interpretation

### DIFF
--- a/src/libnml/posemath/_posemath.c
+++ b/src/libnml/posemath/_posemath.c
@@ -1846,7 +1846,7 @@ int pmCircleInit(PmCircle * const circle,
        2PI. */
     pmCartCartCross(&circle->rTan, &rEnd, &v);
     pmCartCartDot(&v, &circle->normal, &d);
-    if (d < 0.0) {
+    if (d < DOUBLE_FUZZ) {
         circle->angle = PM_2_PI - circle->angle;
     }
     /* Issue #1528 24-Jan-2022. Additional test for nearly-straight   *


### PR DESCRIPTION
A bit of a corner case but it is repeatable.

The following gcode in the standard axis sim will show that a full circle is not being interpreted correctly.

`G91`
`G0 Z0.001`
`G90`
`F100`
`G0 X0.0 Y0.5`
`M3 $0 S1`
`G3 X0.0 Y0.5 I0.5`
`M5`
`G0 X0 Y0`
`M2`

