### PR TITLE
tp: fix missing state tag during blended motion

### DIFF
--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -839,6 +839,9 @@ STATIC int tpInitBlendArcFromPrev(TP_STRUCT const * const tp,
     //In the future, radius may be adjustable.
     tcFinalizeLength(blend_tc);
 
+    // copy state tag from previous segment during blend motion
+    blend_tc->tag = prev_tc->tag;
+
     return TP_ERR_OK;
 }
 


### PR DESCRIPTION
TP was not posting a valid state tag during blend motion (G64). The 
state tag for a motion was not being copied into the blended motion when 
it was created. This caused it to report the default state tag and fail 
the validity check down the track. This fix simply copies the state tag 
from the previous motion when the blend is created.

This fixes the erroneous "Parameter file name is missing" or "Unknown 
oword number" error messages that would have been received in all GUIs 
when motion was Aborted during a blend move.

While I can take credit for getting to the root of this problem and 
figuring out how to repeat it 100% of the time, the credit goes to Rob 
Ellenberg for helping me understand what was going on and ultimately 
providing the solution.