### PR TITLE
emctask: remove debug error message

### DIFF
--- a/src/emc/task/emctask.cc
+++ b/src/emc/task/emctask.cc
@@ -222,9 +222,6 @@ int emcTaskStateRestore()
     if (emcStatus->task.mode == EMC_TASK_MODE_AUTO) {
         // Validity of state tag checked within restore function
         res = pinterp->restore_from_tag(emcStatus->motion.traj.tag);
-	if (res != INTERP_OK)
-	    // Print error but don't bail
-	    print_interp_error(res);
     }
     return 0;
 }


### PR DESCRIPTION
Per Rob Ellenberg this was left over from the development of state tags. 
It's not an error if the tag isn't valid, we just dont change the interp 
state in that case.