### PR TITLE
rs274ngc_pre: fix parameter_file_name logic check

### DIFF
--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -2504,10 +2504,11 @@ int Interp::ini_load(const char *filename)
         logDebug("did not find PARAMETER_FILE");
     }
     SET_PARAMETER_FILE_NAME(parameter_file_name);
-    CHKS(strlen(parameter_file_name) > 0, _("Parameter file name is missing"));
 
     // close it
     inifile.Close();
+
+    CHKS((strlen(parameter_file_name) == 0), _("Parameter file name is missing"));
 
     return 0;
 }


### PR DESCRIPTION
The original check would erroneously report "Parameter file name is 
missing" when the Parameter file name was in fact present in the INI 
file. This push fixes that logic.