### PR TITLE
Added 'eatmydata' to optimize auto-builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ jobs:
     - name: Build RIP & test
       run: |
         ./scripts/travis-install-build-deps.sh
+        sudo apt-get install -y eatmydata
         cd src
-        ./autogen.sh
-        ./configure --with-realtime=uspace --disable-check-runtime-deps
-        make -O -j$((1+$(nproc))) default pycheck V=1
+        eatmydata ./autogen.sh
+        eatmydata ./configure --with-realtime=uspace --disable-check-runtime-deps
+        eatmydata make -O -j$((1+$(nproc))) default pycheck V=1
         # Note that the package build covers html docs
         ../scripts/rip-environment runtests -p
     
@@ -46,10 +47,11 @@ jobs:
     - name: Build HTML docmentation
       run: |
         ./scripts/travis-install-build-deps.sh
+        sudo apt-get install -y eatmydata
         cd src
-        ./autogen.sh
-        ./configure --with-realtime=uspace --disable-check-runtime-deps --enable-build-documentation=html
-        make -O -j$((1+$(nproc))) docs
+        eatmydata ./autogen.sh
+        eatmydata ./configure --with-realtime=uspace --disable-check-runtime-deps --enable-build-documentation=html
+        eatmydata make -O -j$((1+$(nproc))) docs
         # Note that the package build covers html docs
 
   package:
@@ -68,9 +70,10 @@ jobs:
         set -x
         git fetch --recurse-submodules=no https://github.com/linuxcnc/linuxcnc refs/tags/*:refs/tags/*
         ./scripts/travis-install-build-deps.sh
+        sudo apt-get install -y eatmydata
         codename=$(grep VERSION_CODENAME /etc/os-release | cut -d = -f 2)
         dch --maintmaint --distribution $codename "GitHub test package."
         fakeroot ./debian/rules binary
         sudo apt-get install ../*.deb
-        ./scripts/runtests -p tests/
-        lintian --info --display-info --pedantic --display-experimental ../*.deb
+        eatmydata ./scripts/runtests -p tests/
+        eatmydata lintian --info --display-info --pedantic --display-experimental ../*.deb


### PR DESCRIPTION
This is a bit of an experiment. In principle we could run the build from a ramdisk. "eatmydata" gets a bit closer to that in that a process does not wait on a write to disk to be completed. Particularly with the upcoming humongous I/O with the po4a-generated documentation this is expected to boost build times. If this works. This PR will tell. 