### PR TITLE
RFD: Reduce set of required packages -> sep packages for HAL and GUIs?

### DIFF
--- a/debian/control.main-pkg.in
+++ b/debian/control.main-pkg.in
@@ -19,9 +19,6 @@ Depends:
     python3-opengl,
     python3-configobj,
     python3-xlib,
-    @PYTHON_IMAGING@,
-    @PYTHON_IMAGING_TK@,
-    @QTVCP_DEPENDS@,
     libgtksourceview-3.0-dev,
     tcl@TCLTK_VERSION@,
     tk@TCLTK_VERSION@,
@@ -31,6 +28,10 @@ Depends:
     tclx,
     procps, psmisc,
     udev
+Recommends:
+    @PYTHON_IMAGING@,
+    @PYTHON_IMAGING_TK@,
+    @QTVCP_DEPENDS@
 Suggests: mesaflash
 Description: motion controller for CNC machines and robots
  LinuxCNC is a fully-realised CNC machine controller that can interpret

--- a/debian/control.main-pkg.in
+++ b/debian/control.main-pkg.in
@@ -1,9 +1,6 @@
 Package: @MAIN_PACKAGE_NAME@
 Conflicts: linuxcnc-sim, @OTHER_MAIN_PACKAGE_NAME@
 Architecture: any
-Recommends: linuxcnc-doc-en | linuxcnc-doc,
-    librsvg2-dev,
-    @EXTRA_RECOMMENDS@
 Depends:
     ${misc:Depends},
     ${python3:Depends},
@@ -29,6 +26,9 @@ Depends:
     procps, psmisc,
     udev
 Recommends:
+    linuxcnc-doc-en | linuxcnc-doc,
+    librsvg2-dev,
+    @EXTRA_RECOMMENDS@,
     @PYTHON_IMAGING@,
     @PYTHON_IMAGING_TK@,
     @QTVCP_DEPENDS@

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -49,9 +49,9 @@ Package: @MAIN_PACKAGE_NAME@-dev
 Architecture: any
 Conflicts: linuxcnc-sim-dev, @OTHER_MAIN_PACKAGE_NAME@-dev
 Depends: ${misc:Depends},
+         ${python3:Depends},
          @KERNEL_HEADERS@,
          python3-serial,
-         ${python3:Depends},
          @MAIN_PACKAGE_NAME@ (= ${binary:Version}),
          udev,
          @YAPPS_RUNTIME@


### PR DESCRIPTION
I just wanted to give latency-test a spin and then ran into a Python conflict in Debian unstable since python3-opencv is not yet ready for python3.10.

And then I thought - waitaminute - opencv? Yip, very nice for integrating video. But what about those who only want to use HAL or (like me) aimed at insights on the latency of their hardware.

In this PR I propose to move some hard dependencies of the Debian package to "recommended", which means these get installed by default but if there is a problem then not. But what this PR is really asking is if there should be a more fine-grained set of packages for LinuxCNC. There could be linuxcnc-uspace-hal, maybe also linuxcnc-uspace-gui. The current linuxcnc-uspace package could depend on them all so there would not bit a difference in user experience.