### PR TITLE
Debian uses -A and -B flags to decide if dpkg-buildpackages builds docs

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -15,6 +15,8 @@ Build-Depends:
     desktop-file-utils,
     gettext,
     intltool,
+    asciidoc (>= 8.5),
+    dblatex (>= 0.2.12),
     libboost-python-dev,
     libepoxy-dev,
     libgl1-mesa-dev | libgl1-mesa-swx11-dev,

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -15,8 +15,6 @@ Build-Depends:
     desktop-file-utils,
     gettext,
     intltool,
-    asciidoc (>= 8.5),
-    dblatex (>= 0.2.12),
     libboost-python-dev,
     libepoxy-dev,
     libgl1-mesa-dev | libgl1-mesa-swx11-dev,

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -29,8 +29,8 @@ export DATE=$(shell LANG=C date --date='@$(TIMESTAMP)' '+%d\ %b\ %Y')
 export TIME=$(shell LANG=C date --date='@$(TIMESTAMP)' '+%T')
 
 kernel_version = @KERNEL_VERSION@
-enable_build_documentation = @ENABLE_BUILD_DOCUMENTATION@
 configure_realtime_arg = @CONFIGURE_REALTIME_ARG@
+enable_build_documentation = @ENABLE_BUILD_DOCUMENTATION@
 DESTDIR=$(CURDIR)/debian/@MAIN_PACKAGE_NAME@
 DEV_PACKAGE_NAME=@MAIN_PACKAGE_NAME@-dev
 
@@ -44,7 +44,7 @@ override_dh_auto_configure:
 	    --prefix=/usr --sysconfdir=/etc \
 	    --mandir=/usr/share/man \
 	    $(configure_realtime_arg) \
-            $(enable_build_documentation) \
+	    $(enable_build_documentation) \
 	    --disable-check-runtime-deps
 
 override_dh_auto_build-arch:
@@ -105,21 +105,22 @@ override_dh_auto_install:
 	mv -t $$d $(DESTDIR)/usr/share/applications/linuxcnc-integratorinfo.desktop ; \
 	mv -t $$d $(DESTDIR)/usr/share/applications/linuxcnc-manualpages.desktop
 
-ifneq "$(enable_build_documentation)" ""
 	# Only the English developer documentation goes to the -dev package
-	mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/share/doc/linuxcnc-dev
-	mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/doc/linuxcnc-dev/ $(DESTDIR)/usr/share/doc/linuxcnc/LinuxCNC_Developer.pdf
 	# The translated developer documentation goes to the respective regular -doc package
-	mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/doc/linuxcnc-dev/ $(DESTDIR)/usr/share/doc/linuxcnc/LinuxCNC_Developer_*.pdf
-	for lang in zh_CN es fr; do \
-		p=$$(echo $$lang | tr _ - | tr A-Z a-z); \
-		d=debian/linuxcnc-doc-$$p/usr/share/doc/linuxcnc ; \
-		mkdir -p $$d ; \
-		find $(DESTDIR)/usr/share/doc/linuxcnc -name "*_$${lang}.pdf" | xargs -r mv -t $$d ; \
-	done
 	# english documentation has no "en" suffix
-	d=debian/linuxcnc-doc-en/usr/share/doc/linuxcnc && mkdir -p $$d && mv -t $$d $(DESTDIR)/usr/share/doc/linuxcnc/*.pdf
-endif
+	if [ -r $(DESTDIR)/usr/share/doc/linuxcnc/LinuxCNC_Developer.pdf ]; then \
+		mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/share/doc/linuxcnc-dev; \
+		mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/doc/linuxcnc-dev/ $(DESTDIR)/usr/share/doc/linuxcnc/LinuxCNC_Developer.pdf; \
+		mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/doc/linuxcnc-dev/ $(DESTDIR)/usr/share/doc/linuxcnc/LinuxCNC_Developer_*.pdf; \
+		for lang in zh_CN es fr; do \
+			p=$$(echo $$lang | tr _ - | tr A-Z a-z); \
+			d=debian/linuxcnc-doc-$$p/usr/share/doc/linuxcnc ; \
+			mkdir -p $$d ; \
+			find $(DESTDIR)/usr/share/doc/linuxcnc -name "*_$${lang}.pdf" | xargs -r mv -t $$d ; \
+		done; \
+		d=debian/linuxcnc-doc-en/usr/share/doc/linuxcnc && mkdir -p $$d && mv -t $$d $(DESTDIR)/usr/share/doc/linuxcnc/*.pdf; \
+	fi
+
 	mkdir -p $(DESTDIR)/usr/share/doc/linuxcnc/examples 
 	cd $(DESTDIR)/usr/share/doc/linuxcnc/examples && ln -sf ../../../linuxcnc/ncfiles ./nc_files
 

--- a/debian/rules.in
+++ b/debian/rules.in
@@ -82,8 +82,11 @@ override_dh_auto_install:
 	cd debian/@EXTRAS@ && cp -a * $(DESTDIR)
 	DESTDIR=$(DESTDIR) $(MAKE) -C src INSTALL=install
 	py3clean .
-	mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/lib
-	cp lib/*.a debian/$(DEV_PACKAGE_NAME)/usr/lib
+	# In case that only the indep packages are built
+	if ls lib|egrep -q "*.a$$"; then \
+		mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/lib ; \
+		cp lib/*.a debian/$(DEV_PACKAGE_NAME)/usr/lib ; \
+	fi
 	mkdir -p $(DESTDIR)/usr/share/doc/linuxcnc
 	cp docs/html/gcode*.html $(DESTDIR)/usr/share/doc/linuxcnc/
 
@@ -124,15 +127,18 @@ endif
 	mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/include
 	mv -t debian/$(DEV_PACKAGE_NAME)/usr/include $(DESTDIR)/usr/include/linuxcnc
 
-	mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/lib
-	mv -t debian/$(DEV_PACKAGE_NAME)/usr/lib/ $(DESTDIR)/usr/lib/*.a $(DESTDIR)/usr/lib/*.so
-	mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/bin
-	mv -t debian/$(DEV_PACKAGE_NAME)/usr/bin $(DESTDIR)/usr/bin/halcompile
-	mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/share/man/man1
-	mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/man/man1  $(DESTDIR)/usr/share/man/man1/halcompile.1
-	mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/man $(DESTDIR)/usr/share/man/man3
-	mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/share/linuxcnc
-	mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/linuxcnc $(DESTDIR)/usr/share/linuxcnc/Makefile.modinc
+	# In case that only the indep packages are built
+	if ls $(DESTDIR)/usr/lib/*.a $(DESTDIR)/usr/lib/*.so | egrep -q "*.(a|so)$$"; then \
+		mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/lib; \
+		mv -t debian/$(DEV_PACKAGE_NAME)/usr/lib/ $(DESTDIR)/usr/lib/*.a $(DESTDIR)/usr/lib/*.so; \
+		mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/bin; \
+		mv -t debian/$(DEV_PACKAGE_NAME)/usr/bin $(DESTDIR)/usr/bin/halcompile; \
+		mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/share/man/man1; \
+		mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/man/man1  $(DESTDIR)/usr/share/man/man1/halcompile.1; \
+		mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/man $(DESTDIR)/usr/share/man/man3; \
+		mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/share/linuxcnc; \
+		mv -t debian/$(DEV_PACKAGE_NAME)/usr/share/linuxcnc $(DESTDIR)/usr/share/linuxcnc/Makefile.modinc; \
+	fi
 	#mkdir -p debian/$(DEV_PACKAGE_NAME)/usr/share/doc/
 	#mkdir -t debian/$(DEV_PACKAGE_NAME)/usr/share/doc/ $(DESTDIR)/usr/share/doc/linuxcnc-dev/
 	# not a package: drivers
@@ -148,7 +154,10 @@ override_dh_compress:
 
 override_dh_fixperms:
 	dh_fixperms -X/linuxcnc_module_helper -X/rtapi_app
-	chmod -x $(DESTDIR)/usr/lib/tcltk/linuxcnc/linuxcnc.tcl
+	# In case that only the indep packages are built
+	if [ -r  "$(DESTDIR)/usr/lib/tcltk/linuxcnc/linuxcnc.tcl" ]; then \
+		chmod -x $(DESTDIR)/usr/lib/tcltk/linuxcnc/linuxcnc.tcl; \
+	fi
 	# override_dh_python3: # not executed, so we attach it to fixperms
 	DEB_HOST_ARCH=`dpkg-architecture -qDEB_HOST_ARCH` dh_python3
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -612,8 +612,18 @@ NC_FILES=$(filter-out %/butterfly.ngc,$(call GLOB,../nc_files/*))
 TCL=$(call GLOB,../tcl/*.tcl)
 TCL_BIN=$(call GLOB,../tcl/bin/*.tcl) ../tcl/bin/popimage
 
-install: install-kernel-dep install-kernel-indep
+install:
+	$(MAKE) install-docs || echo "Ignored."
+	$(MAKE) install-kernel-dep || echo "Ignored."
+	$(MAKE) install-kernel-indep || echo "Ignored."
 	$(ECHO) "Installed in DESTDIR='$(DESTDIR)' with prefix $(prefix)"
+
+install-docs:
+	$(DIR) $(DESTDIR)$(docsdir)
+	$(FILE) $(addprefix ../docs/,$(DOCS)) $(DESTDIR)$(docsdir)
+	$(FILE) $(DOCS_HELP) $(DESTDIR)$(docsdir)
+	$(FILE) emc/usr_intf/axis/etc/axis_light_background $(DESTDIR)$(docsdir)
+	$(FILE) emc/usr_intf/axis/README $(DESTDIR)$(docsdir)/README.axis
 
 install-dirs:
 	$(DIR) $(DESTDIR)$(EMC2_RTLIB_DIR) \
@@ -684,8 +694,6 @@ install-kernel-indep: install-dirs
 	cp --no-dereference $(filter ../lib/%.so, $(TARGETS)) $(DESTDIR)$(libdir)
 	-ldconfig $(DESTDIR)$(libdir)
 	$(FILE) $(HEADERS) $(DESTDIR)$(includedir)/linuxcnc/
-	$(FILE) $(addprefix ../docs/,$(DOCS)) $(DESTDIR)$(docsdir)
-	$(FILE) $(DOCS_HELP) $(DESTDIR)$(docsdir)
 	$(TREE) $(NC_FILES) $(DESTDIR)$(ncfilesdir)
 	$(EXE) ../nc_files/M101 $(DESTDIR)$(ncfilesdir)
 	$(FILE) ../tcl/TkLinuxCNC $(DESTDIR)/etc/X11/app-defaults
@@ -787,8 +795,6 @@ install-python: install-dirs
 	$(EXE) ../bin/scorbot-er-3 $(DESTDIR)$(bindir)
 	$(EXE) $(patsubst %.py,../bin/%,$(VISMACH_PY)) $(DESTDIR)$(bindir)
 	$(FILE) ../share/linuxcnc/linuxcnc-wizard.gif $(DESTDIR)$(prefix)/share/linuxcnc
-	$(FILE) emc/usr_intf/axis/etc/axis_light_background $(DESTDIR)$(docsdir)
-	$(FILE) emc/usr_intf/axis/README $(DESTDIR)$(docsdir)/README.axis
 	$(FILE) ../share/axis/images/*.png ../share/axis/images/*.gif ../share/axis/images/*.xbm ../share/axis/images/*.ngc $(DESTDIR)$(datadir)/axis/images
 	$(FILE) ../share/axis/tcl/*.tcl $(DESTDIR)$(datadir)/axis/tcl
 	$(FILE) ../share/gscreen/images/*.gif $(DESTDIR)$(datadir)/gscreen/images

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1039,12 +1039,14 @@ AC_ARG_ENABLE(build-documentation,
 if ( test "$BUILD_DOCS" = "yes" ) ; then
     AC_PATH_PROG(ASCIIDOC,asciidoc,"none")
     if ( test "none" = "$ASCIIDOC" ) ; then
-	AC_MSG_ERROR([no AsciiDoc, documentation cannot be built])
+	AC_MSG_WARN([no AsciiDoc, documentation cannot be built])
+        BUILD_DOCS=no
     fi
 
     AC_PATH_PROG(A2X,a2x,"none")
     if ( test "none" = "$A2X" ) ; then
-	AC_MSG_ERROR([no a2x, documentation cannot be built])
+	AC_MSG_WARN([no a2x, documentation cannot be built])
+        BUILD_DOCS=no
     fi
 
     AC_MSG_CHECKING([whether to specify latex.encoding])
@@ -1070,7 +1072,8 @@ EOF
 
     AC_PATH_PROG(DBLATEX,dblatex,"none")
     if ( test "none" = "$DBLATEX" ) ; then
-	AC_MSG_ERROR([no dblatex, documentation cannot be built])
+	AC_MSG_WARN([no dblatex, documentation cannot be built])
+        BUILD_DOCS=no
     fi
 
     AC_MSG_CHECKING([dblatex version])
@@ -1079,26 +1082,30 @@ EOF
     micro=`echo $3 | sed 's/\([[0-9]]*\).*/\1/g'`
 
     if test $1 -eq 0 -a \( $2 -lt 2 -o \( $2 -eq 2 -a ${micro:-0} -lt 12 \) \); then
-        AC_MSG_ERROR([dblatex version $DBLATEX_VER less than 0.2.12.
+        AC_MSG_WARN([dblatex version $DBLATEX_VER less than 0.2.12.
 Documentation cannot be built.])
+        BUILD_DOCS=no
     fi
     AC_MSG_RESULT([$DBLATEX_VER])
 
 
     AC_PATH_PROG(SOURCE_HIGHLIGHT,source-highlight,"none")
     if ( test "none" = "$SOURCE_HIGHLIGHT" ) ; then
-	AC_MSG_ERROR([no source-highlight, documentation cannot be built])
+	AC_MSG_WARN([no source-highlight, documentation cannot be built])
+        BUILD_DOCS=no
     fi
 
 
     AC_PATH_PROG(CONVERT,convert,"none")
     if ( test "none" = "$CONVERT" ) ; then
-	AC_MSG_ERROR([no convert, documentation cannot be built])
+	AC_MSG_WARN([no convert, documentation cannot be built])
+        BUILD_DOCS=no
     fi
 
     AC_PATH_PROG(GS,gs,"none")
     if ( test "none" = "$GS" ) ; then
-	AC_MSG_ERROR([no gs, documentation cannot be built])
+	AC_MSG_WARN([no gs, documentation cannot be built])
+        BUILD_DOCS=no
     fi
 fi
 
@@ -1106,7 +1113,8 @@ fi
 if ( test "$BUILD_DOCS_PDF" = "yes" ) ; then
     AC_PATH_PROG(PDFLATEX,pdflatex,"none")
     if ( test "none" = "$PDFLATEX" ) ; then
-	AC_MSG_ERROR([no pdflatex, PDF documentation cannot be built])
+	AC_MSG_WARN([no pdflatex, PDF documentation cannot be built])
+        BUILD_DOCS=no
     fi
 fi
 
@@ -1114,25 +1122,29 @@ fi
 if ( test "$BUILD_DOCS_HTML" = "yes" ) ; then
     AC_PATH_PROG(XSLTPROC,xsltproc,"none")
     if ( test "none" = "$XSLTPROC" ) ; then
-	AC_MSG_ERROR([no xsltproc, HTML documentation cannot be built])
+	AC_MSG_WARN([no xsltproc, HTML documentation cannot be built])
+        BUILD_DOCS=no
     fi
 
     AC_PATH_PROG(DVIPNG,dvipng,"none")
     if ( test "none" = "$DVIPNG" ) ; then
-	AC_MSG_ERROR([no dvipng, HTML documentation cannot be built])
+	AC_MSG_WARN([no dvipng, HTML documentation cannot be built])
+        BUILD_DOCS=no
     fi
 
     AC_MSG_CHECKING([for HTML support in groff])
     if ! groff -Thtml < /dev/null > /dev/null 2>&1 ; then
-        AC_MSG_ERROR([no groff -Thtml, HTML documentation cannot be built])
+        AC_MSG_WARN([no groff -Thtml, HTML documentation cannot be built])
+        BUILD_DOCS=no
     else
         AC_MSG_RESULT(yes)
     fi
 
     AC_PATH_PROG(CHECKLINK,checklink,"none")
     if ( test "none" = "$CHECKLINK" ) ; then
-	AC_MSG_ERROR([no checklink, HTML documentation cannot be built
+	AC_MSG_WARN([no checklink, HTML documentation cannot be built
 install with "sudo apt-get install w3c-linkchecker"])
+        BUILD_DOCS=no
     fi
 fi
 

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1076,36 +1076,43 @@ EOF
         BUILD_DOCS=no
     fi
 
-    AC_MSG_CHECKING([dblatex version])
-    set -- `dblatex --version`; DBLATEX_VER=$3
-    set -- `echo $DBLATEX_VER | sed 's/[[.-]]/ /g'`
-    micro=`echo $3 | sed 's/\([[0-9]]*\).*/\1/g'`
+    if ( test "$BUILD_DOCS" = "yes" ) ; then
+        AC_MSG_CHECKING([dblatex version])
+        set -- `dblatex --version`; DBLATEX_VER=$3
+        set -- `echo $DBLATEX_VER | sed 's/[[.-]]/ /g'`
+        micro=`echo $3 | sed 's/\([[0-9]]*\).*/\1/g'`
 
-    if test $1 -eq 0 -a \( $2 -lt 2 -o \( $2 -eq 2 -a ${micro:-0} -lt 12 \) \); then
-        AC_MSG_WARN([dblatex version $DBLATEX_VER less than 0.2.12.
+        if test $1 -eq 0 -a \( $2 -lt 2 -o \( $2 -eq 2 -a ${micro:-0} -lt 12 \) \); then
+            AC_MSG_WARN([dblatex version $DBLATEX_VER less than 0.2.12.
 Documentation cannot be built.])
-        BUILD_DOCS=no
-    fi
-    AC_MSG_RESULT([$DBLATEX_VER])
-
-
-    AC_PATH_PROG(SOURCE_HIGHLIGHT,source-highlight,"none")
-    if ( test "none" = "$SOURCE_HIGHLIGHT" ) ; then
-	AC_MSG_WARN([no source-highlight, documentation cannot be built])
-        BUILD_DOCS=no
+            BUILD_DOCS=no
+        else
+            AC_MSG_RESULT([$DBLATEX_VER])
+        fi
     fi
 
-
-    AC_PATH_PROG(CONVERT,convert,"none")
-    if ( test "none" = "$CONVERT" ) ; then
-	AC_MSG_WARN([no convert, documentation cannot be built])
-        BUILD_DOCS=no
+    if ( test "$BUILD_DOCS" = "yes" ) ; then
+        AC_PATH_PROG(SOURCE_HIGHLIGHT,source-highlight,"none")
+        if ( test "none" = "$SOURCE_HIGHLIGHT" ) ; then
+            AC_MSG_WARN([no source-highlight, documentation cannot be built])
+            BUILD_DOCS=no
+        fi
     fi
 
-    AC_PATH_PROG(GS,gs,"none")
-    if ( test "none" = "$GS" ) ; then
-	AC_MSG_WARN([no gs, documentation cannot be built])
-        BUILD_DOCS=no
+    if ( test "$BUILD_DOCS" = "yes" ) ; then
+        AC_PATH_PROG(CONVERT,convert,"none")
+        if ( test "none" = "$CONVERT" ) ; then
+            AC_MSG_WARN([no convert, documentation cannot be built])
+            BUILD_DOCS=no
+        fi
+    fi
+
+    if ( test "$BUILD_DOCS" = "yes" ) ; then
+        AC_PATH_PROG(GS,gs,"none")
+        if ( test "none" = "$GS" ) ; then
+            AC_MSG_WARN([no gs, documentation cannot be built])
+            BUILD_DOCS=no
+        fi
     fi
 fi
 


### PR DESCRIPTION
Hello,

The autobuilders of Debian are just a bit opinionated on how they think they want everything configured. And I can upload only one kind of Debian package, not multiple, to switch between "documentation builds" or not. This PR
 * resets the BUILD_DOCS configure flag in configure.ac if key packages like asciidoc or dblatex are not installed but does not error out of the build. This avoids the need to install asciidoc and dblatex when only compiling the binary packages (running dpkg-buildpackage -B)
 * fixes d/rules' install target to tolerate when files are not existing - was important both for -A and -B

I am not 100% confident that this is the last patch in this direction. We'll see. Without addressing this, we will not get the build demons to function.