### PR TITLE
Gmoccapy: fix button state when enter setting page from MDI or Auto Mode 2.8

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -2675,7 +2675,8 @@ class gmoccapy(object):
             state = True
         if self.stat.task_state != linuxcnc.STATE_ON:
             state = False
-        self._sensitize_widgets(widgetlist, state)
+        if not self.widgets.tbtn_setup.get_active():
+            self._sensitize_widgets(widgetlist, state)
 
     def on_hal_status_metric_mode_changed(self, widget, metric_units):
         print("hal status metric mode changed")


### PR DESCRIPTION
Like mentioned in https://github.com/LinuxCNC/linuxcnc/pull/1548#issuecomment-1092156808 the MDI and Auto Mode buttons are only disabled when entering the settings page from manual mode. When entering the setup page from the other modes, MDI and Auto mode is clickable. 
I am not 100% sure if this is intended, but I think so. Otherwise the else branch in 
`on_tbtn_setup_toggled()` wouldn't make sense if it is allowed to leave the settings page by clicking on a mode button.
