### PR TITLE
emcmodule - Allowing wait for spindle

### DIFF
--- a/docs/src/config/python-interface.adoc
+++ b/docs/src/config/python-interface.adoc
@@ -749,10 +749,13 @@ c.tool_offset(toolno, z_offset,  x_offset, diameter, frontangle, backangle, orie
 `set_spindle_override(int [, int])`::
     set spindle override enabled. Defaults to spindle 0.
 
-`spindle(int [[float] [int] [float,int]])`::
-    set spindle direction. Argument one of SPINDLE_FORWARD,
-    SPINDLE_REVERSE, SPINDLE_OFF, SPINDLE_INCREASE,
-    SPINDLE_DECREASE, or SPINDLE_CONSTANT.
+`spindle(direction: int, speed: float=0, spindle: int=0, wait_for_speed: int=0)`::
+    - WARNING: MDI commands will ignore this. "S1000" after this will turn the spindle off
+    - Direction: [SPINDLE_FORWARD, SPINDLE_REVERSE, SPINDLE_OFF, SPINDLE_INCREASE,
+                SPINDLE_DECREASE, or SPINDLE_CONSTANT]
+    - Speed: Speed in RPM, defaults to 0
+    - Spindle: Spindle number to command defaults to 0
+    - Wait_for_speed: if 1 motion will wait for speed before continuing, defaults to not.
 
 `text_msg(string)`::
     sends a operator text message to the screen. (max 254 characters)

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -923,7 +923,8 @@ static PyObject *spindleoverride(pyCommandChannel *s, PyObject *o) {
 static PyObject *spindle(pyCommandChannel *s, PyObject *o) {
     int dir;
     double arg1 = 0,arg2 = 0;
-    if(!PyArg_ParseTuple(o, "i|dd", &dir, &arg1, &arg2)) return NULL;
+    int arg3 = 0;
+    if(!PyArg_ParseTuple(o, "i|ddi", &dir, &arg1, &arg2, &arg3)) return NULL;
     switch(dir) {
         case LOCAL_SPINDLE_FORWARD:
         case LOCAL_SPINDLE_REVERSE:
@@ -931,6 +932,7 @@ static PyObject *spindle(pyCommandChannel *s, PyObject *o) {
             EMC_SPINDLE_ON m;
             m.speed = dir * arg1;
             m.spindle = (int)arg2;
+            m.wait_for_spindle_at_speed = arg3;
             emcSendCommand(s, m);
         }
             break;


### PR DESCRIPTION
Adds optional Argument to allow for waiting for spindle.


How does more python-ish documentation look?