### PR TITLE
docs/fr_sync_en_fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ position.txt
 # Ignore test results
 *.result
 
+gettextization.failed.po

--- a/docs/po/checksync
+++ b/docs/po/checksync
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+l=es
+
+po4a-gettextize -f AsciiDoc -M UTF-8 -L UTF-8 -m "$1.adoc" -l "$1_$l.adoc" > /dev/null && echo "Sync OK"

--- a/docs/src/code/building-linuxcnc.adoc
+++ b/docs/src/code/building-linuxcnc.adoc
@@ -1,4 +1,5 @@
 :lang: en
+:toc:
 
 = Building LinuxCNC
 
@@ -47,7 +48,6 @@ After you've successfully built LinuxCNC it's time to run the tests:
 This might fail too!  Read this whole document, but especially the section
 on <<Setting-up-the-environment, Setting up the test environment>>.
 
-
 == Supported Platforms
 
 The LinuxCNC project targets modern Debian-based distributions, including
@@ -57,32 +57,28 @@ We continuously test on the platforms listed at
 http://buildbot.linuxcnc.org.
 
 LinuxCNC builds on most other Linux distributions, though dependency
-management will be more manual and less automatic.  Patches to improve
+management will be more manual and less automatic. Patches to improve
 portability to new platforms are always welcome.
-
 
 === Realtime
 
 LinuxCNC is a machine tool controller, and it requires a realtime platform
-to do this job.  This version of LinuxCNC supports three realtime platforms
+to do this job. This version of LinuxCNC supports three realtime platforms
 
 RTAI::
-
-    From https://www.rtai.org.  A Linux kernel with the RTAI patch is
-    available from the Debian archive at http://www.linuxcnc.org.  See
-    <<cha:getting-linuxcnc, Getting LinuxCNC>> for installation instructions.
+  From https://www.rtai.org. A Linux kernel with the RTAI patch is
+  available from the Debian archive at http://www.linuxcnc.org. See
+  <<cha:getting-linuxcnc, Getting LinuxCNC>> for installation instructions.
 
 Xenomai::
-
-    From https://xenomai.org.  You will have to compile or obtain a Xenomai
-    kernel yourself.
+  From https://xenomai.org. You will have to compile or obtain a Xenomai
+  kernel yourself.
 
 Preempt-RT::
-
-    From https://rt.wiki.kernel.org.  A Linux kernel with the
-    Preempt-RT patch is occasionally available from the Debian
-    archive at https://www.debian.org, and from the wayback machine at
-    https://snapshot.debian.org.
+  From https://rt.wiki.kernel.org. A Linux kernel with the
+  Preempt-RT patch is occasionally available from the Debian
+  archive at https://www.debian.org, and from the wayback machine at
+  https://snapshot.debian.org.
 
 To make use of the realtime capabilities of LinuxCNC, certain parts of
 LinuxCNC need to run with root privileges.  To enable root for these
@@ -91,7 +87,6 @@ parts, run this extra command after the `make` that builds LinuxCNC:
 -----
 > sudo make setuid
 -----
-
 
 === Non-realtime
 
@@ -103,12 +98,10 @@ it is useful for simulating the execution of G-code and for testing the
 non-realtime parts of the system (such as the user interfaces, and some
 kinds of components and device drivers).
 
-
 == Build modes
 
 There are two ways to build LinuxCNC: the developer-friendly "run in
 place" mode and the user-friendly Debian packaging mode.
-
 
 === Building for Run In Place
 
@@ -126,7 +119,6 @@ Building for Run-In-Place follows the steps in the <<Quick-Start,
 Quick Start>> section at the top of this document, possibly with
 different arguments to `src/configure` and `make`.
 
-
 [[src-configure-arguments]]
 ==== `src/configure` arguments
 
@@ -143,62 +135,52 @@ List all arguments to `src/configure` by running this:
 The most commonly used arguments are:
 
 `--with-realtime=uspace`::
-
-    Build for any realtime platform, or for non-realtime.
-    The resulting LinuxCNC executables will run on both a Linux kernel
-    with Preempt-RT patches (providing realtime machine control) and
-    on a vanilla (un-patched) Linux kernel (providing G-code simulation
-    but no realtime machine control).  If development files are installed
-    for Xenomai (typically from package libxenomai-dev) or RTAI (typically
-    from a package with a name starting "rtai-modules"), support for
-    these real-time kernels will also be enabled.
+  Build for any realtime platform, or for non-realtime.
+  The resulting LinuxCNC executables will run on both a Linux kernel
+  with Preempt-RT patches (providing realtime machine control) and
+  on a vanilla (un-patched) Linux kernel (providing G-code simulation
+  but no realtime machine control).  If development files are installed
+  for Xenomai (typically from package libxenomai-dev) or RTAI (typically
+  from a package with a name starting "rtai-modules"), support for
+  these real-time kernels will also be enabled.
 
 `--with-realtime=/usr/realtime-$VERSION`::
-
-    Build for the RTAI realtime platform using the older "kernel realtime"
-    model.
-    This requires that
-    you have an RTAI kernel and the RTAI modules installed in
-    `/usr/realtime-$VERSION`.  The resulting LinuxCNC executables will
-    only run on the specified RTAI kernel.  As of LinuxCNC 2.7, this
-    produces the best realtime performance.
+  Build for the RTAI realtime platform using the older "kernel realtime"
+  model.
+  This requires that you have an RTAI kernel and the RTAI modules
+  installed in `/usr/realtime-$VERSION`. The resulting LinuxCNC
+  executables will only run on the specified RTAI kernel. As of
+  LinuxCNC 2.7, this produces the best realtime performance.
 
 `--enable-build-documentation`::
-
-    Build the documentation, in addition to the executables.  This option
-    adds significantly to the time required for compilation, as building
-    the docs is quite time consuming.  If you are not actively working
-    on the documentation you may want to omit this argument.
-
+  Build the documentation, in addition to the executables.  This option
+  adds significantly to the time required for compilation, as building
+  the docs is quite time consuming.  If you are not actively working
+  on the documentation you may want to omit this argument.
 
 [[make-arguments]]
 ==== `make` arguments
 
 The `make` command takes two useful optional arguments.
 
-
 Parallel compilation::
-
-    `make` takes an optional argument `-jN` (where N is a number).
-    This enables parallel compilation with N simultaneous processes, which
-    can significantly speed up your build.
+  `make` takes an optional argument `-jN` (where N is a number).
+  This enables parallel compilation with N simultaneous processes, which
+  can significantly speed up your build.
 +
 A useful value for N is the number of CPUs in your build system.  You can
 discover the number of CPUs by running `nproc`.
 
-
 Building just a specific target::
-
-    If you want to build just a specific part of LinuxCNC, you can name
-    the thing you want to build on the `make` command line.  For example,
-    if you are working on a component named `froboz`, you can build its
-    executable by running:
+  If you want to build just a specific part of LinuxCNC, you can name
+  the thing you want to build on the `make` command line.  For example,
+  if you are working on a component named `froboz`, you can build its
+  executable by running:
 +
 -----
 > cd linuxcnc-dev/src
 > make ../bin/froboz
 -----
-
 
 === Building Debian Packages
 
@@ -253,7 +235,6 @@ the `linuxcnc-dev` directory, *not* from `linuxcnc-dev/debian`):
 > dpkg-buildpackage -b -uc
 -----
 
-
 [[debian-configure-arguments]]
 ==== `debian/configure` arguments
 
@@ -264,44 +245,38 @@ It takes a single argument which specifies the realtime or non-realtime
 platform to build for.  The normal values for this argument are:
 
 `uspace`::
-
-    Configure the Debian package for Preempt-RT realtime or for
-    non-realtime (these two are compatible).
+  Configure the Debian package for Preempt-RT realtime or for
+  non-realtime (these two are compatible).
 
 `noauto`::
 `rtai`::
 `xenomai`::
-
-    Normally, the lists of RTOSes for uspace realtime to support is detected
-    automatically.  However, if you wish, you may specify one or more of these
-    after `uspace` to enable support for these RTOSes.  Or, to disable
-    autodetection, specify `noauto`.
-
-    If you want just the traditional RTAI "kernel module" realtime, use
-    `-r` or `$KERNEL_VERSION` instead.
+  Normally, the lists of RTOSes for uspace realtime to support is detected
+  automatically.  However, if you wish, you may specify one or more of these
+  after `uspace` to enable support for these RTOSes.  Or, to disable
+  autodetection, specify `noauto`.
++
+If you want just the traditional RTAI "kernel module" realtime, use
+`-r` or `$KERNEL_VERSION` instead.
 
 `rtai=<package name>`::
-
-    If the development package for rtai lxrt does not start with
-    "rtai-modules", or if the first such package listed by apt-cache search
-    is not the desired one, then explicitly specify the package name.
+  If the development package for rtai lxrt does not start with
+  "rtai-modules", or if the first such package listed by apt-cache search
+  is not the desired one, then explicitly specify the package name.
 
 `-r`::
-
-    Configure the Debian package for the currently running RTAI kernel.
-    You must be running an RTAI kernel on your build machine for this
-    to work!
+  Configure the Debian package for the currently running RTAI kernel.
+  You must be running an RTAI kernel on your build machine for this
+  to work!
 
 `$KERNEL_VERSION`::
-
-    Configure the debian package for the specified RTAI kernel version
-    (for example "3.4.9-rtai-686-pae").  The matching kernel headers
-    debian package must be installed on your build machine (for example
-    "linux-headers-3.4.9-rtai-686-pae").  Note that you can _build_
-    LinuxCNC in this configuration, but if you are not running the
-    matching RTAI kernel you will not be able to _run_ LinuxCNC, including
-    the test suite.
-
+  Configure the debian package for the specified RTAI kernel version
+  (for example "3.4.9-rtai-686-pae").  The matching kernel headers
+  debian package must be installed on your build machine (for example
+  "linux-headers-3.4.9-rtai-686-pae").  Note that you can _build_
+  LinuxCNC in this configuration, but if you are not running the
+  matching RTAI kernel you will not be able to _run_ LinuxCNC, including
+  the test suite.
 
 [[Satisfying-Build-Dependencies]]
 == Satisfying Build Dependencies
@@ -345,7 +320,6 @@ on your system, but that are not installed yet.  Install them all with
 
 You can rerun `dpkg-checkbuilddeps` any time you want, to list any
 missing packages.
-
 
 [[Setting-up-the-environment]]
 == Setting up the environment

--- a/docs/src/code/code-notes.adoc
+++ b/docs/src/code/code-notes.adoc
@@ -1,5 +1,7 @@
 :lang: en
+:toc:
 
+[[cha:code-notes]]
 = Code Notes
 
 == Intended audience
@@ -57,10 +59,35 @@ very much a work in progress, and its layout may change in the future.
   the ini file uses the term 'axis' for data that would more accurately
   be described as joint data, such as input and output scaling, etc.
 
+Ed. In version 2.8 of LinuxCNC this distinction is already made.
+The .ini file has a new section [JOINT_<num>]. Many of the parameters that were previously
+were proper to the [AXIS_<letter>] section are now in the new section. other sections,
+such as [KINS], also take on new parameters to match this.
+A mechanism has been provided to transform old .ini files to the new configuration
+axles/joints.
+
 * 'POSE' - A pose is a fully specified position in 3-D Cartesian space. In
   the LinuxCNC motion controller, when we refer to a pose we mean an
   EmcPose structure, containing six linear coordinates (X, Y, Z, U,
   V, and W) and three angular ones (A, B, and C).
+
+* 'coord', or coordinated mode, means that all articulations are synchronized and
+  they move together as directed by the higher-level code. It is the normal mode when machining.
+  In coordinated mode, commands are assumed to be given in the Cartesian reference frame,
+  and if the machine is not Cartesian, the commands are translated by the kinematics to drive
+  each joint into the joint space as needed.
+
+* 'free' means that commands are interpreted in joint space.
+  It is used to manually move (jog) individual joints, although it does not prevent them from moving
+  multiple joints at once (I think).
+  Homing is also done in free mode; in fact, machines with non-trivial kinematics
+  must be homed before they can go into coord or teleop mode.
+
+* 'teleop' is the mode you probably need if you are jogging with a hexapod.
+  The jog commands implemented by the motion controller are joint jogs, which
+  work in free mode. But if you want to move a hexapod or similar machine along a
+  cartesian axis in particular, you must operate more than one joint.
+  That's what 'teleop' is for.
 
 == Architecture overview
 
@@ -74,7 +101,9 @@ things, etc.).
 
 image::LinuxCNC-block-diagram-small.png[align="center"]
 
-LinuxCNC software architecture. At the coarsest level, LinuxCNC is a
+=== LinuxCNC software architecture
+
+At the coarsest level, LinuxCNC is a
 hierarchy of three controllers: the task level command handler and program
 interpreter, the motion controller, and the discrete I/O controller. The
 discrete I/O controller is implemented as a hierarchy of controllers,
@@ -136,9 +165,8 @@ is in a single joint structure. Some members of that structure are
 visible in the block diagram, such as coarse_pos, pos_cmd, and
 motor_pos_fb.
 
-image::emc2-motion-joint-controller-block-diag.png[align="center"]
-
 .Joint Controller Block Diagram
+image::emc2-motion-joint-controller-block-diag.png[align="center"]
 
 The above figure shows five of the
 seven sets of position information that form the main data flow through
@@ -213,6 +241,11 @@ More on that function later.
 There are approximately 44 commands - this list is still under
 construction.
 
+Ed. The cmd_code_t enumeration, in motion.h, contains 73 commands (as of 6-5-2020)
+Ed. The switch statement in command.c contemplates 70
+Ed. ENABLE_WATCHDOG / DISABLE_WATCHDOG commands are in motion-logger.c. Maybe they are obsolete.
+Ed. The SET_TELEOP_VECTOR command only appears in motion-logger.c, with no effect other than its own log.
+
 === ABORT
 
 The ABORT command simply stops all motion. It can be issued at any
@@ -223,7 +256,7 @@ higher level code (TASK and above) also use ABORT to clear faults.
 Whenever there is a persistent fault (such as being outside the
 hardware limit switches), the higher level code sends a constant
 stream of ABORTs to the motion controller trying to make the
-fault go away. Thousands of 'em.... That means that the motion
+fault go away. Thousands of them.... That means that the motion
 controller should avoid persistent faults. This needs to be looked
 into.]
 
@@ -762,7 +795,7 @@ nml message numbers: from emc.hh:
 
 == User Interfaces
 
- + FIXME User Interfaces
+  FIXME User Interfaces
 
 == libnml Introduction
 
@@ -998,6 +1031,7 @@ is reading or writing at the time.
 timeout < 0 or INF Access is blocked until the buffer is available.
 
 == NML base class
+
 // FIXME
 
 Expand on the lists and the relationship between NML, NMLmsg, and the
@@ -1044,7 +1078,7 @@ a specific line to the cms constructor. The cms constructor then parses
 the line again to extract a couple of variables... It would make more
 sense to do ALL the parsing and save the variables in a struct that is
 passed to the cms constructor - This would eliminate string handling
-and reduce duplicate code in cms....
+and reduce duplicate code in cms...
 
 ==== NML read/write
 
@@ -1066,8 +1100,8 @@ emc.cc.
 NMLmsg is the base class from which all message classes are derived.
 Each message class must have a unique ID defined (and passed to the
 constructor) and also an update(*cms) function. The update() will be
-called by the NML read/write functions when the NML formatter is called
-- The pointer to the formatter will have been declared in the NML
+called by the NML read/write functions when the NML formatter is called -
+The pointer to the formatter will have been declared in the NML
 constructor at some point. By virtue of the linked lists NML creates,
 it is able to select cms pointer that is passed to the formatter and
 therefor which buffer is to be used.
@@ -1142,7 +1176,8 @@ the tool information for the new tool, and the pocket that the new tool
 came from has the tool information for the old tool (the tool that was
 in the spindle before the tool change), if any.
 
-NOTE: In LinuxCNC configured for random toolchanger, tool 0 (T0) has *no*
+[NOTE]
+In LinuxCNC configured for random toolchanger, tool 0 (T0) has *no*
 special meaning.  It is treated exactly like any other tool in the tool
 table.  It is customary to use T0 to represent "no tool" (ie, a tool with
 zero TLO), so that the spindle can be conveniently emptied when needed.
@@ -1156,11 +1191,10 @@ tool number::
   An integer that uniquely identifies this tool.  Tool numbers are
   handled differently by LinuxCNC when configured for random and
   nonrandom toolchangers:
-
++
   * When LinuxCNC is configured for a nonrandom toolchanger this
     number must be positive.  T0 gets special handling and is not
     allowed to appear in the tool table.
-
   * When LinuxCNC is configured for a random toolchanger this number
     must be non-negative.  T0 is allowed in the tool table, and is
     usually used to represent "no tool", ie the empty pocket.
@@ -1170,14 +1204,13 @@ pocket number::
   hardware where the tool resides.  Pocket numbers are handled
   differently by LinuxCNC when configured for random and nonrandom
   toolchangers:
-
++
   * When LinuxCNC is configured for a nonrandom toolchanger, the pocket
     number in the tool file can be any positive integer (pocket
     0 is not allowed).  LinuxCNC silently compactifies the pocket
     numbers when it loads the tool file, so there may be a difference
     between the pocket numbers in the tool file and the internal
     pocket numbers used by LinuxCNC-with-nonrandom-toolchanger.
-
   * When LinuxCNC is configured for a random toolchanger, the pocket
     numbers in the tool file must be between 0 and 1000, inclusive.
     Pockets 1-1000 are in the toolchanger, pocket 0 is the spindle.
@@ -1203,27 +1236,24 @@ Handled by +Interp::convert_tool_select()+.
 . The machine is asked to prepare to switch to the selected tool by
   calling the Canon function +SELECT_TOOL()+ with the tool number
   of the requested tool.
-
-  .. (saicanon) No-op.
-
-  .. (emccanon) Builds an +EMC_TOOL_PREPARE+ message with the requested
-     pocket number and sends it to Task, which sends it on
-     to IO.  IO gets the message and asks HAL to prepare
-     the pocket by setting +iocontrol.0.tool-prep-pocket+,
-     +iocontrol.0.tool-prep-number+, and +iocontrol.0.tool-prepare+.
-     IO then repeatedly calls +read_tool_inputs()+ to poll the HAL pin
-     +iocontrol.0.tool-prepared+, which signals from the toolchanger
-     hardware, via HAL, to IO that the requested tool prep is complete.
-     When that pin goes True, IO sets +emcioStatus.tool.pocketPrepped+
-     to the requested tool's pocket number.
-
+.. (saicanon) No-op.
+.. (emccanon) Builds an +EMC_TOOL_PREPARE+ message with the requested
+   pocket number and sends it to Task, which sends it on
+   to IO.  IO gets the message and asks HAL to prepare
+   the pocket by setting +iocontrol.0.tool-prep-pocket+,
+   +iocontrol.0.tool-prep-number+, and +iocontrol.0.tool-prepare+.
+   IO then repeatedly calls +read_tool_inputs()+ to poll the HAL pin
+   +iocontrol.0.tool-prepared+, which signals from the toolchanger
+   hardware, via HAL, to IO that the requested tool prep is complete.
+   When that pin goes True, IO sets +emcioStatus.tool.pocketPrepped+
+   to the requested tool's pocket number.
 . Back in interp, +settings->selected_pocket+ is assigned the tooldata
   index of the requested tool _xxx_.
 
 [NOTE]
 The legacy names *selected_pocket* and *current_pocket* actually reference
 a sequential tooldata index for tool items loaded from a tool
-table ([EMCIO]TOOL_TABLE) or via a tooldata database ([EMCIO]DB_PROGRAM)
+table ([EMCIO]TOOL_TABLE) or via a tooldata database ([EMCIO]DB_PROGRAM).
 
 ==== M6
 
@@ -1235,37 +1265,31 @@ Handled by +Interp::convert_tool_change()+.
 . The machine is asked to change to the selected tool
   by calling the Canon function +CHANGE_TOOL()+ with
   +settings->selected_pocket+ (a tooldata index).
-
-  .. (saicanon) Sets sai's +_active_slot+ to the passed-in pocket
-     number.  Tool information is copied from the selected pocket
-     of of the tool table (ie, from sai's +_tools[_active_slot]+)
-     to the spindle (aka sai's +_tools[0]+).
-
-  .. (emccanon) Sends an +EMC_TOOL_LOAD+ message to Task, which
-     sends it to IO.  IO sets +emcioStatus.tool.toolInSpindle+
-     to the tool number of the tool in the pocket identified
-     by +emcioStatus.tool.pocketPrepped+ (set by +Txxx+
-     aka +SELECT_TOOL()+).  It then requests that the
-     toolchanger hardware perform a tool change, by setting
-     the HAL pin +iocontrol.0.tool-change+ to True.  Later,
-     IO's +read_tool_inputs()+ will sense that the HAL pin
-     +iocontrol.0.tool_changed+ has been set to True, indicating the
-     toolchanger has completed the tool change.  When this happens,
-     it calls +load_tool()+ to update the machine state.
-
-    ... +load_tool()+ with a nonrandom toolchanger
-        config copies the tool information from the selected pocket
-        to the spindle (pocket 0).
-
-    ... +load_tool()+ with a random toolchanger config swaps tool
-        information between pocket 0 (the spindle) and the selected
-        pocket, then saves the tool table.
-
+.. (saicanon) Sets sai's +_active_slot+ to the passed-in pocket
+   number.  Tool information is copied from the selected pocket
+   of of the tool table (ie, from sai's +_tools[_active_slot]+)
+   to the spindle (aka sai's +_tools[0]+).
+.. (emccanon) Sends an +EMC_TOOL_LOAD+ message to Task, which
+   sends it to IO.  IO sets +emcioStatus.tool.toolInSpindle+
+   to the tool number of the tool in the pocket identified
+   by +emcioStatus.tool.pocketPrepped+ (set by +Txxx+
+   aka +SELECT_TOOL()+).  It then requests that the
+   toolchanger hardware perform a tool change, by setting
+   the HAL pin +iocontrol.0.tool-change+ to True.  Later,
+   IO's +read_tool_inputs()+ will sense that the HAL pin
+   +iocontrol.0.tool_changed+ has been set to True, indicating the
+   toolchanger has completed the tool change.  When this happens,
+   it calls +load_tool()+ to update the machine state.
+... +load_tool()+ with a nonrandom toolchanger
+    config copies the tool information from the selected pocket
+    to the spindle (pocket 0).
+... +load_tool()+ with a random toolchanger config swaps tool
+    information between pocket 0 (the spindle) and the selected
+    pocket, then saves the tool table.
 . Back in interp, +settings->current_pocket+ is assigned the new
   tooldata index from +settings->selected_pocket+ (set by +Txxx+).  The relevant
   numbered parameters (<<sub:numbered-parameters,#5400-#5413>>) are
   updated with the new tool information from pocket 0 (spindle).
-
 
 ==== G43/G43.1/G49
 
@@ -1281,22 +1305,17 @@ Handled by +Interp::convert_tool_length_offset()+.
   current block.  For +G43+ these offsets come from the current tool
   (the tool in pocket 0), or from the tool specified by the H-word in
   the block.  For G49, the offsets are all 0.
-
 . The offsets are passed to Canon's +USE_TOOL_LENGTH_OFFSET()+ function.
-
-  .. (saicanon) Records the TLO in +_tool_offset+.
-
-  .. (emccanon) Builds an +EMC_TRAJ_SET_OFFSET+ message containing the
-     offsets and sends it to Task.  Task copies the offsets to
-     +emcStatus->task.toolOffset+ and sends them on to Motion via
-     an +EMCMOT_SET_OFFSET+ command.  Motion copies the offsets
-     to +emcmotStatus->tool_offset+, where it gets used to offset
-     future motions.
-
+.. (saicanon) Records the TLO in +_tool_offset+.
+.. (emccanon) Builds an +EMC_TRAJ_SET_OFFSET+ message containing the
+   offsets and sends it to Task.  Task copies the offsets to
+   +emcStatus->task.toolOffset+ and sends them on to Motion via
+   an +EMCMOT_SET_OFFSET+ command.  Motion copies the offsets
+   to +emcmotStatus->tool_offset+, where it gets used to offset
+   future motions.
 . Back in interp, the offsets are recorded in +settings->tool_offset+.
   The effective pocket is recorded in +settings->tool_offset_index+,
   though this value is never used.
-
 
 ==== G10 L1/L10/L11
 
@@ -1306,35 +1325,28 @@ Handled by +Interp::convert_setup_tool()+.
 
 . Picks the tool number out of the P-word in the block and finds the
   pocket for that tool:
-
-  .. With a nonrandom toolchanger config this is always the
-     pocket number in the toolchanger (even when the tool is in
-     the spindle).
-
-  .. With a random toolchanger config, if the tool is currently
-     loaded it uses pocket 0 (pocket 0 means "the spindle"),
-     and if the tool is not loaded it uses the pocket number in
-     the tool changer.  (This difference is important.)
-
+.. With a nonrandom toolchanger config this is always the
+   pocket number in the toolchanger (even when the tool is in
+   the spindle).
+.. With a random toolchanger config, if the tool is currently
+   loaded it uses pocket 0 (pocket 0 means "the spindle"),
+   and if the tool is not loaded it uses the pocket number in
+   the tool changer.  (This difference is important.)
 . Figures out what the new offsets should be.
-
 . The new tool information (diameter, offsets, angles, and orientation),
   along with the tool number and pocket number, are passed to the Canon
   call SET_TOOL_TABLE_ENTRY().
-
-  .. (saicanon)  Copy the new tool information to the specified pocket
-     (in sai's internal tool table, +_tools+).
-
-  .. (emccanon)  Build an +EMC_TOOL_SET_OFFSET+ message with the new
-     tool information, and send it to Task, which passes it
-     to IO.  IO updates the specified pocket in its internal
-     copy of the tool table (+emcioStatus.tool.toolTable+), and
-     if the specified tool is currently loaded (it is compared to
-     +emcioStatus.tool.toolInSpindle+) then the new tool information
-     is copied to pocket 0 (the spindle) as well.  (FIXME: that's a
-     buglet, should only be copied on nonrandom machines.)  Finally IO
-     saves the new tool table.
-
+.. (saicanon)  Copy the new tool information to the specified pocket
+   (in sai's internal tool table, +_tools+).
+.. (emccanon)  Build an +EMC_TOOL_SET_OFFSET+ message with the new
+   tool information, and send it to Task, which passes it
+   to IO.  IO updates the specified pocket in its internal
+   copy of the tool table (+emcioStatus.tool.toolTable+), and
+   if the specified tool is currently loaded (it is compared to
+   +emcioStatus.tool.toolInSpindle+) then the new tool information
+   is copied to pocket 0 (the spindle) as well.  (FIXME: that's a
+   buglet, should only be copied on nonrandom machines.)  Finally IO
+   saves the new tool table.
 . Back in interp, if the modified tool is currently loaded in the
   spindle, and if the machine is a non-random toolchanger, then
   the new tool information is copied from the tool's home pocket
@@ -1342,14 +1354,12 @@ Handled by +Interp::convert_setup_tool()+.
   +settings->tool_table+.  (This copy is not needed on random tool
   changer machines because there, tools don't have a home pocket and
   instead we just updated the tool in pocket 0 directly.)
-
 . The relevant numbered parameters
   (<<sub:numbered-parameters,#5400-#5413>>) are updated from the tool
   information in the spindle (by copying the information from interp's
   +settings->tool_table+ to +settings->parameters+).  (FIXME: this is
   a buglet, the params should only be updated if it was the current
   tool that was modified).
-
 . If the modified tool is currently loaded in the
   spindle, and if the config is for a nonrandom toolchanger, then the
   new tool information is written to the tool table's pocket 0 as well,
@@ -1457,14 +1467,13 @@ settings.random_toolchanger::
 
 settings.tool_offset::
   This is an +EmcPose+ variable.
-
-  * Used to compute position in various places.
-
-  * Sent to Motion via the +EMCMOT_SET_OFFSET+ message.
-    All motion does with the offsets is export them to the HAL
-    pins +motion.0.tooloffset.[xyzabcuvw]+.  FIXME: export these from
-    someplace closer to the tool table (io or interp, probably)
-    and remove the EMCMOT_SET_OFFSET message.
++
+* Used to compute position in various places.
+* Sent to Motion via the +EMCMOT_SET_OFFSET+ message.
+  All motion does with the offsets is export them to the HAL
+  pins +motion.0.tooloffset.[xyzabcuvw]+.  FIXME: export these from
+  someplace closer to the tool table (io or interp, probably)
+  and remove the EMCMOT_SET_OFFSET message.
 
 settings.pockets_max::
   Used interchangeably with +CANON_POCKETS_MAX+ (a #defined constant,
@@ -1497,39 +1506,39 @@ FIXME: `axis_mask` and `axes` overspecify the number of axes
 
 `status.motion.traj.axis_mask`::
   A bitmask with a "1" for the axes that are present and a "0"
-  for the axes that are not present.  X is bit 0, Y is bit 1, etc.
+  for the axes that are not present. X is bit 0, Y is bit 1, etc.
   For example, a machine with X and Z axes would have an `axis_mask`
   of 0x5, an XYZ machine would have 0x7, and an XYZB machine would
   have an `axis_mask` of 0x17.
 
 `status.motion.traj.axes` (deprecated)::
   The value of this variable is one more than the index of the
-  highest-numbered axis present on the machine.  As in the `axis_mask`,
+  highest-numbered axis present on the machine. As in the `axis_mask`,
   the index of X in 0, Y is 1, etc.  An XZ machine has `axes` value
   of 3, as does an XYZ machine.  An XYZW machine has `axes` value 9.
   This variable is not terribly helpful, and its use is deprecated.
   Use `axis_mask` instead.
 
 `status.motion.traj.joints`::
-  A count of the number of joints the machine has.  A normal lathe
+  A count of the number of joints the machine has. A normal lathe
   has 2 joints; one driving the X axis and one driving the Z axis.
   An XYYZ gantry mill has 4 joints; one driving X, one driving one side
   of the Y, one driving the other side of the Y, and one driving Z.
   An XYZA mill also has 4 joints.
 
 `status.motion.axis[EMCMOT_MAX_AXIS]`::
-  An array of `EMCMOT_MAX_AXIS` axis structures.  `axis[n]` is valid
-  if `(axis_mask & (1 << n))` is True.  If `(axis_mask & (1 << n))`
+  An array of `EMCMOT_MAX_AXIS` axis structures. `axis[n]` is valid
+  if `(axis_mask & (1 << n))` is True. If `(axis_mask & (1 << n))`
   is False, then `axis[n]` does not exist on this machine and must
   be ignored.
 
 `status.motion.joint[EMCMOT_MAX_JOINTS]`::
-  An array of `EMCMOT_MAX_JOINTS` joint structures.  `joint[0]` through
+  An array of `EMCMOT_MAX_JOINTS` joint structures. `joint[0]` through
   `joint[joints-1]` are valid, the others do not exist on this machine
   and must be ignored.
 
 Things are not this way currently in the joints-axes branch, but
-deviations from this design are considered bugs.  For an example of such
+deviations from this design are considered bugs. For an example of such
 a bug, see the treatment of axes in src/emc/ini/initraj.cc:loadTraj().
 There are undoubtedly more, and I need your help to find them and
 fix them.

--- a/docs/src/common/glossary.adoc
+++ b/docs/src/common/glossary.adoc
@@ -32,7 +32,7 @@ Gmoccapy (GUI)::
     LinuxCNC. It features the use and feel of an industrial control and can
     be used with touch screen, mouse and keyboard. It support embedded tabs and
     hal driven user messages, it offers a lot of hal beens to be controlled with
-    hardware. Gmoccapy is highly cusomizable.
+    hardware. Gmoccapy is highly customizable.
 
 
 Backlash::
@@ -379,3 +379,4 @@ World Coordinates::
     frame that is attached to some point (generally the base) of the
     machine tool.
 
+// vim: set syntax=asciidoc:

--- a/docs/src/common/overleaf.adoc
+++ b/docs/src/common/overleaf.adoc
@@ -1,8 +1,8 @@
 :lang: en
 
-This handbook is a work in progress. If you are able to help with 
-writing, editing, or graphic preparation please contact any member 
-of the writing team or join and send an email to 
+This handbook is a work in progress. If you are able to help with
+writing, editing, or graphic preparation please contact any member
+of the writing team or join and send an email to
 emc-users@lists.sourceforge.net.
 
 Copyright © 2000-2020 LinuxCNC.org
@@ -13,6 +13,15 @@ or any later version published by the Free Software Foundation;
 with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 A copy of the license is included in the section entitled "GNU
 Free Documentation License".
+
+If you do not find the license you may order a copy from:
+
+  Free Software Foundation, Inc.
+  51 Franklin Street
+  Fifth Floor
+  Boston, MA 02110-1301 USA.
+
+(The English language version is authoritative)
 
 LINUX® is the registered trademark of Linus Torvalds in the U.S. and other
 countries.  The registered trademark Linux® is used pursuant to a sublicense
@@ -25,3 +34,5 @@ Inc.
 
 The LinuxCNC project is not affiliated with UBUNTU®.
 _UBUNTU_ is a registered trademark owned by Canonical Limited.
+
+// vim: set syntax=asciidoc:

--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -55,7 +55,7 @@ INCORRECT = value     # and a comment
 CORRECT = value
 ----
 
-=== Sections
+=== Sections(((Sections)))
 
 Related parts of an ini file are separated into sections.
 A section name is enclosed in brackets like this '[THIS_SECTION]'
@@ -257,8 +257,8 @@ User Manual.
   the graphics display
 * 'MAX_FEED_OVERRIDE = 1.2' - The maximum feed override the user may select.
   1.2 means 120% of the programmed feed rate.
-* 'MIN_SPINDLE_OVERRIDE = 0.5' - The minimum spindle override the user may
-  select. 0.5 means 50% of the programmed spindle speed. (This is used to
+* 'MIN_SPINDLE_OVERRIDE = 0.5' - The minimum spindle override the user may select.
+  0.5 means 50% of the programmed spindle speed. (This is used to
   set the minimum spindle speed).
 * 'MIN_SPINDLE_0_OVERRIDE = 0.5' - The minimum spindle override the user may select.
   0.5 means 50% of the programmed spindle speed.  (This is used to
@@ -522,11 +522,11 @@ if __name__ == "__main__":
 [[gcode:ini-features]]
 === [RS274NGC] Section(((INI File,RS274NGC Section)))
 
-* 'PARAMETER_FILE = myfile.var' -
-  (((PARAMETER FILE))) The file located in the same directory as the ini
+* 'PARAMETER_FILE = myfile.var' - (((PARAMETER FILE)))
+  The file located in the same directory as the ini
   file which contains the parameters used by the interpreter (saved between runs).
-* 'ORIENT_OFFSET = 0' -
-  (((ORIENT OFFSET))) A float value added to the R word parameter of an <<mcode:m19,M19 Orient Spindle>> operation.
+* 'ORIENT_OFFSET = 0' - (((ORIENT OFFSET)))
+  A float value added to the R word parameter of an <<mcode:m19,M19 Orient Spindle>> operation.
   Used to define an arbitrary zero position regardless of encoder mount orientation.
 * 'RS274NGC_STARTUP_CODE = G17 G20 G40 G49 G64 P0.001 G80 G90 G92 G94 G97 G98' - (((RS274NGC STARTUP CODE)))
   A string of NC codes that the interpreter
@@ -768,7 +768,7 @@ APP = halscope -i my.halscope
 === [TRAJ] Section(((INI File, TRAJ Section)))
 
 [WARNING]
-----
+====
 The new Trajectory Planner (TP) is on by default.
 If you have no TP settings in your [TRAJ] section - LinuxCNC defaults to: +
 ARC_BLEND_ENABLE = 1 +
@@ -776,7 +776,7 @@ ARC_BLEND_FALLBACK_ENABLE = 0 +
 ARC_BLEND_OPTIMIZATION_DEPTH = 50 +
 ARC_BLEND_GAP_CYCLES = 4 +
 ARC_BLEND_RAMP_FREQ = 100
-----
+====
 
 The [TRAJ] section contains general parameters for the trajectory
 planning module in 'motion'.
@@ -1317,7 +1317,7 @@ See the following table for an example of voltage measurements.
 // latexmath:[ raw=(cmd-b)/a ]
 
 .Output Voltage Measurements
-[width="50%", cols="2*^", options="header"]
+[width="50%",cols="2*^",options="header"]
 |===============
 |Raw | Measured
 |-10 | -9.93
@@ -1452,11 +1452,11 @@ The value of 'num_spindles' is set by [TRAJ]SPINDLES=
 
 * 'EMCIO = io' - Name of IO controller program.
 * 'CYCLE_TIME = 0.100' - The period, in seconds, at which EMCIO will run.
-   Making it 0.0 or a negative number will tell EMCIO not to sleep at all.
-   There is usually no need to change this number.
+  Making it 0.0 or a negative number will tell EMCIO not to sleep at all.
+  There is usually no need to change this number.
 * 'TOOL_TABLE = tool.tbl' - The file which contains tool information, described in the User Manual.
 * 'DB_PROGRAM = db_program' - Path to an executable program that manages tool data.
-   (When a DB_PROGRAM is specified, a TOOL_TABLE entry is ignored)
+  (When a DB_PROGRAM is specified, a TOOL_TABLE entry is ignored)
 * 'TOOL_CHANGE_POSITION = 0 0 2' -
   Specifies the XYZ location to move to when performing a tool change if three digits are used.
   Specifies the XYZABC location when 6 digits are used.
@@ -1464,14 +1464,14 @@ The value of 'num_spindles' is set by [TRAJ]SPINDLES=
   Tool Changes can be combined.
   For example if you combine the quill up with change position you can move the Z first theun the X and Y.
 * 'TOOL_CHANGE_WITH_SPINDLE_ON = 1' -
-   The spindle will be left on during the tool change when the value is 1.
-   Useful for lathes or machines where the material is in the spindle, not the tool.
+  The spindle will be left on during the tool change when the value is 1.
+  Useful for lathes or machines where the material is in the spindle, not the tool.
 * 'TOOL_CHANGE_QUILL_UP = 1' -
-   The Z axis will be moved to machine zero prior to the tool change when
-   the value is 1. This is the same as issuing a G0 G53 Z0.
+  The Z axis will be moved to machine zero prior to the tool change when
+  the value is 1. This is the same as issuing a G0 G53 Z0.
 * 'TOOL_CHANGE_AT_G30 = 1' -
-   The machine is moved to reference point defined by parameters 5181-5186 for G30 if the value is 1.
-   For more information see <<sec:overview-parameters,G-Code Parameters>> and <<gcode:g30-g30.1,G-Code G30-G30.1>>.
+  The machine is moved to reference point defined by parameters 5181-5186 for G30 if the value is 1.
+  For more information see <<sec:overview-parameters,G-Code Parameters>> and <<gcode:g30-g30.1,G-Code G30-G30.1>>.
 * 'RANDOM_TOOLCHANGER = 1' -
-   This is for machines that cannot place the tool back into the pocket it came from.
-   For example, machines that exchange the tool in the active pocket with the tool in the spindle.
+  This is for machines that cannot place the tool back into the pocket it came from.
+  For example, machines that exchange the tool in the active pocket with the tool in the spindle.

--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -79,6 +79,7 @@ The following sections are used by LinuxCNC:
 * '[<<sec:kins-section,KINS>>]' kinematics variables
 * '[<<sec:emcio-section,EMCIO>>]' settings used by the I/O Controller
 
+[[sub:ini-variables]]
 === Variables
 
 A variable line is made up of a variable name, an equals sign (=), and
@@ -171,7 +172,6 @@ G1 Z#5063
 G10 L20 P0 Z#<_ini[probe]z_offset>
 ---------------------------------------------------------------------
 
-
 === Include Files
 
 An INI file may include the contents of another file by using a #INCLUDE directive.
@@ -203,23 +203,24 @@ The #INCLUDE directives are supported for one level of expansion only -- an
 included file may not include additional files.  The recommended file extension
 is .inc.  Do not use a file extension of .ini for included files.
 
+[[sec:ini-file-sections]]
 == INI File Sections
 
 [[sec:emc-section]]
-=== [EMC] Section(((INI File, EMC Section)))
+=== [EMC] Section(((INI File,EMC Section)))
 
- * 'VERSION = 1.1' - The version number for the configuration. Any value other
-    than 1.1 will cause the configuration checker to run and try to update the
-    configuration to the new style joint axes type of configuration.
- * 'MACHINE = My Controller' - This is the name of the controller, which is
-    printed out at the top of most graphical interfaces. You can put whatever
-    you want here as long as you make it a single line long.
- * 'DEBUG = 0' - Debug level 0 means no messages will be printed when LinuxCNC is
-    run from a <<faq:terminal,terminal>>. Debug flags are usually only useful to
-    developers. See src/emc/nml_intf/debugflags.h for other settings.
+* 'VERSION = 1.1' - The version number for the configuration. Any value other
+  than 1.1 will cause the configuration checker to run and try to update the
+  configuration to the new style joint axes type of configuration.
+* 'MACHINE = My Controller' - This is the name of the controller, which is
+  printed out at the top of most graphical interfaces. You can put whatever
+  you want here as long as you make it a single line long.
+* 'DEBUG = 0' - Debug level 0 means no messages will be printed when LinuxCNC is
+  run from a <<faq:terminal,terminal>>. Debug flags are usually only useful to
+  developers. See src/emc/nml_intf/debugflags.h for other settings.
 
 [[sec:display-section]]
-=== [DISPLAY] Section(((INI File, DISPLAY Section)))
+=== [DISPLAY] Section(((INI File,DISPLAY Section)))
 
 Different user interface programs use different options, and not every
 option is supported by every user interface. There are several interfaces,
@@ -230,79 +231,79 @@ can be used both ways and offers also many connections for hardware controls.
 Descriptions of the interfaces are in the Interfaces section of the
 User Manual.
 
- * 'DISPLAY = axis' - The name of the user interface to use. Valid options
-    may include: 'axis', 'touchy', 'gmoccapy', 'gscreen', 'tklinuxcnc', 'qtvcp'
- * 'POSITION_OFFSET = RELATIVE' - The coordinate system (RELATIVE or MACHINE)
-    to show on the DRO when the user interface starts. The RELATIVE coordinate
-    system reflects the G92 and G5x coordinate offsets currently in effect.
- * 'POSITION_FEEDBACK = COMMANDED' - The coordinate value (COMMANDED or ACTUAL)
-    to show on the DRO when the user interface starts. In Axis this can be changed
-    from the View menu. The COMMANDED position is the position requested by
-    LinuxCNC. The ACTUAL position is the feedback position of the motors if they
-    have feedback like most servo systems. Typically the COMMANDED value is used.
- * 'DRO_FORMAT_MM = %+08.6f' - Over-ride the default DRO formatting in metric
-    mode. (normally 3 decimal places, padded with spaces to 6 digits to the left)
-    the example above will pad with zeros, display 6 decimal digits and force
-    display of a + sign for positive numbers. Formatting follows Python practice.
-    https://docs.python.org/2/library/string.html#format-specification-mini-language
-    an error will be raised if the format can not accept a floating-point value.
- * 'DRO_FORMAT_IN = % 4.1f' - Over-ride the default DRO formatting in imperial
-    mode. (normally 4 decimal places, padded with spaces to 6 digits to the left)
-    the example above will display only one decimal digit. Formatting follows
-    Python practice.
-    https://docs.python.org/2/library/string.html#format-specification-mini-language
-    An error will be raised if the format can not accept a floating-point value.
- * 'CONE_BASESIZE = .25' - Over-ride the default cone/tool base size of .5 in
-    the graphics display
- * 'MAX_FEED_OVERRIDE = 1.2' - The maximum feed override the user may select.
-    1.2 means 120% of the programmed feed rate.
- * 'MIN_SPINDLE_OVERRIDE = 0.5' - The minimum spindle override the user may
-    select. 0.5 means 50% of the programmed spindle speed. (This is used to
-    set the minimum spindle speed).
- * 'MIN_SPINDLE_0_OVERRIDE = 0.5' - The minimum spindle override the user may select.
-    0.5 means 50% of the programmed spindle speed.  (This is used to
-    set the minimum spindle speed).
-    On multi spindle machine there will be entries for each spindle number. Qtvcp only.
- * 'MAX_SPINDLE_OVERRIDE = 1.0' - The maximum spindle override the user may
-    select. 1.0 means 100% of the programmed spindle speed.
- * 'MAX_SPINDLE_0_OVERRIDE = 1.0' - The maximum feed override the user may select.
-    1.2 means 120% of the programmed feed rate.
-    On multi spindle machine there will be entries for each spindle number. Qtvcp only
- * 'DEFAULT_SPINDLE_SPEED = 100' - The default spindle RPM when the spindle
-    is started in manual mode. if this setting is not present, this
-    defaults to 1 RPM for AXIS and 300 RPM for gmoccapy.
-    - deprecated - use the [SPINDLE_n] section instead
- * 'DEFAULT_SPINDLE_0_SPEED = 100' - The default spindle RPM when the spindle
-    is started in manual mode. On multi spindle machine there will be entries for each spindle number. Qtvcp only
-    - deprecated - use the [SPINDLE_n] section instead
- * 'SPINDLE_INCREMENT = 200' - The increment used when clicking increase/decrease buttons Qtvcp only
-    - deprecated - use the [SPINDLE_n] section instead
- * 'MIN_SPINDLE_0_SPEED = 1000' - The minimum RPM that can be manually selected.
-    On multi spindle machine there will be entries for each spindle number. Qtvcp only.
-    - deprecated - use the [SPINDLE_n] section instead
- * 'MAX_SPINDLE_0_SPEED = 20000' - The maximum RPM that can be manually selected.
-    On multi spindle machine there will be entries for each spindle number. Qtvcp only.
-    - deprecated - use the [SPINDLE_n] section instead
- * 'PROGRAM_PREFIX = ~/linuxcnc/nc_files' - The default location for G-code
-    files and the location for user-defined M-codes. This location is searched
-    for the file name before the subroutine path and user M path if specified
-    in the [RS274NGC] section.
- * 'INTRO_GRAPHIC = emc2.gif' - The image shown on the splash screen.
- * 'INTRO_TIME = 5' - The maximum time to show the splash screen, in seconds.
- * 'CYCLE_TIME = 100' - Cycle time of the Display GUI.
-    Depending on the screen, this can be in seconds or ms (ms preferred).
-    This is often the update rate rather then sleep time between updates.
-    If the update time is not set right the screen can become unresponsive or very jerky.
-    A value of 100ms (0.1 seconds) is a common setting though a range of 50 - 200ms (.05 - .2 seconds) may be useable.
-    An under powered CPU may see improvement with a longer setting. Usually the default is fine.
+* 'DISPLAY = axis' - The name of the user interface to use. Valid options
+  may include: 'axis', 'touchy', 'gmoccapy', 'gscreen', 'tklinuxcnc', 'qtvcp'
+* 'POSITION_OFFSET = RELATIVE' - The coordinate system (RELATIVE or MACHINE)
+  to show on the DRO when the user interface starts. The RELATIVE coordinate
+  system reflects the G92 and G5x coordinate offsets currently in effect.
+* 'POSITION_FEEDBACK = COMMANDED' - The coordinate value (COMMANDED or ACTUAL)
+  to show on the DRO when the user interface starts. In Axis this can be changed
+  from the View menu. The COMMANDED position is the position requested by
+  LinuxCNC. The ACTUAL position is the feedback position of the motors if they
+  have feedback like most servo systems. Typically the COMMANDED value is used.
+* 'DRO_FORMAT_MM = %+08.6f' - Over-ride the default DRO formatting in metric
+  mode. (normally 3 decimal places, padded with spaces to 6 digits to the left)
+  the example above will pad with zeros, display 6 decimal digits and force
+  display of a + sign for positive numbers. Formatting follows Python practice.
+  https://docs.python.org/2/library/string.html#format-specification-mini-language
+  an error will be raised if the format can not accept a floating-point value.
+* 'DRO_FORMAT_IN = % 4.1f' - Over-ride the default DRO formatting in imperial
+  mode. (normally 4 decimal places, padded with spaces to 6 digits to the left)
+  the example above will display only one decimal digit. Formatting follows
+  Python practice.
+  https://docs.python.org/2/library/string.html#format-specification-mini-language
+  An error will be raised if the format can not accept a floating-point value.
+* 'CONE_BASESIZE = .25' - Over-ride the default cone/tool base size of .5 in
+  the graphics display
+* 'MAX_FEED_OVERRIDE = 1.2' - The maximum feed override the user may select.
+  1.2 means 120% of the programmed feed rate.
+* 'MIN_SPINDLE_OVERRIDE = 0.5' - The minimum spindle override the user may
+  select. 0.5 means 50% of the programmed spindle speed. (This is used to
+  set the minimum spindle speed).
+* 'MIN_SPINDLE_0_OVERRIDE = 0.5' - The minimum spindle override the user may select.
+  0.5 means 50% of the programmed spindle speed.  (This is used to
+  set the minimum spindle speed).
+  On multi spindle machine there will be entries for each spindle number. Qtvcp only.
+* 'MAX_SPINDLE_OVERRIDE = 1.0' - The maximum spindle override the user may
+  select. 1.0 means 100% of the programmed spindle speed.
+* 'MAX_SPINDLE_0_OVERRIDE = 1.0' - The maximum feed override the user may select.
+  1.2 means 120% of the programmed feed rate.
+  On multi spindle machine there will be entries for each spindle number. Qtvcp only
+* 'DEFAULT_SPINDLE_SPEED = 100' - The default spindle RPM when the spindle
+  is started in manual mode. if this setting is not present, this
+  defaults to 1 RPM for AXIS and 300 RPM for gmoccapy.
+  - deprecated - use the [SPINDLE_n] section instead
+* 'DEFAULT_SPINDLE_0_SPEED = 100' - The default spindle RPM when the spindle
+  is started in manual mode. On multi spindle machine there will be entries for each spindle number. Qtvcp only
+  - deprecated - use the [SPINDLE_n] section instead
+* 'SPINDLE_INCREMENT = 200' - The increment used when clicking increase/decrease buttons Qtvcp only
+  - deprecated - use the [SPINDLE_n] section instead
+* 'MIN_SPINDLE_0_SPEED = 1000' - The minimum RPM that can be manually selected.
+  On multi spindle machine there will be entries for each spindle number. Qtvcp only.
+  - deprecated - use the [SPINDLE_n] section instead
+* 'MAX_SPINDLE_0_SPEED = 20000' - The maximum RPM that can be manually selected.
+  On multi spindle machine there will be entries for each spindle number. Qtvcp only.
+  - deprecated - use the [SPINDLE_n] section instead
+* 'PROGRAM_PREFIX = ~/linuxcnc/nc_files' - The default location for G-code
+  files and the location for user-defined M-codes. This location is searched
+  for the file name before the subroutine path and user M path if specified
+  in the [RS274NGC] section.
+* 'INTRO_GRAPHIC = emc2.gif' - The image shown on the splash screen.
+* 'INTRO_TIME = 5' - The maximum time to show the splash screen, in seconds.
+* 'CYCLE_TIME = 100' - Cycle time of the Display GUI.
+  Depending on the screen, this can be in seconds or ms (ms preferred).
+  This is often the update rate rather then sleep time between updates.
+  If the update time is not set right the screen can become unresponsive or very jerky.
+  A value of 100ms (0.1 seconds) is a common setting though a range of 50 - 200ms (.05 - .2 seconds) may be useable.
+  An under powered CPU may see improvement with a longer setting. Usually the default is fine.
 
 [NOTE]
 The following [DISPLAY] items are used by GladeVCP, see the
 gladevcp:embeding-tab,embedding a tab section of the GladeVCP Chapter.
 //<<gladevcp:embeding-tab,embedding a tab>> section of the GladeVCP Chapter. FIXME SPANISH
 
- * 'EMBED_TAB_NAME=GladeVCP demo'
- * 'EMBED_TAB_COMMAND=halcmd loadusr -Wn gladevcp gladevcp -c gladevcp -x {XID} -u ./gladevcp/hitcounter.py ./gladevcp/manual-example.ui'
+* 'EMBED_TAB_NAME=GladeVCP demo'
+* 'EMBED_TAB_COMMAND=halcmd loadusr -Wn gladevcp gladevcp -c gladevcp -x {XID} -u ./gladevcp/hitcounter.py ./gladevcp/manual-example.ui'
 
 [NOTE]
 Different user interface programs use different options, and not every
@@ -310,43 +311,43 @@ option is supported by every user interface.
 See <<cha:axis-gui,AXIS GUI>> document for AXIS details.
 See <<cha:gmoccapy,gmoccapy>> document for Gmoccapy details.
 
- * 'DEFAULT_LINEAR_VELOCITY = .25' - The default velocity for linear jogs, in <<sec:traj-section,machine units>> per second.
- * 'MIN_VELOCITY = .01' - The approximate lowest value the jog slider.
- * 'MAX_LINEAR_VELOCITY = 1.0' - The maximum velocity for linear jogs, in machine units per second.
- * 'MIN_LINEAR_VELOCITY = .01' - The approximate lowest value the jog slider.
- * 'DEFAULT_ANGULAR_VELOCITY = .25' - The default velocity for angular jogs, in machine units per second.
- * 'MIN_ANGULAR_VELOCITY = .01' - The approximate lowest value the angular jog slider.
- * 'MAX_ANGULAR_VELOCITY = 1.0' - The maximum velocity for angular jogs, in machine units per second.
- * 'INCREMENTS = 1 mm, .5 in, ...' - Defines the increments available for incremental jogs.
-    The INCREMENTS can be used to override the default.
-    The values can be decimal numbers (e.g., 0.1000) or fractional numbers (e.g., 1/16),
-    optionally followed by a unit (cm, mm, um, inch, in or mil).
-    If a unit is not specified the machine unit is assumed.
-    Metric and imperial distances may be mixed:
-    INCREMENTS = 1 inch, 1 mil, 1 cm, 1 mm, 1 um is a valid entry.
- * 'GRIDS = 10 mm, 1 in, ...' - Defines the preset values for grid lines.
-    The value is interpreted the same way as 'INCREMENTS'.
- * 'OPEN_FILE = /full/path/to/file.ngc' - The file to show in the preview plot when AXIS starts.
-    Use a blank string "" and no file will be loaded at start up.
-    gmoccapy will not use this setting, as it offers a corresponding entry on its settings page.
- * 'EDITOR = gedit' - The editor to use when selecting File > Edit to edit the G-code from the AXIS menu.
-    This must be configured for this menu item to work.
-    Another valid entry is gnome-terminal -e vim.
-    This entry does not apply to gmoccapy, as gmoccapy has an integrated editor.
- * 'TOOL_EDITOR = tooledit' - The editor to use when editing the tool table
-    (for example by selecting "File > Edit tool table..." in Axis).
-    Other valid entries are "gedit", "gnome-terminal -e vim", and "gvim".
-    This entry does not apply to gmoccapy, as gmoccapy has an integrated editor.
- * 'PYVCP = /filename.xml' - The PyVCP panel description file.
-    See the PyVCP Chapter for more information.  //<<cha:pyvcp,Capítulo PyVCP>>PyVCP Chapter 
- * 'PYVCP_POSITION = BOTTOM' - The placement of the PyVCP panel in the AXIS user interface.
-    If this variable is omitted the panel will default to the right side. The only valid
-    alternative is BOTTOM. See the PyVCP Chapter for more information.  //<<cha:pyvcp,Capítulo PyVCP>>PyVCP Chapter 
- * 'LATHE = 1' - Any non-empty value (including "0") causes axis to use "lathe mode" with a top view and with Radius and Diameter on the DRO.
- * 'BACK_TOOL_LATHE = 1' - Any non-empty value (including "0") causes axis to use "back tool lathe mode" with inverted X axis.
- * 'FOAM = 1' - Any non-empty value (including "0") causes axis to change the display for foam-cutter mode.
- * 'GEOMETRY = XYZABCUVW' - Controls the *preview* and *backplot* of motion.
-    This item consists of a sequence of axis letters and control characters, optionally preceeded with a "-" sign:
+* 'DEFAULT_LINEAR_VELOCITY = .25' - The default velocity for linear jogs, in <<sec:traj-section,machine units>> per second.
+* 'MIN_VELOCITY = .01' - The approximate lowest value the jog slider.
+* 'MAX_LINEAR_VELOCITY = 1.0' - The maximum velocity for linear jogs, in machine units per second.
+* 'MIN_LINEAR_VELOCITY = .01' - The approximate lowest value the jog slider.
+* 'DEFAULT_ANGULAR_VELOCITY = .25' - The default velocity for angular jogs, in machine units per second.
+* 'MIN_ANGULAR_VELOCITY = .01' - The approximate lowest value the angular jog slider.
+* 'MAX_ANGULAR_VELOCITY = 1.0' - The maximum velocity for angular jogs, in machine units per second.
+* 'INCREMENTS = 1 mm, .5 in, ...' - Defines the increments available for incremental jogs.
+  The INCREMENTS can be used to override the default.
+  The values can be decimal numbers (e.g., 0.1000) or fractional numbers (e.g., 1/16),
+  optionally followed by a unit (cm, mm, um, inch, in or mil).
+  If a unit is not specified the machine unit is assumed.
+  Metric and imperial distances may be mixed:
+  INCREMENTS = 1 inch, 1 mil, 1 cm, 1 mm, 1 um is a valid entry.
+* 'GRIDS = 10 mm, 1 in, ...' - Defines the preset values for grid lines.
+  The value is interpreted the same way as 'INCREMENTS'.
+* 'OPEN_FILE = /full/path/to/file.ngc' - The file to show in the preview plot when AXIS starts.
+  Use a blank string "" and no file will be loaded at start up.
+  gmoccapy will not use this setting, as it offers a corresponding entry on its settings page.
+* 'EDITOR = gedit' - The editor to use when selecting File > Edit to edit the G-code from the AXIS menu.
+  This must be configured for this menu item to work.
+  Another valid entry is gnome-terminal -e vim.
+  This entry does not apply to gmoccapy, as gmoccapy has an integrated editor.
+* 'TOOL_EDITOR = tooledit' - The editor to use when editing the tool table
+  (for example by selecting "File > Edit tool table..." in Axis).
+  Other valid entries are "gedit", "gnome-terminal -e vim", and "gvim".
+  This entry does not apply to gmoccapy, as gmoccapy has an integrated editor.
+* 'PYVCP = /filename.xml' - The PyVCP panel description file.
+  See the PyVCP Chapter for more information.  //<<cha:pyvcp,Capítulo PyVCP>>PyVCP Chapter 
+* 'PYVCP_POSITION = BOTTOM' - The placement of the PyVCP panel in the AXIS user interface.
+  If this variable is omitted the panel will default to the right side. The only valid
+  alternative is BOTTOM. See the PyVCP Chapter for more information.  //<<cha:pyvcp,Capítulo PyVCP>>PyVCP Chapter 
+* 'LATHE = 1' - Any non-empty value (including "0") causes axis to use "lathe mode" with a top view and with Radius and Diameter on the DRO.
+* 'BACK_TOOL_LATHE = 1' - Any non-empty value (including "0") causes axis to use "back tool lathe mode" with inverted X axis.
+* 'FOAM = 1' - Any non-empty value (including "0") causes axis to change the display for foam-cutter mode.
+* 'GEOMETRY = XYZABCUVW' - Controls the *preview* and *backplot* of motion.
+  This item consists of a sequence of axis letters and control characters, optionally preceeded with a "-" sign:
 
 . The letters X,Y,Z specify translation along the named coordinate.
 . The letters A,B,C specify rotation about the corresponding axes X,Y,Z.
@@ -409,7 +410,7 @@ The following [DISPLAY] item is used by the TKLinuxCNC interface only.
 * 'HELP_FILE = tklinucnc.txt' - Path to help file.
 
 [[sec:filter-section]]
-=== [FILTER] Section(((INI File, FILTER Section)))
+=== [FILTER] Section(((INI File,FILTER Section)))
 
 AXIS and gmoccapy have the ability to send loaded files through a filter program.
 This filter can do any desired task: Something as simple as making sure
@@ -423,33 +424,43 @@ must write RS274NGC code to standard output. This output is what will
 be displayed in the text area, previewed in the display area, and
 executed by LinuxCNC when Run.
 
-* 'PROGRAM_EXTENSION = .extension Description'
+----
+PROGRAM_EXTENSION = .extension Description
+----
 
 If your post processor outputs files in all caps you might want to add
 the following line:
 
-* 'PROGRAM_EXTENSION = .NGC XYZ Post Processor'
+----
+PROGRAM_EXTENSION = .NGC XYZ Post Processor
+----
 
 The following lines add support for the image-to-G-code converter
 included with LinuxCNC.
 
-* 'PROGRAM_EXTENSION = .png,.gif,.jpg Greyscale Depth Image'
-** 'png = image-to-gcode'
-** 'gif = image-to-gcode'
-** 'jpg = image-to-gcode'
+----
+PROGRAM_EXTENSION = .png,.gif,.jpg Greyscale Depth Image
+  png = image-to-gcode
+  gif = image-to-gcode
+  jpg = image-to-gcode
+----
 
 An example of a custom G-code converter located in the linuxcnc directory.
 
-* 'PROGRAM_EXTENSION = .gcode 3D Printer'
-** 'gcode = /home/mill/linuxcnc/convert.py'
+----
+PROGRAM_EXTENSION = .gcode 3D Printer
+  gcode = /home/mill/linuxcnc/convert.py
+----
 
 NOTE: The program file associated with an extension must have either the full
 path to the program or be located in a directory that is on the system path.
 
 It is also possible to specify an interpreter:
 
-* 'PROGRAM_EXTENSION = .py Python Script'
-** 'py = python'
+----
+PROGRAM_EXTENSION = .py Python Script
+  py = python
+----
 
 In this way, any Python script can be opened, and its output is
 treated as G-code. One such example script is available at
@@ -461,7 +472,9 @@ http://wiki.linuxcnc.org/[http://wiki.linuxcnc.org/].
 If the environment variable AXIS_PROGRESS_BAR is set, then lines
 written to stderr of the form
 
-* 'FILTER_PROGRESS=%d'
+----
+FILTER_PROGRESS=%d
+----
 
 sets the AXIS progress bar to the given percentage. This feature
 should be used by any filter that runs for a long time.
@@ -505,9 +518,9 @@ if __name__ == "__main__":
   main(sys.argv[1:])
 ----
 
-[[sec:rs274ngc-section]](((INI File, RS274NGC Section)))
+[[sec:rs274ngc-section]]
 [[gcode:ini-features]]
-=== [RS274NGC] Section
+=== [RS274NGC] Section(((INI File,RS274NGC Section)))
 
 * 'PARAMETER_FILE = myfile.var' -
   (((PARAMETER FILE))) The file located in the same directory as the ini
@@ -537,16 +550,16 @@ if __name__ == "__main__":
   Specifies a list of colon (:) separated directories for user defined functions.
   Directories are specified relative to the current directory for the ini file or as absolute paths.
   The list must contain no intervening whitespace.
-
++
 A search is made for each possible user defined function, typically
 (M100-M199). The search order is:
-
++
 . [DISPLAY]PROGRAM_PREFIX (if specified)
 . If [DISPLAY]PROGRAM_PREFIX is not specified, search the default location: nc_files
 . Then search each directory in the list [RS274NGC]USER_M_PATH
-
++
 The first executable M1xx found in the search is used for each M1xx.
-
++
 [NOTE]
 The maximum number of USER_M_PATH directories is defined at compile time (typ: 'USER_DEFINED_FUNCTION_MAX_DIRS == 5').
 
@@ -583,7 +596,7 @@ implemented and the results of using it are unpredictable.
   See <<cha:remap,Remap Extending G-Code>> chapter for details.
 
 [[sec:emcmot-section]]
-=== [EMCMOT] Section(((INI File, EMCMOT Section)))
+=== [EMCMOT] Section(((INI File,EMCMOT Section)))
 
 This section is a custom section and is not used by LinuxCNC directly. Most
 configurations use values from this section to load the motion controller. For
@@ -599,14 +612,13 @@ Section.
   realtime part of the motion controller) to acknowledge receipt of
   messages from Task (the non-realtime part of the motion controller).
 * HOMEMOD = alternate_homing_module [home_parms=value]
-
-The HOMEMOD variable is optional.  If specified, use a specified (user-built)
-module instead of the default (homemod).  Module parameters (home_parms) may be
-included if supported by the named module.  The setting may be overridden
-from the command line using the -m option ($linuxcnc -h)
+  The HOMEMOD variable is optional. If specified, use a specified (user-built)
+  module instead of the default (homemod). Module parameters (home_parms) may be
+  included if supported by the named module. The setting may be overridden
+  from the command line using the -m option ($linuxcnc -h)
 
 [[sec:task-section]]
-=== [TASK] Section(((INI File, TASK Section)))
+=== [TASK] Section(((INI File,TASK Section)))
 
 * 'TASK = milltask' -
   Specifies the name of the 'task' executable. The 'task' executable does various
@@ -630,24 +642,27 @@ from the command line using the -m option ($linuxcnc -h)
   stepper configuration ('core_stepper.hal') and one which specifies
   the machine pin out ('xxx_pinout.hal').
 
-  HALFILES are found using a search.
-  If the named file is found in the directory containing the ini file, it is used.
-  If the named file is not found in this ini file directory, a search is made using a system library of halfiles.
+HALFILES are found using a search.
+If the named file is found in the directory containing the ini file, it is used.
+If the named file is not found in this ini file directory, a search is made using a system library of halfiles.
 
-  If LinuxCNC is started with the linuxcnc script using the "-H dirname" option,
-  the specified dirname is prepended to the search described above so that
-  "dirname" is searched first.  The "-H dirname" option may be specified more
-  than once, directories are prepended in order.
+If LinuxCNC is started with the linuxcnc script using the "-H dirname" option,
+the specified dirname is prepended to the search described above so that
+"dirname" is searched first.  The "-H dirname" option may be specified more
+than once, directories are prepended in order.
 
-  A HALFILE may also be specified as an absolute path (when the name starts with
-  a '/' character).  Absolute paths are not recommended as their use may limit
-  relocation of configurations.
-* 'HALFILE = texample.tcl [arg1 [arg2] ...]]' - Execute the tcl file 'texample.tcl'
+A HALFILE may also be specified as an absolute path (when the name starts with
+a '/' character).  Absolute paths are not recommended as their use may limit
+relocation of configurations.
+
+* 'HALFILE = texample.tcl [arg1 [arg2] ...]' - Execute the tcl file 'texample.tcl'
   at start up with arg1, arg2, etc as ::argv list.  Files with a .tcl suffix are
   processed as above but use haltcl for processing  See the
   <<cha:haltcl,HALTCL Chapter>> for more information.
+
 * 'HALFILE = LIB:sys_example.hal' - Execute the system library file 'sys_example.hal' at start up.
   Explicit use of the LIB: prefix causes use of the system library HALFILE without searching the ini file directory.
+
 * 'HALFILE = LIB:sys_texample.tcl [arg1 [arg2 ...]]' - Execute the system library file 'sys_texample.tcl' at start up.
   Explicit use of the LIB: prefix causes use of the system library HALFILE without searching the ini file directory.
 
@@ -661,7 +676,7 @@ A system library file is provided to make checks for these conditions and
 report to stdout and in a popup gui:
 
 ----
-    HALFILE = LIB:halcheck.tcl [ nopopup ]
+HALFILE = LIB:halcheck.tcl [ nopopup ]
 ----
 
 [NOTE]
@@ -669,34 +684,38 @@ The LIB:halcheck.tcl line should be the last [HAL]HALFILE.
 Specify the 'nopopup' option to suppress the popup message and allow immediate starting.
 Connections made using a POSTGUI_HALFILE are not checked.
 
- * 'TWOPASS = ON' - Use twopass processing for loading HAL components.
-   With TWOPASS processing, [HAL]HALFILE= lines are processed in two passes.
-   In the first pass (pass0), all HALFILES are read and multiple appearances of loadrt and loadusr commands are accumulated.
-   These accumulated load commands are executed at the end of pass0.
-   This accumulation allows load lines to be specified more than once for a given component (provided the names= names used are unique on each use).
-   In the second pass (pass1), the HALFILES are reread and all commands except the previously executed load commands are executed.
- * 'TWOPASS = nodelete verbose' - The TWOPASS feature can be activated with any non-null string including the keywords verbose and nodelete.
-   The verbose keyword causes printing of details to stdout.
-   The nodelete keyword preserves temporary files in /tmp.
+* 'TWOPASS = ON' - Use twopass processing for loading HAL components.
+  With TWOPASS processing, [HAL]HALFILE= lines are processed in two passes.
+  In the first pass (pass0), all HALFILES are read and multiple appearances of loadrt and loadusr commands are accumulated.
+  These accumulated load commands are executed at the end of pass0.
+  This accumulation allows load lines to be specified more than once for a given component (provided the names= names used are unique on each use).
+  In the second pass (pass1), the HALFILES are reread and all commands except the previously executed load commands are executed.
+
+* 'TWOPASS = nodelete verbose' - The TWOPASS feature can be activated with any non-null string including the keywords verbose and nodelete.
+  The verbose keyword causes printing of details to stdout.
+  The nodelete keyword preserves temporary files in /tmp.
 
 For more information see the <<cha:hal-twopass,Hal TWOPASS>> chapter.
 
- * 'HALCMD = command' - Execute 'command' as a single HAL command.
-   If 'HALCMD' is specified multiple times, the commands are executed in the order
-   they appear in the ini file.
-   'HALCMD' lines are executed after all 'HALFILE' lines.
- * 'SHUTDOWN = shutdown.hal' - Execute the file 'shutdown.hal' when LinuxCNC is exiting.
-   Depending on the hardware drivers used, this may make it possible to set outputs to
-   defined values when LinuxCNC is exited normally. However, because there is
-   no guarantee this file will be executed (for instance, in the case of a
-   computer crash) it is not a replacement for a proper physical e-stop
-   chain or other protections against software failure.
- * 'POSTGUI_HALFILE = example2.hal' - Execute 'example2.hal' after the GUI has created its HAL pins.
-   Some GUIs create hal pins and support the use of a postgui halfile to use them.
-   GUIs that support postgui halfiles include Touchy, Axis, Gscreen, and gmoccapy.
-   See section <<sec:pyvcp-with-axis,pyVCP with Axis>> for more information.
- * 'HALUI = halui' - adds the HAL user interface pins.
-   For more information see the <<cha:hal-user-interface,HAL User Interface>> chapter.
+* 'HALCMD = command' - Execute 'command' as a single HAL command.
+  If 'HALCMD' is specified multiple times, the commands are executed in the order
+  they appear in the ini file. 'HALCMD' lines are executed after all
+  'HALFILE' lines.
+
+* 'SHUTDOWN = shutdown.hal' - Execute the file 'shutdown.hal' when LinuxCNC is exiting.
+  Depending on the hardware drivers used, this may make it possible to set outputs to
+  defined values when LinuxCNC is exited normally. However, because there is
+  no guarantee this file will be executed (for instance, in the case of a
+  computer crash) it is not a replacement for a proper physical e-stop
+  chain or other protections against software failure.
+
+* 'POSTGUI_HALFILE = example2.hal' - Execute 'example2.hal' after the GUI has created its HAL pins.
+  Some GUIs create hal pins and support the use of a postgui halfile to use them.
+  GUIs that support postgui halfiles include Touchy, Axis, Gscreen, and gmoccapy.
+
+See section <<sec:pyvcp-with-axis,pyVCP with Axis>> for more information.
+
+* 'HALUI = halui' - adds the HAL user interface pins. For more information see the <<cha:hal-user-interface,HAL User Interface>> chapter.
 
 [[sec:halui-section]]
 === [HALUI] section(((INI File, HALUI Section)))
@@ -719,24 +738,31 @@ gui-dependent actions (like creating gui-specific hal pins).
   This specification can be included multiple times.
   The appname can be explicitly named as an absolute or tilde specified filename (first character is / or ~),
   a relative filename (first characters of filename are ./), or as a file in the inifile directory.
-  If no executable file is found using these names, then the user search PATH is used to find the application.
-
+  If no executable file is found using these names, then the user search PATH is used to find the application. +
   Examples:
 ** Simulate inputs to hal pins for testing (using sim_pin -- a simple gui to set inputs to parameters,
    unconnected pins, or signals with no writers):
-
-   APP = sim_pin motion.probe-input halui.abort motion.analog-in-00
++
+----
+APP = sim_pin motion.probe-input halui.abort motion.analog-in-00
+----
 ** Invoke halshow with a previuosly saved watchlist.
    Since linuxcnc sets the working directory to the directory for the inifile,
    you can refer to files in that directory (example: my.halshow):
-
-   APP = halshow my.halshow
++
+----
+APP = halshow my.halshow
+----
 ** Alternatively, a watchlist file identified with a full pathname could be specified:
-
-   APP = halshow ~/saved_shows/spindle.halshow
++
+----
+APP = halshow ~/saved_shows/spindle.halshow
+----
 ** Open halscope using a previously saved configuration:
-
-   APP = halscope -i my.halscope
++
+----
+APP = halscope -i my.halscope
+----
 
 [[sec:traj-section]]
 === [TRAJ] Section(((INI File, TRAJ Section)))
@@ -762,11 +788,11 @@ planning module in 'motion'.
   However, this estimate is rough, and it seems that just disabling it gives better performance.
   Default value 0.
 * 'ARC_BLEND_OPTIMIZATION_DEPTH = 50' - Look ahead depth in number of segments.
-  +
-  To expand on this a bit, you can choose this value somewhat arbitrarily.
-  Here's a formula to estimate how much 'depth' you need for a particular
-  config:
-  +
++
+To expand on this a bit, you can choose this value somewhat arbitrarily.
+Here's a formula to estimate how much 'depth' you need for a particular
+config:
++
 ----
 # n = v_max / (2.0 * a_max * t_c)
 # where:
@@ -775,67 +801,67 @@ planning module in 'motion'.
 # a_max = max axis acceleration (UU / sec)
 # t_c = servo period (seconds)
 ----
-  +
-  So, a machine with a maximum axis velocity of 10 IPS, a max acceleration
-  of 100 IPS^2, and a servo period of 0.001 sec would need:
-  +
-  10 / (2.0 * 100 * 0.001) = 50 segments to always reach maximum velocity
-  along the fastest axis.
-  +
-  In practice, this number isn't that important to tune, since the
-  look ahead rarely needs the full depth unless you have lots of very short
-  segments. If during testing, you notice strange slowdowns and can't
-  figure out where they come from, first try increasing this depth using
-  the formula above.
-  +
-  If you still see strange slowdowns, it may be because you have short
-  segments in the program. If this is the case, try adding a small
-  tolerance for Naive CAM detection. A good rule of thumb is this:
-  +
++
+So, a machine with a maximum axis velocity of 10 IPS, a max acceleration
+of 100 IPS^2, and a servo period of 0.001 sec would need:
++
+10 / (2.0 * 100 * 0.001) = 50 segments to always reach maximum velocity
+along the fastest axis.
++
+In practice, this number isn't that important to tune, since the
+look ahead rarely needs the full depth unless you have lots of very short
+segments. If during testing, you notice strange slowdowns and can't
+figure out where they come from, first try increasing this depth using
+the formula above.
++
+If you still see strange slowdowns, it may be because you have short
+segments in the program. If this is the case, try adding a small
+tolerance for Naive CAM detection. A good rule of thumb is this:
++
 ----
 # min_length ~= v_req * t_c
 # where:
 # v_req = desired velocity in UU / sec
 # t_c = servo period (seconds)
 ----
-  +
-  If you want to travel along a path at 1 IPS = 60 IPM, and your servo
-  period is 0.001 sec, then any segments shorter than min_length will slow
-  the path down. If you set Naive CAM tolerance to around this min length,
-  overly short segments will be combined together to eliminate this
-  bottleneck. Of course, setting the tolerance too high means big path
-  deviations, so you have to play with it a bit to find a good value. I'd
-  start at 1/2 of the min_length, then work up as needed.
++
+If you want to travel along a path at 1 IPS = 60 IPM, and your servo
+period is 0.001 sec, then any segments shorter than min_length will slow
+the path down. If you set Naive CAM tolerance to around this min length,
+overly short segments will be combined together to eliminate this
+bottleneck. Of course, setting the tolerance too high means big path
+deviations, so you have to play with it a bit to find a good value. I'd
+start at 1/2 of the min_length, then work up as needed.
 * 'ARC_BLEND_GAP_CYCLES = 4' How short the previous segment must be before the trajectory planner 'consumes' it.
-  +
-  Often, a circular arc blend will leave short line segments in between
-  the blends. Since the geometry has to be circular, we can't blend over
-  all of a line if the next one is a little shorter. Since the trajectory
-  planner has to touch each segment at least once, it means that very tiny
-  segments will slow things down significantly. My fix to this way to
-  "consume" the short segment by making it a part of the blend arc. Since
-  the line+blend is one segment, we don't have to slow down to hit the
-  very short segment. Likely, you won't need to touch this setting.
++
+Often, a circular arc blend will leave short line segments in between
+the blends. Since the geometry has to be circular, we can't blend over
+all of a line if the next one is a little shorter. Since the trajectory
+planner has to touch each segment at least once, it means that very tiny
+segments will slow things down significantly. My fix to this way to
+"consume" the short segment by making it a part of the blend arc. Since
+the line+blend is one segment, we don't have to slow down to hit the
+very short segment. Likely, you won't need to touch this setting.
 * 'ARC_BLEND_RAMP_FREQ = 20' - This is a 'cutoff' frequency for using ramped velocity.
-  +
-  'Ramped velocity' in this case just means constant acceleration over the whole segment.
-  This is less optimal than a trapezoidal velocity profile, since the acceleration is not maximized.
-  However, if the segment is short enough, there isn't enough time to accelerate much before we hit the next segment.
-  Recall the short line segments from the previous example.
-  Since they're lines, there's no cornering acceleration, so we're free to accelerate up to the requested speed.
-  However, if this line is between two arcs, then it will have to quickly decelerate again to be within the maximum speed of the next segment.
-  This means that we have a spike of acceleration, then a spike of deceleration, causing a large jerk, for very little performance gain.
-  This setting is a way to eliminate this jerk for short segments.
-  +
-  Basically, if a segment will complete in less time than 1 /
-  ARC_BLEND_RAMP_FREQ, we don't bother with a trapezoidal velocity profile
-  on that segment, and use constant acceleration. (Setting
-  ARC_BLEND_RAMP_FREQ = 1000 is equivalent to always using trapezoidal
-  acceleration, if the servo loop is 1kHz).
-  +
-  You can characterize the worst-case loss of performance by comparing the
-  velocity that a trapezoidal profile reaches vs. the ramp:
-  +
++
+'Ramped velocity' in this case just means constant acceleration over the whole segment.
+This is less optimal than a trapezoidal velocity profile, since the acceleration is not maximized.
+However, if the segment is short enough, there isn't enough time to accelerate much before we hit the next segment.
+Recall the short line segments from the previous example.
+Since they're lines, there's no cornering acceleration, so we're free to accelerate up to the requested speed.
+However, if this line is between two arcs, then it will have to quickly decelerate again to be within the maximum speed of the next segment.
+This means that we have a spike of acceleration, then a spike of deceleration, causing a large jerk, for very little performance gain.
+This setting is a way to eliminate this jerk for short segments.
++
+Basically, if a segment will complete in less time than 1 /
+ARC_BLEND_RAMP_FREQ, we don't bother with a trapezoidal velocity profile
+on that segment, and use constant acceleration. (Setting
+ARC_BLEND_RAMP_FREQ = 1000 is equivalent to always using trapezoidal
+acceleration, if the servo loop is 1kHz).
++
+You can characterize the worst-case loss of performance by comparing the
+velocity that a trapezoidal profile reaches vs. the ramp:
++
 ----
 # v_ripple = a_max / (4.0 * f)
 # where:
@@ -843,16 +869,16 @@ planning module in 'motion'.
 # a_max = max axis acceleration
 # f = cutoff frequency from INI
 ----
-  +
-  For the aforementioned machine, the ripple for a 20Hz cutoff frequency
-  is 100 / (4 * 20) = 1.25 IPS. This seems high, but keep in mind that it
-  is only a worst-case estimate. In reality , the trapezoidal motion
-  profile is limited by other factors, such as normal acceleration or
-  requested velocity, and so the actual performance loss should be much
-  smaller. Increasing the cutoff frequency can squeeze out more
-  performance, but make the motion rougher due to acceleration
-  discontinuities. A value in the range 20Hz to 200Hz should be reasonable
-  to start.
++
+For the aforementioned machine, the ripple for a 20Hz cutoff frequency
+is 100 / (4 * 20) = 1.25 IPS. This seems high, but keep in mind that it
+is only a worst-case estimate. In reality , the trapezoidal motion
+profile is limited by other factors, such as normal acceleration or
+requested velocity, and so the actual performance loss should be much
+smaller. Increasing the cutoff frequency can squeeze out more
+performance, but make the motion rougher due to acceleration
+discontinuities. A value in the range 20Hz to 200Hz should be reasonable
+to start.
 
 Finally, no amount of tweaking will speed up a toolpath with lots of
 small, tight corners, since you're limited by cornering acceleration.
@@ -902,9 +928,9 @@ small, tight corners, since you're limited by cornering acceleration.
   option set to 1.
 
 [WARNING]
-----
+====
 LinuxCNC will not know your joint travel limits when using 'NO_FORCE_HOMING = 1'.
-----
+====
 
 * 'HOME = 0 0 0 0 0 0 0 0 0' - World home position needed for kinematics modules
   that compute world coordinates using kinematicsForward() when switching
@@ -914,14 +940,13 @@ LinuxCNC will not know your joint travel limits when using 'NO_FORCE_HOMING = 1'
   kinematics (mill, lathe, gantry types) this value is ignored.
   Note: the sim hexapod config requires a non-zero value for the Z coordinate.
 * TPMOD = alternate_trajectory_planning module [tp_parms=value]
-
-The TPMOD variable is optional.  If specified, use a specified (user-built)
-module instead of the default (tpmod).  Module parameters (tp_parms) may be
-included if supported by the named module.  The setting may be overridden
-from the command line using the -t option ($linuxcnc -h)
+  The TPMOD variable is optional.  If specified, use a specified (user-built)
+  module instead of the default (tpmod).  Module parameters (tp_parms) may be
+  included if supported by the named module.  The setting may be overridden
+  from the command line using the -t option ($linuxcnc -h)
 
 [[sec:kins-section]]
-=== [KINS] Section(((INI File, KINS Section)))
+=== [KINS] Section(((INI File,KINS Section)))
 
 * 'JOINTS = 3' - Specifies the number of joints (motors) in the system.
   For example, a trivkins XYZ machine with a single motor for each axis has 3 joints.
@@ -932,7 +957,7 @@ from the command line using the -t option ($linuxcnc -h)
   For more information on kinematics modules see the manpage: '$ man kins'
 
 [[sec:axis-section]]
-=== [AXIS_<letter>] Section(((INI File, AXIS Section)))
+=== [AXIS_<letter>] Section(((INI File,AXIS Section)))
 
 The <letter> specifies one of: X Y Z A B C U V W
 
@@ -957,24 +982,28 @@ The <letter> specifies one of: X Y Z A B C U V W
   After the move the joint.4.unlock will be false and motion will wait for joint.4.is-unlocked to go false.
   Moving with other joints is not allowed when moving a locked rotary joint.
   To create the unlock pins, use the motmod parameter:
-
-      unlock_joints_mask=jointmask
-
-  The jointmask bits are: (LSB)0:joint0, 1:joint1, 2:joint2, ...
-
-  Example: loadrt motmod ... unlock_joints_mask=0x38
-  creates  unlock  pins for joints 3,4,5
-* 'OFFSET_AV_RATIO = 0.1' - If nonzero, this item enables the use of hal input pins for external axis offsets:
++
 ----
-axis.<letter>.eoffset-enable
-axis.<letter>.eoffset-counts
-axis.<letter>.eoffset-scale
+unlock_joints_mask=jointmask
+----
++
+The jointmask bits are: (LSB)0:joint0, 1:joint1, 2:joint2, ...
++
+Example: `loadrt motmod ... unlock_joints_mask=0x38` creates unlock pins for joints 3,4,5
+
+* 'OFFSET_AV_RATIO = 0.1' - If nonzero, this item enables the use of hal input pins for external axis offsets:
++
+----
+'axis.<letter>.eoffset-enable'
+'axis.<letter>.eoffset-counts'
+'axis.<letter>.eoffset-scale'
 ----
 
 See the chapter: <<cha:external-offsets,'External Axis Offsets'>> for usage information.
 
 [[sec:joint-section]]
-=== [JOINT_<num>] Section(((INI File, JOINT Section)))
+=== [JOINT_<num>] Section(((INI File,JOINT Section)))
+
 The <num> specifies the joint number 0 ... (num_joints-1)
 The value of 'num_joints' is set by [KINS]JOINTS=
 
@@ -1029,17 +1058,19 @@ For more information on kinematics modules see the manpage: '$ man kins'
   Compensation files must start with the smallest nominal and be in ascending order to the largest value of nominals.
   File names are case sensitive and can contain letters and/or numbers.
   Currently the limit inside LinuxCNC is for 256 triplets per joint.
-  +
-  If COMP_FILE is specified for an joint, BACKLASH is not used.
-  A 'COMP_FILE_TYPE' must be specified for each 'COMP_FILE'.
-* 'COMP_FILE_TYPE = 0 or 1' - Specifies the type of compensation file.
-  The first value is the nominal (commanded) position for both types.
++
+If COMP_FILE is specified for an joint, BACKLASH is not used. +
+A 'COMP_FILE_TYPE' must be specified for each 'COMP_FILE'.
+
+* 'COMP_FILE_TYPE = 0 or 1' - Specifies the type of compensation file. The
+  first value is the nominal (commanded) position for both types.
 ** 'Type 0:' The second value specifies the actual position as the joint is moving
    in the positive direction (increasing value) and the third value specifies
    the actual position as the joint is moving in the negative direction
    (decreasing value).
-   +
-.Type 0 Example
++
+Type 0 Example:
++
 ----
 -1.000 -1.005 -0.995
 0.000 0.002 -0.003
@@ -1048,8 +1079,9 @@ For more information on kinematics modules see the manpage: '$ man kins'
 ** 'Type 1:' The second value specifies positive offset from nominal while
    traveling in the positive direction. The third value specifies the negative
    offset from nominal while traveling in a negative direction.
-   +
-.Type 1 Example
++
+Type 1 Example:
++
 ----
 -1.000 0.005 -0.005
 0.000 0.002 -0.003
@@ -1065,15 +1097,15 @@ For more information on kinematics modules see the manpage: '$ man kins'
   For a rotary joint with unlimited rotation having no MAX_LIMIT for that joint in the [JOINT_N] section a the value 1e99 is used.
 
 [NOTE]
-----
+====
 For *identity* kinematics, the [JOINT_N]MIN_LIMIT,MAX_LIMIT settings must equal
 or exceed the corresponding (one-to-one identity) [AXIS_L] limits.  These
 settings are verified at startup when the trivkins kinematics modules is
 specified.
-----
+====
 
 [NOTE]
-----
+====
 The [JOINT_N]MIN_LIMIT, MAX_LIMIT settings are enforced while jogging in joint
 mode prior to homing.  After homing, [AXIS_L]MIN_LIMIT,MAX_LIMIT coordinate
 limits are used as constraints for axis (coordinate letter) jogging and
@@ -1085,7 +1117,7 @@ trajectory planning position limits when non identity kinematics are used.  The
 motion module always detects joint position limit violations and faults if they
 occur during the execution of G-code commands.  See also related github issue
 #97.
-----
+====
 
 * 'MIN_FERROR = 0.010' - (((MIN FERROR)))
   This is the value in machine units by which the joint is permitted to deviate from commanded position at very low speeds.
@@ -1105,7 +1137,8 @@ occur during the execution of G-code commands.  See also related github issue
   following errors will always be present due to vibration, etc.
 * 'LOCKING_INDEXER = 1' - Indicates the joint is used as a locking indexer.
 
-.Homing
+==== Homing
+
 These parameters are Homing related, for a better explanation read the
 <<cha:homing-configuration,Homing Configuration>> Chapter.
 
@@ -1161,7 +1194,8 @@ These parameters are Homing related, for a better explanation read the
   When enabled (set to 1) this joint will be unhomed if the Machine Power is off or if E-Stop is on.
   This is useful if your machine has home switches and does not have position feedback such as a step and direction driven machine.
 
-.Servo
+==== Servos
+
 These parameters are relevant to joints controlled by servos.
 
 [WARNING]
@@ -1283,8 +1317,8 @@ See the following table for an example of voltage measurements.
 // latexmath:[ raw=(cmd-b)/a ]
 
 .Output Voltage Measurements
-[width="50%",cols="2*^",options="header"]
-|===
+[width="50%", cols="2*^", options="header"]
+|===============
 |Raw | Measured
 |-10 | -9.93
 | -9 | -8.83
@@ -1292,14 +1326,14 @@ See the following table for an example of voltage measurements.
 |  1 |  0.96
 |  9 |  9.87
 | 10 | 10.87
-|===
+|===============
 
 * 'MAX_OUTPUT = 10' - The maximum value for the output of the PID compensation that is written to the motor amplifier, in volts.
   The computed output value is clamped to this limit.
   The limit is applied before scaling to raw output units.
   The value is applied symmetrically to both the plus and the minus side.
-* 'INPUT_SCALE = 20000' - in Sample configs
-* 'ENCODER_SCALE = 20000' - in PNCconf built configs
+* 'INPUT_SCALE = 20000' - in Sample configs(((INPUT SCALE)))
+* 'ENCODER_SCALE = 20000' - in PNCconf built configs(((ENCODER SCALE)))
 
 Specifies the number of pulses that corresponds to a move of one machine unit as set in the [TRAJ] section.
 For a linear joint one machine unit will be equal to the setting of LINEAR_UNITS.
@@ -1313,7 +1347,8 @@ image::images/encoder-scale.png[align="center"]
 //\frac{2000\, counts}{rev} \times \frac{10\, rev}{inch} =
 //\frac{20000\, counts}{inch} ]
 
-.Stepper
+==== Steppers
+
 These parameters are relevant to joints controlled by steppers.
 
 [WARNING]
@@ -1324,8 +1359,8 @@ custom INI file entries see the <<sub:custom-variables,Custom Sections and Varia
 
 The following items might be used by a stepgen component.
 
-* 'SCALE = 4000' - in Sample configs
-* 'STEP_SCALE = 4000' - in PNCconf built configs
+* 'SCALE = 4000' - in Sample configs(((SCALE)))(((INPUT SCALE)))
+* 'STEP_SCALE = 4000' - in PNCconf built configs(((STEP_SCALE)))
 
 Specifies the number of pulses that corresponds to a move of one machine unit as set in the [TRAJ] section.
 For stepper systems, this is the number of step pulses issued per machine unit.
@@ -1343,6 +1378,9 @@ image::images/stepper-scale.png[align="center"]
 //latexmath:[ scale =
 //\frac{2\, steps}{1.8\, degree} \times \frac{360\, degree}{rev} \times \frac{10\, rev}{inch} =
 //\frac{4000\, steps}{inch} ]
+
+[NOTE]
+Old .ini and .hal files used INPUT_SCALE for this value.
 
 * 'ENCODER_SCALE = 20000' (Optionally used in PNCconf built configs) -
   Specifies the number of pulses that
@@ -1420,11 +1458,11 @@ The value of 'num_spindles' is set by [TRAJ]SPINDLES=
 * 'DB_PROGRAM = db_program' - Path to an executable program that manages tool data.
    (When a DB_PROGRAM is specified, a TOOL_TABLE entry is ignored)
 * 'TOOL_CHANGE_POSITION = 0 0 2' -
-   Specifies the XYZ location to move to when performing a tool change if three digits are used.
-   Specifies the XYZABC location when 6 digits are used.
-   Specifies the XYZABCUVW location when 9 digits are used.
-   Tool Changes can be combined.
-   For example if you combine the quill up with change position you can move the Z first then the X and Y.
+  Specifies the XYZ location to move to when performing a tool change if three digits are used.
+  Specifies the XYZABC location when 6 digits are used.
+  Specifies the XYZABCUVW location when 9 digits are used.
+  Tool Changes can be combined.
+  For example if you combine the quill up with change position you can move the Z first theun the X and Y.
 * 'TOOL_CHANGE_WITH_SPINDLE_ON = 1' -
    The spindle will be left on during the tool change when the value is 1.
    Useful for lathes or machines where the material is in the spindle, not the tool.

--- a/docs/src/config/ini-homing.adoc
+++ b/docs/src/config/ini-homing.adoc
@@ -18,10 +18,11 @@ However, different machines have different requirements, and homing is actually 
 complicated. 
 
 [NOTE]
-While it is possible to use linuxcnc without homing switches/home procedures or limit switches, 
-It defeats the extra security of the soft limits. 
+While it is possible to use linuxcnc without homing switches/home procedures or limit switches,
+It defeats the extra security of the soft limits.
 
 == Prerequisite
+
 Homing relies on some fundamental machine assumptions.
 
 * The negative and positive directions are based on <<sec:machine-configurations,Tool Movement>> which can be different
@@ -79,7 +80,6 @@ which is probably easiest to remember. Do this by setting MIN_LIMIT = 0 and make
 This example shows a maximum limit switch and a combined minimum limit/home switch.
 
 .Demonstrative Shared Switch Layout
-
 image::images/HomeAxisTravel_V3.png["Example shared Home Limit Switch layout",align="center"]
 
 
@@ -125,7 +125,7 @@ They are defined in an [JOINT_n] section of the inifile.
 [NOTE]
 Any other combinations may result in an error.
 
-=== HOME_SEARCH_VEL (((HOME SEARCH VEL)))
+=== HOME_SEARCH_VEL(((HOME SEARCH VEL)))
 
 This variable has units of machine-units per second.
 
@@ -145,7 +145,7 @@ overshoot enough to hit a limit switch or crash into the end of travel.
 On the other hand, if HOME_SEARCH_VEL is too low, homing can take a
 long time.
 
-=== HOME_LATCH_VEL (((HOME LATCH VEL)))
+=== HOME_LATCH_VEL(((HOME LATCH VEL)))
 
 This variable has units of machine-units per second.
 
@@ -174,7 +174,7 @@ HOME_OFFSET to the HOME position. If the HOME_FINAL_VEL is missing from
 the ini file, then the maximum joint speed is used to make this move.
 The value must be a positive number.
 
-=== HOME_IGNORE_LIMITS (((HOME IGNORE LIMITS)))
+=== HOME_IGNORE_LIMITS(((HOME IGNORE LIMITS)))
 
 Can hold the values YES / NO. The default value for this parameter is NO.
 This flag determines whether LinuxCNC will ignore the limit switch input
@@ -185,7 +185,7 @@ will ignore the limit switch input for this joint while homing. To use only
 one input for all homing and limits you will have to block the limit signals
 of the joints not homing in HAL and home one joint at a time.
 
-=== HOME_USE_INDEX (((HOME USE INDEX)))
+=== HOME_USE_INDEX(((HOME USE INDEX)))
 
 Specifies whether or not there is an index pulse. If the flag is true
 (HOME_USE_INDEX = YES), LinuxCNC will latch on the rising edge of the index
@@ -197,7 +197,7 @@ HOME_LATCH_VEL). The default value is NO.
 HOME_USE_INDEX requires connections in your hal file to joint.n.index-enable
 from the encoder.n.index-enable.
 
-=== HOME_INDEX_NO_ENCODER_RESET (((HOME INDEX NO ENCODER RESET)))
+=== HOME_INDEX_NO_ENCODER_RESET(((HOME INDEX NO ENCODER RESET)))
 
 Default is NO.   Use YES if the encoder used for this joint does not
 reset its counter when an index pulse is detected after assertion
@@ -205,7 +205,7 @@ of the joint index_enable hal pin.
 Applicable only for HOME_USE_INDEX = YES.
 
 
-=== HOME_OFFSET (((HOME OFFSET)))
+=== HOME_OFFSET(((HOME OFFSET)))
 
 This defines the location of the origin zero point of the G53 machine coordinate system.
 It is the distance (offset), in joint units, from the machine origin to the home switch
@@ -218,7 +218,7 @@ NOTE: The home switch location, as indicated by the HOME_OFFSET variable,
 can be inside or outside the soft limits. They will be shared with or inside the 
 hard limit switches.
 
-=== HOME (((HOME)))
+=== HOME(((HOME)))
 
 The position that the joint will go to upon completion of the homing
 sequence. After detecting the home switch or home switch then index pulse
@@ -237,7 +237,7 @@ establishes the origin location and scale on the machine by applying the 'HOME_O
 value to the location where home was found, and then 'HOME' says where the
 joint should move to on that scale.
 
-=== HOME_IS_SHARED (((HOME IS SHARED)))
+=== HOME_IS_SHARED(((HOME IS SHARED)))
 
 If there is not a separate home switch input for this joint, but a
 number of momentary switches wired to the same pin, set this value to 1
@@ -245,7 +245,7 @@ to prevent homing from starting if one of the shared switches is
 already closed. Set this value to 0 to permit homing even if the switch
 is already closed.
 
-=== HOME_ABSOLUTE_ENCODER (((HOME ABSOLUTE ENCODER)))
+=== HOME_ABSOLUTE_ENCODER(((HOME ABSOLUTE ENCODER)))
 
 Use for absolute encoders.  When a request is made to home the joint,
 the current joint position is set to the '[JOINT_n]HOME_OFFSET' value.
@@ -306,7 +306,7 @@ to misalignment (racking).  Note that conventional jogging in
 world coordinates is always available once a machine is homed.
 
 Examples for a 3 joint system
-    
+
 Two sequences (0,1), no synchronization
 
 ----
@@ -314,7 +314,7 @@ Two sequences (0,1), no synchronization
 [JOINT_1]HOME_SEQUENCE =  1
 [JOINT_2]HOME_SEQUENCE =  1
 ----
-    
+
 Two sequences, joints 1 and 2 synchronized
 
 ----
@@ -331,7 +331,7 @@ With mixed positive and negative values, joints 1 and 2 synchronized
 [JOINT_2]HOME_SEQUENCE =  1
 ----
 
-    
+
 One sequence, no synchronization
 
 ----
@@ -339,7 +339,7 @@ One sequence, no synchronization
 [JOINT_1]HOME_SEQUENCE =  0
 [JOINT_2]HOME_SEQUENCE =  0
 ----
-    
+
 One sequence, all joints synchronized
 
 ----
@@ -347,9 +347,9 @@ One sequence, all joints synchronized
 [JOINT_1]HOME_SEQUENCE = -1
 [JOINT_2]HOME_SEQUENCE = -1
 ----
-    
 
-=== VOLATILE_HOME (((VOLATILE HOME)))
+
+=== VOLATILE_HOME(((VOLATILE HOME)))
 
 If this setting is true, this joint becomes unhomed whenever the
 machine transitions into the OFF state. This is appropriate for
@@ -357,12 +357,12 @@ any joint that does not maintain position when the joint drive is
 off.  Some stepper drives, especially microstep drives, may need
 this.
 
-=== LOCKING_INDEXER (((LOCKING INDEXER)))
+=== LOCKING_INDEXER(((LOCKING INDEXER)))
 
 If this joint is a locking rotary indexer, it will unlock before
 homing, and lock afterward.
 
-=== Immediate Homing (((Immediate Homing)))
+=== Immediate Homing(((Immediate Homing)))
 
 If a joint does not have home switches or does not have a logical
 home position like a rotary joint and you want that joint to home at
@@ -382,7 +382,7 @@ omitted when requesting immediate homing.  A valid HOME_SEQUENCE
 number should usually be included since omitting a HOME_SEQUENCE
 eliminates the joint from *HOME ALL* behavior as noted above.
 
-=== Inhibiting Homing (((Inhibiting Homing)))
+=== Inhibiting Homing(((Inhibiting Homing)))
 
 A hal pin (motion.homing-inhibit) is provided to disallow
 homing initiation for both "Home All" and individual joint

--- a/docs/src/config/integrator-concepts.adoc
+++ b/docs/src/config/integrator-concepts.adoc
@@ -47,10 +47,11 @@ section.
 Each configuration directory requires at least the following files:
 
 * An INI file .ini
-* A HAL file .hal or HALTCL file .tcl specified in the 
-  <<sec:hal-section,HAL>> section of the INI file.
+* A HAL file .hal or HALTCL file .tcl specified in the <<sec:hal-section,HAL>>
+  section of the INI file.
 
-[NOTE]Other files may be required for some GUI's.
+[NOTE]
+Other files may be required for some GUI's.
 
 Optionally you can also have:
 
@@ -68,12 +69,12 @@ Optionally you can also have:
 
 === Base Period
 
-BASE_PERIOD is the 'heartbeat' of your LinuxCNC computer.footnote:[This 
-section refers to using *stepgen*, LinuxCNC's built-in 
-step generator. Some hardware devices have their own step 
-generator and do not use LinuxCNC's built-in one. In that case, refer to 
-your hardware manual.] Every period, the 
-software step generator decides if it is time for another step pulse. 
+BASE_PERIOD is the 'heartbeat' of your LinuxCNC computer.footnote:[This
+section refers to using *stepgen*, LinuxCNC's built-in
+step generator. Some hardware devices have their own step
+generator and do not use LinuxCNC's built-in one. In that case, refer to
+your hardware manual.] Every period, the
+software step generator decides if it is time for another step pulse.
 A shorter period will allow you to generate more pulses per second,
 within limits. But if you go too short, your computer will spend so
 much time generating step pulses that everything else will slow to a
@@ -87,23 +88,23 @@ a while and are impossible to troubleshoot.
 
 The simplest way to avoid this problem is to choose a BASE_PERIOD that
 is the sum of the longest timing requirement of your drive, and the
-worst case latency of your computer. This is not always the best choice. 
-For example, if you are running a drive with a 20 us  direction signal hold time 
+worst case latency of your computer. This is not always the best choice.
+For example, if you are running a drive with a 20 us  direction signal hold time
 requirement, and your latency test said you have a maximum latency of
-11 us , then if you set the BASE_PERIOD to 20+11 = 31 us  you get a 
-not-so-nice 32,258 steps per second in one mode and 16,129 steps per 
-second in another mode. 
+11 us , then if you set the BASE_PERIOD to 20+11 = 31 us  you get a
+not-so-nice 32,258 steps per second in one mode and 16,129 steps per
+second in another mode.
 
-The problem is with the 20 us  hold time requirement. That plus the 11 us 
+The problem is with the 20 us  hold time requirement. That plus the 11 us
 latency is what forces us to use a slow 31 us  period. But the LinuxCNC
 software step generator has some parameters that let you increase the
-various times from one period to several. For example, if 'steplen' footnote:[steplen 
-refers to a parameter that adjusts the performance of LinuxCNC's built-in step generator, 
-'stepgen', which is a HAL component. This parameter adjusts the length of the 
+various times from one period to several. For example, if 'steplen' footnote:[steplen
+refers to a parameter that adjusts the performance of LinuxCNC's built-in step generator,
+'stepgen', which is a HAL component. This parameter adjusts the length of the
 step pulse itself. Keep reading, all will be explained eventually.] is
 changed from 1 to 2, then there will be two periods between the
-beginning and end of the step pulse. Likewise, if 'dirhold' footnote:[dirhold 
-refers to a parameter that adjusts the length of the direction hold time.] is 
+beginning and end of the step pulse. Likewise, if 'dirhold' footnote:[dirhold
+refers to a parameter that adjusts the length of the direction hold time.] is
 changed from 1 to 3, there will be at least three periods between the step
 pulse and a change of the direction pin.
 
@@ -131,38 +132,38 @@ edge then the output pin should be inverted.
 
 === Basic Operation
 
-Servo systems are capable of greater speed and accuracy than equivalent 
-stepper systems, but are more costly and complex. 
-Unlike stepper systems, servo systems require some type of position 
-feedback device, and must be adjusted or 'tuned', as they don't quite 
-work right out of the box as a stepper system might. These differences 
-exist because servos are a 'closed loop' system, 
-unlike stepper motors which are generally run 'open loop'. What does 
-'closed loop' mean? Let's look at a simplified diagram of how a servomotor 
-system is connected. 
+Servo systems are capable of greater speed and accuracy than equivalent
+stepper systems, but are more costly and complex.
+Unlike stepper systems, servo systems require some type of position
+feedback device, and must be adjusted or 'tuned', as they don't quite
+work right out of the box as a stepper system might. These differences
+exist because servos are a 'closed loop' system,
+unlike stepper motors which are generally run 'open loop'. What does
+'closed loop' mean? Let's look at a simplified diagram of how a servomotor
+system is connected.
 
 .Servo Loop
 image::images/servo-feedback.png["simplified diagram of how a servomotor system is connected"]
 
-This diagram shows that the input signal (and the feedback signal) drive 
-the summing amplifier, the summing amplifier drives the power amplifier, 
-the power amplifier drives the motor, the motor drives the load 
-(and the feedback device), and the feedback device (and the input signal) 
-drive the motor.  This looks very much like a circle (a closed loop) where 
-A controls B, B controls C, C controls D, and D controls A. 
+This diagram shows that the input signal (and the feedback signal) drive
+the summing amplifier, the summing amplifier drives the power amplifier,
+the power amplifier drives the motor, the motor drives the load
+(and the feedback device), and the feedback device (and the input signal)
+drive the motor.  This looks very much like a circle (a closed loop) where
+A controls B, B controls C, C controls D, and D controls A.
 
-If you have not worked with servo systems before, this will no doubt seem a 
-very strange idea at first, especially as compared to more normal electronic 
-circuits, where the inputs proceed smoothly to the outputs, and never go 
-back.footnote:[If it helps, the closest equivalent to this in the digital 
-world are 'state machines', 'sequential machines' and so forth, where what 
-the outputs are doing 'now' depends on what the inputs (and the outputs) 
-were doing 'before'. If it doesn't help, then nevermind.] If 'everything' 
-controls 'everything else', how can that ever work, who's in 
-charge? The answer is that LinuxCNC 'can' control this system, 
-but it has to do it by choosing one of several control methods. 
-The control method that LinuxCNC uses, one of the simplest and best, 
-is called PID. 
+If you have not worked with servo systems before, this will no doubt seem a
+very strange idea at first, especially as compared to more normal electronic
+circuits, where the inputs proceed smoothly to the outputs, and never go
+back.footnote:[If it helps, the closest equivalent to this in the digital
+world are 'state machines', 'sequential machines' and so forth, where what
+the outputs are doing 'now' depends on what the inputs (and the outputs)
+were doing 'before'. If it doesn't help, then nevermind.] If 'everything'
+controls 'everything else', how can that ever work, who's in
+charge? The answer is that LinuxCNC 'can' control this system,
+but it has to do it by choosing one of several control methods.
+The control method that LinuxCNC uses, one of the simplest and best,
+is called PID.
 
 PID stands for Proportional, Integral, and Derivative. The Proportional
 value determines the reaction to the current error, the Integral value
@@ -185,25 +186,25 @@ oscillation.
 
 === Proportional term
 
-The proportional term (sometimes called gain) makes a change to the 
-output that is proportional to the current error value. A high 
-proportional gain results in a large change in the output for a given 
-change in the error. If the proportional gain is too high, the system 
-can become unstable. In contrast, a small gain results in a small 
-output response to a large input error. If the proportional gain is too 
-low, the control action may be too small when responding to system 
-disturbances. 
+The proportional term (sometimes called gain) makes a change to the
+output that is proportional to the current error value. A high
+proportional gain results in a large change in the output for a given
+change in the error. If the proportional gain is too high, the system
+can become unstable. In contrast, a small gain results in a small
+output response to a large input error. If the proportional gain is too
+low, the control action may be too small when responding to system
+disturbances.
 
-In the absence of disturbances, pure proportional control will not 
-settle at its target value, but will retain a steady state error that 
-is a function of the proportional gain and the process gain. Despite 
-the steady-state offset, both tuning theory and industrial practice 
-indicate that it is the proportional term that should contribute the 
-bulk of the output change. 
+In the absence of disturbances, pure proportional control will not
+settle at its target value, but will retain a steady state error that
+is a function of the proportional gain and the process gain. Despite
+the steady-state offset, both tuning theory and industrial practice
+indicate that it is the proportional term that should contribute the
+bulk of the output change.
 
 === Integral term
 
-The contribution from the integral term (sometimes called reset) is 
+The contribution from the integral term (sometimes called reset) is
 proportional to both the magnitude of the error and the duration of the
 error. Summing the instantaneous error over time (integrating the
 error) gives the accumulated offset that should have been corrected
@@ -276,4 +277,3 @@ shutdown has been started, and that's why you might need to push the power
 button to completely turn off your computer. The RTAI group has been 
 improving this in recent releases, so your LinuxCNC system may shut off by 
 itself after all. 
-

--- a/docs/src/config/lathe-config.adoc
+++ b/docs/src/config/lathe-config.adoc
@@ -20,8 +20,8 @@ in the preamble of the g code file.
 == INI Settings
 
 The following .ini settings are needed for lathe mode in Axis in addition to
-or replacing normal settings in the .ini file.  These historical settings use
-identity kinematics (trivkins) and 'three' joints (0,1,2) corresponding to 
+or replacing normal settings in the .ini file. These historical settings use
+identity kinematics (trivkins) and 'three' joints (0,1,2) corresponding to
 coordinates x,y,z.  The joint 1 for the unused y axis is required but not used
 in these historical configurations.  Simulated lathe configs may use these
 historical settings.

--- a/docs/src/config/pncconf.adoc
+++ b/docs/src/config/pncconf.adoc
@@ -190,7 +190,8 @@ QtPlasmaC
 This page allows you to select external controls such as for jogging or
 overrides.
 
-image::images/pncconf-external.png["External Controls"]
+.External Controls
+image::images/pncconf-external.png["External Controls",align="center"]
 
 If you select a Joystick for jogging, You will need it always connected for LinuxCNC
 to load. To use the analog sticks for useful jogging you probably need to add
@@ -204,13 +205,12 @@ Requires a custom 'device rule' to be installed in the system. This is a file
 that LinuxCNC uses to connect to LINUX's device list. PNCconf will help to make this
 file.
 
-'Search for device rule' will search the system for rules, you can use this to
-find the name of devices you have already built with PNCconf.
-
-'Add a device rule' will allow you to configure a new device by following the
-prompts. You will need your device available.
-
-'test device' allows you to load a device, see its pin names and check its functions with halmeter.
+* 'Search for device rule' will search the system for rules, you can use this to
+  find the name of devices you have already built with PNCconf.
+* 'Add a device rule' will allow you to configure a new device by following the
+  prompts. You will need your device available.
+* 'test device' allows you to load a device, see its pin names and check its
+  functions with halmeter.
 
 joystick jogging uses HALUI and hal_input components.
 
@@ -238,8 +238,8 @@ generator (MPG) or switches (eg. rotary).
 Here you can set defaults for the display screens, add virtual control panels
 (VCP), and set some LinuxCNC options..
 
-//.GUI Configuration
-image::images/pncconf-gui.png["GUI parameter settings"]
+.GUI Configuration
+image::images/pncconf-gui.png["GUI Configuration"]
 
 Front-end GUI Options::
 
@@ -354,7 +354,7 @@ On the basic page you selected a Mesa card here you pick the available firmware
 and select what and how many components are available.
 
 .Mesa Board Configuration
-image::images/pncconf-mesa-config.png[alt="Mesa Config"]
+image::images/pncconf-mesa-config.png["Mesa Board Configuration"]
 
 Parport address is used only with Mesa parport card, the 7i43. An on board
 parallel port usually uses 0x278 or 0x378 though you should be able to find the
@@ -410,7 +410,7 @@ The tabs are used to configure the input and output pins of the Mesa boards.
 PNCconf allows one to create custom signal names for use in custom HAL files.
 
 .Mesa I/O C2 Setup
-image::images/pncconf-mesa-io2.png["Mesa I/O C2"]
+image::images/pncconf-mesa-io2.png["Mesa I/O C2 Setup"]
 
 On this tab with this firmware the components are setup for a 7i33 daughter
 board, usually used with closed loop servos. Note the component numbers of the
@@ -418,14 +418,14 @@ encoder counters and PWM drivers are not in numerical order. This follows the
 daughter board requirements.
 
 .Mesa I/O C3 Setup
-image::images/pncconf-mesa-io3.png["Mesa I/O C3"]
+image::images/pncconf-mesa-io3.png["Mesa I/O C3 Setup"]
 
 On this tab all the pins are GPIO. Note the 3 digit numbers - they will match
 the HAL pin number. GPIO pins can be selected as input or output and can be
 inverted.
 
 .Mesa I/O C4 Setup
-image::images/pncconf-mesa-io4.png["Mesa I/O C4"]
+image::images/pncconf-mesa-io4.png["Mesa I/O C4 Setup"]
 
 On this tab there are a mix of step generators and GPIO.
 Step generators output and direction pins can be inverted. Note that inverting a
@@ -434,13 +434,13 @@ what your controller expects.
 
 == Parallel port configuration
 
-image::images/pncconf-parport.png["Parport configuration"]
+image::images/pncconf-parport.png["Parallel port configuration"]
 
 The parallel port can be used for simple I/O similar to Mesa's GPIO pins.
 
 == Axis Configuration
 
-//.Axis Drive Configuration
+.Axis Drive Configuration
 image::images/pncconf-axis-drive.png["Axis Drive Configuration"]
 
 This page allows configuring and testing of the motor and/or encoder combination.
@@ -545,7 +545,7 @@ from one manufacturer to another. It is only partially supported and will
 require one to finish the HAL connections. Contact the mail-list or forum for
 more help.
 
-//.Axis Scale Calculation
+.Axis Scale Calculation
 image::images/pncconf-scale-calc.png["Axis Scale Calculation"]
 
 The scale settings can be directly entered or one can use the 'calculate scale'
@@ -554,8 +554,8 @@ that 'pulley teeth' requires the number of teeth not the gear ratio. Worm turn
 ratio is just the opposite it requires the gear ratio. If your happy with the
 scale press apply otherwise push cancel and enter the scale directly.
 
-//.Axis Configuration
-image::images/pncconf-axis-config.png["Axis Configuration 2"]
+.Axis Configuration
+image::images/pncconf-axis-config.png["Axis Configuration"]
 
 Also refer to the diagram tab for two examples of
 home and limit switches. These are two examples of
@@ -736,7 +736,7 @@ Allows setting of simple backlash compensation. Can
 not be used with Compensation File. See <<sec:axis-section,AXIS Section>>
 of the INI Chapter.
 
-//.AXIS Help Diagram
+.AXIS Help Diagram
 image::images/pncconf-diagram-lathe.png["AXIS Help Diagram"]
 
 The diagram should help to demonstrate an example of limit switches and
@@ -806,7 +806,7 @@ The serial modbus program is basically a blank template program that sets up
 classicladder for serial modbus. See the << cha:classicladder,Classicladder Chapter >>
 in the manual.
 
-//.PnCConf, Advanced Options
+.PnCConf, Advanced Options
 image::images/pncconf-advanced.png["PnCConf Advanced Options"]
 
 == HAL Components
@@ -816,8 +816,8 @@ HAL files.
 In this way one should not have to hand edit the main HAL file, while still
 allowing user needed components.
 
-//.HAL Components
-image::images/pncconf-hal.png["HAL components"]
+.HAL Components
+image::images/pncconf-hal.png["HAL Components"]
 
 The first selection is components that pncconf uses internally.
 You may configure pncconf to load extra instances of the components for your

--- a/docs/src/config/pncconf.adoc
+++ b/docs/src/config/pncconf.adoc
@@ -759,14 +759,15 @@ control.
 TIP: Many of the option on this page will not show unless the proper option was
 selected on previous pages!
 
-//.Spindle Configuration
+.Spindle Motor/Encoder Configuration
 image::images/pncconf-spindle-config.png["Spindle Configuration"]
 
 This page is similar to the axis motor configuration page.
 
 There are some differences:
 
-* Unless one has chosen a stepper driven spindle there is no acceleration or velocity limiting.
+* Unless one has chosen a stepper driven spindle there is no acceleration or
+  velocity limiting.
 * There is no support for gear changes or ranges.
 * If you picked a VCP spindle display option then spindle-at-speed scale and
   filter settings may be shown.

--- a/docs/src/config/stepconf.adoc
+++ b/docs/src/config/stepconf.adoc
@@ -50,7 +50,7 @@ These next options will be recorded in a preference file for the next run of Ste
 == Basic Information
 
 [[cap:Basic-Information-Page]]
-//.Basic Information Page
+.Basic Information Page
 image::images/stepconf-base_en.png["Basic Information Page",align="center"]
 
 * 'Create Simulated Hardware' - This allows you to build a config for testing,
@@ -235,8 +235,8 @@ image::images/stepconf-axis-x_en.png["Axis X Configuration Page",align="center"]
 * 'Test this axis' - (((Test this axis)))
   This will open a window to allow testing for each axis. This can be used after filling out all the information for this axis.
 
-//.Test This Axis B
-image::images/stepconf-x-test_en.png[align="center"]
+.Axis Test
+image::images/stepconf-x-test_en.png["Axis Test",align="center"]
 
 Test this axis is a basic tester that only outputs step and direction signals
 to try different values for acceleration and velocity.
@@ -247,7 +247,8 @@ is required. If your driver has a charge pump you will have to bypass it.
 Test this axis does not react to limit switch inputs. Use with caution.
 
 [[sub:finding-maximum-velocity]]
-=== Finding Maximum Velocity
+=== Finding Maximum Velocity(((Finding Maximum Velocity)))
+
 Begin with a low Acceleration
 // comment out latexmath until a fix is found for the html docs
 // (e.g., latexmath:[ 2 in/s^2 ] or latexmath:[ 50 mm/s^2 ])
@@ -290,7 +291,7 @@ Once you have found a speed at which the axis does not stall or lose steps
 during this testing procedure, reduce it by 10% and use that as the axis 'Maximum Velocity'.
 
 [[sub:finding-maximum-acceleration]]
-.Finding Maximum Acceleration(((Finding Maximum Acceleration)))
+=== Finding Maximum Acceleration(((Finding Maximum Acceleration)))
 
 With the Maximum Velocity you found in the previous step,
 enter the acceleration value to test.
@@ -304,12 +305,12 @@ reduce it by 10% and use that as the axis Maximum Acceleration.
 
 == Spindle Configuration
 
-//.Spindle Configuration Page
+.Spindle Configuration Page
 image::images/stepconf-spindle_en.png["Spindle Configuration Page",align="center"]
 
 This page only appears when 'Spindle PWM' is chosen in the 'Parallel Port Pinout' page for one of the outputs.
 
-=== Spindle Speed Control
+=== Spindle Speed Control(((Spindle Speed Control)))
 
 If 'Spindle PWM' appears on the pinout, the following information should be entered:
 
@@ -321,7 +322,7 @@ If 'Spindle PWM' appears on the pinout, the following information should be ente
   values are not known, they can be determined. For more information see
   <<sub:determining-spindle-calibration,Determining Spindle Calibration>>.
 
-=== Spindle-synchronized motion
+=== Spindle-synchronized motion(((Spindle-synchronized motion)))
 
 When the appropriate signals from a spindle encoder are connected to 
 LinuxCNC via HAL, LinuxCNC supports lathe threading.
@@ -353,7 +354,7 @@ on the pinout, the following information should be entered:
 
 Enter the following values in the Spindle Configuration page:
 
-[width="80%"]
+[width="80%",options="header",cols="^,^,^,^"]
 |============================
 |Speed 1: | 0    | PWM 1: | 0
 |Speed 2: | 1000 | PWM 2: | 1
@@ -382,8 +383,8 @@ then find the PWM values that give 1600 RPM (40%) and 2800 RPM (70%).
 
 == Options
 
-//.Options Configuration
-image::images/stepconf-options_en.png["Advanved Options Configuration",align="center"]
+.Advanced Options Configuration
+image::images/stepconf-options_en.png["Advanced Options Configuration",align="center"]
 
 * 'Include Halui' - This will add the Halui user interface component. See the
   <<cha:hal-user-interface,HALUI Chapter>> for more information on.
@@ -396,7 +397,7 @@ image::images/stepconf-options_en.png["Advanved Options Configuration",align="ce
   pause and prompt you to change the tool when 'M6' is encountered. This feature
   is usually only useful if you have presettable tools.
 
-== Machine Configuration Complete
+== Complete Machine Configuration(((Complete Machine Configuration)))
 
 Click 'Apply' to write the configuration files. 
 Later, you can re-run this program and tweak the settings you entered before.

--- a/docs/src/config/stepconf.adoc
+++ b/docs/src/config/stepconf.adoc
@@ -25,31 +25,26 @@ The Stepconf Wizard works best with at least 800 x 600 screen resolution.
 
 == Start Page
 
-[[cap:init-Page]]
-//.Stepconf splash screen
-image::images/stepconf-start_1_es.png["Pagina de entrada",align="center"]
-
-[[cap:Entry-Page]]
-//.Stepconf entry page
-image::images/stepconf-start_en.png["Entry Page",align="center"]
+.The StepConf Entry Page
+image::images/stepconf-start_en.png["StepConf Entry Page",align="center"]
 
 The three first radio buttons are self-explanatory:
 
- * 'Create New' - Creates a fresh configuration.
- * 'Modify' - Modify an existing configuration.
-    After selecting this a file picker pops up so you can select the .stepconf file for modification.
-    If you made any modifications to the main .hal or the .ini file these will be lost.
-    Modifications to custom.hal and custom_postgui.hal will not be changed by the Stepconf Wizard.
-    Stepconf will highlight the lastconf that was built.
- * 'Import' - Import a Mach configuration file and attempt to convert it to a linuxcnc config file.
-    After the import, you will go though the pages of stepconf to confirm/modify the entries.
-    The original mach xml file will not be changed.
+* 'Create New' - Creates a fresh configuration.
+* 'Modify' - Modify an existing configuration.
+  After selecting this a file picker pops up so you can select the .stepconf file for modification.
+  If you made any modifications to the main .hal or the .ini file these will be lost.
+  Modifications to custom.hal and custom_postgui.hal will not be changed by the Stepconf Wizard.
+  Stepconf will highlight the lastconf that was built.
+* 'Import' - Import a Mach configuration file and attempt to convert it to a linuxcnc config file.
+  After the import, you will go though the pages of stepconf to confirm/modify the entries.
+  The original mach xml file will not be changed.
 
 These next options will be recorded in a preference file for the next run of Stepconf.
 
- * 'Create Desktop Shortcut' - This will place a link on your desktop to the files.
- * 'Create Desktop Launcher' - This will place a launcher on your desktop to start your application.
- * 'Create Simulated Hardware' - This allows you to build a config for testing, even if you don't have the actual hardware.
+* 'Create Desktop Shortcut' - This will place a link on your desktop to the files.
+* 'Create Desktop Launcher' - This will place a launcher on your desktop to start your application.
+* 'Create Simulated Hardware' - This allows you to build a config for testing, even if you don't have the actual hardware.
 
 [[sec:Basic-Information]]
 == Basic Information
@@ -58,29 +53,35 @@ These next options will be recorded in a preference file for the next run of Ste
 //.Basic Information Page
 image::images/stepconf-base_en.png["Basic Information Page",align="center"]
 
- * 'Create Simulated Hardware' - This allows you to build a config for testing, even if you don't have the actual hardware.
- * 'Machine Name' - (((Machine Name))) Choose a name for your machine.  Use only uppercase letters, lowercase letters, digits, - and _.
- * 'Axis Configuration' - (((Axis Configuration))) Choose XYZ (Mill), XYZA (4-axis mill) or XZ (Lathe).
- * 'Machine Units' - (((Machine Units)))
-    Choose Inch or mm. All subsequent entries will be in the
-    chosen units. Changing this also changes the default values in the Axes section.
-    If you change this after selecting values in any of the axes sections, they will
-    be over-written by the default values of the selected units.
- * 'Driver Type' - (((Driver Type)))
-    If you have one of the stepper drivers listed in the pull down box, choose it.
-    Otherwise, select 'Other' and find the timing values in your
-    driver's data sheet and enter them as 'nano seconds' in the 'Driver Timing Settings'.
-    If the data sheet gives a value in microseconds, multiply by 1000.
-    For example, enter 4.5us as 4500ns.
-
-A list of some popular drives, along with their timing values, is on the LinuxCNC.org Wiki under http://wiki.linuxcnc.org/cgi-bin/wiki.pl?Stepper_Drive_Timing[Stepper Drive Timing].
-
-Additional signal conditioning or isolation such as optocouplers and RC filters on break out boards can impose timing constraints of their own, in addition to those of the driver.
-You may find it necessary to add some time to the
-drive requirements to allow for this.
-
-The LinuxCNC Configuration Selector has configs for Sherline already configured.
-
+* 'Create Simulated Hardware' - This allows you to build a config for testing,
+  even if you don't have the actual hardware.
+* 'Machine Name' - (((Machine Name)))
+  Choose a name for your machine.
+  Use only uppercase letters, lowercase letters, digits, - and _.
+* 'Axis Configuration' - (((Axis Configuration)))
+  Choose XYZ (Mill), XYZA (4-axis mill) or XZ (Lathe).
+* 'Machine Units' - (((Machine Units)))
+  Choose Inch or mm. All subsequent entries will be in the
+  chosen units. Changing this also changes the default values in the Axes section.
+  If you change this after selecting values in any of the axes sections, they will
+  be over-written by the default values of the selected units.
+* 'Driver Type' - (((Driver Type)))
+  If you have one of the stepper drivers listed in the pull down box, choose it.
+  Otherwise, select 'Other' and find the timing values in your
+  driver's data sheet and enter them as 'nano seconds' in the 'Driver Timing Settings'.
+  If the data sheet gives a value in microseconds, multiply by 1000.
+  For example, enter 4.5us as 4500ns.
+  +
+  A list of some popular drives, along with their timing values, is on the
+  LinuxCNC.org Wiki under
+  http://wiki.linuxcnc.org/cgi-bin/wiki.pl?Stepper_Drive_Timing[Stepper Drive Timing].
+  +
+  Additional signal conditioning or isolation such as optocouplers and RC filters
+  on break out boards can impose timing constraints of their own, in addition
+  to those of the driver. You may find it necessary to add some time to the
+  drive requirements to allow for this.
+  +
+  The LinuxCNC Configuration Selector has configs for Sherline already configured.
 * 'Step Time' - How long the step pulse is 'on' in nano seconds. If your not
   sure about this setting a value of 20,000 will work with most drives.
 * 'Step Space' - Minimum time between step pulses in nano seconds. If your
@@ -89,10 +90,10 @@ The LinuxCNC Configuration Selector has configs for Sherline already configured.
   direction in nanoseconds. If your not sure about this setting a value of
   20,000 will work with most drives.
 * 'Direction Setup' - How long before a direction change after the last
-  step pulse in nanoseconds.  If your not sure about this setting a value of
+  step pulse in nanoseconds. If your not sure about this setting a value of
   20,000 will work with most drives.
 * 'One / Two Parport' - Select how many parallel port are to be configured. 
-* 'Base Period Maximum Jitter' - (((Jitter Maximo del Periodo Base)))
+* 'Base Period Maximum Jitter' - (((Base Period Maximum Jitter)))
   Enter the result of the Latency Test here.
   To run a latency test press the 'Test Base Period Jitter' button. See the
   <<sec:latency-test,Latency Test>> section for more details.
@@ -119,7 +120,7 @@ to be connected to run the test.
 [WARNING]
 Do not attempt run LinuxCNC while the latency test is running.
 
-//.Latency Test
+.Latency Test
 image::images/latency-test_en.png["Latency Test",align="center"]
 
 Latency is how long it takes the PC to stop what it is doing and
@@ -182,7 +183,7 @@ Turn on the 'invert' check box if the signal is inverted (0V for true/active, 5V
 
 == Parallel Port 2 Setup
 
-//.Parallel Port 2 Setup Page
+.Parallel Port 2 Setup Page
 image::images/stepconf-parallel-2_en.png["Parallel Port 2 Setup Page",align="center"]
 
 The second Parallel port (if selected) can be configured and It's pins assigned on this page.
@@ -193,7 +194,7 @@ You may specify the address as a hexadecimal (often 0x378) or as linux's default
 [[sec:Axis-Configuration]]
 == Axis Configuration(((Axis Configuration)))
 
-//.Axis Configuration Page
+.Axis Configuration Screen
 image::images/stepconf-axis-x_en.png["Axis X Configuration Page",align="center"]
 
 * 'Motor Steps Per Revolution' - (((Motor Steps Per Revolution)))
@@ -240,7 +241,7 @@ image::images/stepconf-x-test_en.png[align="center"]
 Test this axis is a basic tester that only outputs step and direction signals
 to try different values for acceleration and velocity.
 
-[IMPORTANT] 
+[IMPORTANT]
 In order to use test this axis you have to manually enable the axis if this
 is required. If your driver has a charge pump you will have to bypass it.
 Test this axis does not react to limit switch inputs. Use with caution.
@@ -402,8 +403,14 @@ Later, you can re-run this program and tweak the settings you entered before.
 
 == Axis Travel and Home
 
+image::images/HomeAxisTravel.png[]
+
 For each axis, there is a limited range of travel.
 The physical end of travel is called the 'hard stop'.
+
+[WARNING]
+[red]#If a mechanical hard stop were to be exceeded,
+the screw or the machine frame would be damaged!#
 
 Before the 'hard stop' there is a 'limit switch'.
 If the limit switch is encountered during normal operation, 
@@ -484,5 +491,8 @@ The following combinations of switches are permitted in Stepconf:
 * Combine both limit switches for one axis
 * Combine both limit switches and the home switch for one axis
 * Combine one limit switch and the home switch for one axis
+
+The last two combinations are also appropriate when the type
+contact + home is used.
 
 // vim: set syntax=asciidoc:

--- a/docs/src/config/stepper.adoc
+++ b/docs/src/config/stepper.adoc
@@ -55,7 +55,8 @@ for more information on HAL.
 As it is described in the HAL Introduction and tutorial, we have
 signals, pins and parameters inside the HAL.
 
-NOTE: We are presenting one axis to keep it short, all others are similar.
+[NOTE]
+We are presenting one axis to keep it short, all others are similar.
 
 The ones relevant for our pinout are:
 

--- a/docs/src/drivers/pico-ppmc.adoc
+++ b/docs/src/drivers/pico-ppmc.adoc
@@ -14,9 +14,10 @@ distinguish between boards, it simply numbers I/O channels (encoders,
 etc) starting from 0 on the first board.  The driver is named hal_ppmc.ko
 The analog servo interface is also called the PPMC for Parallel Port Motion
 Control.  There is also the Universal Stepper Controller, abbreviated the
-USC.  And the Universal PWM Controller, or UPC.
+USC. And the Universal PWM Controller, or UPC.
 
 Installing:
+
 ----
 loadrt hal_ppmc port_addr=<addr1>[,<addr2>[,<addr3>...]]
 ----
@@ -88,20 +89,20 @@ All parallel ports I have here work with the new default behavior.  As on the ot
 
 In the following pins, parameters, and functions, <port> is the parallel
 port ID. According to the naming conventions the first port should always
-have an ID of zero.  All the boards have some method of setting the
-address on the EPP bus.  USC and UPC have simple provisions for only
+have an ID of zero. All the boards have some method of setting the
+address on the EPP bus. USC and UPC have simple provisions for only
 two addresses, but jumper foil cuts allow up to 4 boards to be addressed.
-The PPMC boards have 16 possible addresses.  In all cases, the driver
+The PPMC boards have 16 possible addresses. In all cases, the driver
 enumerates the boards by type and exports the appropriate HAL pins.
 For instance, the encoders will be enumerated from zero up, in the
 same order as the address switches on the board specify.  So, the first
 board will have encoders 0 -- 3, the second board would have encoders
 4 -- 7.
 The first column after the bullet tells which boards will have this
-HAL pin or parameter associated with it.  All means that this pin is
+HAL pin or parameter associated with it. All means that this pin is
 available on all three board types.  Option means that this pin
 will only be exported when that option is enabled by an optional
-parameter in the loadrt HAL command.  These options require the
+parameter in the loadrt HAL command. These options require the
 board to have a sufficient revision level to support the feature.
 
 * '(All s32 output) ppmc.<port>.encoder.<channel>.count' - Encoder position, in counts.
@@ -228,4 +229,3 @@ board to have a sufficient revision level to support the feature.
   outputs, stepgens, PWMs) on one port.
   These writes are organized into blocks of contiguous registers to be
   written in a block to minimize CPU overhead.
-

--- a/docs/src/drivers/pluto-p.adoc
+++ b/docs/src/drivers/pluto-p.adoc
@@ -24,65 +24,65 @@ Supported Hardware] page on the wiki.
 
 === Connectors
 
- * The Pluto-P board is shipped with the left connector presoldered, with
-   the key in the indicated position. The other connectors are
-   unpopulated. There does not seem to be a standard 12-pin IDC connector,
-   but some of the pins of a 16P connector can hang off the board next to
-   QA3/QZ3.
- * The bottom and right connectors are on the same .1" grid, but the left
-   connector is not. If OUT2…OUT9 are not required, a single IDC connector
-   can span the bottom connector and the bottom two rows of the right
-   connector.
+* The Pluto-P board is shipped with the left connector presoldered, with
+  the key in the indicated position. The other connectors are
+  unpopulated. There does not seem to be a standard 12-pin IDC connector,
+  but some of the pins of a 16P connector can hang off the board next to
+  QA3/QZ3.
+* The bottom and right connectors are on the same .1" grid, but the left
+  connector is not. If OUT2…OUT9 are not required, a single IDC connector
+  can span the bottom connector and the bottom two rows of the right
+  connector.
 
 === Physical Pins
 
- * Read the ACEX1K datasheet for information about input and output
-   voltage thresholds. The pins are all configured in 'LVTTL/LVCMOS' mode
-   and are generally compatible with 5V TTL logic.
- * Before configuration and after properly exiting LinuxCNC, all Pluto-P pins
-   are tristated with weak pull-ups (20k-ohms min, 50k-ohms max). If the
-   watchdog timer is enabled (the default),
-   these pins are also tristated after an interruption of communication
-   between LinuxCNC and the board. The watchdog timer takes approximately
-   6.5ms to activate. However, software bugs in the pluto_servo firmware
-   or LinuxCNC can leave the Pluto-P pins in an undefined state.
- * In pwm+dir mode, by default dir is HIGH for negative values and LOW
-   for positive values. To select HIGH for positive values and LOW for
-   negative values, set the corresponding dout-NN-invert parameter TRUE to
-   invert the signal.
- * The index input is triggered on the rising edge. Initial testing has
-   shown that the QZx inputs are particularly noise sensitive, due to
-   being polled every 25ns. Digital filtering has been added to filter
-   pulses shorter than 175ns (seven polling times). Additional external
-   filtering on all input pins, such as a Schmitt buffer or inverter, RC
-   filter, or differential receiver (if applicable) is recommended.
- * The IN1…IN7 pins have 22-ohm series resistors to their associated FPGA
-   pins. No other pins have any sort of protection for out-of-spec
-   voltages or currents. It is up to the integrator to add appropriate
-   isolation and protection. Traditional parallel port optoisolator boards
-   do not work with pluto_servo due to the bidirectional nature of the EPP
-   protocol.
+* Read the ACEX1K datasheet for information about input and output
+  voltage thresholds. The pins are all configured in 'LVTTL/LVCMOS' mode
+  and are generally compatible with 5V TTL logic.
+* Before configuration and after properly exiting LinuxCNC, all Pluto-P pins
+  are tristated with weak pull-ups (20k-ohms min, 50k-ohms max). If the
+  watchdog timer is enabled (the default),
+  these pins are also tristated after an interruption of communication
+  between LinuxCNC and the board. The watchdog timer takes approximately
+  6.5ms to activate. However, software bugs in the pluto_servo firmware
+  or LinuxCNC can leave the Pluto-P pins in an undefined state.
+* In pwm+dir mode, by default dir is HIGH for negative values and LOW
+  for positive values. To select HIGH for positive values and LOW for
+  negative values, set the corresponding dout-NN-invert parameter TRUE to
+  invert the signal.
+* The index input is triggered on the rising edge. Initial testing has
+  shown that the QZx inputs are particularly noise sensitive, due to
+  being polled every 25ns. Digital filtering has been added to filter
+  pulses shorter than 175ns (seven polling times). Additional external
+  filtering on all input pins, such as a Schmitt buffer or inverter, RC
+  filter, or differential receiver (if applicable) is recommended.
+* The IN1…IN7 pins have 22-ohm series resistors to their associated FPGA
+  pins. No other pins have any sort of protection for out-of-spec
+  voltages or currents. It is up to the integrator to add appropriate
+  isolation and protection. Traditional parallel port optoisolator boards
+  do not work with pluto_servo due to the bidirectional nature of the EPP
+  protocol.
 
 === LED
 
- * When the device is unprogrammed, the LED glows faintly. When the
-   device is programmed, the LED glows according to the duty cycle of PWM0
-   ('LED' = 'UP0' 'xor' 'DOWN0') or STEPGEN0 ('LED' = 'STEP0' 'xor'
-   'DIR0').
+* When the device is unprogrammed, the LED glows faintly. When the
+  device is programmed, the LED glows according to the duty cycle of PWM0
+  ('LED' = 'UP0' 'xor' 'DOWN0') or STEPGEN0 ('LED' = 'STEP0' 'xor'
+  'DIR0').
 
 === Power
 
- * A small amount of current may be drawn from VCC. The available current
-   depends on the unregulated DC input to the board. Alternately,
-   regulated +3.3VDC may be supplied to the FPGA through these VCC pins.
-   The required current is not yet known, but is probably around 50mA plus
-   I/O current.
- * The regulator on the Pluto-P board is a low-dropout type. Supplying 5V
-   at the power jack will allow the regulator to work properly.
+* A small amount of current may be drawn from VCC. The available current
+  depends on the unregulated DC input to the board. Alternately,
+  regulated +3.3VDC may be supplied to the FPGA through these VCC pins.
+  The required current is not yet known, but is probably around 50mA plus
+  I/O current.
+* The regulator on the Pluto-P board is a low-dropout type. Supplying 5V
+  at the power jack will allow the regulator to work properly.
 
 === PC interface
 
- * Only a single pluto_servo or pluto_step board is supported.
+* Only a single pluto_servo or pluto_step board is supported.
 
 === Rebuilding the FPGA firmware
 
@@ -115,57 +115,48 @@ limit switches.
 
 This driver features:
 
- * 4 quadrature channels with 40MHz sample rate. The counters operate in
-   '4x' mode. The maximum useful quadrature rate is 8191 counts per LinuxCNC
-   servo cycle, or about 8MHz for LinuxCNC's default 1ms servo rate.
- * 4 PWM channels, 'up/down' or 'pwm+dir' style. 4095 duty cycles from
-   -100% to +100%, including 0%. The PWM period is approximately 19.5kHz
-   (40MHz / 2047). A PDM-like mode is also available.
- * 18 digital outputs: 10 dedicated, 8 shared with PWM functions.
-   (Example: A lathe with unidirectional PWM spindle control may use 13
-   total digital outputs)
- * 20 digital inputs: 8 dedicated, 12 shared with Quadrature functions.
-   (Example: A lathe with index pulse only on the spindle may use 13 total
-   digital inputs)
- * EPP communication with the PC. The EPP communication typically takes
-   around 100 us on machines tested so far, enabling servo rates above
-   1kHz.
+* 4 quadrature channels with 40MHz sample rate. The counters operate in
+  '4x' mode. The maximum useful quadrature rate is 8191 counts per LinuxCNC
+  servo cycle, or about 8MHz for LinuxCNC's default 1ms servo rate.
+* 4 PWM channels, 'up/down' or 'pwm+dir' style. 4095 duty cycles from
+  -100% to +100%, including 0%. The PWM period is approximately 19.5kHz
+  (40MHz / 2047). A PDM-like mode is also available.
+* 18 digital outputs: 10 dedicated, 8 shared with PWM functions.
+  (Example: A lathe with unidirectional PWM spindle control may use 13
+  total digital outputs)
+* 20 digital inputs: 8 dedicated, 12 shared with Quadrature functions.
+  (Example: A lathe with index pulse only on the spindle may use 13 total
+  digital inputs)
+* EPP communication with the PC. The EPP communication typically takes
+  around 100 us on machines tested so far, enabling servo rates above
+  1kHz.
 
 === Pinout
 
- * 'UPx' - The 'up' (up/down mode) or 'pwm' (pwm+direction mode) signal from PWM
-   generator X. May be used as a digital output if the corresponding PWM
-   channel is unused, or the output on the channel is always negative. The
-   corresponding digital output invert may be set to TRUE to make UPx
-   active low rather than active high.
-
- * 'DNx' - The 'down' (up/down mode) or 'direction' (pwm+direction mode) signal
-   from PWM generator X. May be used as a digital output if the
-   corresponding PWM channel is unused, or the output on the channel is
-   never negative. The corresponding digital output invert may be set to
-   TRUE to make DNx active low rather than active high.
-
- * 'QAx, QBx' - The A and B signals for Quadrature counter X. May be used as a digital
-   input if the corresponding quadrature channel is unused.
-
- * 'QZx' - The Z (index) signal for quadrature counter X. May be used as a
-   digital input if the index feature of the corresponding quadrature
-   channel is unused.
-
- * 'INx' - Dedicated digital input #x
-
- * 'OUTx' - Dedicated digital output #x
-
- * 'GND' - Ground
-
- * 'VCC' - +3.3V regulated DC
+* 'UPx' - The 'up' (up/down mode) or 'pwm' (pwm+direction mode) signal from PWM
+  generator X. May be used as a digital output if the corresponding PWM
+  channel is unused, or the output on the channel is always negative. The
+  corresponding digital output invert may be set to TRUE to make UPx
+  active low rather than active high.
+* 'DNx' - The 'down' (up/down mode) or 'direction' (pwm+direction mode) signal
+  from PWM generator X. May be used as a digital output if the
+  corresponding PWM channel is unused, or the output on the channel is
+  never negative. The corresponding digital output invert may be set to
+  TRUE to make DNx active low rather than active high.
+* 'QAx, QBx' - The A and B signals for Quadrature counter X. May be used as a digital
+  input if the corresponding quadrature channel is unused.
+* 'QZx' - The Z (index) signal for quadrature counter X. May be used as a
+  digital input if the index feature of the corresponding quadrature
+  channel is unused.
+* 'INx' - Dedicated digital input #x
+* 'OUTx' - Dedicated digital output #x
+* 'GND' - Ground
+* 'VCC' - +3.3V regulated DC
 
 .Pluto-Servo Pinout(((pluto-servo pinout)))
-
 image::images/pluto-pinout.png["Pluto-Servo Pinout",align="center"]
 
 .Pluto-Servo Alternate Pin Functions
-
 [width="90%", options="header"]
 |========================================
 |Primary function | Alternate Function | Behavior if both functions used
@@ -233,11 +224,11 @@ limit switches.
 
 The board features:
 
- * 4 'step+direction' channels with 312.5kHz maximum step rate,
-   programmable step length, space, and direction change times
- * 14 dedicated digital outputs
- * 16 dedicated digital inputs
- * EPP communication with the PC
+* 4 'step+direction' channels with 312.5kHz maximum step rate,
+  programmable step length, space, and direction change times
+* 14 dedicated digital outputs
+* 16 dedicated digital inputs
+* EPP communication with the PC
 
 === Pinout
 
@@ -255,7 +246,6 @@ different than the layout of a standard 26-pin ribbon cable to DB25
 connector.
 
 .Pluto-Step Pinout (((pluto-step pinout)))
-
 image::images/pluto-step-pinout.png["Pluto-Step Pinout",align="center"]
 
 === Input latching and output updating
@@ -276,11 +266,9 @@ are the same as for the software stepgen component, except that
 step timings are always applied to all channels.
 
 .Pluto-Step Timings (((pluto-step timings)))
-
 image::images/pluto_step_waveform.png["Pluto-Step Timings",align="center"]
 
 === HAL Functions, Pins and Parameters
 
 A list of all 'loadrt' arguments, HAL function names, pin names and
 parameter names is in the manual page, 'pluto_step.9'.
-

--- a/docs/src/drivers/pmx485.adoc
+++ b/docs/src/drivers/pmx485.adoc
@@ -12,6 +12,7 @@ a change in the status output. One should always have an Estop circuit that
 kills the power to the unit in case of emergency.
 
 This component is loaded using the halcmd "loadusr" command:
+
 ----
 loadusr -Wn pmx485 pmx485 /dev/ttyUSB0
 ----
@@ -24,31 +25,18 @@ It is necessary to name the port to use for communications.
 == Pins
 
 * *pmx485.mode-set* (bit, in) #set cutting mode
-
 * *pmx485.current-set* (bit, in) #set cutting current
-
 * *pmx485.pressure-set* (bit, in) #set gas pressure
-
 * *pmx485.enable* (bit, in) #enable the component
-
 * *pmx485.mode* (bit, out) #cut mode feedback
-
 * *pmx485.current* (bit, out) #cutting current feedback
-
 * *pmx485.pressure* (bit, out) #gas pressure feedback
-
 * *pmx485.fault* (bit, out) #powermax fault code
-
 * *pmx485.status* (bit, out) #connection status
-
 * *pmx485.current-min* (bit, out) #minimum allowed current
-
 * *pmx485.current-max* (bit, out) #maximum allowed current
-
 * *pmx485.pressure-min* (bit, out) #minimum allowed gas pressure
-
 * *pmx485.pressure-max* (bit, out) #maximum allowed gas pressure
-
 
 == Description
 
@@ -68,13 +56,12 @@ While in remote mode, the mode, current and pressure may be changed as needed.
 
 To terminate the communications, do one of the following:
 
- * Set all set pins to zero: *mode-set*, *current-set*, and *pressure-set*.
- * Disconnect the Powermax power supply from its power source for approximately
-   30 seconds. When you power the system back ON, it will no longer be in remote
-   mode.
+* Set all set pins to zero: *mode-set*, *current-set*, and *pressure-set*.
+* Disconnect the Powermax power supply from its power source for approximately
+  30 seconds. When you power the system back ON, it will no longer be in remote
+  mode.
 
 == Reference:
 
 * Hypertherm Application Note #807220 +
-  "Powermax45 XP/65/85/105/125® Serial Communication Protocol"
-
+"Powermax45 XP/65/85/105/125® Serial Communication Protocol"

--- a/docs/src/drivers/servo-to-go.adoc
+++ b/docs/src/drivers/servo-to-go.adoc
@@ -11,11 +11,11 @@ bits digital I/O, an interval timer with interrupt and a watchdog. For more
 information see the http://www.servotogo.com/[Servo To Go] web page.
 
 NOTE: We have had reports that the opamps on the Servo To Go card do
-    not work with newer ATX power supplies that use modern switch
-    mode DC-DC converters.  The failure mode is that STG card outputs a
-    constant voltage regardless of what the driver is commanding it to do.
-    Older ATX power supplies with linear voltage regulators do not have
-    this problem, and work fine with the STG cards.
+not work with newer ATX power supplies that use modern switch
+mode DC-DC converters.  The failure mode is that STG card outputs a
+constant voltage regardless of what the driver is commanding it to do.
+Older ATX power supplies with linear voltage regulators do not have
+this problem, and work fine with the STG cards.
 
 == Installing
 
@@ -36,7 +36,7 @@ C (Port C - DIO.16-23), and the fourth sets port D (Port D -
 DIO.24-31). The model field can be used in case the driver doesn't
 autodetect the right card version.
 
-hint: after starting up the driver, 'dmesg' can be consulted for
+HINT: after starting up the driver, 'dmesg' can be consulted for
 messages relevant to the driver (e.g. autodetected version number and
 base address). For example:
 
@@ -62,13 +62,13 @@ configured as Output.
 
 == Pins
 
- * 'stg.<channel>.counts' - (s32) Tracks the counted encoder ticks.
- * 'stg.<channel>.position' - (float) Outputs a converted position.
- * 'stg.<channel>.dac-value' - (float) Drives the voltage for the corresponding DAC.
- * 'stg.<channel>.adc-value' - (float) Tracks the measured voltage from the corresponding ADC.
- * 'stg.in-<pinnum>' - (bit) Tracks a physical input pin.
- * 'stg.in-<pinnum>-not' - (bit) Tracks a physical input pin, but inverted.
- * 'stg.out-<pinnum>' - (bit) Drives a physical output pin
+* 'stg.<channel>.counts' - (s32) Tracks the counted encoder ticks.
+* 'stg.<channel>.position' - (float) Outputs a converted position.
+* 'stg.<channel>.dac-value' - (float) Drives the voltage for the corresponding DAC.
+* 'stg.<channel>.adc-value' - (float) Tracks the measured voltage from the corresponding ADC.
+* 'stg.in-<pinnum>' - (bit) Tracks a physical input pin.
+* 'stg.in-<pinnum>-not' - (bit) Tracks a physical input pin, but inverted.
+* 'stg.out-<pinnum>' - (bit) Drives a physical output pin
 
 For each pin, <channel> is the axis number, and <pinnum> is the logic
 pin number of the STG if `IIOO` is defined, there are 16 input pins (in-00 .. in-15)
@@ -82,13 +82,13 @@ other, the user can determine the state of the input.
 
 == Parameters
 
- * 'stg.<channel>.position-scale' - (float) The number of counts / user unit
-   (to convert from counts to units).
- * 'stg.<channel>.dac-offset' - (float) Sets the offset for the corresponding DAC.
- * 'stg.<channel>.dac-gain' - (float) Sets the gain of the corresponding DAC.
- * 'stg.<channel>.adc-offset' - (float) Sets the offset of the corresponding ADC.
- * 'stg.<channel>.adc-gain' - (float) Sets the gain of the corresponding ADC.
- * 'stg.out-<pinnum>-invert' - (bit) Inverts an output pin.
+* 'stg.<channel>.position-scale' - (float) The number of counts / user unit
+  (to convert from counts to units).
+* 'stg.<channel>.dac-offset' - (float) Sets the offset for the corresponding DAC.
+* 'stg.<channel>.dac-gain' - (float) Sets the gain of the corresponding DAC.
+* 'stg.<channel>.adc-offset' - (float) Sets the offset of the corresponding ADC.
+* 'stg.<channel>.adc-gain' - (float) Sets the gain of the corresponding ADC.
+* 'stg.out-<pinnum>-invert' - (bit) Inverts an output pin.
 
 The -invert parameter determines whether an output pin is active high
 or active low. If -invert is FALSE, setting the HAL out- pin TRUE
@@ -97,11 +97,10 @@ TRUE, then setting the HAL out- pin TRUE will drive the physical pin low.
 
 == Functions
 
- * 'stg.capture-position' - Reads the encoder counters from the axis <channel>.
- * 'stg.write-dacs' - Writes the voltages to the DACs.
- * 'stg.read-adcs' - Reads the voltages from the ADCs.
- * 'stg.di-read' - Reads physical in- pins of all ports and updates
-   all HAL in-<pinnum> and in-<pinnum>-not pins.
- * 'stg.do-write' - Reads all HAL out-<pinnum> pins and updates all
-   physical output pins.
-
+* 'stg.capture-position' - Reads the encoder counters from the axis <channel>.
+* 'stg.write-dacs' - Writes the voltages to the DACs.
+* 'stg.read-adcs' - Reads the voltages from the ADCs.
+* 'stg.di-read' - Reads physical in- pins of all ports and updates
+  all HAL in-<pinnum> and in-<pinnum>-not pins.
+* 'stg.do-write' - Reads all HAL out-<pinnum> pins and updates all
+  physical output pins.

--- a/docs/src/drivers/shuttle.adoc
+++ b/docs/src/drivers/shuttle.adoc
@@ -61,7 +61,6 @@ using the Debian packaging you'll need to install this file by hand.
 If you install the file by hand you'll need to tell udev to reload its
 rules files by running `udevadm control --reload-rules`.
 
-
 == Pins
 
 All HAL pin names are prefixed with `shuttle` followed by the index
@@ -69,28 +68,19 @@ of the device (the order in which the driver found them), for example
 "shuttle.0" or "shuttle.2".
 
 '<Prefix>.button-<ButtonNumber>' (bit out)::
-
-    These pins are True (1) when the button is pressed.
-
+  These pins are True (1) when the button is pressed.
 '<Prefix>.button-<ButtonNumber>-not' (bit out)::
-
-    These pins have the inverse of the button state, so they're True
-    (1) when the button is not pressed.
-
+  These pins have the inverse of the button state, so they're True
+  (1) when the button is not pressed.
 '<Prefix>.counts' (s32 out)::
-
-    Accumulated counts from the jog wheel (the inner wheel).
-
+  Accumulated counts from the jog wheel (the inner wheel).
 '<Prefix>.spring-wheel-s32' (s32 out)::
-
-    The current deflection of the spring-wheel (the outer wheel).
-    It's 0 at rest, and ranges from -7 at the counter-clockwise extreme
-    to +7 at the clockwise extreme.
-
+  The current deflection of the spring-wheel (the outer wheel).
+  It's 0 at rest, and ranges from -7 at the counter-clockwise extreme
+  to +7 at the clockwise extreme.
 '<Prefix>.spring-wheel-f' (float out)::
-
-    The current deflection of the spring-wheel (the outer wheel).
-    It's 0.0 at rest, -1.0 at the counter-clockwise extreme, and +1.0 at
-    the clockwise extreme. (The Shuttle devices report the spring-wheel
-    position as an integer from -7 to +7, so this pin reports only 15
-    discrete values in it's range.)
+  The current deflection of the spring-wheel (the outer wheel).
+  It's 0.0 at rest, -1.0 at the counter-clockwise extreme, and +1.0 at
+  the clockwise extreme. (The Shuttle devices report the spring-wheel
+  position as an integer from -7 to +7, so this pin reports only 15
+  discrete values in it's range.)

--- a/docs/src/drivers/vfs11.adoc
+++ b/docs/src/drivers/vfs11.adoc
@@ -19,6 +19,7 @@ TCP-based devices or through a terminal server.
 Regardless of the connection type, vfs11_vfd operates as a Modbus master.
 
 This component is loaded using the halcmd "loadusr" command:
+
 ----
 loadusr -Wn spindle-vfd vfs11_vfd -n spindle-vfd
 ----
@@ -50,130 +51,98 @@ may result in a flood of timeout errors.
 
 Where <n> is +vfs11_vfd+ or the name given during loading with the -n  option.
 
- * '<n>.acceleration-pattern' (bit, in) when true, set acceleration and
-   deceleration times as defined in registers F500 and F501
-   respectively.  Used in PID loops to choose shorter ramp
-   times to avoid oscillation.
-
- * '<n>.alarm-code' (s32, out) non-zero if drive is in alarmed
-   state. Bitmap describing alarm information (see register
-   FC91 description).  Use err-reset (see below) to clear the
-   alarm.
-
- * '<n>.at-speed' (bit, out)
-   when drive is at commanded speed (see speed-tolerance below)
-
- * '<n>.current-load-percentage' (float, out)
-   reported from the VFD
-
- * '<n>.dc-brake' (bit, in)
-   engage the DC brake. Also turns off spindle-on.
-
- * '<n>.enable' (bit, in)
-   enable the VFD. If false, all operating parameters are still read but control is released and  panel  control
-   is enabled (subject to VFD setup).
-
- * '<n>.err-reset' (bit, in)
-   reset  errors  (alarms a.k.a Trip and e-stop status). Resetting the VFD may cause a 2-second delay until it's
-   rebooted and Modbus is up again.
-
- * '<n>.estop' (bit, in)
-   put the VFD into emergency-stopped status. No operation possible until cleared  with  err-reset  or  powercycling.
-
- * '<n>.frequency-command' (float, out)
-   current target frequency in HZ as set through speed-command (which is in RPM), from the VFD
-
- * '<n>.frequency-out' (float, out)
-   current output frequency of the VFD
-
- * '<n>.inverter-load-percentage' (float, out)
-   current load report from VFD
-
- * '<n>.is-e-stopped' (bit, out)
-   the VFD is in emergency stop status (blinking "E" on panel). Use err-reset to reboot the VFD and clear the e-
-   stop status.
-
- * '<n>.is-stopped' (bit, out)
-   true when the VFD reports 0 Hz output
-
- * '<n>.max-rpm' (float, R)
-   actual RPM limit based on maximum frequency the VFD may  generate,  and  the  motors  nameplate  values.  For
-   instance,  if  nameplate-HZ is 50, and nameplate-RPM_ is 1410, but the VFD may generate up to 80Hz, then max-
-   rpm would read as 2256 (80*1410/50). The frequency limit is read from the VFD at startup.   To  increase  the
-   upper  frequency  limit,  the  UL  and FH parameters must be changed on the panel.  See the VF-S11 manual for
-   instructions how to set the maximum frequency.
-
- * '<n>.modbus-ok' (bit, out)
-   true when the Modbus session is successfully established and the last 10 transactions returned without error.
-
- * '<n>.motor-RPM' (float, out)
-   estimated current RPM value, from the VFD
-
- * '<n>.output-current-percentage' (float, out)
-   from the VFD
-
- * '<n>.output-voltage-percentage' (float, out)
-   from the VFD
-
- * '<n>.output-voltage' (float, out)
-   from the VFD
-
- * '<n>.speed-command' (float, in)
-   speed sent to VFD in RPM. It is an error to send a speed faster than the Motor Max RPM as set in the VFD
-
- * '<n>.spindle-fwd' (bit, in)
-   1 for FWD and 0 for REV, sent to VFD
-
- * '<n>.spindle-on' (bit, in)
-   1 for ON and 0 for OFF sent to VFD, only on when running
-
- * '<n>.spindle-rev' (bit, in)
-   1 for ON and 0 for OFF, only on when running
-
- * '<n>.jog-mode' (bit, in)
-   1 for ON and 0 for OFF, enables the VF-S11 'jog mode'. Speed control is disabled, and the output frequency is
-   determined by register F262 (preset to 5Hz). This might
-   be useful for spindle orientation. In normal mode, the
-   VFD shuts off if the frequency drops below 12Hz.
-
- * '<n>.status' (s32, out)
-   Drive Status of the VFD (see the TOSVERT VF-S11 Communications Function Instruction Manual, register FD01). A
-   bitmap.
-
- * '<n>.trip-code' (s32, out)
-   trip code if VF-S11 is in tripped state.
-
- * '<n>.error-count' (s32, out)
-   number of Modbus transactions which returned an error
-
- * '<n>.max-speed' (bit, in)
-   ignore the loop-time parameter and run Modbus at maximum
-   speed, at the expense of higher CPU usage. Suggested use
-   during spindle positioning.
+* '<n>.acceleration-pattern' (bit, in) when true, set acceleration and
+  deceleration times as defined in registers F500 and F501
+  respectively.  Used in PID loops to choose shorter ramp
+  times to avoid oscillation.
+* '<n>.alarm-code' (s32, out) non-zero if drive is in alarmed
+  state. Bitmap describing alarm information (see register
+  FC91 description).  Use err-reset (see below) to clear the
+  alarm.
+* '<n>.at-speed' (bit, out)
+  when drive is at commanded speed (see speed-tolerance below)
+* '<n>.current-load-percentage' (float, out)
+  reported from the VFD
+* '<n>.dc-brake' (bit, in)
+  engage the DC brake. Also turns off spindle-on.
+* '<n>.enable' (bit, in)
+  enable the VFD. If false, all operating parameters are still read but control is released and  panel  control
+  is enabled (subject to VFD setup).
+* '<n>.err-reset' (bit, in)
+  reset  errors  (alarms a.k.a Trip and e-stop status). Resetting the VFD may cause a 2-second delay until it's
+  rebooted and Modbus is up again.
+* '<n>.estop' (bit, in)
+  put the VFD into emergency-stopped status. No operation possible until cleared  with  err-reset  or  powercycling.
+* '<n>.frequency-command' (float, out)
+  current target frequency in HZ as set through speed-command (which is in RPM), from the VFD
+* '<n>.frequency-out' (float, out)
+  current output frequency of the VFD
+* '<n>.inverter-load-percentage' (float, out)
+  current load report from VFD
+* '<n>.is-e-stopped' (bit, out)
+  the VFD is in emergency stop status (blinking "E" on panel). Use err-reset to reboot the VFD and clear the e-
+  stop status.
+* '<n>.is-stopped' (bit, out)
+  true when the VFD reports 0 Hz output
+* '<n>.max-rpm' (float, R)
+  actual RPM limit based on maximum frequency the VFD may  generate,  and  the  motors  nameplate  values.  For
+  instance,  if  nameplate-HZ is 50, and nameplate-RPM_ is 1410, but the VFD may generate up to 80Hz, then max-
+  rpm would read as 2256 (80*1410/50). The frequency limit is read from the VFD at startup.   To  increase  the
+  upper  frequency  limit,  the  UL  and FH parameters must be changed on the panel.  See the VF-S11 manual for
+  instructions how to set the maximum frequency.
+* '<n>.modbus-ok' (bit, out)
+  true when the Modbus session is successfully established and the last 10 transactions returned without error.
+* '<n>.motor-RPM' (float, out)
+  estimated current RPM value, from the VFD
+* '<n>.output-current-percentage' (float, out)
+  from the VFD
+* '<n>.output-voltage-percentage' (float, out)
+  from the VFD
+* '<n>.output-voltage' (float, out)
+  from the VFD
+* '<n>.speed-command' (float, in)
+  speed sent to VFD in RPM. It is an error to send a speed faster than the Motor Max RPM as set in the VFD
+* '<n>.spindle-fwd' (bit, in)
+  1 for FWD and 0 for REV, sent to VFD
+* '<n>.spindle-on' (bit, in)
+  1 for ON and 0 for OFF sent to VFD, only on when running
+* '<n>.spindle-rev' (bit, in)
+  1 for ON and 0 for OFF, only on when running
+* '<n>.jog-mode' (bit, in)
+  1 for ON and 0 for OFF, enables the VF-S11 'jog mode'. Speed control is disabled, and the output frequency is
+  determined by register F262 (preset to 5Hz). This might
+  be useful for spindle orientation. In normal mode, the
+  VFD shuts off if the frequency drops below 12Hz.
+* '<n>.status' (s32, out)
+  Drive Status of the VFD (see the TOSVERT VF-S11 Communications Function Instruction Manual, register FD01). A
+  bitmap.
+* '<n>.trip-code' (s32, out)
+  trip code if VF-S11 is in tripped state.
+* '<n>.error-count' (s32, out)
+  number of Modbus transactions which returned an error
+* '<n>.max-speed' (bit, in)
+  ignore the loop-time parameter and run Modbus at maximum
+  speed, at the expense of higher CPU usage. Suggested use
+  during spindle positioning.
 
 == Parameters
 
 Where <n> is +vfs11_vfd+ or the name given during loading with the -n  option.
 
- * '<n>.frequency-limit' (float, RO)
-   upper limit read from VFD setup.
-
- * '<n>.loop-time' (float, RW)
-   how often the Modbus is polled (default interval 0.1 seconds)
-
- * '<n>.nameplate-HZ' (float, RW)
-   Nameplate Hz of motor (default 50). Used to calculate target frequency (together with nameplate-RPM )  for  a
-   target RPM value as given by speed-command.
-
- * '<n>.nameplate-RPM' (float, RW)
-   Nameplate RPM of motor (default 1410)
-
- * '<n>.rpm-limit' (float, RW)
-   do-not-exceed soft limit for motor RPM (defaults to nameplate-RPM ).
-
- * '<n>.tolerance' (float, RW)
-   speed tolerance (default 0.01) for determining whether spindle is at speed (0.01 meaning: output frequency is
-   within 1% of target frequency)
+* '<n>.frequency-limit' (float, RO)
+  upper limit read from VFD setup.
+* '<n>.loop-time' (float, RW)
+  how often the Modbus is polled (default interval 0.1 seconds)
+* '<n>.nameplate-HZ' (float, RW)
+  Nameplate Hz of motor (default 50). Used to calculate target frequency (together with nameplate-RPM )  for  a
+  target RPM value as given by speed-command.
+* '<n>.nameplate-RPM' (float, RW)
+  Nameplate RPM of motor (default 1410)
+* '<n>.rpm-limit' (float, RW)
+  do-not-exceed soft limit for motor RPM (defaults to nameplate-RPM ).
+* '<n>.tolerance' (float, RW)
+  speed tolerance (default 0.01) for determining whether spindle is at speed (0.01 meaning: output frequency is
+  within 1% of target frequency)
 
 == INI file configuration
 
@@ -303,10 +272,8 @@ are set to default values, and the driver will sleep for
 +RECONNECT_DELAY+ seconds (default 1 second).
 
 * Serial (+TYPE=rtu+) mode: on error, close and reopen the serial port.
-
 * TCP server (+TYPE=tcpserver+) mode: on losing the TCP connection, the
   driver will go back to listen for incoming connections.
-
 * TCP client (+TYPE=tcpclient+) mode: on losing the TCP connection, the
   driver will reconnect to 'TCPDEST:PORTNO'.
 
@@ -359,9 +326,10 @@ flags. Therefore, building vfs11_vfd using this library might generate
 a warning if RTS_MODE= is specified in the ini file.
 
 To use the full functionality on lucid and precise:
- * remove the libmodbus packages: `sudo apt-get remove libmodbus5 libmodbus-dev`
- * build and install libmodbus version 3 from source as outlined
-   https://github.com/stephane/libmodbus/blob/master/README.rst[here].
+
+* remove the libmodbus packages: `sudo apt-get remove libmodbus5 libmodbus-dev`
+* build and install libmodbus version 3 from source as outlined
+  https://github.com/stephane/libmodbus/blob/master/README.rst[here].
 
 Libmodbus does not build on Ubuntu Hardy, hence vfs11_vfd is not
 available on hardy.

--- a/docs/src/examples/gcode.adoc
+++ b/docs/src/examples/gcode.adoc
@@ -79,4 +79,3 @@ tool table.
 - Description: Facing, threading and parting off.
 
 This file shows an example of threading on a lathe using parameters.
-

--- a/docs/src/examples/gs2-example.adoc
+++ b/docs/src/examples/gs2-example.adoc
@@ -48,15 +48,15 @@ based on your physical requirements but these are beyond the scope of this
 manual. Refer to the GS2 manual that came with the drive for more
 information on the drive parameters.
 
- * The communications switches must be set to RS-232C
- * The motor parameters must be set to match the motor
- * P3.00 (Source of Operation Command) must be set to Operation
-   determined by RS-485 interface, 03 or 04
- * P4.00 (Source of Frequency Command) must be set to Frequency
-   determined by RS232C/RS485 communication interface, 05
- * P9.01 (Transmission Speed) must be set to 9600 baud, 01
- * P9.02 (Communication Protocol) must be set to "Modbus RTU mode,
-   8 data bits, no parity, 2 stop bits", 03
+* The communications switches must be set to RS-232C
+* The motor parameters must be set to match the motor
+* P3.00 (Source of Operation Command) must be set to Operation
+  determined by RS-485 interface, 03 or 04
+* P4.00 (Source of Frequency Command) must be set to Frequency
+  determined by RS232C/RS485 communication interface, 05
+* P9.01 (Transmission Speed) must be set to 9600 baud, 01
+* P9.02 (Communication Protocol) must be set to "Modbus RTU mode,
+  8 data bits, no parity, 2 stop bits", 03
 
 A PyVCP panel based on this example is <<gs2-rpm-meter,here>>.
 

--- a/docs/src/examples/spindle.adoc
+++ b/docs/src/examples/spindle.adoc
@@ -105,13 +105,15 @@ is changed as shown in the following example:
 In case you have not run across them before, here's a quick introduction
 to the two HAL components used in the following example.
 
-* A "limit2" is a HAL component (floating point) that accepts an input value
-  and provides an output that has been limited to a max/min range,
-  and also limited to not exceed a specified rate of change.
-* A "near" is a HAL component (floating point) with a binary output that says
-  whether two inputs are approximately equal.
+* A "limit2" is a HAL component (floating point) that accepts an
+  input value and provides an output that has been limited to a
+  max/min range, and also limited to not exceed a specified
+  rate of change.
+* A "near" is a HAL component (floating point) with a binary output
+  that says whether two inputs are approximately equal.
 
-More info is available in the documentation for HAL components, or from the man pages, just say 'man limit2' or 'man near' in a terminal.
+More info is available in the documentation for HAL components, or from
+the man pages, just say 'man limit2' or 'man near' in a terminal.
 
 ----
 # load real time a limit2 and a near with names so it is easier to follow
@@ -146,7 +148,7 @@ net spindle-ready <= spindle-at-speed.out => spindle.0.at-speed
 
 == Spindle Feedback
 
-=== Spindle Synchronized Motion (((Spindle Synchronized Motion Example)))
+=== Spindle Synchronized Motion(((Spindle Synchronized Motion Example)))
 
 Spindle feedback is needed by LinuxCNC to perform any spindle coordinated
 motions like threading and constant surface speed.
@@ -166,12 +168,16 @@ Hardware assumptions:
 * The encoder index pulse is connected to the parallel port pin 11
 
 Basic Steps to add the components and configure them:
-footnote:[In this example, we will assume that some encoders have already been
-issued to axes/joints 0, 1, and 2. So the next encoder available for us to attach to the spindle would be number 3. Your situation may differ.]
-footnote:[The HAL encoder index-enable is an exception to the rule in that it
-behaves as both an input and an output, see the <<sec:encoder,Encoder Section>> for details]
-footnote:[It is because we selected 'non-quadrature simple counting...' above that
-we can get away with 'quadrature' counting without having any B quadrature input.]
+footnote:[In this example, we will assume that some encoders have already
+been issued to axes/joints 0, 1, and 2. So the next encoder available
+for us to attach to the spindle would be number 3. Your situation may
+differ.]
+footnote:[The HAL encoder index-enable is an exception to the rule in
+that it behaves as both an input and an output, see the
+<<sec:encoder,Encoder Section>> for details]
+footnote:[It is because we selected 'non-quadrature simple counting...'
+above that we can get away with 'quadrature' counting without having any
+B quadrature input.]
 
 ----
 # add the encoder to HAL and attach it to threads.
@@ -236,4 +242,3 @@ net spindle-at-speed spindle.0.at-speed <= near.0.out
 # set the spindle speed inputs to agree if within 1%
 setp near.0.scale 1.01
 ----
-

--- a/docs/src/gcode/coordinates.adoc
+++ b/docs/src/gcode/coordinates.adoc
@@ -53,7 +53,7 @@ in machine coordinate system is desired
 
 [[fig:coordinate-systems-example]]
 .Coordinate Systems Example
-image::images/offsets.png["Coordinate systems example",align="center"]
+image::images/offsets.png["Coordinate Systems Example",align="center"]
 
 .Coordinate System Offsets
 * G54 - use coordinate system 1
@@ -237,6 +237,7 @@ the other offsets.
 offset".
 
 The 'G92' set of commands includes:
+
 * 'G92' - This command, when used with axis names, sets values to offset variables.
 * 'G92.1' - This command sets zero values to the G92 variables.
 * 'G92.2' - This command suspends but does not zero out the G92 variables.

--- a/docs/src/gcode/g-code.adoc
+++ b/docs/src/gcode/g-code.adoc
@@ -120,9 +120,9 @@ as the 'L number', and so on for any other letter.
 [[gcode:g0]]
 == G0 Rapid Move(((G0 Rapid Move)))
 
--------------------
+----
 G0 axes
--------------------
+----
 
 For rapid motion, program 'G0 axes', where all the axis words are optional.
 The 'G0' is optional if the current motion mode is 'G0'. This will produce
@@ -138,7 +138,6 @@ rapid traverse rate can be slower than the MAX_VELOCITY setting in the [TRAJ]
 section if an axis MAX_VELOCITY or trajectory constraints limit it.
 
 .G0 Example
-
 ----
 G90 (set absolute distance mode)
 G0 X1 Y-2.3 (Rapid linear move from current location to X1 Y-2.3)
@@ -183,7 +182,6 @@ produce coordinated motion to the destination point at the current feed
 rate (or slower).
 
 .G1 Example
-
 ----
 G90 (set absolute distance mode)
 G1 X1.2 Y-3 F10 (linear move at a feed rate of 10 from current position to X1.2 Y-3)
@@ -193,7 +191,7 @@ M2 (end program)
 ----
 
 * See <<gcode:g90-g91,G90>> & <<sec:set-feed-rate,F>> & <<mcode:m2-m30,M2>> sections
-for more information.
+  for more information.
 
 If cutter compensation is active, the motion will differ from
 the above; see the <<sec:cutter-radius-compensation,Cutter Compensation>> Section.
@@ -311,7 +309,6 @@ For more information on 'Absolute Arc Distance Mode see the
 <<gcode:g90.1-g91.1,G90.1>> section.
 
 .XY-plane (G17)
-
 ----
 G2 or G3 <X- Y- Z- I- J- P->
 ----
@@ -322,7 +319,6 @@ G2 or G3 <X- Y- Z- I- J- P->
 * 'P' - number of turns
 
 .XZ-plane (G18)
-
 ----
 G2 or G3 <X- Z- Y- I- K- P->
 ----
@@ -333,7 +329,6 @@ G2 or G3 <X- Z- Y- I- K- P->
 * 'P' - number of turns
 
 .YZ-plane (G19)
-
 ----
 G2 or G3 <Y- Z- X- J- K- P->
 ----
@@ -346,9 +341,7 @@ G2 or G3 <Y- Z- X- J- K- P->
 It is an error if:
 
 * No feed rate is set with the <<sec:set-feed-rate,F>> word.
-
 * No offsets are programmed.
-
 * When the arc is projected on the selected plane, the distance from
   the current point to the center differs from the distance from the end
   point to the center by more than (.05 inch/.5 mm)
@@ -378,7 +371,6 @@ us an offset from the start position of 1 in the X axis and 0 in the Y
 axis. In this case only an I offset is needed.
 
 .G2 Example Line
-
 [source,{ngc}]
 ----
 G0 X0 Y0
@@ -386,7 +378,6 @@ G2 X1 Y1 I1 F10 (clockwise arc in the XY plane)
 ----
 
 .G2 Example
-
 image::images/g2_en.svg["G2 Example",align="center"]
 
 In the next example we see the difference between the offsets for Y if
@@ -396,7 +387,6 @@ both moves. The G2 move the J offset is 0.5 and the G3 move the J
 offset is -0.5.
 
 .G2-G3 Example Line
-
 [source,{ngc}]
 ----
 G0 X0 Y0
@@ -405,14 +395,12 @@ G3 X0 Y0 I1 J-0.5 F25 (counterclockwise arc in the XY plane)
 ----
 
 .G2-G3 Example
-
 image::images/g2-3_en.svg["G2-G3 Example",align="center"]
 
 In the next example we show how the arc can make a helix in the Z axis
 by adding the Z word.
 
 .G2 Example Helix
-
 [source,{ngc}]
 ----
 G0 X0 Y0 Z0
@@ -422,7 +410,6 @@ G17 G2 X10 Y16 I3 J4 Z-1 (helix arc with Z added)
 In the next example we show how to make more than one turn using the P word.
 
 .P word Example
-
 ----
 G0 X0 Y0 Z0
 G2 X0 Y1 Z-1 I1 J0.5 P2 F25
@@ -490,7 +477,6 @@ It is an error if:
 * the end point of the arc is the same as the current point.
 
 .G2 Example Line
-
 [source,{ngc}]
 ----
 G17 G2 X10 Y15 R20 Z5 (radius format with arc)
@@ -516,7 +502,6 @@ The P number is a floating point number so fractions of a second may be used.
 G4 does not affect spindle, coolant and any I/O.
 
 .G4 Example Line
-
 ----
 G4 P0.5 (wait for 0.5 seconds before proceeding)
 ----
@@ -550,7 +535,6 @@ Q).
 For example, to program a curvy N shape:
 
 .G5 Sample initial cubic spline
-
 ----
 G90 G17
 G0 X0 Y0
@@ -561,7 +545,6 @@ A second curvy N that attaches smoothly to this one can now be made
 without specifying I and J:
 
 .G5 Sample subsequent cubic spline
-
 ----
 G5 P0 Q-3 X2 Y2
 ----
@@ -591,7 +574,6 @@ so one or both must be given.
 For example, to program a parabola, through the origin, from X-2 Y4 to X2 Y4:
 
 .G5.1 Sample quadratic spline
-
 ----
 G90 G17
 G0 X-2 Y4
@@ -614,7 +596,7 @@ X- Y- <P->
 G5.3
 ----
 
-Warning: G5.2, G5.3 is experimental and not fully tested.
+WARNING: G5.2, G5.3 is experimental and not fully tested.
 
 G5.2 is for opening the data block defining a NURBS and G5.3 for
 closing the data block. In the lines between these two codes the curve
@@ -629,7 +611,6 @@ The default weight if P is unspecified is 1.  The default order if L is
 unspecified is 3.
 
 .G5.2 Example
-
 [source,{ngc}]
 ----
 G0 X0 Y0 (rapid move)
@@ -715,7 +696,6 @@ G10 L1 sets the tool table for the 'P' tool number to the values of the words.
 A valid G10 L1 rewrites and reloads the tool table for the specified tool.
 
 .G10 L1 Example Line
-
 ----
 G10 L1 P1 Z1.5 (set tool 1 Z offset from the machine origin to 1.5)
 G10 L1 P2 R0.015 Q3 (lathe example setting tool 2 radius to 0.015 and orientation to 3)
@@ -749,7 +729,6 @@ the coordinate system specified. Axis words not used will not be changed.
 Program P0 to P9 to specify which coordinate system to change.
 
 .Coordinate System
-
 [width="50%", options="header", cols="^,^,^"]
 |========================================
 |P Value |Coordinate System |G-code
@@ -792,7 +771,6 @@ It is an error if:
 * An axis is programmed that is not defined in the configuration.
 
 .G10 L2 Example Line
-
 [source,{ngc}]
 ----
 G10 L2 P1 X3.5 Y17.2
@@ -804,7 +782,6 @@ Because only X and Y are specified, the origin point is only moved in X and Y;
 the other coordinates are not changed.
 
 .G10 L2 Example Line
-
 [source,{ngc}]
 ----
 G10 L2 P1 X0 Y0 Z0 (clear offsets for X,Y & Z axes in coordinate system 1)
@@ -835,7 +812,6 @@ not specified in the G10 L10 command will not be changed. This could be
 useful with a probe move as described in the <<gcode:g38,G38>> section.
 
 .G10 L10 Example
-
 ----
 T1 M6 G43 (load tool 1 and tool length offsets)
 G10 L10 P1 Z1.5 (set the current position for Z to be 1.5)
@@ -902,7 +878,6 @@ offset/entry to the given value, it is set to a calculated value that
 makes the current coordinates become the given value.
 
 .G10 L20 Example Line
-
 ----
 G10 L20 P1 X1.5 (set the X axis current location in coordinate system 1 to 1.5)
 ----
@@ -957,16 +932,13 @@ the <<sec:machine-coordinate-system,machine origin>>.
 
 * 'G28' - makes a <<gcode:g0,rapid move>> from the current
   position to the 'absolute' position of the values in parameters 5161-5166.
-
 * 'G28 axes' - makes a rapid move to the position specified by
   'axes' including any offsets, then will make a rapid move to the 'absolute'
   position of the values in parameters 5161-5166 for all 'axes' specified. Any
   'axis' not specified will not move.
-
 * 'G28.1' - stores the current 'absolute' position into parameters 5161-5166.
 
 .G28 Example Line
-
 ----
 G28 Z2.5 (rapid to Z2.5 then to Z location specified in #5163)
 ----
@@ -996,16 +968,13 @@ if TOOL_CHANGE_AT_G30=1 is in the [EMCIO] section of the ini file.
 
 * 'G30' - makes a <<gcode:g0,rapid move>> from the current
   position to the 'absolute' position of the values in parameters 5181-5189.
-
 * 'G30 axes' - makes a rapid move to the position specified
   by 'axes' including any offsets, then will make a rapid move to the
   'absolute' position of the values in parameters 5181-5189 for all 'axes'
   specified. Any 'axis' not specified will not move.
-
 * 'G30.1' - stores the current absolute position into parameters 5181-5186.
 
 .G30 Example Line
-
 ----
 G30 Z2.5 (rapid to Z2.5 then to the Z location specified in #5i83)
 ----
@@ -1131,7 +1100,6 @@ so multiple passes line up.'G33.1' moves end at the original coordinate.
 All the axis words are optional, except that at least one must be used.
 
 .G33.1 Example
-
 [source,{ngc}]
 ----
 G90 (set absolute mode)
@@ -1148,7 +1116,7 @@ It is an error if:
 * All axis words are omitted.
 * The spindle is not turning when this command is executed
 * The requested linear motion exceeds machine velocity limits
-   due to the spindle speed
+  due to the spindle speed
 
 [[gcode:g38]]
 == G38.n Straight Probe(((G38.n Probe)))
@@ -1228,12 +1196,11 @@ It is an error if:
 [[gcode:g40]]
 == G40 Compensation Off(((G40 Cutter Compensation Off)))
 
- * 'G40' - turn cutter compensation off. If tool compensation was on the
-   next move must be a linear move and longer than the tool diameter.
-   It is OK to turn compensation off when it is already off.
+* 'G40' - turn cutter compensation off. If tool compensation was on the
+  next move must be a linear move and longer than the tool diameter.
+  It is OK to turn compensation off when it is already off.
 
 .G40 Example
-
 ----
 ; current location is X1 after finishing cutter compensated move
 G40 (turn compensation off)
@@ -1245,8 +1212,8 @@ See <<gcode:g0,G0>> & <<mcode:m2-m30,M2>> sections for more information.
 
 It is an error if:
 
- * A G2/G3 arc move is programmed next after a G40.
- * The linear move after turning compensation off is less than the tool diameter.
+* A G2/G3 arc move is programmed next after a G40.
+* The linear move after turning compensation off is less than the tool diameter.
 
 [[gcode:g41-g42]]
 == G41, G42 Cutter Compensation(((G41 G42 Cutter Compensation)))
@@ -1256,7 +1223,7 @@ G41 <D-> (left of programmed path)
 G42 <D-> (right of programmed path)
 ----
 
- * 'D' - tool number
+* 'D' - tool number
 
 The D word is optional; if there is no D word the radius of the currently
 loaded tool will be used (if no tool is loaded and no D word is given,
@@ -1331,10 +1298,10 @@ G43 <H->
 
 * 'H' - tool number (optional)
 
-G43 enables tool length compensation.  G43 changes subsequent motions
-by offsetting the axis coordinates by the length of the offset. G43
-does not cause any motion. The next time a compensated axis is moved,
-that axis's endpoint is the compensated location.
+* 'G43' - enables tool length compensation.  G43 changes subsequent motions
+  by offsetting the axis coordinates by the length of the offset. G43
+  does not cause any motion. The next time a compensated axis is moved,
+  that axis's endpoint is the compensated location.
 
 'G43' without an H word uses the currently loaded tool from the last
 'Tn M6'.
@@ -1351,7 +1318,6 @@ machines, 'G43 H0' applies the TLO of the tool T0 defined in the tool
 table file (or causes an error if T0 is not defined in the tool table).
 
 .G43 H- Example Line
-
 ----
 G43 H1 (set tool offsets using the values from tool 1 in the tool table)
 ----
@@ -1372,8 +1338,8 @@ G43.1 axes
 ----
 
 * 'G43.1 axes' - change subsequent motions by replacing the current offset(s)
-of axes. G43.1 does not cause any motion. The next time a compensated axis
-is moved, that axis's endpoint is the compensated location.
+  of axes. G43.1 does not cause any motion. The next time a compensated axis
+  is moved, that axis's endpoint is the compensated location.
 
 .G43.1 Example
 
@@ -1392,7 +1358,7 @@ M2 (end program)
 ----
 
 * See <<gcode:g90-g91,G90>> & <<sec:select-tool,T>> & <<mcode:m6,M6>>
-sections for more information.
+  sections for more information.
 
 It is an error if:
 
@@ -1407,9 +1373,10 @@ G43.1 does not write to the tool table.
 ----
 G43.2 H- axes-
 ----
+
 * 'H' - tool number
 
-G43.2 applies an additional simultaneous tool offset.
+* 'G43.2' - applies an additional simultaneous tool offset.
 
 .G43.2 Example
 ----
@@ -1471,13 +1438,12 @@ For example 'G53 G0 X0 Y0 Z0' will move the axes to the home position even if
 the currently selected coordinate system has offsets in effect.
 
 .G53 Example
-
 ----
 G53 G0 X0 Y0 Z0 (rapid linear move to the machine origin)
 G53 X2 (rapid linear move to absolute coordinate X2)
 ----
 
-* See <<gcode:g0,G0>> section for more information.
+See <<gcode:g0,G0>> section for more information.
 
 It is an error if:
 
@@ -1502,7 +1468,6 @@ XY rotation angle around the Z axis
 in the parameters shown in the following table.
 
 .Coordinate System Parameters
-
 [width="80%", options="header", cols="<,11*^"]
 |============================================================
 |Select|CS|X   |Y   |Z   |A   |B   |C   |U   |V   |W   |R
@@ -1528,14 +1493,14 @@ systems.
 == G61 Exact Path Mode(((G61 Exact Path Mode)))(((Trajectory Control)))
 
 * 'G61' - Exact path mode, movement exactly as programmed. Moves will slow or
-stop as needed to reach every programmed point. If two sequential moves are
-exactly co-linear movement will not stop.
+  stop as needed to reach every programmed point. If two sequential moves are
+  exactly co-linear movement will not stop.
 
 [[gcode:g61.1]]
 == G61.1 Exact Stop Mode(((G61.1 Exact Stop Mode)))(((Trajectory Control)))
 
 * 'G61.1' - Exact stop mode, movement will stop at the end of each programmed
-segment.
+  segment.
 
 [[gcode:g64]]
 == G64 Path Blending(((G64 Path Blending)))(((Trajectory Control)))
@@ -1548,30 +1513,29 @@ G64 <P- <Q->>
 * 'Q' - naive cam tolerance
 
 * 'G64' - best possible speed. Without P means to keep the best speed possible, no matter how
-far away from the programmed point you end up.
+  far away from the programmed point you end up.
 * 'G64 P-' - Blend between best speed and deviation tolerance
 * 'G64 P- <Q- >' blending with tolerance. It is a way to fine tune your system for best compromise
-between speed and accuracy. The P- tolerance means that the actual path
-will be no more than P- away from the programmed endpoint. The velocity
-will be reduced if needed to maintain the path. In addition, when you
-activate G64 P- Q- it turns on the 'naive cam detector'; when there are
-a series of linear XYZ feed moves at the same <<sec:set-feed-rate,feed rate>>
-that are less than Q- away from being collinear, they are collapsed into a
-single linear move. On G2/G3 moves in the G17 (XY) plane when the maximum
-deviation of an arc from a straight line is less than the G64 P-
-tolerance the arc is broken into two lines (from start of arc to
-midpoint, and from midpoint to end). those lines are then subject to
-the naive cam algorithm for lines. Thus, line-arc, arc-arc, and
-arc-line cases as well as line-line benefit from the 'naive cam
-detector'. This improves contouring performance by simplifying the
-path. It is OK to program for the mode that is already active. See also
-the <<sec:trajectory-control,Trajectory Control>> Section for more
-information on these modes.
-If Q is not specified then it will have the same behavior as before and
-use the value of P-.
+  between speed and accuracy. The P- tolerance means that the actual path
+  will be no more than P- away from the programmed endpoint. The velocity
+  will be reduced if needed to maintain the path. In addition, when you
+  activate G64 P- Q- it turns on the 'naive cam detector'; when there are
+  a series of linear XYZ feed moves at the same <<sec:set-feed-rate,feed rate>>
+  that are less than Q- away from being collinear, they are collapsed into a
+  single linear move. On G2/G3 moves in the G17 (XY) plane when the maximum
+  deviation of an arc from a straight line is less than the G64 P-
+  tolerance the arc is broken into two lines (from start of arc to
+  midpoint, and from midpoint to end). those lines are then subject to
+  the naive cam algorithm for lines. Thus, line-arc, arc-arc, and
+  arc-line cases as well as line-line benefit from the 'naive cam
+  detector'. This improves contouring performance by simplifying the
+  path. It is OK to program for the mode that is already active. See also
+  the <<sec:trajectory-control,Trajectory Control>> Section for more
+  information on these modes.
+  If Q is not specified then it will have the same behavior as before and
+  use the value of P-.
 
 .G64 P- Example Line
-
 ----
 G64 P0.015 (set path following to be within 0.015 of the actual path)
 ----
@@ -1585,6 +1549,7 @@ of each G-code file.
 ----
 G70 Q- <X-> <Z-> <D-> <E-> <P->
 ----
+
 * 'Q' - The subroutine number.
 * 'X' - The starting X position, defaults to the initial position.
 * 'Z' - The starting Z position, defaults to the initial position.
@@ -1597,15 +1562,15 @@ in the subroutine with number Q has been cut with G71 or G72.
 
 * Preliminary motion.
   ** If Z or X are used a <<gcode:g0,rapid move>> to that position
-  is done. This position is also used between each finishing pass.
+     is done. This position is also used between each finishing pass.
   ** Then a <<gcode:g0,rapid move>> to the start of the profile is
-  executed.
+     executed.
   ** The path given in Q- is followed using the <<gcode:g1,G1>> and
-  <<gcode:g2-g3>> commands.
+     <<gcode:g2-g3>> commands.
   ** If a next pass is required there is another rapid to the intermediate
-  location, before a rapid is done to the start of the profile.
+     location, before a rapid is done to the start of the profile.
   ** After the final pass, the tool is left at the end of the profile
-  including E-.
+     including E-.
 * Multiple passes.
   The distance between the pass and the final profile is (pass-1)*(D-E)/P+E.
   Where pass the pass number and D,E and P are the D/E/P numbers.
@@ -1632,6 +1597,7 @@ G72   Q- <X-> <Z-> <D-> <I-> <R->
 G72.1 Q- <X-> <Z-> <D-> <I-> <R->
 G72.2 Q- <X-> <Z-> <D-> <I-> <R->
 ----
+
 * 'Q' - The subroutine number.
 * 'X' - The starting X position, defaults to the initial position.
 * 'Z' - The starting Z position, defaults to the initial position.
@@ -1668,13 +1634,13 @@ from one pocket to the next.
 
 The normal G7x cycles cut the entire profile in one cycle.
 
- . Preliminary motion.
-   ** If Z or X are used a <<gcode:g0,rapid move>> to that position
-   is done.
-   ** After the profile has been cut, the tool stops at the end of the
-   profile, including the distance specified in D.
- . The D number is used to  keep a distance from the final profile,
-   to allow material to remain for finishing.
+. Preliminary motion.
+  ** If Z or X are used a <<gcode:g0,rapid move>> to that position
+     is done.
+  ** After the profile has been cut, the tool stops at the end of the
+     profile, including the distance specified in D.
+. The D number is used to  keep a distance from the final profile,
+  to allow material to remain for finishing.
 
 It is an error if:
 
@@ -1699,7 +1665,7 @@ This cycle takes a Q number which represents a 'delta' increment along the Z axi
 
 * Preliminary motion.
   ** If the current Z position is below the R position, The Z axis does a
-  <<gcode:g0,rapid move>> to the R position.
+     <<gcode:g0,rapid move>> to the R position.
   ** Move to the X Y coordinates
 * Move the Z-axis only at the current <<sec:set-feed-rate,feed rate>> downward
   by delta or to the Z position, whichever is less deep.
@@ -1729,22 +1695,15 @@ WARNING: G74 does not use synchronized motion.
 
 The 'G74' cycle is intended for tapping with floating chuck and dwell at the bottom of the hole.
 
-    1. Preliminary motion, as described in the
-       <<gcode:preliminary-motion,Preliminary and In-Between Motion>> section.
-
-    2. Disable Feed and Speed Overrides.
-
-    3. Move the Z-axis at the current feed rate to the Z position.
-
-    4. Stop the selected spindle (chosen by the $ parameter)
-
-    5. Start spindle rotation clockwise.
-
-    6. Dwell for the P number of seconds.
-
-    7. Move the Z-axis at the current feed rate to clear Z
-
-    8. Restore Feed and Speed override enables to previous state
+  1. Preliminary motion, as described in the
+     <<gcode:preliminary-motion,Preliminary and In-Between Motion>> section.
+  2. Disable Feed and Speed Overrides.
+  3. Move the Z-axis at the current feed rate to the Z position.
+  4. Stop the selected spindle (chosen by the $ parameter)
+  5. Start spindle rotation clockwise.
+  6. Dwell for the P number of seconds.
+  7. Move the Z-axis at the current feed rate to clear Z
+  8. Restore Feed and Speed override enables to previous state
 
 The length of the dwell is specified by a 'P-' word in the G74 block. The feed rate 'F-' is spindle speed multiplied by distance per revolution (thread pitch).
 In example S100 with 1.25MM per revolution thread pitch gives a feed of F125.
@@ -1759,13 +1718,10 @@ G76 P- Z- I- J- R- K- Q- H- E- L- $-
 .G76 Threading
 image::images/g76-threads_en.svg["G76 Threading",align="center"]
 
-
 * 'Drive Line' - A line through the initial X position parallel to the Z.
-
 * 'P-' - The 'thread pitch' in distance per revolution.
-
 * 'Z-' - The final position of threads. At the end of the cycle the tool will
-be at this Z position.
+  be at this Z position.
 
 [NOTE]
 When G7 'Lathe Diameter Mode' is in force the values for 'I', 'J' and 'K' are
@@ -1773,60 +1729,54 @@ diameter measurements. When G8 'Lathe Radius Mode' is in force the values for
 'I', 'J' and 'K' are radius measurements.
 
 * 'I-' - The 'thread peak' offset from the 'drive line'. Negative 'I' values
-are external threads, and positive 'I' values are internal threads.
-Generally the material has been turned to this size before the 'G76' cycle.
-
+  are external threads, and positive 'I' values are internal threads.
+  Generally the material has been turned to this size before the 'G76' cycle.
 * 'J-' - A positive value specifying the 'initial cut depth'. The first
-threading cut will be 'J' beyond the 'thread peak' position.
-
+  threading cut will be 'J' beyond the 'thread peak' position.
 * 'K-' - A positive value specifying the 'full thread depth'. The final
-threading cut will be 'K' beyond the 'thread peak' position.
+  threading cut will be 'K' beyond the 'thread peak' position.
 
 Optional settings
 
 * '$-' - The spindle number to which the motion will be synchronised
-(default 0). For example is $1 is programmed then the motion will begin
-on the reset od spindle.1.index-enable and proceed in synchrony with the
-value of spindle.1.revs
-
+  (default 0). For example is $1 is programmed then the motion will begin
+  on the reset od spindle.1.index-enable and proceed in synchrony with the
+  value of spindle.1.revs
 * 'R-' - The 'depth degression'. 'R1.0' selects constant depth on successive
-threading passes. 'R2.0' selects constant area. Values between 1.0 and
-2.0 select decreasing
-depth but increasing area. Values above 2.0 select decreasing area.
-Beware that unnecessarily high degression values will cause a large
-number of passes to be used. (degression = a descent by stages or
-steps.)
+  threading passes. 'R2.0' selects constant area. Values between 1.0 and
+  2.0 select decreasing
+  depth but increasing area. Values above 2.0 select decreasing area.
+  Beware that unnecessarily high degression values will cause a large
+  number of passes to be used. (degression = a descent by stages or
+  steps.)
 
 [WARNING]
 Unnecessarily high degression values will produce an unnecessarily high
 number of passes. (degressing = dive in stages)
 
-
 * 'Q-' - The 'compound slide angle' is the angle (in degrees) describing to
-what extent successive passes should be offset along the drive line.
-This is used to cause one side of the tool to remove more material than
-the other. A positive 'Q' value causes the leading edge of the tool to
-cut more heavily.
-Typical values are 29, 29.5 or 30.
-
+  what extent successive passes should be offset along the drive line.
+  This is used to cause one side of the tool to remove more material than
+  the other. A positive 'Q' value causes the leading edge of the tool to
+  cut more heavily.
+  Typical values are 29, 29.5 or 30.
 * 'H-' - The number of 'spring passes'. Spring passes are additional passes at
-full thread depth. If no additional passes are desired, program 'H0'.
+  full thread depth. If no additional passes are desired, program 'H0'.
 
 Thread entries and exits can be programmed tapered with the 'E'
 and 'L' values.
 
 * 'E-' - Specifies the distance along the drive line used for the taper. The
-angle of the taper will be so the last pass tapers to the thread crest
-over the distance specified with E.' E0.2' will give a taper for the
-first/last 0.2 length units along the
-thread. For a 45 degree taper program E the same as K
-
+  angle of the taper will be so the last pass tapers to the thread crest
+  over the distance specified with E.' E0.2' will give a taper for the
+  first/last 0.2 length units along the
+  thread. For a 45 degree taper program E the same as K
 * 'L-' - Specifies which ends of the thread get the taper. Program 'L0' for no
-taper (the default), 'L1' for entry taper, 'L2' for exit taper, or 'L3'
-for both entry and exit tapers. Entry tapers will pause at the drive line to
-synchronize with the index pulse then move at the <<sec:set-feed-rate,feed rate>>
-in to the beginning of the taper. No entry taper and the tool will rapid to the
-cut depth then synchronize and begin the cut.
+  taper (the default), 'L1' for entry taper, 'L2' for exit taper, or 'L3'
+  for both entry and exit tapers. Entry tapers will pause at the drive line to
+  synchronize with the index pulse then move at the <<sec:set-feed-rate,feed rate>>
+  in to the beginning of the taper. No entry taper and the tool will rapid to the
+  cut depth then synchronize and begin the cut.
 
 The tool is moved to the initial X and Z positions prior to issuing
 the G76. The X position is the 'drive line' and the Z position is the
@@ -1874,7 +1824,6 @@ and can be previewed and
 executed on any machine using the 'sim/lathe.ini' configuration.
 
 .G76 Example Code
-
 [source,{ngc}]
 ---------------
 G0 Z-0.5 X0.2
@@ -1972,7 +1921,7 @@ If the XY plane is active, the Z number is sticky, and it is an error
 if:
 
 * the Z number is missing and the same canned cycle was not already
-   active,
+  active,
 * or the R number is less than the Z number.
 
 If other planes are active, the error conditions are analogous to the
@@ -1990,9 +1939,9 @@ In addition, at the beginning of the first cycle and each repeat, the
 following one or two moves are made
 
 * A <<gcode:g0,rapid move>> parallel to the XY-plane to
-the given XY-position,
+  the given XY-position,
 * The Z-axis make a rapid move to the R position, if it is
-not already at the R position.
+  not already at the R position.
 
 If another plane is active, the preliminary and in-between motions are
 analogous.
@@ -2067,7 +2016,6 @@ It is an error if:
 *  Axis words are programmed when G80 is active.
 
 .G80 Example
-
 ----
 G90 G81 X1 Y1 Z1.5 R2.8 (absolute distance canned cycle)
 G80 (turn off canned cycle motion)
@@ -2078,7 +2026,6 @@ The following code produces the same final position and machine state as
 the previous code.
 
 .G0 Example
-
 ----
 G90 G81 X1 Y1 Z1.5 R2.8 (absolute distance canned cycle)
 G0 X0 Y0 Z0 (rapid move to coordinate home)
@@ -2095,7 +2042,6 @@ that contains an X, Y, or Z word. The following file drills (G81) a set
 of eight holes as shown in the following caption.
 
 .G80 Example 1
-
 ----
 N100 G90 G0 X0 Y0 Z0 (coordinate home)
 N110 G1 X0 G4 P0.1
@@ -2118,9 +2064,6 @@ N240 M2 (program end)
 Notice the z position change after the first four holes.
 Also, this is one of the few places where line numbers have some value,
 being able to point a reader to a specific line of code.
-
-.G80 Cycle
-image::images/g81mult_en.svg[align="center", alt="G80 Cycle"]
 
 The use of G80 in line N200 is optional because the G0 on the next
 line will turn off the G81 cycle. But using the G80 as shown in
@@ -2145,8 +2088,12 @@ The cycle functions as follows:
   position.
 * The Z-axis does a <<gcode:g0,rapid move>> to clear Z.
 
+.G81 Cycle
+image::images/g81mult_en.svg["G81 Cycle",align="center"]
+
 [[gcode:g81-example]]
 .Example 1 - Absolute Position G81
+
 Suppose the current position is (X1, Y2, Z3) and the following line of NC
 code is interpreted.
 
@@ -2268,7 +2215,7 @@ The 'G82' cycle is intended for drilling with a dwell at the bottom of
 the hole.
 
 * Preliminary motion, as described in the
-<<gcode:preliminary-motion,Preliminary and In-Between Motion>> section.
+  <<gcode:preliminary-motion,Preliminary and In-Between Motion>> section.
 * Move the Z-axis at the current <<sec:set-feed-rate,feed rate>> to the Z position.
 * Dwell for the P number of seconds.
 * The Z-axis does a <<gcode:g0,rapid move>> to clear Z.
@@ -2385,15 +2332,13 @@ It is an error if:
 * the spindle is not turning before this cycle is executed.
 
 [[gcode:g87]]
-== G87 Back Boring Cycle
-(((G87 Back Boring Cycle)))
+== G87 Back Boring Cycle(((G87 Back Boring Cycle)))
 
 This code is currently unimplemented in LinuxCNC. It is accepted, but the
 behavior is undefined.
 
 [[gcode:g88]]
-== G88 Boring Cycle, Spindle Stop, Manual Out
-(((G88 Boring Cycle, Spindle Stop, Manual Out)))
+== G88 Boring Cycle, Spindle Stop, Manual Out(((G88 Boring Cycle, Spindle Stop, Manual Out)))
 
 This code is currently unimplemented in LinuxCNC. It is accepted, but the
 behavior is undefined.
@@ -2511,8 +2456,7 @@ overview of coordinate systems.
 See the <<sec:overview-parameters,Parameters>> Section for more information.
 
 [[gcode:g92.1-g92.2]]
-== G92.1, G92.2 Reset G92 Offsets
-(((G92.1, G92.2 Reset G92 Offsets)))
+== G92.1, G92.2 Reset G92 Offsets(((G92.1, G92.2 Reset G92 Offsets)))
 
 * 'G92.1' - turn off G92 offsets and reset <<sub:numbered-parameters,parameters>> 5211 - 5219 to zero.
 * 'G92.2' - turn off G92 offsets but keep <<sub:numbered-parameters,parameters>> 5211 - 5219 available.
@@ -2541,26 +2485,24 @@ the offsets saved in the first program.
   means the move should be completed in [one divided by the F number]
   minutes. For example, if the F number is 2.0, the move should be
   completed in half a minute.
-
-When the inverse time feed rate mode is active, an F word must appear
-on every line which has a G1, G2, or G3 motion, and an F word on a line
-that does not have G1, G2, or G3 is ignored. Being in inverse time feed
-rate mode does not affect G0 (<<gcode:g0,rapid move>>) motions.
-
+  +
+  When the inverse time feed rate mode is active, an F word must appear
+  on every line which has a G1, G2, or G3 motion, and an F word on a line
+  that does not have G1, G2, or G3 is ignored. Being in inverse time feed
+  rate mode does not affect G0 (<<gcode:g0,rapid move>>) motions.
 * 'G94' - is Units per Minute Mode.
-In units per minute feed mode, an F word is interpreted to mean
-the controlled point should move at a certain number of inches per
-minute, millimeters per minute, or degrees per minute, depending upon
-what length units are being used and which axis or axes are moving.
-
+  In units per minute feed mode, an F word is interpreted to mean
+  the controlled point should move at a certain number of inches per
+  minute, millimeters per minute, or degrees per minute, depending upon
+  what length units are being used and which axis or axes are moving.
 * 'G95' - is Units per Revolution Mode
-In units per revolution mode, an F word is interpreted to mean the
-controlled point should move a certain number of inches per revolution
-of the spindle, depending on what length units are being used and which
-axis or axes are moving. G95 is not suitable for threading, for
-threading use G33 or G76.
-G95 requires that spindle.N.speed-in to be connected. The actual spindle
-to which the feed is synchronised is chosen by the $ parameter
+  In units per revolution mode, an F word is interpreted to mean the
+  controlled point should move a certain number of inches per revolution
+  of the spindle, depending on what length units are being used and which
+  axis or axes are moving. G95 is not suitable for threading, for
+  threading use G33 or G76.
+  G95 requires that spindle.N.speed-in to be connected. The actual spindle
+  to which the feed is synchronised is chosen by the $ parameter
 
 It is an error if:
 
@@ -2595,7 +2537,6 @@ for each spindle prior to issuing M3.
 * 'G97' selects RPM mode.
 
 .G96 Example Line
-
 ----
 G96 D2500 S250 (set CSS with a max rpm of 2500 and a surface speed of 250)
 ----
@@ -2622,7 +2563,6 @@ used. The R word has different meanings in absolute distance mode and
 incremental distance mode.
 
 .G98 Retract to Origin
-
 ----
 G0 X1 Y2 Z3
 G90 G98 G81 X4 Y5 Z-0.6 R1.8 F10

--- a/docs/src/gcode/m-code.adoc
+++ b/docs/src/gcode/m-code.adoc
@@ -42,13 +42,12 @@
 == M0, M1 Program Pause(((M0, M1 Program Pause)))(((M0 Mandatory Program Pause)))(((M1 Optional Program Pause)))
 
 * 'M0' - pause a running program temporarily. LinuxCNC remains in the Auto Mode
-so MDI and other manual actions are not enabled. Pressing the resume
-button will restart the program at the following line.
-
+  so MDI and other manual actions are not enabled. Pressing the resume
+  button will restart the program at the following line.
 * 'M1' - pause a running program temporarily if the optional stop switch is on.
-LinuxCNC remains in the Auto Mode so MDI and other manual actions are
-not enabled. Pressing the resume button will restart the program at the
-following line.
+  LinuxCNC remains in the Auto Mode so MDI and other manual actions are
+  not enabled. Pressing the resume button will restart the program at the
+  following line.
 
 [NOTE]
 It is OK to program 'M0' and 'M1' in MDI mode,
@@ -57,14 +56,13 @@ because normal behavior in MDI mode is
 to stop after each line of input anyway.
 
 [[mcode:m2-m30]]
-== M2, M30 Program End(((M2, M30 Program End)))(((M2 Program End)))(((M30 Pallet Exchange and Program End)))
+== M2, M30 Program End(((M2 Program End)))(((M30 Pallet Exchange and Program End)))
 
 * 'M2' - end the program. Pressing `Cycle Start` ("R" in the Axis GUI)
-will restart the program at the beginning of the file.
-
+  will restart the program at the beginning of the file.
 * 'M30' - exchange pallet shuttles and end the program.
-Pressing `Cycle Start` will start the program
-at the beginning of the file.
+  Pressing `Cycle Start` will start the program
+  at the beginning of the file.
 
 Both of these commands have the following effects:
 
@@ -84,17 +82,17 @@ Lines of code after M2/M30 will not be executed. Pressing `Cycle Start`
 will start the program at the beginning of the file.
 
 [WARNING]
-Using % to wrap the G-code does not do the same thing as a 'Program End'. See
-<<gcode:file-requirements,File Requirements>> for more information on what using
-% does not do.
+Using % to wrap the G-code does not do the same thing as a 'Program End'.
+See <<gcode:file-requirements,File Requirements>> for more information
+on what using % does not do.
 
 [[mcode:m60]]
 == M60 Pallet Change Pause(((M60 Pallet Change Pause)))
 
 * 'M60' - exchange pallet shuttles and then pause a running program
-temporarily (regardless of the setting of the optional stop
-switch). Pressing the cycle start button
-will restart the program at the following line.
+  temporarily (regardless of the setting of the optional stop
+  switch). Pressing the cycle start button
+  will restart the program at the following line.
 
 [[mcode:m3-m4-m5]]
 == M3, M4, M5 Spindle Control(((M3, M4, M5 Spindle Control)))
@@ -120,6 +118,7 @@ M3 $-1
 
 This example will then reverse spindle 1 but leave the other spindles
 rotating forwards:
+
 [source,{ngc}]
 ----
 M4 $1
@@ -165,15 +164,15 @@ When the tool change is complete:
 
 * The spindle will be stopped.
 * The tool that was selected (by a T word on the same line or on any
-line after the previous tool change) will be in the spindle.
+  line after the previous tool change) will be in the spindle.
 * If the selected tool was not in the spindle before the tool change,
-the tool that was in the spindle (if there was one) will be placed
-back into the tool changer magazine.
+  the tool that was in the spindle (if there was one) will be placed
+  back into the tool changer magazine.
 * If configured in the .ini file some axis positions may move when a M6
-is issued. See the <<sec:emcio-section,EMCIO section>> for more
-information on tool change options.
+  is issued. See the <<sec:emcio-section,EMCIO section>> for more
+  information on tool change options.
 * No other changes will be made. For example, coolant will continue to
-flow during the tool change unless it has been turned off by an 'M9'.
+  flow during the tool change unless it has been turned off by an 'M9'.
 
 [NOTE]
 The 'T-' word is an integer number designating the tool pocket number in
@@ -214,14 +213,14 @@ M19 R- Q- [P-] [$-]
 
 * 'R' Position to rotate to from 0, valid range is 0-360 degrees
 * 'Q' Number of seconds to wait until orient completes. If
-spindle.N.is-oriented does not become true within Q timeout
-an error occurs.
+  spindle.N.is-oriented does not become true within Q timeout
+  an error occurs.
 * 'P' Direction to rotate to position.
   ** '0' rotate for smallest angular movement (default)
   ** '1' always rotate clockwise (same as M3 direction)
   ** '2' always rotate counterclockwise (same as M4 direction)
 * '$' The spindle to orient (actually only determines which HAL pins
-carry the spindle position commands)
+  carry the spindle position commands)
 
 M19 is a command of modal group 7, like M3, M4 and M5.
 M19 is cleared by any of M3,M4,M5.
@@ -314,12 +313,12 @@ cutters and wire spark eroders but it is not limited to such applications.
 == M53 Feed Stop Control(((M53 Feed Stop Control)))
 
 * 'M53 <P1>' - enable the feed stop switch. The P1 is optional.
-Enabling the feed stop switch will allow motion to be
-interrupted by means of the feed stop control. In LinuxCNC,
-the HAL pin 'motion.feed-hold' is used for this purpose. A 'true'
-value will cause the motion to stop when 'M53' is active.
+  Enabling the feed stop switch will allow motion to be
+  interrupted by means of the feed stop control. In LinuxCNC,
+  the HAL pin 'motion.feed-hold' is used for this purpose. A 'true'
+  value will cause the motion to stop when 'M53' is active.
 * 'M53 P0' - disable the feed stop switch. The state of 'motion.feed-hold'
-will have no effect on feed when M53 is not active.
+  will have no effect on feed when M53 is not active.
 
 [[mcode:m61]]
 == M61 Set Current Tool(((M61 Set Current Tool)))
@@ -505,13 +504,13 @@ Note that in particular, the motion mode (G1 etc) is NOT restored.
 'current call level' means either:
 
 * executing in the main program. There is a single storage location
-for state at the main program level; if several 'M70' instructions
-are executed in turn, only the most recently saved state is restored
-when an 'M72' is executed.
+  for state at the main program level; if several 'M70' instructions
+  are executed in turn, only the most recently saved state is restored
+  when an 'M72' is executed.
 * executing within a G-code subroutine. The state saved with 'M70'
-within a subroutine behaves exactly like a local named parameter - it
-can be referred to only within this subroutine invocation with an
-'M72' and when the subroutine exits, the parameter goes away.
+  within a subroutine behaves exactly like a local named parameter - it
+  can be referred to only within this subroutine invocation with an
+  'M72' and when the subroutine exits, the parameter goes away.
 
 A recursive invocation of a subroutine introduces a new call level.
 
@@ -719,7 +718,6 @@ right click/properties/permissions) before running LinuxCNC. Make sure the
 parallel port pin is not connected to anything in a HAL file.
 
 .M101 Example File
-
 ----
 #!/bin/bash
 # file to turn on parport pin 14 to open the collet closer
@@ -728,7 +726,6 @@ exit 0
 ----
 
 .M102 Example File
-
 ----
 #!/bin/bash
 # file to turn off parport pin 14 to open the collet closer
@@ -743,7 +740,6 @@ M100 P123.456 Q321.654
 ----
 
 .M100 Example file
-
 ----
 #!/bin/bash
 voltage=$1
@@ -758,7 +754,6 @@ use a graphic display program like Eye of Gnome to display the graphic
 file. When you close it the program will resume.
 
 .M110 Example file
-
 ----
 #!/bin/bash
 eog /home/john/linuxcnc/nc_files/message.png
@@ -769,7 +764,6 @@ To display a graphic message and continue processing the G-code file
 suffix an ampersand to the command.
 
 .M110 Example display and keep going
-
 ----
 #!/bin/bash
 eog /home/john/linuxcnc/nc_files/message.png &

--- a/docs/src/gcode/machining-center.adoc
+++ b/docs/src/gcode/machining-center.adoc
@@ -42,17 +42,17 @@ linear axis.
 The X, Y, and Z axes produce linear motion in three mutually
 orthogonal directions.
 
-.Secondary Linear Axes (((axes, secondary linear)))
+.Secondary Linear Axes(((axes, secondary linear)))
 The U, V, and W axes produce linear motion in three mutually
 orthogonal directions. Typically, X and U are parallel, Y and V are
 parallel, and Z and W are parallel.
 
-.Rotational Axes (((axes, rotational)))
+.Rotational Axes(((axes, rotational)))
 The A, B and C axes produce angular motion (rotation). Typically, A
 rotates around a line parallel to X, B rotates around a line parallel
 to Y, and C rotates around a line parallel to Z.
 
-=== Spindle (((spindle)))
+=== Spindle(((spindle)))
 
 A CNC machine typically has a spindle which holds one cutting tool,
 probe, or the material in the case of a lathe. The spindle may or may
@@ -164,17 +164,20 @@ rate is interpreted as follows (unless 'inverse time feed' or 'feed
 per revolution' modes are being used, in which case see Section
 <<gcode:g93-g94-g95,G93-G94-G95-Mode,G93 G94 G95>>).
 
- . If any of XYZ are moving, F is in units per minute in the XYZ
-   cartesian system, and all other axes (ABCUVW) move so as to start and
-   stop in coordinated fashion.
- . Otherwise, if any of UVW are moving, F is in units per minute in the
-   UVW cartesian system, and all other axes (ABC) move so as to start and
-   stop in coordinated fashion.
- . Otherwise, the move is pure rotary motion and the F word is in rotary
-   units in the ABC 'pseudo-cartesian' system.
-=== Coolant(((coolant)))
+. If any of XYZ are moving, F is in units per minute in the XYZ
+  cartesian system, and all other axes (ABCUVW) move so as to start and
+  stop in coordinated fashion.
+. Otherwise, if any of UVW are moving, F is in units per minute in the
+  UVW cartesian system, and all other axes (ABC) move so as to start and
+  stop in coordinated fashion.
+. Otherwise, the move is pure rotary motion and the F word is in rotary
+  units in the ABC 'pseudo-cartesian' system.
 
-Flood coolant and fog coolant can be turned on independently. The RS274/NGC language turns them off together with a single M-code. See Section <<mcode:m7-m8-m9,M7 M8 M9>>.
+=== Cooling(((Cooling)))
+
+Flood or droplets cooling can be enabled separately.
+RS274/NGC language stops them together.
+See section about <<mcode:m7-m8-m9,cooling control>>.
 
 === Dwell(((dwell)))
 
@@ -203,9 +206,9 @@ and the controller always knows where that is. The numbers
 representing the current position must be adjusted in the absence of
 any axis motion if any of several events take place:
 
- . Length units are changed.
- . Tool length offset is changed.
- . Coordinate system offsets are changed.
+. Length units are changed.
+. Tool length offset is changed.
+. Coordinate system offsets are changed.
 
 === Selected Plane
 
@@ -225,6 +228,15 @@ A machining center may be commanded to change tools.
 === Pallet Shuttle
 
 The two pallets may be exchanged by command.
+
+=== Correcteurs de vitesses
+
+The speed override buttons can be activated (they
+function normally) or rendered inoperative (they no longer have any
+effect). The RS274/NGC language has a command that activates all the
+buttons and another that disables them.
+See inhibition and activation <<mcode:m48-m49, speed correctors>>.
+See also <<sec:speed-interaction,here for further details>>.
 
 [[sec:path-control-mode]]
 === Path Control Mode(((Path Control Mode)))
@@ -253,8 +265,8 @@ The Interpreter interacts with several switches. This section
 describes the interactions in more detail. In no case does the
 Interpreter know what the setting of any of these switches is.
 
-[[sec:Interaction-speed]]
-=== Feed and Speed Override Switches(((Interaction-speed)))
+[[sec:speed-interaction]]
+=== Feed and Speed Override Switches(((Feed and Speed Interaction)))
 
 The Interpreter will interpret RS274/NGC commands which enable 'M48'
 or disable 'M49' the feed and speed override switches. For certain
@@ -301,7 +313,7 @@ same name as your ini file, but with a tbl extension:
 TOOL_TABLE = acme_300.tbl
 ----
 
-or
+or:
 
 ----
 TOOL_TABLE = EMC-AXIS-SIM.tbl

--- a/docs/src/gcode/o-code.adoc
+++ b/docs/src/gcode/o-code.adoc
@@ -22,7 +22,6 @@ number zero as the first character in the number like O100 or o100.
 Numbered O codes must have a unique number for each subroutine,
 
 .Numbering Example
-
 ----
 (the start of o100)
 o100 sub
@@ -90,6 +89,7 @@ o100 sub
     (DEBUG, parameter 1 is [#1])
 o100 endsub
 ----
+
 See the <<gcode:binary-operators,Binary Operators>> and <<sec:overview-parameters,Parameters>> sections for more information.
 
 .O- Call
@@ -130,7 +130,7 @@ be visible to the calling code. Subroutines may also change the value of global
 named parameters.
 
 [[ocode:fanuc-style-programs]]
-=== Fanuc-Style Numbered Programs(((Subroutines, M98, M99)))
+=== Fanuc-Style Numbered Programs(((Subroutines,M98,M99)))
 
 Numbered programs (both main and subprograms), the 'M98' call and
 'M99' return M-codes, and their respective semantic differences are an
@@ -171,18 +171,15 @@ following numbered subprogram defined with `o100`...`M99`.  An
 optional 'L'-word specifies a loop count.
 
 .'M30'
-
 The main program must be terminated with `M02` or `M30` (or `M99`; see
 below).
 
 .'O-' subprogram definition start
-
 Marks the start of a numbered subprogram definition.  The block `O100`
 is similar to `o100 sub`, except that it must be placed later in the
 file than the `M98 P100` calling block.
 
 .'M99' return from numbered subroutine
-
 The block `M99` is analogous to the traditional `o100 endsub` syntax,
 but may only terminate a numbered program (`o100` in this example),
 and may not terminate a subroutine beginning with the `o100 sub`
@@ -193,15 +190,12 @@ following ways:
 
 * The numbered subprogram must follow the `M98` call in the program file.
   The interpreter will throw an error if the subprogram precedes the call block.
-
 * Parameters `#1`, `#2`, ..., `#30` are global and accessible in
   numbered subprograms, similar to higher-numbered parameters in
   traditional style calls.  Modifications to these parameters within
   a subprogram are global modifications, and will be persist after
   subprogram return.
-
 * `M98` subprogram calls have no return value.
-
 * `M98` subprogram call blocks may contain an optional L-word specifying a loop repeat count.
   Without the L-word, the subprogram will execute once only (equivalent to `M98 L1`).
   An `M98 L0` block will not execute the subprogram.
@@ -245,7 +239,7 @@ Note that parameter `#1` is global.  At the end of the main program,
 after updates within `O100` and `O200`, its value will equal `5.25`.
 
 [[ocode:looping]]
-== Looping(((Subroutines, Looping)))
+== Looping(((Subroutines,Looping)))
 
 The 'while loop' has two structures: 'while/endwhile', and 'do/while'. In
 each case, the loop is exited when the 'while' condition evaluates to
@@ -290,7 +284,7 @@ condition. If it is still true, the loop begins again at the top. If
 it is false, it exits the loop.
 
 [[ocode:conditional]]
-== Conditional(((Subroutines, Conditional Loops)))
+== Conditional(((Subroutines,Conditional Loops)))
 
 The 'if' conditional consists of a group of statements with the same 'o' number
 that start with 'if' and end with 'endif'. Optional 'elseif' and 'else' conditions
@@ -346,7 +340,7 @@ O102 endif
 ----
 
 [[ocode:repeat]]
-== Repeat(((Subroutines, Repeat Loop)))
+== Repeat(((Subroutines,Repeat Loop)))
 
 The 'repeat' will execute the statements inside of the
 repeat/endrepeat the specified number of times. The example shows how

--- a/docs/src/gcode/overview.adoc
+++ b/docs/src/gcode/overview.adoc
@@ -109,7 +109,6 @@ Letters which refer to axis names are not valid on a machine which does
 not have the corresponding axis.
 
 .Words and their meanings
-
 [width="75%", options="header", cols="^1,<5"]
 |====
 |Letter | Meaning
@@ -152,15 +151,15 @@ digit is a single character between 0 and 9.
 ** zero to many digits, followed, possibly, by
 ** one decimal point, followed by
 ** zero to many digits - provided that there is at least
-one digit somewhere in the number.
+   one digit somewhere in the number.
 * There are two kinds of numbers:
 ** Integers, that does not have a decimal point,
 ** Decimals, that do have a decimal point.
 * Numbers may have any number of digits, subject to the limitation on
-line length. Only about seventeen significant figures will be retained,
-however (enough for all known applications).
+  line length. Only about seventeen significant figures will be retained,
+  however (enough for all known applications).
 * A non-zero number with no sign but the first character is assumed to be
-positive.
+  positive.
 
 Notice that initial (before the decimal point and the first non-zero
 digit) and trailing (after the decimal point and the last non-zero
@@ -286,11 +285,11 @@ example '##2'  means the value of the parameter whose index is the
 * '5210' - 1 if "G52" or "G92" offset is currently applied, 0
   otherwise.  Volatile by default; persistent if
   'DISABLE_G92_PERSISTENCE = 1' in the '[RS274NGC]' section of the
-'.ini' file.
+  '.ini' file.
 * '5211-5219' - Shared "G52" and "G92" offset for X, Y, Z, A, B, C, U,
   V & W.  Volatile by default; persistent if
   'DISABLE_G92_PERSISTENCE = 1' in the '[RS274NGC]' section of the
-'.ini' file.
+  '.ini' file.
 * '5220' - Coordinate System number 1 - 9 for G54 - G59.3. Persistent.
 * '5221-5230' - Coordinate System 1, G54 for X, Y, Z, A, B, C, U, V, W & R.
   R denotes the XY rotation angle around the Z axis. Persistent.
@@ -616,13 +615,13 @@ cause a runtime error. The names are not case sensitive - they are
 converted to uppercase before consulting the ini file.
 
 * '#<_hal[Hal item]>'
-Allows G-code programs to read the values of HAL pins Variable access is
-read-only, the only way to _set_ HAL pins from G-code remains M62-M65,
-M67, M68 and custom M100-M199 codes.
-Note that the value read will not update in real-time, typically the
-value that was on the pin when the G-code program was started will be
-returned. It is possible to work round this by forcing a state synch.
-One way to do this is with a dummy M66 command: M66E0L0
+  Allows G-code programs to read the values of HAL pins Variable access is
+  read-only, the only way to _set_ HAL pins from G-code remains M62-M65,
+  M67, M68 and custom M100-M199 codes.
+  Note that the value read will not update in real-time, typically the
+  value that was on the pin when the G-code program was started will be
+  returned. It is possible to work round this by forcing a state synch.
+  One way to do this is with a dummy M66 command: M66E0L0
 
 Example:
 
@@ -722,7 +721,6 @@ degrees. Values returned by unary operations which return angle measures
 ('ACOS', 'ASIN', and 'ATAN') are also in degrees.
 
 .Functions
-
 [width="75%", options="header", cols="^,<"]
 |====
 |Function Name | Function result
@@ -874,7 +872,7 @@ distance from the XY zero position increased with each line.
 .Polar Spiral
 image::images/polar01.png["Polar Spiral",align="center"]
 
-The following code will produce our square pattern.
+The following code will produce our square pattern:
 
 ----
 F100 G1 @.5 ^90
@@ -910,7 +908,6 @@ being in effect. The modal groups are shown in the following Table.
 
 [[cap:modal-groups]]
 .G-Code Modal Groups(((Modal Groups: G-Codes)))
-
 [width="80%", cols="4,6", options="header"]
 |====
 |Modal Group Meaning                   | Member Words
@@ -933,7 +930,6 @@ being in effect. The modal groups are shown in the following Table.
 
 [[tbl:mcodes-modal-groups]]
 .M-Code Modal Groups(((Modal Groups: M-Codes)))
-
 [width="80%", cols="4,6", options="header"]
 |====
 |Modal Group Meaning           | Member Words
@@ -1038,7 +1034,7 @@ For more information on probing see the <<gcode:g38,G38>> Section.
   exists, the data is appended.
 * '(LOGCLOSE)' - closes an open log file.
 * '(LOG,)' - everything past the ',' is written to the log file if it is open.
-Supports expansion of parameters as described below.
+  Supports expansion of parameters as described below.
 
 Examples of logging are in 'nc_files/examples/smartprobe.ngc' and in
 'nc_files/ngcgui_lib/rectange_probe.ngc' sample G-code files.
@@ -1065,7 +1061,6 @@ For example: to print a named global variable to stderr (the default
 console window).
 
 .Parameters Example
-
 ----
 (print,endmill dia = #<_endmill_dia>)
 (print,value of variable 123 is: #123)
@@ -1142,9 +1137,9 @@ position of each item on the line, but by the following list:
 * Set distance mode (G90, G91).
 * Set retract mode (G98, G99).
 * Go to reference location (G28, G30) or change coordinate system
-data (G10) or set axis offsets (G52, G92, G92.1, G92.2, G94).
+  data (G10) or set axis offsets (G52, G92, G92.1, G92.2, G94).
 * Perform motion (G0 to G3, G33, G38.n, G73, G76, G80 to G89), as modified
-(possibly) by G53.
+  (possibly) by G53.
 * Stop (M0, M1, M2, M30, M60).
 
 [[gcode:best-practices]]

--- a/docs/src/gcode/rs274ngc.adoc
+++ b/docs/src/gcode/rs274ngc.adoc
@@ -41,9 +41,9 @@ future release of LinuxCNC.
 
 G28, G30 with axis words::
 
-When G28 or G30 is programmed with only some axis words present, 
-LinuxCNC only moves the named axes. This is common on other machine 
-controls. To move some axes to an intermediate point and then 
+When G28 or G30 is programmed with only some axis words present,
+LinuxCNC only moves the named axes. This is common on other machine
+controls. To move some axes to an intermediate point and then
 move all axes to the predefined point, write two lines of G code:
 
 ----
@@ -117,4 +117,3 @@ U, V, and W axes::
 
 LinuxCNC allows machines with up to 9 axes by defining an additional
 set of 3 linear axes known as U, V and W
-

--- a/docs/src/gcode/tool-compensation.adoc
+++ b/docs/src/gcode/tool-compensation.adoc
@@ -210,9 +210,9 @@ Tooldata is accessed by an ordered index (idx) that depends on the
 type of toolchanger specified by *[EMCIO]RANDOM_TOOLCHANGER=type*.
 
 . For *RANDOM_TOOLCHANGER = 0*, (0 is default and specifies a non-random
-toolchanger) idx is a number indicating the sequence in which tooldata was loaded.
+  toolchanger) idx is a number indicating the sequence in which tooldata was loaded.
 . For *RANDOM_TOOLCHANGER = 1*, idx is the *current* pocket number
-for the toolnumber specified by the gcode select tool command *Tn*.
+  for the toolnumber specified by the gcode select tool command *Tn*.
 
 The io program provides hal output pins to facilitate toolchanger management:
 
@@ -251,10 +251,10 @@ and 'non-random or fixed location'. Information about configuring a LinuxCNC too
 is in the <<sec:emcio-section,EMCIO Section>> of the INI chapter.
 
 .Manual Tool Changer
-Manual tool changer (you change the tool by hand) is treated like a fixed location tool changer.
-Using the manual tool changer only makes sense if you have toolholders that remain with the tool (Cat, NMTB, Kwik Switch, etc.) so that the tool position is preserved in the spindle.
-Machines with R8 or router collet type toolholders do not retain the tool location and the manual tool changer should not be used.
-Manual toolchanges can be aided by a hal configuration that employs the userspace program *hal_manualtoolchange* and is typically specified in an ini file
+Manual tool changer (you change the tool by hand) is treated like a
+fixed location tool changer.  Manual toolchanges can be aided by
+a hal configuration that employs the userspace program
+*hal_manualtoolchange* and is typically specified in an ini file
 with ini statements:
 
 ----

--- a/docs/src/gcode/tool-compensation.adoc
+++ b/docs/src/gcode/tool-compensation.adoc
@@ -39,7 +39,7 @@ the new tool Z length will be in effect. Tool table touch off is only
 available when a tool is loaded with 'Tn M6'.
 
 [[cap:touch-off-tool]]
-//.Touch Off Tool Table
+.Touch Off Tool Table
 image::images/ToolTable-TouchOff.png["Touch Off Tool Table",align="center"]
 
 == Using G10 L1/L10/L11
@@ -74,7 +74,7 @@ the GUI.
 === Tool Table Format(((Tool Table Format)))
 
 .Tool Table Format
-[width="100%", options="header"]
+[width="100%",options="header"]
 |====
 |T#    |P#  |X  |Y  |Z  |A  |B  |C  |U  |V  |W  |Dia |FA |BA |Ori |Rem
 |; 15+^|(no data after semicolon)
@@ -299,9 +299,9 @@ move will stop short so to not gouge the part. The following figure
 shows how the compensated move will stop at different points depending
 on the next move.
 
-[[cap:compensation-end-point]](((Compensation End Point)))
-//.Compensation End Point
-image:images/comp-path_en.svg["Compensation End Point",align="center"]
+[[cap:compensation-end-point]]
+.Compensation End Point(((Compensation End Point)))
+image::images/comp-path_en.svg["Compensation End Point",align="center"]
 
 === Overview
 
@@ -326,7 +326,7 @@ X0 the resulting profile would leave a bump due to the offset of the
 entry move.
 
 [[cap:entry-move]]
-//.Entry Move
+.Entry Move
 image::images/comp02_en.svg["Entry Move",align="center"]
 
 ==== Z Motion
@@ -348,11 +348,11 @@ Start a program with G40 to make sure compensation is off.
 ==== Outside Profile Example
 
 [[cap:outside-profile]]
-//.Outside Profile
+.Outside Profile
 image::images/outside-comp.png["Outside Profile",align="center"]
 
 ==== Inside Profile Example
 
 [[cap:inside-profile]]
-//.Inside Profile
+.Inside Profile
 image::images/inside-comp.png["Inside Profile",align="center"]

--- a/docs/src/getting-started/about-linuxcnc.adoc
+++ b/docs/src/getting-started/about-linuxcnc.adoc
@@ -14,8 +14,12 @@
 * LinuxCNC provides:
 ** easy discovery and testing without installation with the LiveCD
 ** easy installation from the Live CD
+** Easy to use graphical configuration wizards to rapidly create a configuration
+   specific to the machine
 ** a graphical user interface (actually several interfaces to choose from)
-** an interpreter for 'G-code' (the RS-274 machine tool programming language)
+** A graphical interface creation tool (GladeVCP)
+** an interpreter for 'G-code' (the RS-274 machine tool programming
+   language)
 ** a realtime motion planning system with look-ahead
 ** operation of low-level machine electronics such as sensors and motor drives
 ** an easy to use 'breadboard' layer for quickly creating a unique configuration for your machine

--- a/docs/src/gui/axis.adoc
+++ b/docs/src/gui/axis.adoc
@@ -17,8 +17,8 @@ preview and backplot. It is written in Python and uses
 Tk and OpenGL to display its user interface.
 
 [[fig:axis-window]]
-//.Axis Window
-image::images/axis.png["AXIS screenshot",align="center"]
+.The AXIS Window
+image::images/axis.png["AXIS main window",align="center"]
 
 == Getting Started
 
@@ -54,7 +54,8 @@ CYCLE_TIME = 100
 . Load the G-code file.
 . Use the preview plot to verify that the program is correct.
 . Load the material.
-. Set the proper offset for each axis by jogging and using the `Touch Off` button as needed.
+. Set the proper offset for each axis by jogging and using the `Touch Off`
+  button as needed.
 . Run the program.
 . To machine the same file again, return to step 6.
   To machine a different file, return to step 4.
@@ -127,7 +128,7 @@ file configured. For more information on configuration see the
   you can open the tool table and edit it.
 * 'Reload tool table' - After editing the tool table you must reload it.
 * 'Ladder editor' - If you have loaded Classic Ladder you can edit it from
-  here. See the <<cha:classicladder,Classicladder Chapter>>
+  here. See the <<cha:classicladder,Classicladder chapter>>
   for more information.
 * 'Quit' - Terminates the current LinuxCNC session.
 
@@ -344,9 +345,9 @@ and the program requires 3.83 inches of X travel.
 To move the program so it's within the machine's travel in this case,
 jog to the left and Touch Off X again.
 
-[[fig:soft-limits]](((Soft Limits)))
-//.Soft limits
-image:images/axis-outofrange.png["Soft limits",align="center"]
+[[fig:soft-limits]]
+.The Soft limits(((Soft Limits)))
+image::images/axis-outofrange.png["Soft limits", align="center"]
 
 .Tool Cone
 When no tool is loaded, the location of the tip of the tool is
@@ -477,7 +478,7 @@ See the <<cha:homing-configuration,Homing Configuration Chapter>> for more infor
 
 .Homing (Non-Identity Kinematics)
 Operation is similar to that for Identity Kinematics but, prior to
-homing, the selection radio buttons select joints by number.  The
+homing, the selection radio buttons select joints by number. The
 homing button will show 'Home All' if all joints are configured
 for homing and have valid home sequences.  Otherwise, the homing
 button will show 'Home Joint'.
@@ -541,13 +542,13 @@ running, the MDI controls are unavailable.
 .The MDI tab
 image::images/axis-mdi.png["MDI tab", align="center"]
 
- * 'History' - This shows MDI commands that have been typed earlier in this session.
- * 'MDI Command' - This allows you to enter a G-code command to be executed. Execute the
-   command by pressing Enter or by clicking 'Go'.
- * 'Active G-Codes' - This shows the 'modal codes' that are active in the interpreter. For
-   instance, 'G54' indicates that the 'G54 offset' is applied to all
-   coordinates that are entered. When in Auto the Active G-Codes represent
-   the codes after any read ahead by the interpreter.
+* 'History' - This shows MDI commands that have been typed earlier in this session.
+* 'MDI Command' - This allows you to enter a G-code command to be executed. Execute the
+  command by pressing Enter or by clicking 'Go'.
+* 'Active G-Codes' - This shows the 'modal codes' that are active in the interpreter. For
+  instance, 'G54' indicates that the 'G54 offset' is applied to all
+  coordinates that are entered. When in Auto the Active G-Codes represent
+  the codes after any read ahead by the interpreter.
 
 === Feed Override
 
@@ -601,8 +602,9 @@ to 0% - 100%.
 
 The most frequently used keyboard shortcuts are shown in the following Table:
 
-.Most Common Keyboard Shortcuts(((Keyboard Shortcuts)))
-[width="80%", options="header", cols="^,<,^"]
+[[tab:common-keyboard-shortcuts]]
+.Most Common Keyboard Shortcuts(((AXIS,Keyboard Shortcuts)))
+[width="80%",options="header",cols="^,<,^"]
 |====================================================================
 |Keystroke        | Action Taken                              | Mode
 |F1               | Toggle Emergency Stop                     | Any
@@ -743,7 +745,7 @@ the bottom of the screen, and several controls (such as those for
 preset views) are removed.  The coordinate readouts for X are replaced
 with diameter and radius.
 
-//.Axis Lathe
+.Axis Lathe Mode
 image::images/axis-lathe.png["Axis Lathe",align="center"]
 
 Pressing 'V' zooms out to show the entire file, if one is loaded.
@@ -994,6 +996,7 @@ bit  OUT  axisui.jog.w
 ----
 
 Axis has a Hal pin to indicate the jog increment selected on the 'Manual Tab'.
+
 ----
 Type  Dir Name
 float OUT axisui.jog.increment
@@ -1027,6 +1030,7 @@ bit   IN     axisui.notifications-clear-info
 ----
 
 Axis has a Hal input pin that disables/enables the 'Pause/Resume' function.
+
 ----
 Type  Dir    Name
 bit   IN     axisui.resume-inhibit

--- a/docs/src/gui/axis.adoc
+++ b/docs/src/gui/axis.adoc
@@ -38,7 +38,7 @@ works see the <<sec:display-section,Display Section>> of the INI
 Configuration Chapter.
 
 Adjust the response rate of the GUI in milliseconds. Typical 100, useable range 50 - 200 +
-(will accept time in seconds (.05 -.2) for legacy reasons - milliseconds preferred to match other screens)
+(will accept time in seconds (.05 -.2) for legacy reasons - milliseconds preferred to match other screens).
 
 [source,{ini}]
 ----
@@ -346,8 +346,8 @@ To move the program so it's within the machine's travel in this case,
 jog to the left and Touch Off X again.
 
 [[fig:soft-limits]]
-.The Soft limits(((Soft Limits)))
-image::images/axis-outofrange.png["Soft limits", align="center"]
+.Soft Limits(((Soft Limits)))
+image::images/axis-outofrange.png["Soft Limits", align="center"]
 
 .Tool Cone
 When no tool is loaded, the location of the tip of the tool is
@@ -493,8 +493,8 @@ specified value. Expressions may be entered using the rules for
 rs274ngc programs, except that variables may not be referred to. The
 resulting value is shown as a number.
 
-//.Touch Off Window
-image::images/touchoff.png["Touch Off Window", align="center"]
+.Touch Off Window
+image::images/touchoff.png["Touch Off Window",align="center"]
 
 See also the Machine menu options: 'Touch part' and 'Touch part holder'.
 
@@ -503,8 +503,8 @@ By pressing the 'Tool Touch Off' button the tool length and offsets of
 the currently loaded tool will be changed so that the current tool tip
 position matches the entered coordinate.
 
-//.Tool Touch Off Window
-image::images/tooltouchoff.png["Tool Touch Off Window", align="center"]
+.Tool Touch Off Window
+image::images/tooltouchoff.png["Tool Touch Off Window",align="center"]
 
 See also the 'Tool touch off to workpiece' and 'Tool touch off to fixture'
 options in the Machine menu.
@@ -540,7 +540,7 @@ When the machine is not turned on, or when a program is
 running, the MDI controls are unavailable.
 
 .The MDI tab
-image::images/axis-mdi.png["MDI tab", align="center"]
+image::images/axis-mdi.png["MDI tab",align="center"]
 
 * 'History' - This shows MDI commands that have been typed earlier in this session.
 * 'MDI Command' - This allows you to enter a G-code command to be executed. Execute the
@@ -643,7 +643,7 @@ AXIS includes a program called 'linuxcnctop' which shows some of the
 details of LinuxCNC's state. You can run this program by invoking Machine >
 Show LinuxCNC Status
 
-//.LinuxCNC Status Window
+.LinuxCNC Status Window
 image::images/axis-emc-status.png["LinuxCNC Status Window",align="center"]
 
 The name of each item is shown in the left column. The current value
@@ -711,9 +711,9 @@ This can be very confusing to most users.
 To turn this feature off for the current tool change
 program a G1 with no move after the T<n>.
 
-[[fig:manual-toolchange-window]](((Axis:Manual Toolchange Window)))
-//.The Manual Toolchange Window
-image:images/manual-tool-change.png["The Manual Toolchange Screenshot",align="center"]
+[[fig:manual-toolchange-window]]
+.Manual Toolchange Window(((Axis:Manual Toolchange Window)))
+image::images/manual-tool-change.png["Manual Toolchange Window",align="center"]
 
 [[sec:axis-python-modules]]
 == Python modules(((Axis:Python Modules)))
@@ -746,20 +746,20 @@ preset views) are removed.  The coordinate readouts for X are replaced
 with diameter and radius.
 
 .Axis Lathe Mode
-image::images/axis-lathe.png["Axis Lathe",align="center"]
+image::images/axis-lathe.png["Axis Lathe Mode",align="center"]
 
 Pressing 'V' zooms out to show the entire file, if one is loaded.
 
 When in lathe mode, the shape of the loaded tool (if any) is shown.
 
-//.Lathe Tool Shape
+.Lathe Tool Shape
 image::images/axis-lathe-tool.png["Lathe Tool Shape",align="center"]
 
 To change the display to a back tool lathe you need to have both 'LATHE = 1'
 and 'BACK_TOOL_LATHE = 1' in the [DISPLAY] section. This will invert the view
 and put the tool on the back side of the Z axis.
 
-//.Lathe Back Tool Shape
+.Lathe Back Tool Shape
 image::images/axis-back-tool-lathe.png["Lathe Back Tool Shape",align="center"]
 
 == Using AXIS in Foam Cutting mode
@@ -771,8 +771,8 @@ in another.  In the live plot, lines are drawn between corresponding points on
 the XY plane and the UV plane.  The special comments (XY_Z_POS) and (UV_Z_POS)
 set the Z coordinates of these planes, which default to 0 and 1.5 machine units.
 
-//.Foam cutting mode
-image::images/axis-foam.png["Foam cutting mode",align="center"]
+.Foam Cutting Mode
+image::images/axis-foam.png["Foam Cutting Mode",align="center"]
 
 == Advanced Configuration
 
@@ -823,7 +823,7 @@ treated as G-code. One such example script is available at
 'nc_files/holecircle.py'. This script creates G-code for drilling a
 series of holes along the circumference of a circle.
 
-//.Circular Holes
+.Circular Holes
 image::images/holes.png["Circular Holes",align="center"]
 
 If the environment variable AXIS_PROGRESS_BAR is set, then lines
@@ -862,7 +862,7 @@ AXIS defaults, include the following line in your X Resources:
 
 // These asterisks are not for bold,
 ----
-    *Axis*optionLevel: widgetDefault
+*Axis*optionLevel: widgetDefault
 ----
 // in this case, we want the asterisks to actually appear.
 

--- a/docs/src/gui/gladevcp.adoc
+++ b/docs/src/gui/gladevcp.adoc
@@ -8,7 +8,7 @@
 // - manual-example.ui layout - really bad
 // - restructure faq/troubleshooting/notes section
 // - check wiki vs docs
-// - check other gladevcp docs branch against this
+// - check other GladeVCP docs branch against this
 
 :ini: {basebackend@docbook:'':ini}
 :hal: {basebackend@docbook:'':hal}
@@ -20,7 +20,7 @@
 
 == What is GladeVCP?
 
-GladeVCP is an LinuxCNC component which adds the ability to add a new user
+GladeVCP is a LinuxCNC component which adds the ability to add a new user
 interface panel to LinuxCNC user interfaces like:
 
 * Axis
@@ -75,7 +75,7 @@ GladeVCP panel windows may be run in three different setups:
 .Installed LinuxCNC
 If you're using an installed version of LinuxCNC the examples shown below are in
 the <<cha:starting-linuxcnc,configuration picker>> in the 'Sample
-Configurations > apps > gladevcp' branch.
+Configurations > apps > GladeVCP' branch.
 
 .Git Checkout
 The following instructions only apply if you're using a git checkout. Open a
@@ -107,10 +107,10 @@ image::images/example-tabbed-small.png[]
 
 ////
 To run this panel as a standalone toplevel window besides Axis, just
-start Axis in the background and start gladevcp as follows:
+start Axis in the background and start GladeVCP as follows:
 
 FIXME: I'm not sure how this is supposed to work with axis in one
-directory and gladevcp in a different directory.
+directory and GladeVCP in a different directory.
 
 FIXME: there is a conflict for motion.N.spindle-speed-out since it is used by both
    axis.ini: sim_spindle_encoder.hal
@@ -203,9 +203,9 @@ command' property.
 
 See how a Python callback is integrated into the example:
 
- - in glade, see the +hits+ label widget (a plain GTK+ widget)
- - in the +button1+ widget, look at the 'Signals' tab, and find the signal 'pressed' associated with the handler 'on_button_press'
- - in hitcounter.py, see the method 'on_button_press' and see how it sets the label property in the 'hits' object
+- in glade, see the +hits+ label widget (a plain GTK+ widget)
+- in the +button1+ widget, look at the 'Signals' tab, and find the signal 'pressed' associated with the handler 'on_button_press'
+- in hitcounter.py, see the method 'on_button_press' and see how it sets the label property in the 'hits' object
 
 The is just touching upon the concept - the callback mechanism will be
 handled in more detail in the
@@ -245,10 +245,10 @@ Either modify an existing UI component by running +glade <file>.ui+
 or start a new one by just running the +glade+ command from the shell.
 
 - If LinuxCNC was not installed from a package, the LinuxCNC shell environment needs to be set up with
-+.<linuxcncdir>/scripts/rip-environment+, otherwise glade won't find the LinuxCNC-specific widgets.
+  +.<linuxcncdir>/scripts/rip-environment+, otherwise glade won't find the LinuxCNC-specific widgets.
 - When asked for unsaved Preferences, just accept the defaults and hit 'Close'.
 - From 'Toplevel' (left pane), pick 'Window' (first icon) as top level window, which
-by default will be named 'window1'. Do not change this name - GladeVCP relies on it.
+  by default will be named 'window1'. Do not change this name - GladeVCP relies on it.
 - In the left tab, scroll down and expand  'HAL Python' and 'VCP Actions'.
 - add a container like a HAL_Box or a HAL_Table from 'HAL Python' to the frame
 - pick and place some elements like LED, button, etc. within a container
@@ -287,6 +287,7 @@ to assure some widgets appear active only in a certain state.
 To just activate a container, execute the HAL command +setp gladevcp.<container-name> 1+.
 
 === Preparing the HAL command file
+
 The suggested way of linking HAL pins in a GladeVCP panel is to
 collect them in a separate file with extension +.hal+. This file is
 passed via the +POSTGUI_HALFILE=+ option in the +HAL+ section of your
@@ -426,7 +427,7 @@ Note the following differences to the Axis tab setup:
 
 == GladeVCP command line options
 
-See also 'man gladevcp'. These are the gladevcp command line options:
+See also 'man gladevcp'. These are the GladeVCP command line options:
 
 ----
 Usage: gladevcp [options] myfile.ui
@@ -595,7 +596,6 @@ relevant method is:
   Retrieve the value of the current HAL pin, where '<halpin>' is
   the applicable HAL pin name listed above.
 
-
 === Setting pin and widget values
 
 As a general rule, if you need to set a HAL output widget's value from
@@ -647,15 +647,15 @@ the widget. Buttons have no additional properties compared to their
 base Gtk classes.
 
 - HAL_Button: instantaneous action, does not retain state. Important
-signal: +pressed+
+  signal: +pressed+
 - HAL_ToggleButton, HAL_CheckButton: retains on/off state. Important
-signal: +toggled+
+  signal: +toggled+
 - HAL_RadioButton: a one-of-many group. Important signal: +toggled+ (per
-button).
+  button).
 - Important common methods: +set_active()+, +get_active()+
 - Important properties: +label+, +image+
 
-// .Buttons
+//.Buttons
 .Check button
 image::images/checkbutton.png[]
 
@@ -677,7 +677,7 @@ Defining radio button groups in Glade:
 See +configs/apps/gladevcp/by-widget/+ for a GladeVCP applications
 and UI file for working with radio buttons.
 
-[[gladevcp:hal-scales]]
+[[gladevcp:hal-scales]][[gladevcp:hal-hscale]][[gladevcp:hal-vscale]]
 === Scales
 
 HAL_HScale and HAL_VScale are derived from the GtkHScale and GtkVScale
@@ -716,9 +716,9 @@ image::images/spinbutton.png[]
 [[gladevcp:hal-dial]]
 === Hal_Dial
 
-The hal_dial widget simulates a jogwheel or adjustment dial.
+The hal_dial widget simulates a jogwheel or adjustment dial. +
 It can be operated with the mouse. You can just use the mouse wheel, while the mouse cursor is over the Hal_Dial widget,
-or you hold the left mouse button and move the cursor in circular direction to increase or degrease the counts.
+or you hold the left mouse button and move the cursor in circular direction to increase or degrease the counts. +
 By double clicking the left or right button the scale factor can be increased or decreased.
 
 * Counterclockwise   = reduce counts
@@ -728,7 +728,9 @@ By double clicking the left or right button the scale factor can be increased or
 * left Double Click  = x10 scale
 * Right Double Click = /10 scale
 
-Hal_Dial exports it's count value as hal pins:
+==== Pins
+
+`hal_dial` exports it's count value as hal pins:
 
 <widgetname>::
   out S32 pin
@@ -737,7 +739,9 @@ Hal_Dial exports it's count value as hal pins:
 <widgetname>-delta-scaled::
   out FLOAT pin
 
-It has the following properties:
+==== Properties
+
+`hal_dial` has the following properties:
 
 cpr::
   Sets the Counts per Revolution, allowed values are in the range from 25 to 360 +
@@ -755,12 +759,12 @@ center_color::
 count_type_shown::
   There are three counts available 0) Raw CPR counts 1) Scaled counts 2) Delta scaled counts. +
   default = 1
-* count is based on the CPR selected - it will count positive and negative. It is available as a S32 pin. +
-* Scaled-count is CPR count times the scale - it can be positive and negative. +
-  If you change the scale the output will immediately reflect the change. It is available as a FLOAT pin. +
-* Delta-scaled-count is cpr count CHANGE, times scale. +
-  If you change the scale, only the counts after that change will be scaled and then added to the current value. +
-  It is available as a FLOAT pin.
+  * count is based on the CPR selected - it will count positive and negative. It is available as a S32 pin. +
+  * Scaled-count is CPR count times the scale - it can be positive and negative. +
+    If you change the scale the output will immediately reflect the change. It is available as a FLOAT pin. +
+  * Delta-scaled-count is cpr count CHANGE, times scale. +
+    If you change the scale, only the counts after that change will be scaled and then added to the current value. +
+    It is available as a FLOAT pin.
 scale_adjustable::
   Set this to False if you want to disallow scale changes by double clicking the widget. +
   If this is false the scale factor will not show on the widget. +
@@ -769,54 +773,62 @@ scale::
   Set this to scale the counts. +
   default = 1.0
 
-Direct program control::
+==== Direct program control
 
-  There are ways to directly control the widget using Python.
+There are ways to directly control the widget using Python.
 
 Using goobject to set the above listed properties:
 
-  [widget name].set_property("cpr",int(value))
-  [widget name].set_property("show_counts, True)
-  [widget name].set_property("center_color",gtk.gdk.Color('#bdefbdefbdef'))
-  [widget name].set_property('label', 'Test Dial 12345')
-  [widget name].set_property('scale_adjustable', True)
-  [widget name].set_property('scale', 10.5)
-  [widget name].set_property('count_type_shown', 0)
+----
+[widget name].set_property("cpr",int(value))
+[widget name].set_property("show_counts, True)
+[widget name].set_property("center_color",gtk.gdk.Color('#bdefbdefbdef'))
+[widget name].set_property('label', 'Test Dial 12345')
+[widget name].set_property('scale_adjustable', True)
+[widget name].set_property('scale', 10.5)
+[widget name].set_property('count_type_shown', 0)
+----
 
 There are python methods:
 
-  [widget name].get_value()
-    Will return the counts value as a s32 integer
-  [widget name].get_scaled_value()
-    Will return the counts value as a float
-  [widget name].get_delta_scaled_value()
-    Will return the counts value as a float
-  [widget name].set_label("string")
-    Sets the label content with "string"
+* `[widget name].get_value()` +
+  Will return the counts value as a s32 integer
+* `[widget name].get_scaled_value()` +
+  Will return the counts value as a float
+* `[widget name].get_delta_scaled_value()` +
+  Will return the counts value as a float
+* `[widget name].set_label("string")` +
+  Sets the label content with "string"
 
 There are two GObject signals emitted:
 
-  count_changed
-    emitted when the widget's count changes eg. from being wheel scrolled.
-  scale_changed
-    emitted when the widget's scale changes eg. from double clicking.
-  connect to these like so:
-    [widget name].connect('count_changed', [count function name])
-    [widget name].connect('scale_changed', [scale function name])
+* `count_changed` +
+  Emitted when the widget's count changes eg. from being wheel scrolled.
+* `scale_changed` +
+  Emitted when the widget's scale changes eg. from double clicking.
+
+Connect to these like so:
+
+----
+[widget name].connect('count_changed', [count function name])
+[widget name].connect('scale_changed', [scale function name])
+----
 
 The callback functions would use this pattern:
 
-    def [count function name](widget, count,scale,delta_scale):
+----
+def [count function name](widget, count,scale,delta_scale):
+----
 
 This will return: the widget, the current count, scale and delta scale of that widget.
 
 .Example Hal_Dial
-image::images/Hal_Dial.png[]
+image::images/Hal_Dial.png[align="center"]
 
 [[gladevcp:jogwheel]]
 === Jog Wheel
 
-The jogwheel widget simulates a real jogwheel.
+The `jogwheel` widget simulates a real jogwheel.
 It can be operated with the mouse. You can just use the mouse wheel, while the mouse cursor is over the JogWheel widget, +
 or you push the left mouse button and move the cursor in circular direction to increase or degrease the counts. +
 
@@ -828,12 +840,16 @@ or you push the left mouse button and move the cursor in circular direction to i
 As moving the mouse the drag and drop way may be faster than the widget can update itself, you may loose counts turning to fast.
 It is recommended to use the mouse wheel, and only for very rough movements the drag and drop way.
 
-JogWheel exports it's count value as hal pin:
+==== Pins
+
+`jogwheel` exports it's count value as hal pin:
 
 <widgetname>-s::
    out S32 pin
 
-It has the following properties:
+==== Properties
+
+`jogwheel` has the following properties:
 
 size::
   Sets the size in pixel of the widget, allowed values are in the range of 100 to 500
@@ -846,169 +862,165 @@ show_counts::
 label::
   Set the content of the label which may be shown over the counts value. The purpose is to give the user an idea about the usage of that jogwheel. If the label given is longer than 12 Characters, it will be cut to 12 Characters.
 
-Direct program control::
+==== Direct program control
 
-  There a couple ways to directly control the widget using Python.
+There a couple ways to directly control the widget using Python.
 
 Using gobject to set the above listed properties:
 
-  [widget name].set_property("size",int(value))
-  [widget name].set_property("cpr",int(value))
-  [widget name].set_property("show_counts, True)
+----
+[widget name].set_property("size",int(value))
+[widget name].set_property("cpr",int(value))
+[widget name].set_property("show_counts, True)
+----
 
 There are two python methods:
 
-  [widget name].get_value()
-    Will return the counts value as integer
-  [widget name].set_label("string")
-    Sets the label content with "string"
+* `[widget name].get_value()` +
+  Will return the counts value as integer
+* `[widget name].set_label("string")` +
+  Sets the label content with "string"
 
 .Example JogWheel
-image::images/JogWheel.png[]
+image::images/JogWheel.png[align="center"]
 
 [[gladevcp:speedcontrol]]
 === Speed Control
 
-SpeedControl is a widget specially made to control an adjustment
+`speedcontrol` is a widget specially made to control an adjustment
 with a touch screen. It is a replacement to the normal scale widget
 which is difficult to slide on a touch screen.
 
 The value is controlled with two button to increase or decrease the value.
-The Increment will change as long a button is pressed. The value of each increment
+The increment will change as long a button is pressed. The value of each increment
 as well as the time between two changes can be set using the widget properties.
 
-SpeedControl offers some hal pin:
+==== Pins
+
+`speedcontrol` offers some hal pin:
 
 <widgetname>-value::
-  out float pin
-  The shown value of the widget
-
+  out float pin +
+  The shown value of the widget.
 <widgetname>-scaled-value::
-  out float pin
+  out float pin +
   The shown value divided by the scale value, this is very useful, if the
   velocity is shown in units / min, but linuxcnc expects it to be in units / second
-
 <widgetname>-scale::
-  in float pin
-  The scale to apply
+  in float pin +
+  The scale to apply. +
   Default is 60
-
 <widgetname>-increase::
-  in bit pin
-  As long as the pin is true, the value will increase
-  Very handy with connected momentary switch
-
+  in bit pin +
+  As long as the pin is true, the value will increase. +
+  Very handy with connected momentary switch.
 <widgetname>-decrease::
-  in bit pin
-  As long as the pin is true, the value will decrease
-  Very handy with connected momentary switch
+  in bit pin +
+  As long as the pin is true, the value will decrease. +
+  Very handy with connected momentary switch.
 
-It has the following properties:
+==== Properties
+
+`speedcontrol` has the following properties:
 
 height::
-  integer
-  The height of the widget in pixel
-  allowed values are 24 to 96
-  default is 36
-
+  Integer +
+  The height of the widget in pixel. +
+  Allowed values are 24 to 96. +
+  Default is 36.
 value::
-  float
-  The  start value to set
-  allowed values are in the range from 0.001 to 99999.0
-  default is 10.0
-
+  Float +
+  The start value to set. +
+  Allowed values are in the range from 0.001 to 99999.0. +
+  Default is 10.0.
 min::
-  float
-  The min allowed value
-  allowed values are 0.0 to 99999.0
-  default is 0.0
+  Float +
+  The min allowed value. +
+  Allowed values are 0.0 to 99999.0. +
+  Default is 0.0. +
   If you change this value, the increment will be reset to default, so it might be necessary to set afterwards a new increment.
-
 max::
-  float
-  The max allowed value
-  allowed values are 0.001 to 99999.0
-  default is 100.0
+  Float
+  The max allowed value. +
+  Allowed values are 0.001 to 99999.0. +
+  Default is 100.0. +
   If you change this value, the increment will be reset to default, so it might be necessary to set afterwards a new increment.
-
 increment::
-  float
-  sets the applied increment per mouse click
-  allowed values are 0.001 to 99999.0 and -1
-  default is -1 resulting in 100 increments from min to max
-
+  Float +
+  Sets the applied increment per mouse click. +
+  Allowed values are 0.001 to 99999.0 and -1. +
+  Default is -1, resulting in 100 increments from min to max.
 inc_speed::
-  integer
-  Sets the timer delay for the increment speed holding pressed the buttons
-  allowed values are 20 to 300
-  default is 100
-
+  Integer +
+  Sets the timer delay for the increment speed holding pressed the buttons. +
+  Allowed values are 20 to 300. +
+  Default is 100.
 unit::
-  string
-  Sets the unit to be shown in the bar after the value
-  any string is allowed
-  default is ""
-
-color::
-  Color
-  Sets the color of the bar
-  any hex color is allowed
-  default is "#FF8116"
-
-template::
   String
-  Text template to display the value Python formatting is used
-  Any allowed format
-  default is "%.1f"
-
+  Sets the unit to be shown in the bar after the value. +
+  Any string is allowed. +
+  Default is "".
+color::
+  Color +
+  Sets the color of the bar. +
+  Any hex color is allowed. +
+  Default is "#FF8116".
+template::
+  String +
+  Text template to display the value. Python formatting is used. +
+  Any allowed format. +
+  Default is "%.1f"
 do_hide_button::
-  Boolean
-  Whether to show or hide the increment an decrement button
-  True or False
-  Default = False
+  Boolean +
+  Whether to show or hide the increment an decrement button. +
+  True or False. +
+  Default = False.
 
-Direct program control::
+==== Direct program control
 
-  There a couple ways to directly control the widget using Python.
+There a couple ways to directly control the widget using Python.
 
 Using gobject to set the above listed properties:
 
-  [widget name].set_property("do_hide_button",bool(value))
-  [widget name].set_property("color","#FF00FF")
-  [widget name].set_property("unit", "mm/min")
-  etc.
+----
+[widget name].set_property("do_hide_button",bool(value))
+[widget name].set_property("color","#FF00FF")
+[widget name].set_property("unit", "mm/min")
+etc.
+----
 
 There are also python methods to modify the widget:
 
-  [widget name].set_adjustment(gtk-adjustment)
+----
+[widget name].set_adjustment(gtk-adjustment)
+----
 
 You can assign a existing adjustment to the control, that way it is easy to replace
 existing sliders without many code changes. Be aware, that after changing the adjustment
 you may need to set a new increment, as it will be reset to its default (100 steps from MIN to MAX)
 
-  [widget name].get_value()
-    Will return the counts value as float
-  [widget name].set_value(float(value))
-    Sets the widget to the commanded value
-  [widget name].set_digits(int(value))
-    Sets the digits of the value to be used
-  [widget name].hide_button(bool(value))
-    Hide or show the button
+* `[widget name].get_value()` +
+  Will return the counts value as float
+* `[widget name].set_value(float(value))` +
+  Sets the widget to the commanded value
+* `[widget name].set_digits(int(value))` +
+  Sets the digits of the value to be used
+* `[widget name].hide_button(bool(value))` +
+  Hide or show the button
 
 .Example Speedcontrol
-image::images/SpeedControl.png[]
+image::images/SpeedControl.png[align="center"]
 
 [[gladevcp:hal-label]]
 === Label
 
-HAL_Label is a simple widget based on GtkLabel which represents a HAL
+`hal_label` is a simple widget based on GtkLabel which represents a HAL
 pin value in a user-defined format.
 
 label_pin_type::
   The pin's HAL type  (0:S32, 1:float, 2:U32), see also the tooltip
   on 'General→HAL pin type '(note this is different from PyVCP which has
   three label widgets, one for each type).
-
 text_template::
   Determines the text displayed - a Python
   format string to convert the pin value to text. Defaults to +%s+ (values
@@ -1024,66 +1036,73 @@ text_template::
 * HAL_Table State_Sensitive_Table
 * HAL_HBox
 
-These containers are meant to be used to sensitize (grey out) or hide their children.
-Insensitived children will not respond to input.
-HAL_HideTable has one HAL BIT input pin which controls if it's child widgets are hidden or not.
+These containers are meant to be used to insensitize (grey out) or hide their children. +
+Insensitized children will not respond to input.
 
-<Panel_basename>.<widgetname>::
+`hal_hidetable` has one HAL BIT input pin which controls if it's child widgets are hidden or not.
 
-If the pin is low then child widgets are visible which is the default state.
+<Panel_basename>.<widgetname>:: FIXME pin name
+  If the pin is low then child widgets are visible which is the default state.
 
-HAL_Table and HAL_Hbox have one HAL BIT input pin which controls if their child widgets are sensitive or not.
+`hal_table` and `hal_hbox` have one HAL BIT input pin which controls if their child widgets are sensitive or not. +
 These widgets's pin name uses the convention:
 
-<Panel_basename>.<widgetname>::
+<Panel_basename>.<widgetname>:: FIXME pin name
+  If the pin is low then child widgets are inactive which is the default state.
 
-If the pin is low then child widgets are inactive which is the default state.
-
-State_Sensitive_table responds to the state to linuxcnc's interpreter.
-optionally selectable to respond to 'must-be-all-homed','must-be-on' and 'must-be-idle'
+`state_sensitive_table` responds to the state to LinuxCNC's interpreter. +
+Optionally selectable to respond to 'must-be-all-homed','must-be-on' and 'must-be-idle'. +
 You can combine them. It will always be insensitive at Estop.
  +
-* HAL_Hbox is depreceiated - use HAL_Table.
-If current panels use it it won't fail. You just won't find it in the GLADE editor anymore.
-Future versions of gladeVCP may remove this widget completely and then you will need to update the panel.
+[WARNING]
+**HAL_Hbox is deprecated - use HAL_Table.** +
+If current panels use it, it won't fail. You just won't find it in the GLADE editor anymore. +
+Future versions of GladeVCP may remove this widget completely and then you will need to update the panel.
 
 [TIP]
 ====
-If you find some part of your GladeVCP application is 'grayed
-out' (insensitive), see whether a HAL_Table pin is unset or unconnected.
+If you find some part of your GladeVCP application is
+'grayed out' (insensitive), see whether a HAL_Table pin is unset or unconnected.
 ====
 
 [[gladevcp:hal-led]]
 === LED
 
-The hal_led simulates a real indicator LED. +
-It has a single input BIT pin which controls it's state: ON or OFF. +
-LEDs have several properties which control their look and feel: +
+The `hal_led` simulates a real indicator LED. +
+It has a single input BIT pin which controls it's state: ON or OFF.
+
+==== Properties
+
+LEDs have several properties which control their look and feel:
 
 on_color::
-  a String defining ON color of LED. May be any valid
-  gdk.Color name. Not working on Ubuntu 8.04.
+  String defining ON color of LED. +
+  May be any valid gdk.Color name. +
+  Not working on Ubuntu 8.04.
 off_color::
-  String defining OFF color of LED. May be any valid
-  gdk.Color name or special value `dark`. `dark` means that OFF color
-  will be set to 0.4 value of ON color. Not working on Ubuntu 8.04.
+  String defining OFF color of LED. +
+  May be any valid gdk.Color name or special value `dark`. `dark` means
+  that OFF color will be set to 0.4 value of ON color. +
+  Not working on Ubuntu 8.04.
 pick_color_on, pick_color_off::
-  Colors for ON and OFF states may be
-  represented as `#RRRRGGGGBBBB` strings. These are optional properties
-  which have precedence over `on_color` and `off_color`.
+  Colors for ON and OFF states. +
+  These may be represented as `#RRRRGGGGBBBB` strings and are optional
+  properties which have precedence over `on_color` and `off_color`.
 led_size::
   LED radius (for square - half of LED's side)
 led_shape::
-  LED Shape. Valid values are 0 for round, 1 for oval and 2
-  for square shapes.
+  LED Shape. +
+  Valid values are 0 for round, 1 for oval and 2 for square shapes.
 led_blink_rate::
-  if set and LED is ON then it's blinking. Blink
-  period is equal to "led_blink_rate" specified in milliseconds.
+  If set and LED is ON then it's blinking. +
+  Blink period is equal to "led_blink_rate" specified in milliseconds.
 create_hal_pin::
-  select/deselect making of HAL pin to control LED. With no HAL pin created
-  LED can be controlled with a python function.
+  Select/deselect creation of a HAL pin to control the LED. +
+  With no HAL pin created LED can be controlled with a python function.
 
-As an input widget, LED also supports the +hal-pin-changed signal+. If
+==== Signals
+
+As an input widget, LED also supports the +hal-pin-changed+ signal. If
 you want to get a notification in your code when the LED's HAL pin was
 changed, then connect this signal to a handler, for example
 +on_led_pin_changed+ and provide the handler as follows:
@@ -1105,11 +1124,13 @@ image::images/leds.png[]
 
 [NOTE]
 ====
-This widget might go away. Use the HAL_HBar and HAL_VBar widgets
-instead.
+This widget might go away. +
+Use the HAL_HBar and HAL_VBar widgets instead.
 ====
 
-The HAL_ProgressBar is derived from gtk.ProgressBar and has two float
+==== Pins
+
+The `HAL_ProgressBar` is derived from gtk.ProgressBar and has two float
 HAL input pins:
 
 <widgetname>::
@@ -1117,43 +1138,53 @@ HAL input pins:
 <widgetname>-scale::
   the maximum absolute value of input
 
-It has the following properties:
+==== Properties
+
+`HAL_ProgressBar` has the following properties:
 
 scale::
-  value scale. set maximum absolute value of input. Same as
-  setting the <widgetname>.scale pin. A float, range from
-  -2^24 to +2^24.
+  Value scale. +
+  Sets the maximum absolute value of input. Same as setting
+  the <widgetname>.scale pin. +
+  A float, range from -2^24 to +2^24.
 green_limit::
-  green zone limit lower limit
+  Green zone lower limit
 yellow_limit::
-  yellow zone limit lower limit
+  Yellow zone lower limit
 red_limit::
-  red zone limit lower limit
+  Red zone lower limit
 text_template::
   Text template to display the current value of the
-  +<widgetname>+ pin. Python formatting may be used for dict
-  +{"value":value}+
+  +<widgetname>+ pin. +
+  Python formatting may be used for dict +{"value":value}+
 
 .Example HAL_ProgressBar
-image::images/progressbar2.png[]
+image::images/progressbar2.png[align="center"]
 
 [[gladevcp:hal_combobox]]
 === ComboBox
 
-HAL_ComboBox is derived from gtk.ComboBox. It enables choice of a
+`HAL_ComboBox` is derived from gtk.ComboBox. It enables choice of a
 value from a dropdown list.
 
-It exports two HAL pins:
+==== Pins
+
+`HAL_ComboBox` exports two HAL pins:
 
 <widgetname>-f::
-  the current value, type FLOAT
+  Current value, type FLOAT
 <widgetname>-s::
-  the current value, type S32
+  Current value, type S32
 
-It has the following property which can be set in Glade:
+==== Properties
+
+`HAL_ComboBox` has the following property which can be set in Glade:
 
 column::
-  the column index, type S32, defaults to -1, range from -1..100 .
+  The column index. +
+  Type S32. +
+  Valid range from -1..100. +
+  Defaults value -1.
 
 In default mode this widgets sets the pins to the index of the chosen
 list entry. So if your widget has three labels, it may only assume
@@ -1175,36 +1206,45 @@ CellRenderer, see http://www.youtube.com/watch?v=Z5_F-rW2cL8.
 [[gladevcp:hal-bars]]
 === Bars
 
-HAL Bar and VBar widgets for horizontal and vertical bars representing
-float values. They have one input FLOAT hal pin. Both bars have the
-following properties:
+`HAL_Bar` and `HAL_VBar` widgets for horizontal and vertical bars
+representing float values.
+
+==== Pins
+
+`HAL_Bar` and `HAL_VBar` each have one input FLOAT hal pin.
+
+==== Properties
+
+`HAL_Bar` and `HAL_VBar` both bars have the following properties:
 
 invert::
-  Swap min and max direction. An inverted HBar grows from right
-  to left, an inverted VBar from top to bottom.
+  Swap min and max direction. +
+  An inverted HBar grows from right to left, an inverted VBar from top to bottom.
 min, max::
-  Minimum and maximum value of desired range. It is not an
-  error condition if the current value is outside this range.
+  Minimum and maximum value of desired range.
+  It is not an error condition if the current value is outside this range.
 show limits::
   Used to select/deselect the limits text on bar.
 zero::
-  Zero point of range. If it's inside of min/max range then the
-  bar will grow from that value and not from the left (or right) side of
-  the widget. Useful to represent values that may be both positive or
-  negative.
+  Zero point of range. +
+  If it's inside of min/max range then the bar will grow from that value
+  and not from the left (or right) side of the widget. +
+  Useful to represent values that may be both positive or negative.
 force_width, force_height::
-  Forced width or height of widget. If not
-  set then size will be deduced from packing or from fixed widget size
-  and bar will fill whole area.
+  Forced width or height of widget. +
+  If not set then size will be deduced from packing or from fixed widget
+  size and bar will fill whole area.
 text_template::
-  Like in Label sets text format for min/max/current
-  values. Can be used to turn off value display.
+  Like in Label, sets text format for min/max/current values. +
+  Can be used to turn off value display.
 value::
-  Sets the bar display to the value entered: used only for testing in
-  GLADE editor. The value will be set from A HAL pin.
+  Sets the bar display to the value entered. +
+  Used only for testing in GLADE editor. +
+  The value will be set from a HAL pin.
 target value::
-  Sets the target line to the value entered: used only for testing in
-  GLADE editor. The value will can be set in a Python function
+  Sets the target line to the value entered. +
+  Used only for testing in GLADE editor. +
+  The value will can be set in a Python function.
 target_width::
   Width of the line that marks the target value.
 bg_color::
@@ -1212,39 +1252,47 @@ bg_color::
 target_color::
   Color of the the target line.
 z0_color, z1_color, z2_color::
-  Colors of different value zones.
-  Defaults are `green`, `yellow` and `red`. For description of zones see
-  `z*_border` properties.
+  Colors of different value zones. +
+  Defaults are `green`, `yellow` and `red`. +
+  For description of zones see `z*_border` properties.
 z0_border, z1_border::
-  Define up bounds of color zones. By default
-  only one zone is enabled. If you want more then one zone set
+  Define up bounds of color zones. +
+  By default only one zone is enabled. If you want more then one zone set
   `z0_border` and `z1_border` to desired values so zone 0 will fill from
   0 to first border, zone 1 will fill from first to second border and
-  zone 2 -- from last border to 1. Borders are set as fractions, values
-  from 0 to 1.
+  zone 2 from last border to 1. +
+  Borders are set as fractions. +
+  Valid values range from 0 to 1.
 
 .Horizontal bar
-image::images/hal_hbar.png[]
+image::images/hal_hbar.png[align="center"]
 
 .Vertical bar
-image::images/vscale.png[]
+image::images/vscale.png[align="center"]
 
 [[gladevcp:hal-meter]]
 === Meter
 
-HAL Meter is a widget similar to PyVCP meter - it represents a float value and has
-one input FLOAT hal pin. HAL Meter has the following properties:
+`HAL_Meter` is a widget similar to PyVCP meter - it represents a float value.
+
+==== Pins
+
+`HAL_Meter` has one input FLOAT hal pin.
+
+==== Properties
+
+HAL Meter has the following properties:
 
 min, max::
-  Minimum and maximum value of desired range. It is not an
-  error condition if the current value is outside this range.
+  Minimum and maximum value of desired range. +
+  It is not an error condition if the current value is outside this range.
 force_size::
-  Forced diameter of widget. If not set then size will be
-  deduced from packing or from fixed widget size and meter will fill all
-  available space with respect to aspect ratio.
+  Forced diameter of widget. +
+  If not set then size will be deduced from packing or from fixed widget
+  size, and meter will fill all available space with respect to aspect ratio.
 text_template::
-  Like in Label sets text format for current value. Can
-  be used to turn off value display.
+  Like in Label, sets text format for current value. +
+  Can be used to turn off value display.
 label::
   Large label above center of meter.
 sublabel::
@@ -1252,19 +1300,21 @@ sublabel::
 bg_color::
   Background color of meter.
 z0_color, z1_color, z2_color::
-  Colors of different value
-  zones. Defaults are `green`, `yellow` and `red`. For description of
-  zones see `z*_border` properties.
+  Colors of different value zones. +
+  Defaults are `green`, `yellow` and `red`. +
+  For description of zones see `z*_border` properties.
 z0_border, z1_border::
-  Define up bounds of color zones. By default only
-  one zone is enabled. If you want more then one zone set `z0_border` and
+  Define up bounds of color zones. +
+  By default only one zone is enabled. If you want more then one zone set `z0_border` and
   `z1_border` to desired values so zone 0 will fill from min to first
-  border, zone 1 will fill from first to second border and zone 2 -- from
-  last border to max. Borders are set as values in range min-max.
+  border, zone 1 will fill from first to second border and zone 2 from
+  last border to max. +
+  Borders are set as values in range min-max.
 
 .Example HAL Meters
-image::images/hal_meter.png[]
+image::images/hal_meter.png[align="center"]
 
+[[gladevcp:hal-graph]]
 === HAL_Graph
 
 This widget is for plotting values over time.
@@ -1281,133 +1331,162 @@ GladeVCP application when LinuxCNC is not running, you might get a traceback
 because the Gremlin widget can't find LinuxCNC status, like the current file
 name.
 
-Gremlin does not export any HAL pins. It has the following properties:
+==== Pins
+
+Gremlin does not export any HAL pins.
+
+==== Properties
+
+Gremlin has the following properties:
 
 show tool speed::
-  This displays the tool speed. Defaults true
+  This displays the tool speed. +
+  Default = true.
 show commanded::
-  This selects the DRO to use commanded or actual values. Defaults true
+  This selects the DRO to use: commanded or actual values. +
+  Default = true.
 use metric units::
-  This selects the DRO to use metric or imperial units. Defaults true
+  This selects the DRO to use: metric or imperial units. +
+  Default = true.
 show rapids::
-  This tells the plotter to show the rapid moves. Defaults true
+  This tells the plotter to show the rapid moves. +
+  Default = true.
 show DTG::
-  This selects the DRO to display the distance-to-go value. Defaults true
+  This selects the DRO to display the distance-to-go value. +
+  Default = true.
 show relative::
-  This selects the DRO to show values relative to user system or machine
-  coordinates. Defaults true
+  This selects the DRO to show values relative to user system or machine coordinates. +
+  Default = true.
 show live plot::
-  This tells the plotter to draw or not. Defaults true
+  This tells the plotter to draw or not. +
+  Default = true.
 show limits::
-  This tells the plotter to show the machine's limits. Defaults true
+  This tells the plotter to show the machine's limits. +
+  Default = true.
 show lathe radius::
   This selects the DRO to display the X axis in radius or diameter, if in lathe
-  mode (selectable in the INI file with LATHE = 1). Defaults false
+  mode (selectable in the INI file with LATHE = 1). +
+  Default = true.
 show extents::
-  This tells the plotter to show the extents. Defaults true
+  This tells the plotter to show the extents. +
+  Default = true.
 show tool::
-  This tells the plotter to draw the tool. Defaults true
+  This tells the plotter to draw the tool. +
+  Default = true.
 show program::
   TODO
 use joints mode::
-  Used in non trivialkins machines (eg robots). Defaults false
+  Used in non trivialkins machines (eg robots). +
+  Default = false.
 grid size::
-  Sets the size of the grid. which is only visible in the X, Y and Z view.
+  Sets the size of the grid (only visible in the X, Y and Z views). +
   Defaults to 0
 use default mouse controls::
-  This disables the default mouse controls. This is most useful when using a
-  touchscreen as the default controls do not work well. You can programically
-  add controls using python and the handler file technique. Defaults to 'True'
-view ::
-  may be any of `x`, `y`, 'y2' , `z`, 'z2' , `p` (perspective) . Defaults to
-  `z` view.
-enable_dro ::
-  boolean; whether to draw a DRO on the plot or not.
-  Defaults to `True`
-mouse_btn_mode ::
-  integer; mouse button handling, leads to different functions of the button
-  0 = default: left rotate, middle move,   right zoom
-  1 =          left zoom,   middle move,   right rotate
-  2 =          left move,   middle rotate, right zoom
-  3 =          left zoom,   middle rotate, right move
-  4 =          left move,   middle zoom,   right rotate
-  5 =          left rotate, middle zoom,   right move
-  6 =          left move,   middle zoom,   right zoom
+  This disables the default mouse controls. +
+  This is most useful when using a touchscreen as the default controls do not work well. You can programatically
+  add controls using python and the handler file technique. +
+  Default = true.
+view::
+  May be any of `x`, `y`, `y2` , `z`, `z2` , `p` (perspective). +
+  Defaults to `z` view.
+enable_dro::
+  Type = boolean. +
+  Whether to draw a DRO on the plot or not. +
+  Default = true.
+mouse_btn_mode::
+  Type = integer. +
+  Mouse button handling: leads to different functions of the button:
+  * 0 = default: left rotate, middle move,   right zoom
+  * 1 =          left zoom,   middle move,   right rotate
+  * 2 =          left move,   middle rotate, right zoom
+  * 3 =          left zoom,   middle rotate, right move
+  * 4 =          left move,   middle zoom,   right rotate
+  * 5 =          left rotate, middle zoom,   right move
+  * 6 =          left move,   middle zoom,   right zoom
 
-  mode 6 is recommended for plasmas and lathes, as rotation is not needed for such machines
+Mode 6 is recommended for plasmas and lathes, as rotation is not needed for such machines.
 
-Direct program control::
+==== Direct program control
 
 There a couple ways to directly control the widget using Python.
 
 Using goobject to set the above listed properties:
 
-  [widget name].set_property('view','P')
-  [widget name].set_property('metric_units',False)
-  [widget name].set_property('use_default_controls',False)
-  [widget name].set_property('enable_dro' False)
-  [widget name].set_property('show_program', False)
-  [widget name].set_property('show_limits', False)
-  [widget name].set_property('show_extents_option', False)
-  [widget name].set_property('show_live_plot', False)
-  [widget name].set_property('show_tool', False)
-  [widget name].set_property('show_lathe_radius',True)
-  [widget name].set_property('show_dtg',True)
-  [widget name].set_property('show_velocity',False)
-  [widget name].set_property('mouse_btn_mode', 4)
+----
+[widget name].set_property('view','P')
+[widget name].set_property('metric_units',False)
+[widget name].set_property('use_default_controls',False)
+[widget name].set_property('enable_dro' False)
+[widget name].set_property('show_program', False)
+[widget name].set_property('show_limits', False)
+[widget name].set_property('show_extents_option', False)
+[widget name].set_property('show_live_plot', False)
+[widget name].set_property('show_tool', False)
+[widget name].set_property('show_lathe_radius',True)
+[widget name].set_property('show_dtg',True)
+[widget name].set_property('show_velocity',False)
+[widget name].set_property('mouse_btn_mode', 4)
+----
 
 There are python methods:
 
-  [widget name].show_offsets = True
-  [widget name].grid_size = .75
-  [widget name].select_fire(event.x,event.y)
-  [widget name].select_prime(event.x,event.y)
-  [widget name].start_continuous_zoom(event.y)
-  [widget name].set_mouse_start(0,0)
-  [widget name].gremlin.zoom_in()
-  [widget name].gremlin.zoom_out()
-  [widget name].get_zoom_distance()
-  [widget name].set_zoom_distance(dist)
-  [widget name].clear_live_plotter()
-  [widget name].rotate_view(x,y)
-  [widget name].pan(x,y)
+----
+[widget name].show_offsets = True
+[widget name].grid_size = .75
+[widget name].select_fire(event.x,event.y)
+[widget name].select_prime(event.x,event.y)
+[widget name].start_continuous_zoom(event.y)
+[widget name].set_mouse_start(0,0)
+[widget name].gremlin.zoom_in()
+[widget name].gremlin.zoom_out()
+[widget name].get_zoom_distance()
+[widget name].set_zoom_distance(dist)
+[widget name].clear_live_plotter()
+[widget name].rotate_view(x,y)
+[widget name].pan(x,y)
+----
 
 Hints::
-- If you set all the plotting options false but show_offsets true you get an
-  offsets page instead of a graphics plot.
-
-- If you get the zoom distance before changing the view then reset the zoom
-  distance, it's much more user friendly.
-
-- if you select an element in the preview, the selected element will be used
-  as rotation center point
+  - If you set all the plotting options false but show_offsets true you get an
+    offsets page instead of a graphics plot.
+  - If you get the zoom distance before changing the view then reset the zoom
+    distance, it's much more user friendly.
+  - if you select an element in the preview, the selected element will be used
+    as rotation center point
 
 .Gremlin Example
-image::images/gremlin.png[]
+image::images/gremlin.png[align="center"]
 
 [[gladevcp:hal-offset]]
 === HAL_Offset
 
-The HAL_Offset widget is used to display the offset of a single axis.
-It has the following properties:
+The `HAL_Offset` widget is used to display the offset of a single axis.
+
+==== Properties
+
+`HAL_Offset` has the following properties:
 
 Joint Number::
-  Used to select which axis (technically which joint) is displayed.
+  Used to select which axis (technically which joint) is displayed. +
   On a trivialkins machine (mill, lathe, router) axis vrs joint number are:
-
++
   0:X  1:Y  2:Z  3:A  4:B  5:C  6:U  7:V  8:W
-
++
 Text template for metric units::
   You can use python formatting to display the position with different precision.
 Text template for imperial units::
   You can use python formatting to display the position with different precision.
 Reference Type::
++
   0:G5x 1:tool 2:G92 3:Rotation around Z
 
 [[gladevcp:dro_widget]]
 === DRO widget
 
 The DRO widget is used to display the current axis position.
+
+==== Properties
+
 It has the following properties:
 
 Actual Position::
@@ -1417,213 +1496,210 @@ Text template for metric units::
 Text template for imperial units::
   You can use python formatting to display the position with different precision.
 Reference Type::
-  Absolute <<sec:machine-coordinate-system,(machine origin)>>, Relative
-  (to current user coordinate origin - G5x)
-  or Distance-to-go (relative to current user coordinate origin)
+  * `absolute` <<sec:machine-coordinate-system,(machine origin)>>, or
+  * `relative` (to current user coordinate origin - G5x), or
+  * `distance-to-go` (relative to current user coordinate origin).
 Joint Number::
-  Used to select which axis (technically which joint) is displayed.
+  Used to select which axis (technically which joint) is displayed. +
   On a trivialkins machine (mill, lathe, router) axis vrs joint number are:
-
++
   0:X  1:Y  2:Z  3:A  4:B  5:C  6:U  7:V  8:W
-
++
 Display units::
   Used to toggle the display units between metric and imperial.
 
 Hints::
-- If you want the display to be right justified, set the X align to 1.0
+  - If you want the display to be right justified, set the X align to 1.0
+  - If you want different colors or size or text change the attributes in the
+    glade editor (eg scale is a good way to change the size of the text)
+  - The background of the widget is actually see through - so if you place if over
+    an image the DRO numbers will show on top of it with no background. There is a
+    special technique to do this. See the animated function diagrams below.
+  - The DRO widget is a modified gtk label widget. As such much or what can be
+    done to a gtk label can be done to DRO widget.
 
-- If you want different colors or size or text change the attributes in the
-  glade editor (eg scale is a good way to change the size of the text)
-
-- The background of the widget is actually see through - so if you place if over
-  an image the DRO numbers will show on top of it with no background. There is a
-  special technique to do this. See the animated function diagrams below.
-
-- The DRO widget is a modified gtk label widget. As such much or what can be
-  done to a gtk label can be done to DRO widget.
-
-Direct program control::
+==== Direct program control
 
 There a couple ways to directly control the widget using Python.
 
 Using goobject to set the above listed properties:
 
-  [widget name].set_property("display_units_mm",True)
-  [widget name].set_property("actual",True)
-  [widget name].set_property("mm_text_template","%f")
-  [widget name].set_property("imperial_text_template","%f")
-  [widget name].set_property("Joint_number",3)
-  [widget name].set_property("reference_type",3)
+----
+[widget name].set_property("display_units_mm",True)
+[widget name].set_property("actual",True)
+[widget name].set_property("mm_text_template","%f")
+[widget name].set_property("imperial_text_template","%f")
+[widget name].set_property("Joint_number",3)
+[widget name].set_property("reference_type",3)
+----
 
 There are two python methods:
 
-  [widget name].set_dro_inch()
-  [widget name].set_dro_metric()
+----
+[widget name].set_dro_inch()
+[widget name].set_dro_metric()
+----
 
 [[gladevcp:combi_dro]]
 === Combi_DRO widget
 
-The Combi_DRO widget is used to display the current , the relative axis position and the distance to go in one DRO.
-By clicking on the DRO the Order of the DRO will toggle around.
+The `Combi_DRO` widget is used to display the current, the relative axis position and the distance to go in one DRO. +
+By clicking on the DRO the Order of the DRO will toggle around. +
 In Relative Mode the actual coordinate system will be displayed.
 
-It has the following properties:
+==== Properties
+
+`Combi_DRO` has the following properties:
 
 joint_number::
-  Used to select which axis (technically which joint) is displayed.
+  Used to select which axis (technically which joint) is displayed. +
   On a trivialkins machine (mill, lathe, router) axis vrs. joint number are:
-
++
   0:X  1:Y  2:Z  etc
-
++
 actual::
-  select actual (feedback) or commanded position.
-
+  Select actual (feedback) or commanded position.
 metric_units::
   Used to toggle the display units between metric and imperial.
-
 auto_units::
   Units will toggle between metric and imperial according to the
-  active G-code being G20 or G21 +
-  default is TRUE
-
+  active G-code being G20 or G21. +
+  Default is TRUE.
 diameter::
-  Whether to display position as diameter or radius, in diameter mode
-  the DRO will display the joint value multiplied by 2
-
+  Whether to display position as diameter or radius. +
+  In diameter mode the DRO will display the joint value multiplied by 2.
 mm_text_template::
   You can use python formatting to display the position with different precision. +
-  default is "%10.3f"
-
+  Default is "%10.3f".
 imperial_text_template::
   You can use python formatting to display the position with different precision. +
-  default is "%9.4f"
-
+  Default is "%9.4f".
 homed_color::
-  The foreground color of the DRO numbers if the joint is homed +
-  default is green
-
+  The foreground color of the DRO numbers if the joint is homed. +
+  Default is green.
 unhomed_color::
-  The foreground color of the DRO numbers if the joint is not homed +
-  default is red
-
+  The foreground color of the DRO numbers if the joint is not homed. +
+  Default is red.
 abs_color::
-  the background color of the DRO, if main DRO shows absolute coordinates +
-  default is blue
-
+  The background color of the DRO, if main DRO shows absolute coordinates. +
+  Default is blue.
 rel_color::
-  the background color of the DRO, if main DRO shows relative coordinates +
-  default is black
-
+  The background color of the DRO, if main DRO shows relative coordinates. +
+  Default is black.
 dtg_color::
-  the background color of the DRO, if main DRO shows distance to go +
-  default is yellow
-
+  The background color of the DRO, if main DRO shows distance to go. +
+  Default is yellow.
 font_size::
-  The font size of the big numbers, the small ones will be 2.5 times smaller,
-  the value must be an integer in the range of 8 to 96, +
-  default is 25
-
+  The font size of the big numbers, the small ones will be 2.5 times smaller. +
+  The value must be an integer in the range of 8 to 96. +
+  Default is 25.
 toggle_readout::
-  A left mouse click will toggle the DRO readout through the different modes ["Rel", "Abs", "DTG"].
-  By unchecking the box you can disable that behavior. The toggling can still be done with [widget name].toggle_readout().
-  Value must be bool +
-  default is TRUE
-
+  A left mouse click will toggle the DRO readout through the different modes ["Rel", "Abs", "DTG"]. +
+  By unchecking the box you can disable that behavior. The toggling can still be done with `[widget name].toggle_readout()`. +
+  Value must be boolean. +
+  Default is TRUE.
 cycle_time::
-  The time the DRO waits between two polls,
-  the value must be an integer in the range of 100 to 1000,
-  default is 150, this setting should only be changed if you use more
-  than 5 DRO at the same time, i.e. on a 6 axis config, to avoid, that
-  the DRO slows down the main application too much.
+  The time the DRO waits between two polls. +
+  this setting should only be changed if you use more than 5 DRO at the
+  same time, i.e. on a 6 axis config, to avoid, that the DRO slows down
+  the main application too much. +
+  The value must be an integer in the range of 100 to 1000. FIXME unit=ms ? +
+  Default is 150.
 
-Direct program control::
+==== Direct program control
+
 Using gobject to set the above listed properties:
 
-  [widget name].set_property(property, value)
+----
+[widget name].set_property(property, value)
+----
 
 There are several python methods to control the widget:
 
-  [widget name].set_to_inch(state)
-    sets the DRO to show imperial units
-    state = boolean (True or False)
-
-  [widget name].set_auto_units(state)
-    if True the DRO will change units according to active G-code (G20 / G21)
-    state = boolean (True or False)
-    Default is True
-
-  [widget name].set_to_diameter(state)
-    if True the DRO will show the diameter not the radius, specially needed for lathes
-    the DRO will display the axis value multiplied by 2
-    state = boolean (True or False)
-    Default is False
-
-  [widget name].toggle_readout()
-    toggles the order of the DRO in the widget
-
-  [widget name].change_axisletter(letter)
-    changes the automatically given axis letter
-    very useful to change an lathe DRO from X to R or D
-    letter = string
-
-  [widget name].get_order()
-      returns the order of the DRO in the widget mainly used to maintain them consistent
-      the order will also be transmitted with the clicked signal
-      returns a list containing the order
-
-  [widget name].set_order(order)
-      sets the order of the DRO, mainly used to maintain them consistent
-      order = list object, must be one of
-        ["Rel", "Abs", "DTG"]
-        ["DTG", "Rel", "Abs"]
-        ["Abs", "DTG", "Rel"]
-      Default = ["Rel", "Abs", "DTG"]
-
-  [widget name].get_position()
-      returns the position of the DRO as a list of floats
-      the order is independent of the order shown on the DRO
-      and will be given as [Absolute , relative , DTG]
-      Absolute = the machine coordinates, depends on the actual property
-                will give actual or commanded position
-      Relative = will be the coordinates of the actual coordinate system
-      DTG = the distance to go, will mostly be 0, as this function should not be used
-          while the machine is moving, because of time delays
+* `[widget name].set_to_inch(state)` +
+  Sets the DRO to show imperial units. +
+  `state` = boolean (True or False) +
+  Default is FIXME
+* `[widget name].set_auto_units(state)` +
+  If True the DRO will change units according to active G-code (G20 / G21). +
+  `state` = boolean (True or False) +
+  Default is True
+* `[widget name].set_to_diameter(state)` +
+  If True the DRO will show the diameter not the radius, i.e. the axis
+  value multiplied by 2 (specially needed for lathes). +
+  `state` = boolean (True or False) +
+  Default is False
+* `[widget name].toggle_readout()` +
+  Toggles the order of the DRO in the widget.
+* `[widget name].change_axisletter(letter)` +
+  Changes the automatically given axis letter. +
+  Very useful to change an lathe DRO from 'X' to 'R' or 'D'. +
+  `letter` = string
+* `[widget name].get_order()` +
+  Returns the order of the DRO in the widget mainly used to maintain
+  them consistent. +
+  The order will also be transmitted with the clicked signal. +
+  Returns a list containing the order.
+* `[widget name].set_order(order)` +
+  Sets the order of the DRO, mainly used to maintain them consistent. +
+  `order` = list object, must be one of:
+  ** `["Rel", "Abs", "DTG"]` (default)
+  ** `["DTG", "Rel", "Abs"]`
+  ** `["Abs", "DTG", "Rel"]`
+* `[widget name].get_position()` +
+  Returns the position of the DRO as a list of floats. +
+  The order is independent of the order shown on the DRO and will be
+  given as `[Absolute , relative , DTG]`. +
+  ** `Absolute` = the machine coordinates, depends on the actual property
+     will give actual or commanded position. +
+  ** `Relative` = will be the coordinates of the actual coordinate system. +
+  ** `DTG` = the distance to go. +
+     Will mostly be 0, as this function should not be used while the
+     machine is moving, because of time delays.
 
 The widget will emit the following signals:
 
-  clicked
-    This signal is emitted, when the user has clicked on the Combi_DRO widget,
-    it will send the following data:
-    widget = widget object = The widget object that sends the signal
-    joint_number = integer = The joint number of the DRO, where '0:X  1:Y  2:Z  etc'
-    order = list object = the order of the DRO in that widget
-                          the order may be used to set other Combi_DRO widgets to the same order with [widget name].set_order(order)
-
-  units_changed
-    This signal is emitted, if the DRO units are changed, it will send the following data:
-    widget = widget object = The widget object that sends the signal
-    metric_units = boolean = True if the DRO does display metric units, False in case of imperial display
-
-  system_changed
-    This signal is emitted, if the DRO units are changed, it will send the following data:
-    widget = widget object = The widget object that sends the signal
-    system = string = The actual coordinate system. Will be one of
-                      G54 G55 G56 G57 G58 G59 G59.1 G59.2 G59.3
-                      or Rel if non has been selected at all, what will only happen in Glade with no linuxcnc running
+* `clicked` +
+  This signal is emitted, when the user has clicked on the Combi_DRO widget. +
+  It will send the following data:
+  ** `widget` = widget object +
+     The widget object that sends the signal.
+  ** `joint_number` = integer +
+     The joint number of the DRO, where '0:X  1:Y  2:Z  etc'.
+  ** `order` = list object +
+     The order of the DRO in that widget. +
+     The order may be used to set other Combi_DRO widgets to the same
+     order with `[widget name].set_order(order)`.
+* `units_changed` +
+  This signal is emitted if the DRO units are changed. +
+  It will send the following data:
+  ** `widget` = widget object +
+     The widget object that sends the signal.
+  ** `metric_units` = boolean +
+     True if the DRO does display metric units, False in case of imperial
+     display.
+* `system_changed` +
+  This signal is emitted if the DRO units are changed. +
+  It will send the following data:
+  ** `widget` = widget object +
+     The widget object that sends the signal.
+  ** `system` = string +
+     The actual coordinate system.
+     Will be one of G54 G55 G56 G57 G58 G59 G59.1 G59.2 G59.3 or Rel if
+     non has been selected at all, what will only happen in Glade with
+     no linuxcnc running.
 
 There are some information you can get through commands, which may be of interest for you:
 
-  [widget name].system
-    The actual system, as mentioned in the system_changed signal
+* `[widget name].system` +
+  The actual system, as mentioned in the system_changed signal.
+* `[widget name].homed` +
+  True if the joint is homed.
+* `[widget name].machine_units` +
+  0 if Imperial, 1 if Metric.
 
-  [widget name].homed
-    True if the joint is homed
-
-  [widget name].machine_units
-    0 if Imperial, 1 if Metric
-
-.Example, Three Combi_DRO in a window
-image::images/combi_dro.png[]
+.Example: Three Combi_DRO in a window
+image::images/combi_dro.png[align="center"]
 
 X = Relative Mode +
 Y = Absolute Mode +
@@ -1632,385 +1708,412 @@ Z = DTG Mode +
 [[gladevcp:iconview]]
 === IconView (File Select)
 
-This is touch screen friendly widget to select a file and to change directories.
+This is a touch screen friendly widget to select a file and to change directories.
 
-The widget has the following properties:
+==== Properties
+
+`IconView` widget has the following properties:
 
 icon_size::
   Sets the size of the displayed icon. +
-  Allowed values are integers in the range from 12 to 96 +
-  default is 48
-
+  Allowed values are integers in the range from 12 to 96. +
+  Default is 48.
 start_dir::
-  Sets the directory to start in when the widget is shown first time, +
-  must be a string, containing a valid directory path, +
-  default is "/"
-
+  Sets the directory to start in when the widget is shown first time. +
+  Must be a string, containing a valid directory path. +
+  Default is "/".
 jump_to_dir::
-  Sets the directory "jump to" directory, which is selected by the corresponding
-  button in the bottom button list, the 5th button counting from the left, +
-  must be a string, containing a valid directory path, +
-  default is "~"
-
+  Sets the "jump to" directory, which is selected by the corresponding
+  button in the bottom button list (the 5th button counting from the left). +
+  Must be a string, containing a valid directory path. +
+  Default is "~".
 filetypes::
-  Sets the file filter for the objects to be shown +
-  Must be a string containing a comma separated list of extensions to be shown +
-  Default is "ngc,py"
-
+  Sets the file filter for the objects to be shown. +
+  Must be a string containing a comma separated list of extensions to be shown. +
+  Default is "ngc,py".
 sortorder::
-  Sets the sorting order of the displayed icon
-  must be an integer value from 0 to 3, where +
-  0 = ASCENDING (sorted according to file names) +
-  1 = DESCENDING (sorted according to file names) +
-  2 = FOLDERFIRST (show the folders first, then the files) +
-  3 = FILEFIRST (show the files first, then the folders), +
-  Default = 2 = FOLDERFIRST
+  Sets the sorting order of the displayed icon. +
+  Must be an integer value from 0 to 3, where: +
+  * 0 = ASCENDING (sorted according to file names)
+  * 1 = DESCENDING (sorted according to file names)
+  * 2 = FOLDERFIRST (show the folders first, then the files), default
+  * 3 = FILEFIRST (show the files first, then the folders)
 
-Direct program control::
+==== Direct program control
 
 Using goobject to set the above listed properties:
 
-  [widget name].set_property(property,Value)
+----
+[widget name].set_property(property,Value)
+----
 
 There are python methods to control the widget:
 
-  [widget name].show_buttonbox(state)
-    if False the bottom button box will be hidden, this is helpful in custom screens,
-    with special buttons layouts to not alter the layout of the GUI, good example
-    for that is gmoccapy
-    state = boolean (True or False)
-    Default is True
-
-  [widget name].show_filelabel(state)
-    if True the file label (between the IconView window and the bottom button box will be shown.
-    Hiding this label may save place, but showing it is very useful for debugging reasons,
-    state = boolean (True or False)
-    Default is True
-
-  [widget name].set_icon_size(iconsize)
-    sets the icon size
-    must be an integer in the range from 12 to 96
-    Default = 48
-
-  [widget name].set_directory(directory)
-    Allows to set an directory to be shown
-    directory = string (a valid file path)
-
-  [widget name].set_filetypes(filetypes)
-    sets the file filter to be used, only files with the given extensions will be shown
-    filetypes = string containing a comma separated list of extensions
-    Default = "ngc,py"
-
-  [widget name].get_selected()
-    Returns the path of the selected file, or None if an directory has been selected
-
-  [widget name].refresh_filelist()
-    Refreshes the filelist, needed if you add a file without changing the directory
+* `[widget name].show_buttonbox(state)` +
+  If False the bottom button box will be hidden. +
+  This is helpful in custom screens, with special buttons layouts to
+  not alter the layout of the GUI. Good example for that is gmoccapy. +
+  `state` = boolean (True or False). +
+  Default is True.
+* `[widget name].show_filelabel(state)` +
+  If True the file label (between the IconView window and the bottom button box) will be shown. +
+  Hiding this label may save place, but showing it is very useful for debugging reasons. +
+  `state` = boolean (True or False). +
+  Default is True.
+* `[widget name].set_icon_size(iconsize)` +
+  Sets the icon size. +
+  Must be an integer in the range from 12 to 96. +
+  Default = 48.
+* `[widget name].set_directory(directory)` +
+  Allows to set an directory to be shown. +
+  `directory` = string (a valid file path).
+* `[widget name].set_filetypes(filetypes)` +
+  Sets the file filter to be used. +
+  Only files with the given extensions will be shown. +
+  `filetypes` = string containing a comma separated list of extensions. +
+  Default = "ngc,py".
+* `[widget name].get_selected()` +
+  Returns the path of the selected file, or `None` if a directory has been selected.
+* `[widget name].refresh_filelist()` +
+  Refreshes the filelist. +
+  Needed if you add a file without changing the directory.
 
 If the button box has been hidden, you can reach the functions of this button
 through it's clicked signals like so:
 
-  [widget name].btn_home.emit("clicked")
-  [widget name].btn_jump_to.emit("clicked")
-  [widget name].btn_sel_prev.emit("clicked")
-  [widget name].btn_sel_next.emit("clicked")
-  [widget name].btn_get_selected.emit("clicked")
-  [widget name].btn_dir_up.emit("clicked")
-  [widget name].btn_exit.emit("clicked")
+----
+[widget name].btn_home.emit("clicked")
+[widget name].btn_jump_to.emit("clicked")
+[widget name].btn_sel_prev.emit("clicked")
+[widget name].btn_sel_next.emit("clicked")
+[widget name].btn_get_selected.emit("clicked")
+[widget name].btn_dir_up.emit("clicked")
+[widget name].btn_exit.emit("clicked")
+----
+
+==== Signals
 
 The widget will emit the following signals:
 
-  selected
-    This signal is emitted, when the user selects an icon, it will return a string containing a
-    file path if a file has been selected, or None if an directory has been selected
-  sensitive
-    This signal is emitted, when the buttons change there state from sensitive to not sensitive or vice versa.
-    This signal is useful to maintain surrounding GUI synchronized with the button of the widget. See gmoccapy as example.
-    It will return the buttonname and the new state. Buttonname is one of "btn_home", "btn_dir_up", "btn_sel_prev",
-    "btn_sel_next", "btn_jump_to" or "btn_select". State is a boolean and will be True or False.
-  exit
-    This signal is emitted, when the exit button has been pressed to close the IconView
-    mostly needed if the application is started as stand alone.
+* `selected` +
+  This signal is emitted when the user selects an icon. +
+  It will return a string containing a file path if a file has been
+  selected, or `None` if a directory has been selected.
+* `sensitive` +
+  This signal is emitted when the buttons change their state from
+  sensitive to not sensitive or vice versa. +
+  This signal is useful to maintain surrounding GUI synchronized with
+  the button of the widget. See gmoccapy as example. +
+  It will return the **buttonname** and the new **state**: +
+  ** `buttonname` is one of `btn_home`, `btn_dir_up`, `btn_sel_prev`,
+  `btn_sel_next`, `btn_jump_to` or `btn_select`.
+  ** `state` is a boolean and will be True or False.
+* `exit` +
+  This signal is emitted when the exit button has been pressed to close the IconView. +
+  Mostly needed if the application is started as stand alone.
 
 .Iconview Example
 image::images/iconview.png[]
 
+[[gladevcp:calculator]]
 === Calculator widget
 
 This is a simple calculator widget, that can be used for numerical input. +
 You can preset the display and retrieve the result or that preset value. +
-It has the following properties:
+
+==== Properties
+
+`calculator` has the following properties:
 
 Is editable::
-    This allows the entry display to be typed into from a keyboard.
+  This allows the entry display to be typed into from a keyboard.
 Set Font::
-    This allows you to set the font of the display.
+  This allows you to set the font of the display.
 
-Direct program control::
+==== Direct program control
 
 There a couple ways to directly control the widget using Python.
 
 Using goobject to set the above listed properties:
 
-  [widget name].set_property("is_editable",True)
-  [widget name].set_property("font","sans 25")
+----
+[widget name].set_property("is_editable",True)
+[widget name].set_property("font","sans 25")
+----
 
 There are python methods:
 
-  [widget name].set_value(2.5)
-    This presets the display and is recorded.
-  [widget name].set_font("sans 25")
-  [widget name].set_editable(True)
-  [widget name].get_value()
-    Returns the calculated value - a float.
-  [widget name].set_editable(True)
-  [widget name].get_preset_value()
-    Returns the recorded value: a float.
+* `[widget name].set_value(2.5)` +
+  This presets the display and is recorded.
+* `[widget name].set_font("sans 25")`
+* `[widget name].set_editable(True)`
+* `[widget name].get_value()` +
+  Returns the calculated value - a float.
+* `[widget name].set_editable(True)` +
+* `[widget name].get_preset_value()` +
+  Returns the recorded value: a float.
 
 [[gladevcp:tooledit]]
 === Tooleditor widget
 
-This is a tooleditor widget for displaying and modifying a tool editor file. +
+This is a `tooleditor` widget for displaying and modifying a tool file. +
 If in lathe mode, it will display wear offsets and tool offsets separately. +
-Wear offsets are designated by tool number above 10000 (Fanuc style) +
-Note linuxcnc requires remapping of tool calls to actually use wear offsets +
-It checks the current file once a second to see if linuxcnc updated it. +
-It has the following properties:
+Wear offsets are designated by tool number above 10000 (Fanuc style). +
+It checks the current file once a second to see if LinuxCNC updated it. +
+
+NOTE: LinuxCNC requires remapping of tool calls to actually use wear offsets. +
+
+==== Properties
+
+`tooleditor` has the following properties:
 
 Hidden Columns::
-  This will hide the given columns: The columns are designated (in order) as such:
-  s,t,p,x,y,z,a,b,c,u,v,w,d,i,j,q,; +
-  You can hide any number of columns including the select and comments
+  This will hide the given columns. +
+  The columns are designated (in order) as such: `s,t,p,x,y,z,a,b,c,u,v,w,d,i,j,q`. +
+  You can hide any number of columns including the select and comments.
 
-Direct program control::
+==== Direct program control
 
 There a couple ways to directly control the widget using Python.
 
-using goobject to set the above listed properties:
+Using goobject to set the above listed properties:
 
-  [widget name].set_properties('hide_columns','uvwijq')
-    This would hide the uvwij and q columns and show all others.
+----
+[widget name].set_properties('hide_columns','uvwijq')
+----
+
+This would hide the uvwij and q columns and show all others.
 
 There are python methods:
 
-  [widget name].set_visible("ijq",False)
-    Would hide ij and Q columns and leave the rest as they were.
-  [widget name].set_filename(path_to_file)
-    Sets and loads the tool file.
-  [widget name].reload(None)
-    Reloads the current toolfile
-  [widget name].set_font('sans 16,tab='1')
-    Sets the (Pango) font on the Tab, column title, and tool data.
-    The all_offsets, wear_offsets, tool_offsets can be set at the same time by
-    adding 1,2 and/or 3 to the tab string. Default is all the tabs
-    set.
-  [widget name].set_title_font('sans 16,tab='1')
-    Sets the (Pango) font on the column titles only.
-    The all_offsets, wear_offsets, tool_offsets can be set at the same time by
-    adding 1,2 and/or 3 to the tab string. Default is all the tabs
-    set.
-  [widget name].set_tab_font('sans 16,tab='1')
-    Sets the (Pango) font on the tabs only.
-    The all_offsets, wear_offsets, tool_offsets can be set at the same time by
-    adding 1,2 and/or 3 to the tab string. Default is all the tabs
-    set.
-  [widget name].set_col_visible("abcUVW", False, tab='1')
-    This would hide (False) the abcuvw columns on tab 1 (all_offsets)
-  [widget name].set_lathe_display(value)
-    hides or shows the wear and tool offset tabs used for lathes
-  [widget name].get_toolinfo(toolnum)
-    Returns the tool information array of the requested toolnumber
-    or current tool if no tool number is specified
-    returns None if tool not found in table or if there is no current tool
-  [widget name].hide_buttonbox(self, True)
-    'convenience' method to hide buttons
-    you must call this after show_all()
-  [widget name].get_selected_tool()
-    return the user selected (highlighted) tool number
-  [widget name].set_selected_tool(toolnumber)
-    Selects (highlights) the requested tool
+* `[widget name].set_visible("ijq",False)` +
+  Would hide ij and Q columns and leave the rest as they were.
+* `[widget name].set_filename(path_to_file)` +
+  Sets and loads the tool file.
+* `[widget name].reload(None)` +
+  Reloads the current toolfile.
+* `[widget name].set_font('sans 16,tab='1')` +
+  Sets the (Pango) font on the Tab, column title, and tool data. +
+  The `all_offsets`, `wear_offsets`, `tool_offsets` can be set at the same time by
+  adding 1, 2 and/or 3 to the tab string. +
+  Default is all the tabs set.
+* `[widget name].set_title_font('sans 16,tab='1')` +
+  Sets the (Pango) font on the column titles only. +
+  The `all_offsets`, `wear_offsets`, `tool_offsets` can be set at the same time by
+  adding 1, 2 and/or 3 to the tab string. +
+  Default is all the tabs set.
+* `[widget name].set_tab_font('sans 16,tab='1')` +
+  Sets the (Pango) font on the tabs only. +
+  The `all_offsets`, `wear_offsets`, `tool_offsets` can be set at the same time by
+  adding 1, 2 and/or 3 to the tab string. +
+  Default is all the tabs set.
+* `[widget name].set_col_visible("abcUVW", False, tab='1')` +
+  This would hide (False) the abcuvw columns on tab 1 (all_offsets)
+* `[widget name].set_lathe_display(value)` +
+  Hides or shows the wear and tool offset tabs used for lathes
+* `[widget name].get_toolinfo(toolnum)` +
+  Returns the tool information array of the requested toolnumber or
+  current tool if no tool number is specified. +
+  Returns None if tool not found in table or if there is no current tool.
+* `[widget name].hide_buttonbox(self, True)` +
+  'Convenience' method to hide buttons. +
+  You must call this after show_all().
+* `[widget name].get_selected_tool()` +
+  Return the user selected (highlighted) tool number.
+* `[widget name].set_selected_tool(toolnumber)` +
+  Selects (highlights) the requested tool.
 
 .Tooleditor Example
-image::images/gtk-tooledit.png[]
+image::images/gtk-tooledit.png[align="center"]
 
 [[gladevcp:offsetpage]]
 === Offsetpage
 
-The Offsetpage widget is used to display/edit the offsets of all the axes. +
+The `Offsetpage` widget is used to display/edit the offsets of all the axes. +
 It has convenience buttons for zeroing G92 and Rotation-Around-Z offsets. +
 It will only allow you to select the edit mode when the machine is on and idle. +
-You can directly edit the offsets in the table at this time. Unselect the edit +
-button to allow the OffsetPage to reflect changes.
+You can directly edit the offsets in the table at this time. Unselect the edit
+button to allow the `OffsetPage` to reflect changes.
+
+==== Properties
 
 It has the following properties:
 
 Hidden Columns::
-  A no-space list of columns to hide: The columns are designated (in order) as such: +
-  xyzabcuvwt +
+  A no-space list of columns to hide.
+  The columns are designated (in order) as such: `xyzabcuvwt`. +
   You can hide any of the columns.
 Hidden Rows::
-  A no-space list of rows to hide: the rows are designated (in order) as such +
-  0123456789abc +
+  A no-space list of rows to hide. +
+  The rows are designated (in order) as such: `0123456789abc`. +
   You can hide any of the rows.
 Pango Font::
-  Sets text font type and size
+  Sets text font type and size.
 HighLight color::
-  when editing this is the high light color
+  When editing this is the highlight color.
 Active color::
-  when OffsetPage detects an active user coordinate system it will use this +
-  color for the text
+  When `OffsetPage` detects an active user coordinate system it will use
+  this color for the text.
 Text template for metric units::
   You can use python formatting to display the position with different precision.
 Text template for imperial units::
   You can use python formatting to display the position with different precision.
 
-Direct program control::
+==== Direct program control
 
 There a couple ways to directly control the widget using Python.
 
 Using goobject to set the above listed properties:
 
-  [widget name].set_property("highlight_color",gdk.Color('blue'))
-  [widget name].set_property("foreground_color",gdk.Color('black'))
-  [widget name].set_property("hide_columns","xyzabcuvwt")
-  [widget name].set_property("hide_rows","123456789abc")
-  [widget name].set_property("font","sans 25")
+----
+[widget name].set_property("highlight_color",gdk.Color('blue'))
+[widget name].set_property("foreground_color",gdk.Color('black'))
+[widget name].set_property("hide_columns","xyzabcuvwt")
+[widget name].set_property("hide_rows","123456789abc")
+[widget name].set_property("font","sans 25")
+----
 
 There are python methods to control the widget:
 
-  [widget name].set_filename("../../../configs/sim/gscreen/gscreen_custom/sim.var")
-  [widget name].set_col_visible("Yabuvw",False)
-  [widget name].set_row_visible("456789abc",False)
-  [widget name].set_to_mm()
-  [widget name].set_to_inch()
-  [widget name].hide_button_box(True)
-  [widget name].set_font("sans 20")
-  [widget name].set_highlight_color("violet")
-  [widget name].set_foreground_color("yellow")
-  [widget name].mark_active("G55")
-    Allows you to directly set a row to highlight.
-    (eg in case you wish to use your own navigation controls.
-    See <<cha:gmoccapy,Gmoccapy Chapter>>
-  [widget name].selection_mask = ("Tool","Rot","G5x")
-    These rows are NOT selectable in edit mode.
-  [widget name].set_names([['G54','Default'],["G55","Vice1"],['Rot','Rotational']])
-    This allows you to set the text of the 'T' column of each/any row.
-    This is a list of a list of offset-name/user-name pairs.
-    The default text is the same as the offset name.
-  [widget name].get_names()
-    This returns a list of a list of row-keyword/user-name pairs.
-    The user name column is editable, so saving this list is user friendly.
-    see set_names above.
+* `[widget name].set_filename("../../../configs/sim/gscreen/gscreen_custom/sim.var")`
+* `[widget name].set_col_visible("Yabuvw",False)`
+* `[widget name].set_row_visible("456789abc",False)`
+* `[widget name].set_to_mm()`
+* `[widget name].set_to_inch()`
+* `[widget name].hide_button_box(True)`
+* `[widget name].set_font("sans 20")`
+* `[widget name].set_highlight_color("violet")`
+* `[widget name].set_foreground_color("yellow")`
+* `[widget name].mark_active("G55")` +
+  Allows you to directly set a row to highlight. +
+  Eg in case you wish to use your own navigation controls. +
+  See <<cha:gmoccapy,Gmoccapy Chapter>>.
+* `[widget name].selection_mask = ("Tool","Rot","G5x")` +
+  These rows are NOT selectable in edit mode.
+* `[widget name].set_names([['G54','Default'],["G55","Vice1"],['Rot','Rotational']])` +
+  This allows you to set the text of the 'T' column of each/any row. +
+  This is a list of a list of offset-name/user-name pairs. +
+  The default text is the same as the offset name.
+* `[widget name].get_names()` +
+  This returns a list of a list of row-keyword/user-name pairs. +
+  The user name column is editable, so saving this list is user friendly. +
+  See `set_names` above.
 
 .Offsetpage Example
-image::images/offsetpage.png[]
+image::images/offsetpage.png[align="center"]
 
 [[gladevcp:hal-sourceview]]
 === HAL_sourceview widget
 
-This is for displaying and simple editing of Gcode.
-
-It looks for .ngc highlight specs in ~/share/gtksourceview-2.0/language-specs/
-
+This is for displaying and simple editing of G-code. +
+It looks for `.ngc` highlighting specs in `~/share/gtksourceview-2.0/language-specs/`. +
 The current running line will be highlighted.
 
-With external python glue code:
+With external python glue code it can:
 
-* It can search for text, undo and redo changes.
-* It can be used for program line selection.
+* Search for text, undo and redo changes.
+* Be used for program line selection.
 
-Direct program control::
+==== Direct program control
 
 There are python methods to control the widget:
 
-  [widget name].redo()
-    redo one level of changes.
-  [widget name].undo()
-    undo one level of changes
-  [widget name].text_search(direction=True,mixed_case=True,text='G92')
-    Searches forward (direction = True) or back, +
-    Searches with mixed case (mixed_case = True) or exact match
-  [widget name].set_line_number(linenumber)
-    Sets the line to high light. Uses the sourceview line numbers.
-  [widget name].get_line_number()
-    returns the currently high lighted line.
-  [widget name].line_up()
-    Moves the High lighted line up one line
-  [widget name].line_down()
-    Moves the High lighted line down one line
-  [widget name].load_file('filename')
-    loads a file. Using None (not a filename string) will reload the same program.
-  [widget name].get_filename()
-    FIXME [widget name].get_filename() description
+* `[widget name].redo()` +
+  Redo one level of changes.
+* `[widget name].undo()` +
+  Undo one level of changes
+* `[widget name].text_search(direction=True,mixed_case=True,text='G92')` +
+  Searches forward (direction = True) or backward, +
+  Searches with mixed case (mixed_case = True) or exact match
+* `[widget name].set_line_number(linenumber)` +
+  Sets the line to highlight. +
+  Uses the sourceview line numbers.
+* `[widget name].get_line_number()` +
+  Returns the currently highlighted line.
+* `[widget name].line_up()` +
+  Moves the highlighted line up one line.
+* `[widget name].line_down()` +
+  Moves the highlighted line down one line.
+* `[widget name].load_file('filename')` +
+  Loads a file. +
+  Using None (not a filename string) will reload the same program.
+* `[widget name].get_filename()` +
+  FIXME description
 
 .Sourceview Example
-image::images/hal_sourceview.png[]
+image::images/hal_sourceview.png[align="center"]
 
 [[gladevcp:mdi-history]]
 === MDI history
 
 This is for displaying and entering MDI codes. +
-It will automatically gray out when MDI is not available. +
-Eg during Estop and program running.
+It will be automatically grayed out when MDI is not available, eg during
+E-stop and program running.
+
+==== Properties
 
 font_size_tree::
-  a integer value between 8 and 96+
-  will modify the default font size of the treeview +
-  to the selected value +
+  Integer value between 8 and 96. +
+  Will modify the default font size of the treeview to the selected
+  value.
 font_size_entry::
-  a integer value between 8 and 96+
-  will modify the default font size of the entry +
-  to the selected value +
+  Integer value between 8 and 96. +
+  Will modify the default font size of the entry to the selected value. +
 use_double_click::
-  True or False, setting this to True will enable the mouse double click +
-  feature and a double click on an entry will submit that command +
-  It is not recommended to use this feature on real machines, as a double +
-  click on a wrong entry may cause dangerous situations
+  Boolean, True enables the mouse double click feature and a double
+  click on an entry will submit that command. +
+  It is not recommended to use this feature on real machines, as a
+  double click on a wrong entry may cause dangerous situations
 
-Using goobject to set the above listed properties::
-  Using goobject to set the listed properties:
+==== Direct program control
 
-  [widget name].set_property("font_size_tree", 10)
-  [widget name].set_property("font_size_entry", 20)
-  [widget name].set_property("use_double_click", False)
+Using goobject to set the above listed properties:
+
+----
+  [widget name].set_property("font_size_tree",10)
+  [widget name].set_property("font_size_entry",20)
+  [widget name].set_property("use_double_click",False)
+----
 
 === Animated function diagrams: HAL widgets in a bitmap
 
-For some applications it might be desirable to have background image -
+For some applications it might be desirable to have a background image -
 like a functional diagram - and position widgets at appropriate places
-in that diagram. A good combination is setting a bitmap background
-image, like from a .png file, making the gladevcp window fixed-size,
+in that image. +
+A good combination is setting a bitmap background
+image, like from a .png file, making the GladeVCP window fixed-size,
 and use the glade Fixed widget to position widgets on this image.
 
-The code for the below example can be found in +configs/apps/gladevcp/animated-backdrop+:
+The code for the below example can be found in `configs/apps/gladevcp/animated-backdrop`:
 
 .HAL widgets in a bitmap Example
-image:images/small-screenshot.png[]
+image::images/small-screenshot.png[align="center"]
 
-== Action Widgets reference
+== Action Widgets Reference
 
-GladeVcp includes a collection of "canned actions" called VCP Action
-Widgets for the Glade user interface editor. Other than HAL widgets,
-which interact with HAL pins, VCP Actions interact with LinuxCNC and the
-G-code interpreter.
+GladeVcp includes a collection of "canned actions" called **VCP Action Widgets**
+for the Glade user interface editor. +
+Other than HAL widgets, which interact with HAL pins, VCP Actions interact
+with LinuxCNC and the G-code interpreter.
 
-VCP Action Widgets are derived from the Gtk.Action widget. The Action
-widget in a nutshell:
+VCP Action Widgets are derived from the `Gtk.Action` widget.
 
-- it is an object available in Glade
-- it has no visual appearance by itself
+The Action widget in a nutshell:
+
+- is an object available in Glade
+- has no visual appearance by itself
 - it's purpose: associate a visible, sensitive UI component like menu,
-  toolbutton, button with a command. See these widget's 'General→Related
-  Action' property.
+  toolbutton, button with a command. +
+  See these widget's 'General→Related→Action' property.
 - the "canned action" will be executed when the associated UI component
   is triggered (button press, menu click..)
-- it provides an easy way to execute commands without resorting to
+- provides an easy way to execute commands without resorting to
   Python programming.
 
 The appearance of VCP Actions in Glade is roughly as follows:
 
 .Action Widgets
-image::images/vcp-actions.png[]
+image::images/vcp-actions.png[align="center"]
 
 Tooltip hovers provide a description.
 
@@ -2021,17 +2124,17 @@ are for use in simple buttons, menu entries or radio/check groups.
 
 === VCP Action python
 
-This widget is used to execute small arbitrary python code.
+This widget is used to execute small arbitrary python code. +
 The command string may use special keywords to access important functions.
 
-* 'GSTAT' for access to the Gstat library that is used for linuxcnc status
-* 'STAT' for access to linuxcnc's status via the linuxcnc python module
-* 'CMD' for access to linuxcnc's commands via the linuxcnc python module
-* 'EXT' for access to the handler file functions if available
-* 'linuxcnc' for access to the linuxcnc python module
-* 'self' for access to the widget instance
+* `GSTAT` for access to the Gstat library that is used for linuxcnc status
+* `STAT` for access to linuxcnc's status via the linuxcnc python module
+* `CMD` for access to linuxcnc's commands via the linuxcnc python module
+* `EXT` for access to the handler file functions if available
+* `linuxcnc` for access to the linuxcnc python module
+* `self` for access to the widget instance
 
-There are options to select when the widget will be active.
+There are options to select when the widget will be active. +
 There are options to set the mode before the command is executed.
 
 Example command to just print a message to the terminal:
@@ -2064,86 +2167,90 @@ print('Set Machine Off');CMD.state(linuxcnc.STATE_OFF)
 
 === VCP ToggleAction widgets
 
-These are bi-modal widgets. They implement two actions or use a second
-(usually pressed) state to indicate that currently an action is
-running. Toggle actions are aimed for use in ToggleButtons,
-ToggleToolButtons or toggling menu items. A simplex example is the
-ESTOP toggle button.
+These are **bi-modal** widgets. They implement two actions or use a second
+(usually `pressed`) state to indicate that currently an action is
+running. +
+Toggle actions are aimed for use in `ToggleButtons`, `ToggleToolButtons`
+or toggling menu items. +
+A simplex example is the `ESTOP` toggle button.
 
 Currently the following widgets are available:
 
-- The ESTOP toggle sends ESTOP or ESTOP_RESET commands to LinuxCNC depending
+- The `ESTOP` toggle sends `ESTOP` or `ESTOP_RESET` commands to LinuxCNC depending
   on it's state.
-- The ON/OFF toggle sends STATE_ON and STATE_OFF commands.
-- Pause/Resume sends AUTO_PAUSE or AUTO_RESUME commands.
+- The `ON/OFF` toggle sends `STATE_ON` and `STATE_OFF` commands.
+- `Pause/Resume` sends `AUTO_PAUSE` or `AUTO_RESUME` commands.
 
 The following toggle actions have only one associated command and use
-the 'pressed' state to indicate that the requested operation is
+the `pressed` state to indicate that the requested operation is
 running:
 
-- The Run toggle sends an AUTO_RUN command and waits in the pressed
+- The `Run` toggle sends an `AUTO_RUN` command and waits in the `pressed`
   state until the interpreter is idle again.
-- The Stop toggle is inactive until the interpreter enters the active
-  state (is running G-code) and then allows user to send AUTO_ABORT
+- The `Stop` toggle is inactive until the interpreter enters the active
+  state (is running G-code) and then allows user to send `AUTO_ABORT`
   command.
-- The MDI toggle sends given MDI command and waits for its completion in
-  'pressed' inactive state.
+- The `MDI` toggle sends given MDI command and waits for its completion in
+  `pressed` inactive state.
 
 === The Action_MDI Toggle and Action_MDI widgets
 
-These widgets provide a means to execute arbitrary MDI commands. The
-Action_MDI widget does not wait for command completion as the
-Action_MDI Toggle does, which remains disabled until command complete.
+These widgets provide a means to execute arbitrary MDI commands. +
+The `Action_MDI` widget does not wait for command completion as the
+`Action_MDI` Toggle does, which remains disabled until command complete.
 
 === A simple example: Execute MDI command on button press
 
-+configs/apps/gladevcp/mdi-command-example/whoareyou.ui+ is a Glade UI file which conveys the basics:
+`configs/apps/gladevcp/mdi-command-example/whoareyou.ui` is a Glade UI file which conveys the basics:
 
-Open it in Glade and study how it's done. Start Axis, and then start
-this from a terminal window with `gladevcp whoareyou.ui`. See the
-+hal_action_mdi1+ Action and it's +MDI command+ property - this just
-executes +(MSG, "Hi, I'm an VCP_Action_MDI")+ so there should be a
+Open it in Glade and study how it's done. +
+Start Axis, and then start this from a terminal window with `gladevcp whoareyou.ui`. +
+See the `hal_action_mdi1` action and it's `MDI command` property - this just
+executes `(MSG, "Hi, I'm an VCP_Action_MDI")` so there should be a
 message popup in Axis like so:
 
 .Action_MDI Simple Example
-image::images/whoareyou.png[]
+image::images/whoareyou.png[align="center"]
 
 You'll notice that the button associated with the Action_MDI action is
-grayed out if the machine is off, in E-Stop or the interpreter is running.
+grayed out if the machine is off, in E-Stop or if the interpreter is running. +
 It will automatically become active when the machine is turned on and
 out of E-Stop, and the program is idle.
 
 === Parameter passing with Action_MDI and ToggleAction_MDI widgets
 
-Optionally, 'MDI command' strings may have parameters substituted
-before they are passed to the interpreter. Parameters currently may be
-names of HAL pins in the GladeVCP component. This is how it works:
+Optionally, `MDI command` strings may have parameters substituted
+before they are passed to the interpreter. +
+Parameters currently may be names of HAL pins in the GladeVCP component. +
+This is how it works:
 
 - assume you have a 'HAL SpinBox' named +speed+, and you want to pass it's
-current value as a parameter in an MDI command.
+  current value as a parameter in an MDI command.
 - The HAL SpinBox will have a float-type HAL pin named speed-f (see
-HalWidgets description).
+  HalWidgets description).
 - To substitute this value in the MDI command, insert the HAL pin name
-enclosed like so: `${pin-name}`
-- for the above HAL SpinBox, we could use `(MSG, "The speed is:
-${speed-f}")` just to show what's happening.
+  enclosed like so: `${pin-name}`
+- for the above HAL SpinBox, we could use `(MSG, "The speed is: ${speed-f}")`
+  just to show what's happening.
 
-The example UI file is +configs/apps/gladevcp/mdi-command-example/speed.ui+. Here's what you get when running it:
+The example UI file is `configs/apps/gladevcp/mdi-command-example/speed.ui`. +
+Here's what you get when running it:
 
 .Action_MDI Parameter Passing Example
-image::images/speed.png[]
+image::images/speed.png[align="center"]
 
 === An advanced example: Feeding parameters to an O-word subroutine
 
 It's perfectly OK to call an O-word subroutine in an MDI command, and
-pass HAL pin values as actual parameters. An example UI file
-is in +configs/apps/gladevcp/mdi-command-example/owordsub.ui+.
+pass HAL pin values as actual parameters. +
+An example UI file is in `configs/apps/gladevcp/mdi-command-example/owordsub.ui`.
 
-Place +nc_files/gladevcp_lib/oword.ngc+ so Axis can find it, and run `gladevcp owordsub.ui` from
-a terminal window. This looks like so:
+Place `nc_files/gladevcp_lib/oword.ngc` so Axis can find it, and run
+`gladevcp owordsub.ui` from a terminal window. +
+This looks like so:
 
 .Action_MDI Advanced Example
-image::images/oword.png[]
+image::images/oword.png[align="center"]
 
 === Preparing for an MDI Action, and cleaning up afterwards
 
@@ -2166,7 +2273,7 @@ other handler.
 
 Here's an example how a feed value might be saved and restored by such
 handlers (note that LinuxCNC command and status channels are available as
-+self.linuxcnc+ and +self.stat+ through the VCP_ActionBase class:
++self.linuxcnc+ and +self.stat+ through the VCP_ActionBase class):
 
 [source,python]
 ----
@@ -2180,12 +2287,12 @@ handlers (note that LinuxCNC command and status channels are available as
             pass
 ----
 
-Only the Action_MDI Toggle widget supports these signals.
+Only the `Action_MDI` Toggle widget supports these signals.
 
 [NOTE]
 ====
-In a later release of LinuxCNC, the new M-codes M70-M72 are available which
-make it saving state before a subroutine call, and restoring state on return much easier.
+In a later release of LinuxCNC, the new M-codes M70-M72 will be available. +
+They will make saving state before a subroutine call, and restoring state on return much easier.
 ====
 
 === Using the LinuxCNC Stat object to deal with status changes
@@ -2206,26 +2313,26 @@ LinuxCNC Stat has no visible component - you just add it to your UI with
 Glade. Once added, you can associate handlers with its following
 signals:
 
-* state-related:     emitted when E-Stop condition occurs, is reset, machine is turned on, or is turned off
-  - +state-estop+
-  - +state-estop-reset+
-  - +state-on+,
-  - +state-off+
-* mode-related:    emitted when LinuxCNC enters that particular mode
-  - +mode-manual+
-  - +mode-mdi+
-  - +mode-auto+
-* interpreter-related:  emitted when the G-code interpreter changes into that mode
-  - +interp-run+
-  - +interp-idle+
-  - +interp-paused+
-  - +interp-reading+
-  - +interp-waiting+
-  - +file-loaded+
-  - +line-changed+
+* state-related:
+  - `state-estop`: emitted when E-Stop condition occurs,
+  - `state-estop-reset`: emitted when machine is reset,
+  - `state-on`: emitted when machine is turned on,
+  - `state-off`: emitted when machine is turned off.
+* mode-related:
+  - `mode-manual`: emitted when LinuxCNC enters manual mode,
+  - `mode-mdi`: emitted when LinuxCNC enters MDI mode,
+  - `mode-auto`: emitted when LinuxCNC enters automatic mode,
+* interpreter-related: emitted when the G-code interpreter changes into that mode
+  - `interp-run`
+  - `interp-idle`
+  - `interp-paused`
+  - `interp-reading`
+  - `interp-waiting`
+  - `file-loaded`
+  - `line-changed`
 * homing-related: emitted when linuxcnc is homed or not
-  - +all-homed+
-  - +not-all-homed+
+  - `all-homed`
+  - `not-all-homed`
 
 [[gladevcp:programming]]
 == GladeVCP Programming
@@ -2280,7 +2387,7 @@ In Glade, define a button or HAL button, select the 'Signals' tab, and
 in the GtkButton properties select the 'pressed' line. Enter
 'on_button_press' there, and save the Glade file.
 
-Then add the option '-u handlers.py' to the gladevcp command line. If
+Then add the option '-u handlers.py' to the GladeVCP command line. If
 your event handlers are spread over several files, just add multiple
 '-u <pyfilename>' options.
 
@@ -2288,8 +2395,8 @@ Now, pressing the button should change its label since it's set in the
 callback function.
 
 What the +-u+ flag does: all Python functions in this file are
-collected and setup as potential callback handlers for your Gtk widgets
-- they can be referenced from Glade 'Signals' tabs. The callback
+collected and setup as potential callback handlers for your Gtk widgets -
+they can be referenced from Glade 'Signals' tabs. The callback
 handlers are called with the particular object instance as parameter,
 like the GtkButton instance above, so you can apply any GtkButton
 method from there.
@@ -2309,27 +2416,27 @@ expired, or the change of a HAL pin's value, generates a callback and
 is handled by the same orthogonal mechanism.
 
 For user-defined HAL pins not associated with a particular HAL widget,
-the signal name is 'value-changed'. See the
-<<gladevcp:adding-hal-pins,Adding HAL pins>> section below for
+the signal name is 'value-changed'. +
+See the <<gladevcp:adding-hal-pins,Adding HAL pins>> section below for
 details.
 
-HAL widgets come with a pre-defined signal called 'hal-pin-changed'. See the
-<<gladevcp:hal-pin-changed-signal,Hal Widgets section>> for details.
+HAL widgets come with a pre-defined signal called 'hal-pin-changed'. +
+See the <<gladevcp:hal-pin-changed-signal,Hal Widgets section>> for details.
 
 === Programming model
 
 The overall approach is as follows:
 
 - design your UI with Glade, and set signal handlers where you want
-actions associated with a widget
+  actions associated with a widget
 - write a Python module which contains callable objects (see 'handler
-models' below)
-- pass your module's path name to gladevcp with the '-u <module>' option
-- gladevcp imports the module, inspects it for signal handlers and
-connects them to the widget tree
+  models' below)
+- pass your module's path name to GladeVCP with the '-u <module>' option
+- GladeVCP imports the module, inspects it for signal handlers and
+  connects them to the widget tree
 - the main event loop is run.
 
-.The simple handler model
+==== The simple handler model
 
 For simple tasks it's sufficient to define functions named after the
 Glade signal handlers. These will be called when the corresponding
@@ -2356,7 +2463,7 @@ Note communication between handlers has to go through global
 variables, which does not scale well and is positively un-pythonic.
 This is why we came up with the class-based handler model.
 
-.The class-based handler model
+==== The class-based handler model
 
 The idea here is: handlers are linked to class methods. The underlying
 class(es) are instantiated and inspected during GladeVCP startup and
@@ -2384,13 +2491,13 @@ def get_handlers(halcomp,builder,useropts):
 Now, 'on_this_signal' will be available as signal handler to your
 widget tree.
 
-.GladeVCP-specific signals
+==== GladeVCP-specific signals
 
 For GladevCP panel which respond to HAL inputs it may be important that the handler
 code can tell that the GladeVCP panel is currently active and displayed. For
 example a panel inside the Touchy interface might well need to perform an action
 when the switch connected to touchy.cycle-start is operated (in the same way
-that the native tabs respond differently to the same button.)
+that the native tabs respond differently to the same button). +
 To make this possible a signal is sent from the GUI (at the time of writing, only
 Touchy) to the embedded tab. The signal is of type "Gladevcp" and the two messages
 sent are "Visible" and "Hidden". (Note that the signals  have a fixed length of 20
@@ -2415,19 +2522,21 @@ the [:7] below.) A sample handler for these signals is:
         top.connect('client-event', self.event)
 ----
 
-.The get_handlers protocol
+==== The get_handlers protocol
 
 If during module inspection GladeVCP finds a function `get_handlers`,
 it calls it as follows:
 
-  get_handlers(halcomp,builder,useropts)
+----
+get_handlers(halcomp,builder,useropts)
+----
 
-the arguments are:
+The arguments are:
 
-- halcomp - refers to the HAL component under construction
-- builder - widget tree - result of reading the UI definition (either
+- `halcomp` - refers to the HAL component under construction
+- `builder` - widget tree - result of reading the UI definition (either
   referring to a GtkBuilder or libglade-type object)
-- useropts - a list of strings collected from the gladevcp
+- `useropts` - a list of strings collected from the GladeVCP
   command line `-U <useropts>` option
 
 GladeVCP then inspects the list of class instances and retrieves their
@@ -2513,7 +2622,7 @@ def get_handlers(halcomp,builder,useropts):
 ----
 
 This way you can pass arbitrary Python statements to your module
-through the gladevcp -U option, for example:
+through the `gladevcp -U` option, for example:
 
 ----
 gladevcp -U debug=42 -U "print 'debug=%d' % debug" ...
@@ -2554,12 +2663,12 @@ If you want any of Gtk widget state, HAL widgets output pin's values
 and/or class attributes of your handler class to be retained across
 invocations, proceed as follows:
 
-- import the +gladevcp.persistence+ module
+- import the `gladevcp.persistence` module
 - decide which instance attributes, and their default values you want to
-have retained, if any
+  have retained, if any
 - decide which widgets should have their state retained
 - describe these decisions in your handler class' +__init__()+ method
-through a nested dictionary as follows:
+  through a nested dictionary as follows:
 
 [source,python]
 ----
@@ -2606,16 +2715,15 @@ self.defaults.
 After this incantation, you can use the following IniFil methods:
 
 ini.save_state(obj)::
-  saves objs's attributes as per IniFil.vars
-  dictionary and the widget state as described in IniFile.widgets in
-  self.defaults
+  Saves objs's attributes as per `IniFil.vars` dictionary and the widget
+  state as described in `IniFile.widgets` in `self.defaults`.
 ini.create_default_ini()::
-  create a .ini file with default values
+  Create a .ini file with default values
 ini.restore_state(obj)::
-  restore HAL out pins and obj's attributes as
+  Restore HAL out pins and obj's attributes as
   saved/initialized to default as above
 
-=== Saving the state on Gladvcp shutdown
+=== Saving the state on GladeVCP shutdown
 
 To save the widget and/or variable state on exit, proceed as follows:
 
@@ -2660,8 +2768,8 @@ make sure you use the 'destroy' event from the 'GtkObject' line.
 
 === Saving state when Ctrl-C is pressed
 
-By default, the reaction of GladeVCP to a Ctrl-C event is to just exit
-- +without+ saving state. To make sure that this case is covered, add
+By default, the reaction of GladeVCP to a Ctrl-C event is to just exit -
++without+ saving state. To make sure that this case is covered, add
 a handler call +on_unix_signal+ which will be automatically be called
 on Ctrl-C (actually on the SIGINT and SIGTERM signals). Example
 
@@ -2818,7 +2926,7 @@ I want a blinking LED, but it wont blink::
   type `gint'?  This seems to be a glade bug. Just type over the blink
   rate field, and save again - this works for me.
 
-My gladevcp panel in Axis doesn't save state when I close Axis, although I defined an on_destroy handler linked to the window destroy signal::
+My GladeVCP panel in Axis doesn't save state when I close Axis, although I defined an on_destroy handler linked to the window destroy signal::
 
   Very likely this handler is linked to window1,
   which due to reparenting isn't usable for this purpose. Please link
@@ -2897,7 +3005,7 @@ link:http://wiki.linuxcnc.org/cgi-bin/wiki.pl?GladeVCP_Custom_Widgets[GladeVCP C
 
 == Auxiliary Gladevcp Applications
 
-Support is provided for independently installed gladevcp applications
+Support is provided for independently installed GladeVCP applications
 that conform to system directory placements as defined by the
 LINUXCNC_AUX_GLADEVCP and LINUXCNC_AUX_EXAMPLES items reported by
 the script linuxcnc_var:
@@ -2911,9 +3019,9 @@ $ linuxcnc_var LINUXCNC_AUX_EXAMPLES
 
 The system directory defined by LINUXCNC_AUX_GLADEVCP
 (/usr/share/linuxcnc/aux_gladevcp) specifies the location for
-a gladevcp-compatible python file(s) and related subdirectories.
-The python file is imported at gladevcp startup and made
-available to subsequent gladevcp applications including
+a GladeVCP-compatible python file(s) and related subdirectories.
+The python file is imported at GladeVCP startup and made
+available to subsequent GladeVCP applications including
 embedded usage in supporting guis.
 
 The system directory defined by LINUXCNC_AUX_EXAMPLES
@@ -2945,7 +3053,7 @@ stdout.
 
 [NOTE]
 ====
-Support for auxiliary gladevcp applications requires a python
+Support for auxiliary GladeVCP applications requires a python
 module named 'importlib'.  This module may not be available in
 older installations like Ubuntu-Lucid.
 ====

--- a/docs/src/gui/halui.adoc
+++ b/docs/src/gui/halui.adoc
@@ -12,15 +12,15 @@ is provided by a traditional GUI (Axis, GMoccapy, QtDragon, etc.), is provided b
 pins in Halui.
 
 The easiest way to add halui is to add the following to the [HAL]
-section of the ini file.
+section of the ini file:
 
 ----
 [HAL]
 HALUI = halui
 ----
 
-An alternate way to invoke it is to include the following in your .hal
-file. Make sure you use the correct path to your ini file.
+An alternate way to invoke it (specially if you generate the configuration with StepConf) is to include the following in your `custom.hal` file. +
+Make sure you use the correct path to your ini file.
 
 ----
 loadusr halui -ini /path/to/inifile.ini
@@ -29,8 +29,8 @@ loadusr halui -ini /path/to/inifile.ini
 == MDI
 
 Sometimes the user wants to add more complicated tasks to be performed
-by the activation of a HAL pin. This is possible by adding MDI commands
-to the ini file in the [HALUI] section:
+by the activation of a HAL pin. +
+This is possible by adding MDI commands to the ini file in the [HALUI] section. +
 Example:
 
 ----
@@ -42,11 +42,11 @@ MDI_COMMAND = o<mysub>call
 ...
 ----
 
-When halui starts it will read the MDI_COMMAND fields in the ini and
-export pins from 00 to the number of MDI_COMMAND's found in the ini up
-to a maximum of 64 commands.  These pins can be connected like any
-hal pins.  A common method is to use buttons provided by virtual
-control panels.  Example halfile connections:
+When halui starts it will read the `MDI_COMMAND` fields in the ini and
+export pins from 00 to the number of `MDI_COMMAND` 's found in the ini, up
+to a maximum of 64 commands. These pins can be connected like any
+hal pins. A common method is to use buttons provided by virtual
+control panels. Example halfile connections:
 
 ----
 net quill-up       <= pyvcp.quillup
@@ -57,7 +57,7 @@ net call-mysub     <= pyvcp.callmysub
 net call-mysub     => halui.mdi-command-02
 ----
 
-These nets connect the halui.mdi-command-NN pins
+These nets connect the `halui.mdi-command-NN` pins
 provided by halui:
 
 ----
@@ -71,13 +71,13 @@ Owner  Type  Dir Value  Name
 ----
 
 When a halui MDI pin is set (pulsed) true, halui will send the MDI
-command defined in the ini.
+command defined in the ini. +
 This will not always succeed depending on the current operating
 mode (e.g., while in AUTO halui can't successfully send MDI commands).
 
 == Example Configuration
 
-An example sim config (configs/sim/axis/halui_pyvcp/halui.ini)
+An example sim config (`configs/sim/axis/halui_pyvcp/halui.ini`)
 is included in the distribution.
 
 == Halui Pin Reference
@@ -123,7 +123,7 @@ $ man halui
 === Homing
 
 * 'halui.home-all' (bit, in) - pin for requesting all axis to home. This
-   pin will only be there if HOME_SEQUENCE is set in the ini file.
+  pin will only be there if HOME_SEQUENCE is set in the ini file.
 
 === Lube
 
@@ -135,7 +135,6 @@ $ man halui
 
 * 'halui.machine.units-per-mm' (float out) - pin  for  machine  units-per-mm
   (inch:1/25.4,  mm:1) according to inifile setting: [TRAJ]LINEAR_UNITS
-
 * 'halui.machine.is-on' (bit, out) - indicates machine on
 * 'halui.machine.off' (bit, in) - pin for requesting machine off
 * 'halui.machine.on' (bit, in) - pin for requesting machine on
@@ -156,14 +155,14 @@ that is set in the [TRAJ] section of the ini file.
 === MDI
 
 * 'halui.mdi-command-<nn>' (bit, in) - halui will try to send the MDI
-   command defined in the ini. <nn> is a  two  digit number  starting  at 00. +
-If the command succeeds then it will place LinuxCNC in the MDI mode and then back to Manual mode. +
-If no [HALUI]MDI_COMMAND variables are set in the  ini  file, no halui.mdi-command-<nn> pins will be
-exported by halui.
+  command defined in the ini. <nn> is a  two  digit number  starting  at 00. +
+  If the command succeeds then it will place LinuxCNC in the MDI mode and then back to Manual mode. +
+  If no [HALUI]MDI_COMMAND variables are set in the  ini  file, no halui.mdi-command-<nn> pins will be
+  exported by halui.
 
 === Joint
 
-N = joint number (0 ... num_joints-1)
+N = joint number (0 ... num_joints-1) +
 Example:
 
 * 'halui.joint.N.select' (bit in) - pin for selecting joint N
@@ -192,9 +191,7 @@ Example:
 
 N = joint number (0 ... num_joints-1)
 
-* 'halui.joint.jog-deadband' (float in pin for setting jog  analog  deadband
-       (jog  analog  inputs  smaller/slower  than this (in absolute value) are
-       ignored)
+* 'halui.joint.jog-deadband' (float in) - pin for setting jog analog deadband (jog analog inputs smaller/slower than this - in absolute value - are ignored)
 * 'halui.joint.jog-speed' (float in) - pin for setting jog speed for plus/minus jogging.
 * 'halui.joint.N.analog' (float in) - pin for jogging the joint N using  an  float  value  (e.g.  joy-stick).   The value, typically set between 0.0 and ±1.0, is used as a jog-speed multiplier.
 * 'halui.joint.N.increment' (float in) - pin for setting the jog increment for joint N when using  increment-plus/minus
@@ -213,13 +210,9 @@ N = joint number (0 ... num_joints-1)
 L = axis letter (xyzabcuvw)
 
 * 'halui.axis.L.select' (bit) - pin for selecting axis by letter
-
 * 'halui.axis.L.is-selected' (bit out) - status pin that axis L is selected
-
 * 'halui.axis.L.pos-commanded' (float out) - Commanded axis position in machine coordinates
-
 * 'halui.axis.L.pos-feedback' float out) - Feedback axis position in machine coordinates
-
 * 'halui.axis.L.pos-relative' (float out) - Commanded axis position in relative coordinates
 
 === Axis Jogging
@@ -286,8 +279,7 @@ L = axis letter (xyzabcuvw)
 * 'halui.spindle.N.override.count-enable' (bit, in) - must be true for 'counts' or 'direct-value' to work.
 * 'halui.spindle.N.override.counts' (s32, in) - counts * scale = SO percentage.  Can be used with an encoder or 'direct-value'.
 * 'halui.spindle.N.override.decrease' (bit, in) - pin for decreasing the SO (-=scale)
-* 'halui.spindle.N.override.direct-value' (bit, in) - false when using encoder to change counts,
-true when setting counts directly.
+* 'halui.spindle.N.override.direct-value' (bit, in) - false when using encoder to change counts, true when setting counts directly.
 * 'halui.spindle.N.override.increase' (bit, in) - pin for increasing the SO (+=scale)
 * 'halui.spindle.N.override.scale' (float, in) - pin for setting the scale on changing the SO
 * 'halui.spindle.N.override.value' (float, out) - current SO value

--- a/docs/src/gui/image-to-gcode.adoc
+++ b/docs/src/gui/image-to-gcode.adoc
@@ -4,7 +4,7 @@
 [[cha:image-to-g-code]]
 = Image to G-Code
 
-image::images/image-to-gcode.png[align="center", alt="Image to G-Code"]
+image::images/image-to-gcode.png["Image to G-Code",align="center"]
 
 == What is a depth map?
 
@@ -98,23 +98,23 @@ The spindle speed S code that should be put into the gcode file.
 
 Possible scan patterns are:
 
- - Rows
- - Columns
- - Rows, then Columns
- - Columns, then Rows
+- Rows
+- Columns
+- Rows, then Columns
+- Columns, then Rows
 
 === Scan Direction
 
 Possible scan directions are:
 
- - Positive: Start milling at a low X or Y axis value, and move towards a
-   high X or Y axis value
- - Negative: Start milling at a high X or Y axis value, and move towards
-   a low X or Y axis value
- - Alternating: Start on the same end of the X or Y axis travel that the
-   last move ended on. This reduces the amount of traverse movements
- - Up Milling: Start milling at low points, moving towards high points
- - Down Milling: Start milling at high points, moving towards low points
+- Positive: Start milling at a low X or Y axis value, and move towards a
+  high X or Y axis value
+- Negative: Start milling at a high X or Y axis value, and move towards
+  a low X or Y axis value
+- Alternating: Start on the same end of the X or Y axis travel that the
+  last move ended on. This reduces the amount of traverse movements
+- Up Milling: Start milling at low points, moving towards high points
+- Down Milling: Start milling at high points, moving towards low points
 
 === Depth (units)
 
@@ -153,13 +153,13 @@ This controls whether areas that are relatively flat along a row or
 column are skipped. This option only makes sense when both rows and
 columns are being milled. Possible bounding options are:
 
- - None: Rows and columns are both fully milled.
- - Secondary: When milling in the second direction, areas that do not
-   strongly slope in that direction are skipped.
- - Full: When milling in the first direction, areas that strongly slope
-   in the second direction are skipped. When milling in the second
-   direction, areas that do not strongly slope in that direction are
-   skipped.
+- None: Rows and columns are both fully milled.
+- Secondary: When milling in the second direction, areas that do not
+  strongly slope in that direction are skipped.
+- Full: When milling in the first direction, areas that strongly slope
+  in the second direction are skipped. When milling in the second
+  direction, areas that do not strongly slope in that direction are
+  skipped.
 
 === Contact angle
 
@@ -180,5 +180,4 @@ In this image, Roughing depth per pass is 0.2 inches and roughing
 offset is 0.1 inches.
 
 .Roughing passes and final pass
-image::images/i2g-roughing.png["Roughing passes and final pass"]
-
+image::images/i2g-roughing.png["Roughing passes and final pass",align="center"]

--- a/docs/src/gui/ngcgui.adoc
+++ b/docs/src/gui/ngcgui.adoc
@@ -10,16 +10,16 @@ image::images/ngcgui.png[align="center"]
 == Overview
 
 * 'NGCGUI' is a Tcl application to work with subroutines. It allows you to
-have a conversational interface with LinuxCNC. You can organize the
-subroutines in the order you need them to run and concatenate the
-subroutines into one file for a complete part program.
+  have a conversational interface with LinuxCNC. You can organize the
+  subroutines in the order you need them to run and concatenate the
+  subroutines into one file for a complete part program.
 * 'NGCGUI' can run as a standalone application or can be embedded in
-multiple tab pages in the axis GUI
+  multiple tab pages in the axis GUI
 * 'PYNGCGUI' is an alternate, python implementation of ngcgui.
 * 'PYNGCGUI' can run as a standalone application or can be embedded as
-a tab page (with its own set of multiple subroutine tabs) in any
-GUI that supports embedding of gladevcp applications axis, touchy, gscreen
-and gmoccapy.
+  a tab page (with its own set of multiple subroutine tabs) in any
+  GUI that supports embedding of gladevcp applications axis, touchy, gscreen
+  and gmoccapy.
 
 Using NGCGUI or PYNGCGUI:
 
@@ -28,7 +28,7 @@ Using NGCGUI or PYNGCGUI:
   <<ngcgui-ini,custom tab>>
 * Each subroutine tab page provides entry boxes for all subroutine parameters
 * The entry boxes can have a default value and an label that
-are identified by special comments in the subroutine file
+  are identified by special comments in the subroutine file
 * Subroutine invocations can be concatenated together to form a multiple step
   program
 * Any single-file G-code subroutine that conforms to ngcgui conventions can be used
@@ -65,7 +65,7 @@ A comprehensive example showing gcmc compatibility is at:
 
   Sample Configurations/sim/axis/ngcgui/ngcgui_gcmc
 
-A comprehensive example embedded as a gladevcp app and using gcmc is at:
+A comprehensive example embedded as a GladeVCP app and using gcmc is at:
 
   Sample Configurations/sim/gscreen/ngcgui/pyngcgui_gcmc
 
@@ -133,10 +133,9 @@ may be different.
 [NOTE]
 ====
 The demonstration configs create tab pages for just a few of the provided
-examples.  Any gui with a <<ngcgui-ini,custom tab>> can open any of the library
+examples. Any gui with a <<ngcgui-ini,custom tab>> can open any of the library
 example subroutines or any user file if it is in the LinuxCNC subroutine
 path.
-====
 
 To see special key bindings, click inside an ngcgui tab page to get
 focus and then press Control-k.
@@ -145,6 +144,8 @@ The demonstration subroutines should run on the simulated
 machine configurations included in the distribution.  A user
 should always understand the behavior and purpose of a program
 before running on a real machine.
+====
+
 == Library Locations
 
 In LinuxCNC installations installed from deb packages, the simulation configs
@@ -169,7 +170,7 @@ USER_M_PATH     = ../../nc_files/ngcgui_lib/mfiles
 ====
 These are long lines (not continued on multiple lines)
 that specify the directories used in a search patch.  The
-directory names are separated by colons (:).  No spaces should
+directory names are separated by colons (:). No spaces should
 occur between directory names.
 ====
 
@@ -306,7 +307,7 @@ sections below for additional items needed)
   beginning of the subroutine. When several subroutines are concatenated,
   it is only added once.
 * 'NGCGUI_SUBFILE = simp.ngc' - Creates a tab from the named subroutine.
-//FIXME 'NGCGUI_SUBFILE = "" - Creates a custom tab ?
+//FIXME * 'NGCGUI_SUBFILE = "" - Creates a custom tab ?
 * 'NGCGUI_SUBFILE = "" - Creates a custom tab
 * '#NGCGUI_OPTIONS = opt1 opt2 ...' - Ngcgui options:
 ** 'nonew'    -- Prohibits creation of new custom tab
@@ -315,7 +316,7 @@ sections below for additional items needed)
 ** 'noiframe' -- No internal image, image on separate top level
 * 'TTT = truetype-tracer' - name of the truetype tracer program (it must be in user PATH)
 * 'TTT_PREAMBLE = in_std.ngc' - Optional, specifies filename for preamble used for
-ttt created subfiles. (alternate: mm_std.ngc)
+  ttt created subfiles. (alternate: mm_std.ngc)
 
 [NOTE]
 ====
@@ -361,8 +362,8 @@ that embeds either ngcgui or pyngcgui.
 
 * 'NGCGUI_FONT = Helvetica -12 normal' - specifies the font name,size, normal|bold
 * 'NGCGUI_PREAMBLE = in_std.ngc' - the preamble file to be added in front of the
-subroutines. When concatenating several common subroutine invocations, this preamble
-is only added once.  For mm-based machines, use mm_std.ngc
+  subroutines. When concatenating several common subroutine invocations, this preamble
+  is only added once.  For mm-based machines, use mm_std.ngc
 * 'NGCGUI_SUBFILE = filename1.ngc' - creates a tab from the filename1 subroutine
 * 'NGCGUI_SUBFILE = filename2.ngc' - creates a tab from the filename2 subroutine
 * '... etc'
@@ -376,7 +377,7 @@ is only added once.  For mm-based machines, use mm_std.ngc
 ** 'noauto' - no autosend (use makeFile, then save or manually send)
 ** 'noiframe' - no internal image, display images on separate top level widget
 ** 'nom2' - do not terminate with m2, use % terminator.  This option eliminates all
-the side effects of m2 termination
+  the side effects of m2 termination
 * 'GCMC_INCLUDE_PATH = dirname1:dirname2' - search directories for gcmc include files
 
 This is an example of embedding NGCGUI into Axis. The subroutines need to be
@@ -386,7 +387,7 @@ dependences, if any, in a SUBROUTINE_PATH directory.  Some subroutines may
 use custom Mfiles which must be in a directory specified by the
 [RS274NGC]USER_M_PATH.
 
-The Gcode-meta-compiler (gcmc) can include statements like:
+The G-code-meta-compiler (gcmc) can include statements like:
 
 ----
 include("filename.inc.gcmc");
@@ -397,7 +398,6 @@ the directory containing the linuxCNC ini file.  Additional directories can be
 prepended to the gcmc search order with the GCMC_INCLUDE_PATH item.
 
 .Sample axis-gui-based INI
-
 ----
 [RS274NGC]
 ...
@@ -559,113 +559,111 @@ ngcgui will reject them automatically with a relevant message.
 
 === Summary of INI File item details for NGCGUI usage
 
-====
-Item:    [RS274NGC]SUBROUTINE_PATH = dirname1:dirname2:dirname3 ...
-Example: [RS274NGC]SUBROUTINE_PATH = ../../nc_files/ngcgui_lib:../../nc_files/ngcgui_lib/utilitysubs
-Note:    Optional, but very useful to organize subfiles and utility files
+[RS274NGC]SUBROUTINE_PATH = dirname1:dirname2:dirname3 ...::
+  _Example_: `[RS274NGC]SUBROUTINE_PATH = ../../nc_files/ngcgui_lib:../../nc_files/ngcgui_lib/utilitysubs` +
+  _Note_:    Optional, but very useful to organize subfiles and utility files.
 
-Item:    [RS274NGC]USER_M_PATH = dirname1:dirname2:dirname3 ...
-Example: [RS274NGC]USER_M_PATH = ../../nc_files/ngcgui_lib/mfiles
-Note:    Optional, needed to locate custom user mfiles
+[RS274NGC]USER_M_PATH = dirname1:dirname2:dirname3 ...::
+  _Example_: `[RS274NGC]USER_M_PATH = ../../nc_files/ngcgui_lib/mfiles` +
+  _Note_:    Optional, needed to locate custom user mfiles.
 
-Item:    [DISPLAY]EMBED_TAB_NAME = name to display on embedded tab page
-Example: [DISPLAY]EMBED_TAB_NAME = Pyngcgui
-Note:    The entries: EMBED_TAB_NAME,EMBED_TAB_COMMAND,EMBED_TAB_LOCATION
-         define an embedded application for several LinuxCNC guis
+[DISPLAY]EMBED_TAB_NAME = name to display on embedded tab page::
+  _Example_: `[DISPLAY]EMBED_TAB_NAME = Pyngcgui` +
+  _Note_:    The entries: `EMBED_TAB_NAME`, `EMBED_TAB_COMMAND`, `EMBED_TAB_LOCATION`
+             define an embedded application for several LinuxCNC GUIs.
 
-Item:    [DISPLAY]EMBED_TAB_COMMAND = programname followed by arguments
-Example: [DISPLAY]EMBED_TAB_COMMAND = gladevcp -x {XID} pyngcgui_axis.ui
-Note:    For gladevcp applications, see the <<cha:glade-vcp,GladeVCP Chapter>>
+[DISPLAY]EMBED_TAB_COMMAND = programname followed by arguments::
+  _Example_: `[DISPLAY]EMBED_TAB_COMMAND = gladevcp -x {XID} pyngcgui_axis.ui` +
+  _Note_:    For GladeVCP applications, see the <<cha:glade-vcp,GladeVCP Chapter>>.
 
-Item:    [DISPLAY]EMBED_TAB_LOCATION = name_of_location
-Example: [DISPLAY]EMBED_TAB_LOCATION = notebook_main
-Note:    See example INI files for possible locations
-         Not required for the axis gui
+[DISPLAY]EMBED_TAB_LOCATION = name_of_location::
+  _Example_: `[DISPLAY]EMBED_TAB_LOCATION = notebook_main` +
+  _Note_:    See example INI files for possible locations.
+             Not required for the AXIS GUI.
 
-Item:    [DISPLAY]PROGRAM_PREFIX = dirname
-Example: [DISPLAY]PROGRAM_PREFIX = ../../nc_files
-Note:    Mandatory and needed for numerous LinuxCNC functions
-         It is the first directory used in the search for files
+[DISPLAY]PROGRAM_PREFIX = dirname::
+  _Example_: `[DISPLAY]PROGRAM_PREFIX = ../../nc_files` +
+  _Note_:    Mandatory and needed for numerous LinuxCNC functions.
+             It is the first directory used in the search for files.
 
-item:    [DISPLAY]TKPKG = Ngcgui version_number
-Example: [DISPLAY]TKPKG = Ngcgui 1.0
-Note:    Required only for axis gui embedding, specifies loading of ngcgui axis tab pages
+[DISPLAY]TKPKG = Ngcgui version_number::
+  _Example_: `[DISPLAY]TKPKG = Ngcgui 1.0` +
+  _Note_:    Required only for AXIS GUI embedding. Specifies loading of NGCGUI AXIS tab pages.
 
-Item:    [DISPLAY]NGCGUI_FONT = font_descriptor
-Example: [DISPLAY]NGCGUI_FONT = Helvetica -12 normal
-Note:    Optional, font_descriptor is a tcl-compatible font specifier
-         with items for fonttype -fontsize fontweight
-         Default is: Helvetica -10 normal
-         Smaller font sizes may be useful for small screens
-         Larger font sizes may be helpful for touch screen applications
+[DISPLAY]NGCGUI_FONT = font_descriptor::
+  _Example_: [DISPLAY]NGCGUI_FONT = Helvetica -12 normal +
+  _Note_:    Optional, font_descriptor is a tcl-compatible font specifier
+             with items for fonttype -fontsize fontweight. +
+             Default is: Helvetica -10 normal. +
+             Smaller font sizes may be useful for small screens.
+             Larger font sizes may be helpful for touch screen applications .
 
-Item:    [DISPLAY]NGCGUI_SUBFILE = subfile_filename
-Example: [DISPLAY]NGCGUI_SUBFILE = simp.ngc
-Example: [DISPLAY]NGCGUI_SUBFILE = square.gcmc
-Example: [DISPLAY]NGCGUI_SUBFILE = ""
-Note:    Use one or more items to specify ngcgui-compatible
-         subfiles or gcmc programs that require a tab page on startup.
-         A "Custom" tab will be created when the filename is "".
-         A user can use a "Custom" tab to browse the file system
-         and identify preamble, subfile, and postamble files.
+[DISPLAY]NGCGUI_SUBFILE = subfile_filename::
+  _Example_: `[DISPLAY]NGCGUI_SUBFILE = simp.ngc` +
+  _Example_: `[DISPLAY]NGCGUI_SUBFILE = square.gcmc` +
+  _Example_: `[DISPLAY]NGCGUI_SUBFILE = ""` +
+  _Note_:    Use one or more items to specify ngcgui-compatible
+             subfiles or gcmc programs that require a tab page on startup.
+             A "Custom" tab will be created when the filename is "".
+             A user can use a "Custom" tab to browse the file system
+             and identify preamble, subfile, and postamble files.
 
-Item:    [DISPLAY]NGCGUI_PREAMBLE = preamble_filename
-Example: [DISPLAY]NGCGUI_PREAMBLE = in_std.ngc
-Note:    Optional, when specified, the file is prepended to a subfile.
-         Files created with "Custom" tab pages use the preamble specified
-         with the page.
+[DISPLAY]NGCGUI_PREAMBLE = preamble_filename::
+  _Example_: `[DISPLAY]NGCGUI_PREAMBLE = in_std.ngc` +
+  _Note_:    Optional, when specified, the file is prepended to a subfile.
+             Files created with "Custom" tab pages use the preamble specified
+             with the page.
 
-Item:    [DISPLAY]NGCGUI_POSTAMBLE = postamble_filename
-Example: [DISPLAY]NGCGUI_POSTAMBLE = bye.ngc
-Note:    Optional, when specified, the file is appended to a subfiles.
-         Files created with "Custom" tab pages use the postamble specified
-         with the page.
+[DISPLAY]NGCGUI_POSTAMBLE = postamble_filename::
+  _Example_: `[DISPLAY]NGCGUI_POSTAMBLE = bye.ngc` +
+  _Note_:    Optional, when specified, the file is appended to a subfiles.
+             Files created with "Custom" tab pages use the postamble specified
+             with the page.
 
-Item:    [DISPLAY]NGCGUI_OPTIONS = opt1 opt2 ...
-Example: [DISPLAY]NGCGUI_OPTIONS = nonew noremove
-Note:    Multiple options are separated by blanks.
-         By default, ngcgui configures tab pages so that:
-            1) a user can make new tabs
-            2) a user can remove tabs (except for the last remaining one)
-            3) finalized files are automatically sent to LinuxCNC
-            4) an image frame (iframe) is made available to display
-               an image for the subfile (if an image is provided)
-            5) the ngcgui result file sent to LinuxCNC is terminated with
-               an m2 (and incurs m2 side-effects)
+[DISPLAY]NGCGUI_OPTIONS = opt1 opt2 ...::
+  _Example_: [DISPLAY]NGCGUI_OPTIONS = nonew noremove +
+  _Note_:    Multiple options are separated by blanks.
+             By default, ngcgui configures tab pages so that: +
+               1) a user can make new tabs; +
+               2) a user can remove tabs (except for the last remaining one); +
+               3) finalized files are automatically sent to LinuxCNC; +
+               4) an image frame (iframe) is made available to display
+                  an image for the subfile (if an image is provided); +
+               5) the ngcgui result file sent to LinuxCNC is terminated with
+                  an m2 (and incurs m2 side-effects). +
++
+The options `nonew`, `noremove`, `noauto`, `noiframe`, `nom2` respectively
+disable these default behaviors.
++
+By default, if an image (.png,.gif,jpg,pgm) file
+is found in the same directory as the subfile, the
+image is displayed in the iframe. Specifying
+the `noiframe` option makes available additional buttons
+for selecting a preamble, subfile, and postamble and
+additional checkboxes. Selections of the checkboxes
+are always available with special keys: +
+  `Ctrl-R` Toggle "Retain values on Subfile read", +
+  `Ctrl-E` Toggle "Expand subroutine", +
+  `Ctrl-a` Toggle "Autosend", +
+  `Ctrl-k` lists all keys and functions. +
++
+If `noiframe` is specified and an image file is found,
+the image is displayed in a separate window and
+all functions are available on the tab page.
++
+The `NGCGUI_OPTIONS` apply to all ngcgui tabs except that the
+`nonew`, `noremove`, and `noiframe` options are not applicable
+for "Custom" tabs.  Do not use "Custom" tabs if you want
+to limit the user's ability to select subfiles or create
+additional tab pages.
 
-         The options nonew, noremove, noauto, noiframe, nom2 respectively
-         disable these default behaviors.
-
-         By default, if an image (.png,.gif,jpg,pgm) file
-         is found in the same directory as the subfile, the
-         image is displayed in the iframe.  Specifying
-         the noiframe option makes available additional buttons
-         for selecting a preamble, subfile, and postamble and
-         additional checkboxes.  Selections of the checkboxes
-         are always available with special keys:
-           Ctrl-R Toggle "Retain values on Subfile read"
-           Ctrl-E Toggle "Expand subroutine"
-           Ctrl-a Toggle "Autosend"
-          (Ctrl-k lists all keys and functions)
-
-         If noiframe is specified and an image file is found,
-         the image is displayed in a separate window and
-         all functions are available on the tab page.
-
-         The NGCGUI_OPTIONS apply to all ngcgui tabs except that the
-         nonew, noremove, and noiframe options are not applicable
-         for "Custom" tabs.  Do not use "Custom" tabs if you want
-         to limit the user's ability to select subfiles or create
-         additional tab pages.
-
-Item:    [DISPLAY]GCMC_INCLUDE_PATH = dirname1:dirname2:...
-Example: [DISPLAY]GCMC_INCLUDE_PATH = /home/myname/gcmc_includes:/home/myname/gcmc_includes2
-Note:    Optional, each directory will be included when gcmc is invoked
-         using the option: --include dirname
-====
+[DISPLAY]GCMC_INCLUDE_PATH = dirname1:dirname2:...::
+  _Example_: `[DISPLAY]GCMC_INCLUDE_PATH = /home/myname/gcmc_includes:/home/myname/gcmc_includes2` +
+  _Note_:    Optional, each directory will be included when gcmc is invoked
+             using the option: --include dirname
 
 :showcomments:
-// FIX-ME Keyboard shortcuts do not work in version _fr.
+// FIXME Keyboard shortcuts do not work in version _fr.
 
 == File Requirements for NGCGUI Compatibility
 
@@ -675,11 +673,10 @@ An NGCGUI-compatible subfile contains a single subroutine definition. The name
 of the subroutine must be the same as the filename (not including the .ngc
 suffix). LinuxCNC supports named or numbered subroutines, but only named
 subroutines are compatible with NGCGUI. For more information see the
-<<cha:o-codes,O-Codes>> Chapter.
+<<cha:o-codes,O-Codes>> chapter.
 
-The first non-comment line should be a sub statement.
-
-The last non-comment line should be a endsub statement.
+The first non-comment line should be a `sub` statement. +
+The last non-comment line should be a `endsub` statement.
 
 .examp.ngc:
 ----
@@ -700,7 +697,6 @@ ending with the last used parameter number. Definitions must be provided for
 each of these parameters (no omissions).
 
 .Parameter Numbering
-
 ----
 #<xparm> = #1
 #<yparm> = #2
@@ -717,7 +713,6 @@ Each defining statement may optionally include a special comment and a default
 value for the parameter.
 
 .Statement Prototype
-
 ----
 #<vname> = #n (=default_value)
 or
@@ -833,7 +828,7 @@ The LinuxCNC distribution includes a library (ngcgui_lib directory) that
 includes both example ngcgui-compatible subfiles and utility files
 to illustrate the features of LinuxCNC subroutines and ngcgui usage.
 Another library (gcmc_lib) provides examples for subroutine files for
-the G-code meta compiler (gcmc)
+the G-code meta compiler (gcmc).
 
 Additional user sumitted subroutines can be found on the Forum in the
 Subroutines Section.

--- a/docs/src/gui/pyvcp-examples.adoc
+++ b/docs/src/gui/pyvcp-examples.adoc
@@ -1,4 +1,5 @@
 :lang: en
+:toc:
 
 = PyVCP Examples
 
@@ -60,7 +61,7 @@ Wizard.
 
 [[cap:XYZ-Wizard-Configuration]]
 .XYZ Wizard Configuration
-image::images/xyz_ACO.png["XYZ Wizard Configuration"]
+image::images/xyz_ACO.png["PyVCP XYZ Wizard Configuration"]
 
 The Stepconf Wizard will create several files and place them in the
 linuxcnc/configs/pyvcp_xyz directory. If you left the create link checked
@@ -272,6 +273,7 @@ image::images/ptest.png["Port Tester Panel"]
 To run the HAL commands that we need to get everything up and running
 we put the following in our ptest.hal file.
 
+[source,c]
 ----
 loadrt hal_parport cfg="0x378 out"
 loadusr -Wn ptest pyvcp -c ptest ptest.xml
@@ -501,7 +503,9 @@ MDI_COMMAND = G53 G0 X0 Y0 Z0
 ----
 
 [NOTE]
+====
 Information about <<gcode:g53,G53>> and <<gcode:g0,G0>> G-codes
+====
 
 In the [HAL] section if you don't have a post gui file add the following and
 create a file called 'postgui.hal'.
@@ -518,6 +522,8 @@ net rth halui.mdi-command-00 <= pyvcp.rth-button
 ----
 
 [NOTE]
+====
 Information about the <<sub:hal-net, net>> command
+====
 
 // vim: set syntax=asciidoc:

--- a/docs/src/gui/pyvcp.adoc
+++ b/docs/src/gui/pyvcp.adoc
@@ -38,7 +38,7 @@ contains widget tags between <pyvcp> and </pyvcp>. For example:
 ----
 
 .Simple PyVCP LED Panel Example
-image::images/pyvcp_mypanel.png[]
+image::images/pyvcp_mypanel.png[align="center"]
 
 If you place this text in a file called tiny.xml, and run
 
@@ -231,11 +231,11 @@ modify the signal value with a control widget. Thus there are four
 classes of PyVCP widgets that you can connect to a HAL signal. A fifth
 class of helper widgets allow you to organize and label your panel.
 
-. Widgets for indicating 'bit' signals: led, rectled
-. Widgets for controlling 'bit' signals: button, checkbutton, radiobutton
-. Widgets for indicating 'number' signals: number, s32, u32, bar, meter
-. Widgets for controlling 'number' signals: spinbox, scale, jogwheel
-. Helper widgets: hbox, vbox, table, label, labelframe
+* Widgets for indicating 'bit' signals: `led`, `rectled`.
+* Widgets for controlling 'bit' signals: `button`, `checkbutton`, `radiobutton`.
+* Widgets for indicating 'number' signals: `number`, `s32`, `u32`, `bar`, `meter`.
+* Widgets for controlling 'number' signals: `spinbox`, `scale`, `jogwheel`.
+* Helper widgets: `hbox`, `vbox`, `table`, `label`, `labelframe`.
 
 === Syntax
 
@@ -334,17 +334,17 @@ The label has an optional disable pin that is created when you add
 '<disable_pin>True</disable_pin>'.
 
 [source,xml]
--------------------------------------------------
+----
 <label>
     <text>"This is a Label:"</text>
     <font>("Helvetica",20)</font>
 </label>
--------------------------------------------------
+----
 
 The above code produced this example:
 
 .Simple Label Example
-image::images/pyvcp_label.png[]
+image::images/pyvcp_label.png[align="center"]
 
 === Multi_Label
 
@@ -404,7 +404,7 @@ will be on_color when the halpin is true, and off_color otherwise.
 * '<width>n</width>' - sets the width of the LED in pixels
 * '<disable_pin>false</disable_pin>' - when true adds a disable pin to the led.
 * '<disabled_color>color</disabled_color>' - sets the color of the LED when the
-pin is disabled.
+  pin is disabled.
 
 .Round LED
 
@@ -421,7 +421,7 @@ pin is disabled.
 The above code produced this example:
 
 .Round LED Example
-image::images/pyvcp_led.png[]
+image::images/pyvcp_led.png[align="center"]
 
 .Rectangle LED
 
@@ -446,7 +446,7 @@ The above code produced this example.
 Also showing a vertical box with relief.
 
 .Simple Rectangle LED Example
-image::images/pyvcp_rectled.png[]
+image::images/pyvcp_rectled.png[align="center"]
 
 === Buttons
 
@@ -462,6 +462,7 @@ button is released. Buttons can use the following optional options.
 * '<disable_pin>True</disable_pin>' - disable pin.
 
 .Text Button
+
 A text button controls a 'bit' halpin. The halpin is false until the
 button is pressed then it is true. The button is a momentary button.
 
@@ -483,7 +484,7 @@ add <disable_pin>True</disable_pin>.
 The above code produced this example:
 
 .Simple Buttons Example
-image::images/pyvcp_button.png[]
+image::images/pyvcp_button.png[align="center"]
 
 .Checkbutton
 
@@ -495,10 +496,10 @@ toggle the Checkbutton via HAL, if the value linked is changed, to update the
 display remotely.
 
 .Unchecked button
-image::images/pyvcp_checkbutton1.png[]
+image::images/pyvcp_checkbutton1.png[align="center"]
 
 .Checked button
-image::images/pyvcp_checkbutton2.png[]
+image::images/pyvcp_checkbutton2.png[align="center"]
 
 .Checkbutton Code Example
 [source,xml]
@@ -518,7 +519,7 @@ image::images/pyvcp_checkbutton2.png[]
 The above code produced this example:
 
 .Simple Checkbutton Example
-image::images/pyvcp_checkbutton.png[]
+image::images/pyvcp_checkbutton.png[align="center"]
 
 The coolant checkbutton is checked. +
 Notice the extra spaces in the "Chips" text to keep the checkbuttons aligned.
@@ -542,7 +543,7 @@ number pin set TRUE will have that value.
 The above code produced this example:
 
 .Simple Radiobutton Example
-image::images/pyvcp_radiobutton.png[]
+image::images/pyvcp_radiobutton.png[align="center"]
 
 Note that the HAL pins in the example above will be named
 my-radio.one, my-radio.two, and my-radio.three. +
@@ -636,7 +637,7 @@ them to the same color).
 * <range2>101,135,"orange"</range2> number, number, text, sets the first range
   and color
 * <range3>136, 150,"red"</range3> number, number, text, sets the first range and
-color
+  color
 * <canvas_width>200</canvas_width> number, sets the overall width
 * <canvas_height>50</canvas_height> number, sets the overall height
 * <bar_height>30</bar_height> number, sets the bar height, must be less than
@@ -857,10 +858,10 @@ FWD is displayed when 'selectimage' is false
 and REV is displayed when 'selectimage' is true.
 
 .Selectimage False Example
-image:images/pyvcp_image01.png[]
+image::images/pyvcp_image01.png[]
 
 .Selectimage True Example
-image:images/pyvcp_image02.png[]
+image::images/pyvcp_image02.png[]
 
 .Image u32
 
@@ -883,13 +884,13 @@ The above code produced the following example
 by adding the stb.gif image.
 
 .Simple image_u32 Example with halpin=0
-image:images/pyvcp_image_u32_01.png[]
+image::images/pyvcp_image_u32_01.png[]
 
 .Simple image_u32 Example withhalpin=1
-image:images/pyvcp_image01.png[]
+image::images/pyvcp_image01.png[]
 
 .Simple image_u32 Example withhalpin=2
-image:images/pyvcp_image02.png[]
+image::images/pyvcp_image02.png[]
 
 Notice that the default is the min even though it is set higher than
 max unless there is a negative min.
@@ -905,10 +906,10 @@ Container borders are specified with two tags used together. The
 <relief> tag specifies the type of border and the <bd> specifies the
 width of the border.
 
-* '<relief>type</relief>' -
+'<relief>type</relief>'::
   Where 'type' is FLAT, SUNKEN, RAISED, GROOVE, or RIDGE
 
-* '<bd>n</bd>' -
+'<bd>n</bd>'::
   Where 'n' is the width of the border.
 
 [source,xml]
@@ -953,8 +954,8 @@ Container fill are specified with the '<boxfill fill=""/>' tag. Valid entries
 are none, x, y and both. The x fill is a horizontal fill and the y fill is a
 vertical fill
 
-* '<boxfill fill ="style"/>' -
-  where 'style' is none, x, y, or both. Default is x for Vbox and y for Hbox.
+`<boxfill fill ="style"/>`::
+  Where 'style' is none, x, y, or both. Default is x for Vbox and y for Hbox.
 
 .Anchor
 
@@ -963,15 +964,16 @@ specifies where to position each slave in its parcel. Valid entries are center,
 n, s, e, w, for center, north, south, east and west. Combinations like sw, se,
 nw and ne are also valid.
 
-* '<boxanchor anchor="position"/>' -
-  where 'position' is center, n, s, e, w, ne, nw, se or sw. Default is center.
+`<boxanchor anchor="position"/>`::
+  Where 'position' is center, n, s, e, w, ne, nw, se or sw. Default is center.
 
 .Expand
 
 Container expand is specified with the boolean <boxexpand expand=""/> tag.
 Valid entries are yes, no.
 
-* '<boxexpand expand="boolean"/>' - Where 'boolean' is either yes or no. Default is yes.
+`<boxexpand expand="boolean"/>`::
+  Where 'boolean' is either yes or no. Default is yes.
 
 .Hbox
 
@@ -995,8 +997,8 @@ The above code produced this example:
 .Simple hbox Example
 image::images/pyvcp_hbox.png[]
 
-Inside an Hbox, you can use the '<boxfill fill=""/>', '<boxanchor anchor=""/>'
-, and '<boxexpand expand=""/>' tags to choose how items in the box behave when
+Inside an Hbox, you can use the '<boxfill fill=""/>', '<boxanchor anchor=""/>',
+and '<boxexpand expand=""/>' tags to choose how items in the box behave when
 the window is re-sized.The default is 'fill="y"', 'anchor="center"', 'expand="yes"'
 for a Hbox.
 
@@ -1131,9 +1133,10 @@ A tabbed interface can save quite a bit of space.
 
 The above code produced this example showing each tab selected.
 
-
 image::images/pyvcp_tabs1.png[]
+
 image::images/pyvcp_tabs2.png[]
+
 .Simple Tabs Example
 image::images/pyvcp_tabs3.png[]
 

--- a/docs/src/gui/tklinuxcnc.adoc
+++ b/docs/src/gui/tklinuxcnc.adoc
@@ -1,4 +1,5 @@
 :lang: en
+:toc:
 
 [[cha:tklinuxcnc-intro]]
 = TkLinuxCNC GUI
@@ -109,12 +110,6 @@ step size. For instance, if you command a movement to X 0.0033 on your
 mill, but one step of your stepper motor is 0.00125, then the
 'Commanded' position will be 0.0033 but the 'Actual' position will be
 0.0025 (2 steps) or 0.00375 (3 steps).
-
-* MATCH ME
-* MATCH ME
-* MATCH ME
-* MATCH ME
-* MATCH ME
 
 Another set of radio buttons allows you to choose between 'joint' and
 'world' view. These make little sense on a normal type of machine (e.g.

--- a/docs/src/gui/tooledit.adoc
+++ b/docs/src/gui/tooledit.adoc
@@ -11,6 +11,7 @@ The tooledit elements described here are available
 in version 2.5.1 and later. In version 2.5.0, the graphical interface
 interface does not allow these adjustments.
 
+.Tool Edit GUI - Overview
 image::images/tooledit.png["Tool Edit GUI - Overview",align="center",width="640"]
 
 The 'tooledit' program can update the tool table file with
@@ -28,6 +29,7 @@ order by clicking on the column header.  A second click sorts
 in descending order.  Column sorting requires that the machine
 is configured with the default tcl version >= 8.5.
 
+.Tool Edit GUI - Column Sorting
 image::images/tooledit-sort.png["Tool Edit GUI - Column Sorting",align="center"]
 
 In Ubuntu Lucid 10.04 tcl/tk8.4 it is installed by default.
@@ -45,15 +47,12 @@ sudo update-alternatives --config tclsh  ;# select the option for tclsh8.5
 sudo update-alternatives --config wish   ;# select the option for wish8.5
 ----
 
-== Column Selection
+== Columns Selection
 
 By default, the 'tooledit' program will display all possible
-tool table parameter columns.  Since few machines use all
+tool table parameter columns. Since few machines use all
 parameters, the columns displayed can be limited with the
 following ini file setting:
-
-//.Tooledit GUI
-image::images/tooledit-columns.png["Tool Edit GUI - Column Selection",align="center"]
 
 .Syntax of .INI file
 ----
@@ -66,6 +65,9 @@ TOOL_EDITOR = tooledit column_name column_name ...
 [DISPLAY]
 TOOL_EDITOR = tooledit Z DIAM
 ----
+
+.Tool Edit GUI - Columns Selection Example
+image::images/tooledit-columns.png["Tool Edit GUI - Columns Selection Example",align="center"]
 
 == Stand Alone Use
 
@@ -112,7 +114,7 @@ The axis GUI can optionally use an ini file setting to specify the tool
 editor program:
 
 ----
-DISPLAY]TOOL_EDITOR = path_to_editor_program
+[DISPLAY]TOOL_EDITOR = path_to_editor_program
 ----
 
 By default, the program named 'tooledit' is used. This editor

--- a/docs/src/gui/tooledit.adoc
+++ b/docs/src/gui/tooledit.adoc
@@ -68,6 +68,7 @@ TOOL_EDITOR = tooledit Z DIAM
 ----
 
 == Stand Alone Use
+
 The 'tooledit' program can also be invoked as a standalone
 program. For example, if the program is in the user PATH, typing
 'tooledit' will show the usage syntax:

--- a/docs/src/gui/touchy.adoc
+++ b/docs/src/gui/touchy.adoc
@@ -1,4 +1,5 @@
 :lang: en
+:toc:
 
 [[cha:touchy-gui]]
 = The Touchy Graphical User Interface(((touchygui)))
@@ -42,40 +43,41 @@ For more information on HAL files and the net command see the
 Touchy has several output pins that are meant to be connected to the
 motion controller to control wheel jogging:
 
- - 'touchy.jog.wheel.increment', which is to be connected to the 'axis.N.jog-scale' pin of each axis N.
- - 'touchy.jog.wheel.N', which is to be connected to 'axis.N.jog-enable' for each axis N.
+- 'touchy.jog.wheel.increment', which is to be connected to the 'axis.N.jog-scale' pin of each axis N.
+- 'touchy.jog.wheel.N', which is to be connected to 'axis.N.jog-enable' for each axis N.
 
-[NOTE]'N' represents the axis number 0-8.
+[NOTE]
+'N' represents the axis number 0-8.
 
- - In addition to being connected to 'touchy.wheel-counts', the wheel counts
-   should also be connected to 'axis.N.jog-counts' for
-   each axis N.  If you use HAL component 'ilowpass' to smooth wheel jogging, be
-   sure to smooth only 'axis.N.jog-counts' and not 'touchy.wheel-counts'.
+- In addition to being connected to 'touchy.wheel-counts', the wheel counts
+  should also be connected to 'axis.N.jog-counts' for
+  each axis N.  If you use HAL component 'ilowpass' to smooth wheel jogging, be
+  sure to smooth only 'axis.N.jog-counts' and not 'touchy.wheel-counts'.
 
 .Required controls
 
- - Abort button (momentary contact) connected to the HAL pin 'touchy.abort'
- - Cycle start button (momentary contact) connected to 'touchy.cycle-start'
- - Wheel/MPG, connected to 'touchy.wheel-counts' and motion pins as described above
- - Single block (toggle switch) connected to 'touchy.single-block'
+- Abort button (momentary contact) connected to the HAL pin 'touchy.abort'
+- Cycle start button (momentary contact) connected to 'touchy.cycle-start'
+- Wheel/MPG, connected to 'touchy.wheel-counts' and motion pins as described above
+- Single block (toggle switch) connected to 'touchy.single-block'
 
 .Optional controls
 
- - For continuous jog, one center-off bidirectional momentary toggle
-   (or two momentary buttons) for each axis, hooked to 'touchy.jog.continuous.x.negative',
-   'touchy.jog.continuous.x.positive', etc.
- - If a quill up button is wanted (to jog Z to the top of travel at top
-   speed), a momentary button connected to 'touchy.quill-up'.
+- For continuous jog, one center-off bidirectional momentary toggle
+  (or two momentary buttons) for each axis, hooked to 'touchy.jog.continuous.x.negative',
+  'touchy.jog.continuous.x.positive', etc.
+- If a quill up button is wanted (to jog Z to the top of travel at top
+  speed), a momentary button connected to 'touchy.quill-up'.
 
 .Optional panel lamps
 
- - 'touchy.jog.active' shows when the panel jogging controls are live
- - 'touchy.status-indicator' is on when the machine is executing G-code,
-   and flashes when the machine is executing but is in pause/feedhold.
+- 'touchy.jog.active' shows when the panel jogging controls are live
+- 'touchy.status-indicator' is on when the machine is executing G-code,
+  and flashes when the machine is executing but is in pause/feedhold.
 
 === Recommended for any setup
 
- - Estop button hardwired in the estop chain
+- Estop button hardwired in the estop chain
 
 == Setup
 

--- a/docs/src/hal/basic-hal.adoc
+++ b/docs/src/hal/basic-hal.adoc
@@ -19,7 +19,7 @@ a pin status open the Watch tab and click on each pin you wish to watch
 and it will be added to the watch window.
 
 .HAL Configuration Window
-image::images/HAL_Configuration.png["HAL Configuration Window",align="center"]
+image::images/HAL_Configuration.png["The HAL Configuration Window",align="center"]
 
 [[sub:hal-loart]]
 === loadrt(((HAL loadrt,loadrt)))
@@ -84,7 +84,7 @@ Realtime Threads:
   need a fast response, like making step pulses, and reading and writing
   the parallel port. Does not support floating point math.
 - servo-thread (the slow-speed thread): this thread handles items that
-  can tolerate a slower response, like the motion controller,    ClassicLadder,
+  can tolerate a slower response, like the motion controller, ClassicLadder,
   and the motion command handler and supports floating point math.
 
 .addf Syntax and Example
@@ -160,7 +160,7 @@ A pin can be connected to a signal if it obeys the following rules:
 * An IN pin can always be connected to a signal
 * An IO pin can be connected unless there's an OUT pin on the signal
 * An OUT pin can be connected only if there are no other OUT or IO pins
-on the signal
+  on the signal
 
 The same 'signal-name' can be used in multiple net commands to connect
 additional pins, as long as the rules above are obeyed.
@@ -191,7 +191,6 @@ net xStep => parport.0.pin-06-out
 ----
 
 .I/O pins
-
 An I/O pin like encoder.N.index-enable can be read or set as allowed by the component.
 
 [[sub:hal-setp]]
@@ -313,7 +312,7 @@ A 'float' is a floating point number. In other words the decimal point
 can move as needed.
 
 - float values = a 64 bit floating point value, with approximately 53 bits of
-resolution and over 1000 bits of dynamic range.
+  resolution and over 1000 bits of dynamic range.
 
 For more information on floating point numbers see:
 
@@ -360,7 +359,7 @@ component.
 [horizontal]
 `.time`(((HAL time))):: Time is the number of CPU cycles it took to execute the function.
 `.tmax`(((HAL tmax))):: Tmax is the maximum number of CPU cycles it took to execute the
-function.
+  function.
 
 `tmax` is a read/write parameter so the user can set it to 0 to
 get rid of the first time initialization on the function's execution
@@ -389,22 +388,26 @@ and2 [count=N] | [names=name1[,name2...]]
 ----
 
 .and2 Functions
-  and2.n
+----
+and2.n
+----
 
 .and2 Pins
-  and2.N.in0 (bit, in)
-  and2.N.in1 (bit, in)
-  and2.N.out (bit, out)
+----
+and2.N.in0 (bit, in)
+and2.N.in1 (bit, in)
+and2.N.out (bit, out)
+----
 
 .and2 Truth Table
 [width="90%", options="header"]
-|===
+|======================
 |in0   | in1   | out
 |False | False | False
 |True  | False | False
 |False | True  | False
 |True  | True  | True
-|===
+|======================
 
 [[sub:hal-not]]
 === not(((HAL not,not)))
@@ -417,20 +420,24 @@ not [count=n] | [names=name1[,name2...]]
 ----
 
 .not Functions
-  not.all
-  not.n
+----
+not.all
+not.n
+----
 
 .not Pins
-  not.n.in (bit, in)
-  not.n.out (bit, out)
+----
+not.n.in (bit, in)
+not.n.out (bit, out)
+----
 
 .not Truth Table
 [width="90%", options="header"]
-|===
+|=============
 |in    | out
 |True  | False
 |False | True
-|===
+|=============
 
 [[sub:hal-or2]]
 === or2(((HAL or2,or2)))
@@ -443,22 +450,26 @@ or2[count=n] | [names=name1[,name2...]]
 ----
 
 .or2 Functions
-  or2.n
+----
+or2.n
+----
 
 .or2 Pins
-  or2.n.in0 (bit, in)
-  or2.n.in1 (bit, in)
-  or2.n.out (bit, out)
+----
+or2.n.in0 (bit, in)
+or2.n.in1 (bit, in)
+or2.n.out (bit, out)
+----
 
 .or2 Truth Table
 [width="90%", options="header"]
-|===
+|=====================
 |in0   | in1   | out
 |True  | False | True
 |True  | True  | True
 |False | True  | True
 |False | False | False
-|===
+|=====================
 
 [[sub:hal-xor2]]
 === xor2(((HAL xor2,xor2)))
@@ -471,22 +482,26 @@ xor2[count=n] | [names=name1[,name2...]]
 ----
 
 .xor2 Functions
-  xor2.n
+----
+xor2.n
+----
 
 .xor2 Pins
-  xor2.n.in0 (bit, in)
-  xor2.n.in1 (bit, in)
-  xor2.n.out (bit, out)
+----
+xor2.n.in0 (bit, in)
+xor2.n.in1 (bit, in)
+xor2.n.out (bit, out)
+----
 
 .xor2 Truth Table
 [width="90%", options="header"]
-|===
+|=====================
 |in0   | in1   | out
 |True  | False | True
 |True  | True  | False
 |False | True  | True
 |False | False | False
-|===
+|=====================
 
 [[sec:hal-logic-examples]]
 == Logic Examples(((HAL Logic Examples)))

--- a/docs/src/hal/canonical-devices.adoc
+++ b/docs/src/hal/canonical-devices.adoc
@@ -23,7 +23,6 @@ The canonical digital input (I/O type field: `digin`) is quite simple.
 [[sub:hal-cdi:di:pins]]
 === Pins(((HAL Digital Input Pins)))
 
-[horizontal]
 (bit) *in*:: State of the hardware input.
 (bit) *in-not*:: Inverted state of the input.
 
@@ -75,7 +74,6 @@ continuous range of values.
 [[sub:hal-cdi:ai:parameters]]
 === Parameters(((HAL Analog Input Parameters)))
 
-[horizontal]
 (float) *scale*:: The input voltage (or current) will be multiplied
   by *scale* before being output to *value*.
 (float) *offset*:: This will be subtracted from the hardware input
@@ -101,7 +99,6 @@ of values. Examples are digital to analog converters or PWM generators.
 [[sub:hal-cdi:ao:pins]]
 === Pins(((HAL Analog Output Pins)))
 
-[horizontal]
 (float) *value*:: The value to be written. The actual value output
   to the hardware will depend on the scale and offset parameters.
 (bit) *enable*:: If false, then output 0 to the hardware, regardless
@@ -110,7 +107,6 @@ of values. Examples are digital to analog converters or PWM generators.
 [[sub:hal-cdi:ao:parameters]]
 === Parameters(((HAL Analog Output Parameters)))
 
-[horizontal]
 (float) *offset*:: This will be added to the *value* before the
   hardware is updated
 (float) *scale*:: This should be set so that an input of 1 on the

--- a/docs/src/hal/comp.adoc
+++ b/docs/src/hal/comp.adoc
@@ -35,8 +35,8 @@ old = tmp;
 == Installing
 
 To compile a component, if a packaged version of LinuxCNC is used, development packages
-have to be installed using either Synaptic from the main menu 'System -> Administration
--> Synaptic package manager' or running one of the following commands in a terminal window:
+have to be installed using either Synaptic from the main menu 'System -> Administration -> Synaptic package manager'
+or running one of the following commands in a terminal window:
 
 .Development packages installation
 ----
@@ -167,7 +167,7 @@ collide with reserved names or keywords (e.g., 'min') can be used.
 |===
 
 * 'if CONDITION' - An expression involving the variable 'personality' which is nonzero
-   when the pin or parameter should be created
+  when the pin or parameter should be created
 
 * 'SIZE' - A number that gives the size of an array. The array items are numbered
   from 0 to 'SIZE'-1.
@@ -203,16 +203,16 @@ information on this markup format, see 'groff_man(7)'. Remember that
 'halcompile' interprets backslash escapes in strings, so for instance
 to set the italic font for the word 'example', write:
 
-  ----
-  "\\fIexample\\fB"
-  ----
+----
+"\\fIexample\\fB"
+----
 
 In this case, r-strings are particularly useful, because the backslashes
 in an r-string need not be doubled:
 
-  ----
-  r"\fIexample\fB"
-  ----
+----
+r"\fIexample\fB"
+----
 
 * 'TYPE' - One of the HAL types: 'bit', 'signed', 'unsigned', or 'float'. The old
   names 's32' and 'u32' may also be used, but 'signed' and 'unsigned' are
@@ -269,9 +269,11 @@ The currently defined options are:
   automatically defined. With 'option rtapi_app no', they are not, and
   must be provided in the C code.  Use the following prototypes:
 
-  `int rtapi_app_main(void);`
+----
+`int rtapi_app_main(void);`
 
-  `void rtapi_app_exit(void);`
+`void rtapi_app_exit(void);`
+----
 
 When implementing your own `rtapi_app_main()`, call the function `int
 export(char *prefix, long extra_arg)` to register the pins,
@@ -326,10 +328,10 @@ parameters, and functions for `prefix`.
   in the compiler command line.
 
 * 'option homemod yes' - (default: no)
-   Module is a custom Homing module loaded using [EMCMOT]HOMEMOD=modulename
+  Module is a custom Homing module loaded using [EMCMOT]HOMEMOD=modulename
 
 * 'option tpmod yes' - (default: no)
-   Module is a custom Trajectory Planning (tp) module loaded using [TRAJ]TPMOD=modulename
+  Module is a custom Trajectory Planning (tp) module loaded using [TRAJ]TPMOD=modulename
 
 If an option's VALUE is not specified, then it is equivalent to
 specifying 'option … yes'. +
@@ -342,7 +344,7 @@ The result of using any other option is undefined. +
   MODULE_LICENSE() module declaration. For example, to specify that the
   module's license is GPL v2 or later:
 
-        license "GPL"; // indicates GPL v2 or later
+  license "GPL"; // indicates GPL v2 or later
 
 For additional information on the meaning of MODULE_LICENSE() and
 additional license identifiers, see '<linux/module.h>'. or the manual page
@@ -790,9 +792,9 @@ which creates the following pins:
 
 - A 2-input AND gate: logic.0.and, logic.0.in-00, logic.0.in-01
 - 5-input AND and OR gates: logic.1.and, logic.1.or, logic.1.in-00,
-logic.1.in-01, logic.1.in-02, logic.1.in-03, logic.1.in-04,
+  logic.1.in-01, logic.1.in-02, logic.1.in-03, logic.1.in-04,
 - 3-input AND and XOR gates: logic.2.and, logic.2.xor, logic.2.in-00,
-logic.2.in-01, logic.2.in-02
+  logic.2.in-01, logic.2.in-02
 
 === general functions
 

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -1,4 +1,5 @@
 :lang: en
+:toc:
 
 [[cha:hal-components]]
 = HAL Component List((("HAL Component List")))
@@ -40,6 +41,10 @@ Some of these will have expanded descriptions from the man pages.
 Some will have limited descriptions. All of the components have man pages.
 From this list you know what components exist and can use 'man n name' to get additional information.
 To view the information in the man page, in a terminal window type:
+
+[NOTE]
+If component requires a thread with a float, it is usually the slowest,
+thus _servo-thread_.
 
 [NOTE]
 See also the 'Man Pages' section of the link:../index.html[docs main page] or the
@@ -103,9 +108,10 @@ constant:: (((constant)))Use a parameter to set the value of a pin.
 
 sum2:: (((sum2)))Sum of two inputs (each with a gain) and an offset.
 
-counter:: (((counter)))Counts input pulses (deprecated).  Use the <<sec:encoder, encoder>> component.
-   Utiliser le composant _encoder_ avec _... counter-mode = TRUE_.
-   See section <<sec:encoder,encoder>>.
+counter:: (((counter)))Counts input pulses (deprecated).
++
+Use the _encoder_ component with _... counter-mode = TRUE_.
+See section <<sec:encoder,encoder>>.
 
 updown:: (((updown)))Counts up or down, with optional limits and wraparound behavior.
 
@@ -141,12 +147,19 @@ biquad:: (((biquad)))Biquad IIR filter
 
 lowpass:: (((lowpass)))Low-pass filter
 
-limit1:: (((limit1)))Limit the output signal to fall between min and max. footnote:[When the input
-is a position, this means that the 'position' is limited.]
+limit1:: (((limit1)))Limit the output signal to fall between min and max.
+  footnote:[When the input is a position, this means that the 'position'
+  is limited.]
 
-limit2:: (((limit2)))Limit the output signal to fall between min and max.  Limit its slew rate to less than maxv per second. footnote:[When the input is a position, this means that 'position' and 'velocity' are limited.]
+limit2:: (((limit2)))Limit the output signal to fall between min and max.
+  Limit its slew rate to less than maxv per second. footnote:[When the input
+  is a position, this means that 'position' and 'velocity' are limited.]
 
-limit3:: (((limit3)))Limit the output signal to fall between min and max.  Limit its slew rate to less than maxv per second.  Limit its second derivative to less than MaxA per second squared. footnote:[When the input is a position, this means that the 'position', 'velocity', and 'acceleration' are limited.]
+limit3:: (((limit3)))Limit the output signal to fall between min and max.
+  Limit its slew rate to less than maxv per second.
+  Limit its second derivative to less than MaxA per second squared.
+  footnote:[When the input is a position, this means that the 'position',
+  'velocity', and 'acceleration' are limited.]
 
 maj3:: (((maj3)))Compute the majority of 3 inputs.
 
@@ -203,22 +216,22 @@ kins:: (((kins)))kinematics definitions for LinuxCNC.
 gantrykins:: (((gantrykins)))A kinematics module that maps one axis to multiple joints.
 
 genhexkins:: (((genhexkins)))Gives six degrees of freedom in position and orientation (XYZABC).
-The location of the motors is defined at compile time.
+  The location of the motors is defined at compile time.
 
 genserkins:: (((genserkins))) Kinematics that can model a general serial-link manipulator with up to
-6 angular joints.
+  6 angular joints.
 
 maxkins:: (((maxkins))) Kinematics for a tabletop 5 axis mill named 'max' with tilting head (B axis) and
-horizontal rotary mounted to the table (C axis).
-Provides UVW motion in the rotated coordinate system.
-The source file, maxkins.c, may be a useful starting point for other 5-axis systems.
+  horizontal rotary mounted to the table (C axis).
+  Provides UVW motion in the rotated coordinate system.
+  The source file, maxkins.c, may be a useful starting point for other 5-axis systems.
 
 tripodkins:: (((tripodkins))) The joints represent the distance of the controlled point from three
-predefined locations (the motors), giving three degrees of freedom in
-position (XYZ).
+  predefined locations (the motors), giving three degrees of freedom in
+  position (XYZ).
 
 trivkins:: (((trivkins))) There is a 1:1 correspondence between joints and axes. Most standard
-milling machines and lathes use the trivial kinematics module.
+  milling machines and lathes use the trivial kinematics module.
 
 pumakins:: (((pumakins))) Kinematics for PUMA-style robots.
 
@@ -228,87 +241,90 @@ scarakins:: (((scarakins))) Kinematics for SCARA-type robots.
 
 === Motor control
 
-at_pid:: (((at_pid)))Proportional/integral/derivative controller with auto tuning.
+at_pid:: (((at_pid))) Proportional/integral/derivative controller with auto tuning.
 
 pid:: Proportional/integral/derivative controller. <<sec:pid,Description>>
 
-pwmgen:: (((pwmgen)))Software PWM/PDM generation. <<sec:pwmgen,Description>>
+pwmgen:: (((pwmgen))) Software PWM/PDM generation. <<sec:pwmgen,Description>>
 
-encoder:: (((encoder)))Software counting of quadrature encoder signals. <<sec:encoder,Description>>.
+encoder:: (((encoder))) Software counting of quadrature encoder signals. <<sec:encoder,Description>>.
 
-stepgen:: (((stepgen)))Software step pulse generation. <<sec:stepgen,Description>>.
+stepgen:: (((stepgen))) Software step pulse generation. <<sec:stepgen,Description>>.
 
 === BLDC and 3-phase motor control
 
-bldc_hall3:: (((bldc_hall3)))3-wire Bipolar trapezoidal commutation BLDC motor driver using Hall sensors.
+bldc_hall3:: (((bldc_hall3))) 3-wire Bipolar trapezoidal commutation BLDC motor driver using Hall sensors.
 
-clarke2:: (((clarke2)))Two input version of Clarke transform.
+clarke2:: (((clarke2))) Two input version of Clarke transform.
 
-clarke3:: (((clarke3)))Clarke (3 phase to cartesian) transform.
+clarke3:: (((clarke3))) Clarke (3 phase to cartesian) transform.
 
-clarkeinv:: (((clarkeinv)))Inverse Clarke transform.
+clarkeinv:: (((clarkeinv))) Inverse Clarke transform.
 
 === Other Components
 
-charge_pump:: (((charge_pump)))Creates a square-wave for the 'charge pump' input of some controller boards.
-    The 'Charge Pump' should be added to the base thread function. When enabled the output is on for one period and off for one period. To calculate the frequency of the output 1/(period time in seconds x 2) = hz. For example if you have a base period of 100,000ns that is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 hz or 5 Khz.
+charge_pump:: (((charge_pump))) Creates a square-wave for the 'charge pump' input of some controller boards.
+  The 'Charge Pump' should be added to the base thread function. When enabled the output is on for one period and off for one period. To calculate the frequency of the output 1/(period time in seconds x 2) = hz. For example if you have a base period of 100,000ns that is 0.0001 seconds and the formula would be 1/(0.0001 x 2) = 5,000 hz or 5 Khz.
 
-encoder_ratio:: (((encoder_ratio)))An electronic gear to synchronize two axes.
+encoder_ratio:: (((encoder_ratio))) An electronic gear to synchronize two axes.
 
-estop_latch:: (((estop_latch)))ESTOP latch.
+estop_latch:: (((estop_latch))) ESTOP latch.
 
-feedcomp:: (((feedcomp)))Multiply the input by the ratio of current velocity to the feed rate.
+feedcomp:: (((feedcomp))) Multiply the input by the ratio of current velocity to the feed rate.
 
-gearchange:: (((gearchange)))Select from one of two speed ranges.
+gearchange:: (((gearchange))) Select from one of two speed ranges.
 
 [[sec:ilowpass]]
-ilowpass:: (((ilowpass)))While it may find other applications, this component was written to create smoother motion while jogging with an MPG.
+ilowpass:: (((ilowpass))) While it may find other applications,
+  this component was written to create smoother motion while jogging with an MPG.
++
+In a machine with high acceleration, a short jog can behave almost like a step
+function. By putting the ilowpass component between the MPG encoder counts
+output and the axis jog-counts input, this can be smoothed.
++
+Choose scale conservatively so that during a single session there will never
+be more than about 2e9/scale pulses seen on the MPG. Choose gain according
+to the smoothing level desired. Divide the axis.N.jog-scale values by scale.
 
-    In a machine with high acceleration, a short jog can behave almost like a step
-    function. By putting the ilowpass component between the MPG encoder counts
-    output and the axis jog-counts input, this can be smoothed.
+joyhandle:: (((joyhandle))) Sets nonlinear joypad movements, deadbands and scales.
 
-    Choose scale conservatively so that during a single session there will never
-    be more than about 2e9/scale pulses seen on the MPG. Choose gain according
-    to the smoothing level desired. Divide the axis.N.jog-scale values by scale.
+knob2float:: (((knob2float))) Convert counts (probably from an encoder) to a float value.
 
-joyhandle:: (((joyhandle)))Sets nonlinear joypad movements, deadbands and scales.
+minmax:: (((minmax))) Track the minimum and maximum values of the input to the outputs.
 
-knob2float:: (((knob2float)))Convert counts (probably from an encoder) to a float value.
+sample_hold:: (((sample_hold))) Sample and Hold.
 
-minmax:: (((minmax)))Track the minimum and maximum values of the input to the outputs.
+sampler:: (((sampler))) Sample data from HAL in real time.
 
-sample_hold:: (((sample_hold)))Sample and Hold.
+siggen:: (((siggen))) Signal generator. <<sec:siggen,Description>>.
 
-sampler:: (((sampler)))Sample data from HAL in real time.
+sim_encoder:: (((sim_encoder))) Simulated quadrature encoder. <<sec:simulated-encoder,Description>>.
 
-siggen:: Signal generator. <<sec:siggen,Description>>.
+sphereprobe:: (((sphereprobe))) Probe a pretend hemisphere.
 
-sim_encoder:: (((sim_encoder)))Simulated quadrature encoder. <<sec:simulated-encoder,Description>>.
+steptest:: (((steptest))) Used by Stepconf to allow testing of acceleration and velocity values for an axis.
 
-sphereprobe:: (((sphereprobe)))Probe a pretend hemisphere.
+streamer:: (((streamer))) Stream file data into HAL in real time.
 
-steptest:: (((steptest)))Used by Stepconf to allow testing of acceleration and velocity values for an axis.
+supply:: (((supply))) Set output pins with values from parameters (deprecated).
 
-streamer:: (((streamer)))Stream file data into HAL in real time.
+threadtest:: (((threadtest))) Component for testing thread behavior.
 
-supply:: (((supply)))Set output pins with values from parameters (deprecated).
+time:: (((time))) Accumulated run-time timer counts HH:MM:SS of 'active' input.
 
-threadtest:: (((threadtest)))Component for testing thread behavior.
+timedelay:: (((timedelay))) The equivalent of a time-delay relay.
 
-time:: (((time)))Accumulated run-time timer counts HH:MM:SS of 'active' input.
+timedelta:: (((timedelta))) Component that measures thread scheduling timing behavior.
 
-timedelay:: (((timedelay)))The equivalent of a time-delay relay.
+toggle2nist:: (((toggle2nist))) Toggle button to nist logic.
 
-timedelta:: (((timedelta)))Component that measures thread scheduling timing behavior.
+toggle:: (((toggle))) Push-on, push-off from momentary pushbuttons.
 
-toggle2nist:: (((toggle2nist)))Toggle button to nist logic.
+tristate_bit:: (((tristate_bit))) Place a signal on an I/O pin only when enabled, similar to a tristate
+  buffer in electronics.
 
-toggle:: (((toggle)))Push-on, push-off from momentary pushbuttons.
-
-tristate_bit:: (((tristate_bit)))Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics.
-
-tristate_float:: (((tristate_float)))Place a signal on an I/O pin only when enabled, similar to a tristate buffer in electronics.
+tristate_float:: (((tristate_float))) Place a signal on an I/O pin only when enabled, similar to a tristate
+  buffer in electronics.
 
 watchdog:: (((watchdog)))Monitor one to thirty-two inputs for a 'heartbeat'.
 

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -42,6 +42,10 @@ Some will have limited descriptions. All of the components have man pages.
 From this list you know what components exist and can use 'man n name' to get additional information.
 To view the information in the man page, in a terminal window type:
 
+----
+man motion (or perhaps 'man 9 motion' if your system requires it.)
+----
+
 [NOTE]
 If component requires a thread with a float, it is usually the slowest,
 thus _servo-thread_.
@@ -50,142 +54,139 @@ thus _servo-thread_.
 See also the 'Man Pages' section of the link:../index.html[docs main page] or the
 link:../man/man9/[directory listing of man9].
 
-[NOTE]
-Si el componente requiere un hilo de punto flotante, suele ser el hilo servo, más lento.
-
 [[sec:core-realtime-components]]
 === Core LinuxCNC components
 
-motion:: (((motion)))Accepts NML motion commands, interacts with HAL in realtime.
+motion:: (((motion))) Accepts NML motion commands, interacts with HAL in realtime.
 
-axis:: (((axis)))Accepts NML motion commands, interacts with HAL in realtime.
+axis:: (((axis))) Accepts NML motion commands, interacts with HAL in realtime.
 
-classicladder:: (((classicladder)))Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information.
+classicladder:: (((classicladder))) Realtime software PLC based on ladder logic. See <<cha:classicladder,ClassicLadder>> chapter for more information.
 
-gladevcp:: (((gladevcp)))Displays Virtual Control Panels built with GTK/Glade.
+gladevcp:: (((gladevcp))) Displays Virtual Control Panels built with GTK/Glade.
 
-threads:: (((threads)))Creates hard realtime HAL threads.
+threads:: (((threads))) Creates hard realtime HAL threads.
 
 [[sec:Realtime-Components-logic]]
 === Logic and Bitwise components
 
-and2:: (((and2)))Two-input AND gate. For out to be true both inputs must be true. link:../man/man9/and2.9.html[Details]
+and2:: (((and2))) Two-input AND gate. For out to be true both inputs must be true. link:../man/man9/and2.9.html[Details]
 
-not:: (((not)))Inverter. link:../man/man9/not.9.html[Details]
+not:: (((not))) Inverter. link:../man/man9/not.9.html[Details]
 
-or2:: (((or2)))Two-input OR gate. link:../man/man9/or2.9.html[Details]
+or2:: (((or2))) Two-input OR gate. link:../man/man9/or2.9.html[Details]
 
-xor2:: (((xor2)))Two-input XOR (exclusive OR) gate. link:../man/man9/xor2.9.html[Details]
+xor2:: (((xor2))) Two-input XOR (exclusive OR) gate. link:../man/man9/xor2.9.html[Details]
 
-dbounce:: (((dbounce)))Filter noisy digital inputs. link:../man/man9/dbounce.9.html[Details].
+dbounce:: (((dbounce))) Filter noisy digital inputs. link:../man/man9/dbounce.9.html[Details].
 
-debounce:: (((debounce)))Filter noisy digital inputs. link:../man/man9/debounce.9.html[Details]. <<sec:debounce, Description>>
+debounce:: (((debounce))) Filter noisy digital inputs. link:../man/man9/debounce.9.html[Details]. <<sec:debounce, Description>>
 
-edge:: (((edge)))Edge detector.
+edge:: (((edge))) Edge detector.
 
-flipflop:: (((flipflop)))D type flip-flop.
+flipflop:: (((flipflop))) D type flip-flop.
 
-oneshot:: (((oneshot)))One-shot pulse generator.
+oneshot:: (((oneshot))) One-shot pulse generator.
 
-logic:: (((logic)))General logic function component.
+logic:: (((logic))) General logic function component.
 
-lut5:: (((lut5)))A 5-input logic function based on a look-up table. <<sec:lut5,Description>>
+lut5:: (((lut5))) A 5-input logic function based on a look-up table. <<sec:lut5,Description>>
 
-match8:: (((match8)))8-bit binary match detector.
+match8:: (((match8))) 8-bit binary match detector.
 
-select8:: (((select8)))8-bit binary match detector.
+select8:: (((select8))) 8-bit binary match detector.
 
 [[sec:Realtime-Components-flottant]]
 === Arithmetic and float-components
 
-abs:: [[sub:abs]](((abs)))Compute the absolute value and sign of the input signal.
+abs:: [[sub:abs]](((abs))) Compute the absolute value and sign of the input signal.
 
-blend:: (((blend)))Perform linear interpolation between two values.
+blend:: (((blend))) Perform linear interpolation between two values.
 
-comp:: (((comp)))Two input comparator with hysteresis.
+comp:: (((comp))) Two input comparator with hysteresis.
 
-constant:: (((constant)))Use a parameter to set the value of a pin.
+constant:: (((constant))) Use a parameter to set the value of a pin.
 
-sum2:: (((sum2)))Sum of two inputs (each with a gain) and an offset.
+sum2:: (((sum2))) Sum of two inputs (each with a gain) and an offset.
 
-counter:: (((counter)))Counts input pulses (deprecated).
+counter:: (((counter))) Counts input pulses (deprecated).
 +
 Use the _encoder_ component with _... counter-mode = TRUE_.
 See section <<sec:encoder,encoder>>.
 
-updown:: (((updown)))Counts up or down, with optional limits and wraparound behavior.
+updown:: (((updown))) Counts up or down, with optional limits and wraparound behavior.
 
-ddt:: (((ddt)))Compute the derivative of the input function.
+ddt:: (((ddt))) Compute the derivative of the input function.
 
-deadzone:: (((deadzone)))Return the center if within the threshold.
+deadzone:: (((deadzone))) Return the center if within the threshold.
 
-hypot:: (((hypot)))Three-input hypotenuse (Euclidean distance) calculator.
+hypot:: (((hypot))) Three-input hypotenuse (Euclidean distance) calculator.
 
-mult2:: (((mult2)))Product of two inputs.
+mult2:: (((mult2))) Product of two inputs.
 
-mux16:: (((mux16)))Select from one of sixteen input values.
+mux16:: (((mux16))) Select from one of sixteen input values.
 
-mux2:: (((mux2)))Select from one of two input values.
+mux2:: (((mux2))) Select from one of two input values.
 
-mux4:: (((mux4)))Select from one of four input values.
+mux4:: (((mux4))) Select from one of four input values.
 
-mux8:: (((mux8)))Select from one of eight input values.
+mux8:: (((mux8))) Select from one of eight input values.
 
-near:: (((near)))Determine whether two values are roughly equal.
+near:: (((near))) Determine whether two values are roughly equal.
 
-offset:: (((offset)))Adds an offset to an input, and subtracts it from the feedback value.
+offset:: (((offset))) Adds an offset to an input, and subtracts it from the feedback value.
 
-integ:: (((integ)))Integrator.
+integ:: (((integ))) Integrator.
 
-invert:: (((invert)))Compute the inverse of the input signal.
+invert:: (((invert))) Compute the inverse of the input signal.
 
-wcomp:: (((wcomp)))Window comparator.
+wcomp:: (((wcomp))) Window comparator.
 
-weighted_sum:: (((weighted_sum)))Convert a group of bits to an integer.
+weighted_sum:: (((weighted_sum))) Convert a group of bits to an integer.
 
-biquad:: (((biquad)))Biquad IIR filter
+biquad:: (((biquad))) Biquad IIR filter
 
-lowpass:: (((lowpass)))Low-pass filter
+lowpass:: (((lowpass))) Low-pass filter
 
-limit1:: (((limit1)))Limit the output signal to fall between min and max.
+limit1:: (((limit1))) Limit the output signal to fall between min and max.
   footnote:[When the input is a position, this means that the 'position'
   is limited.]
 
-limit2:: (((limit2)))Limit the output signal to fall between min and max.
+limit2:: (((limit2))) Limit the output signal to fall between min and max.
   Limit its slew rate to less than maxv per second. footnote:[When the input
   is a position, this means that 'position' and 'velocity' are limited.]
 
-limit3:: (((limit3)))Limit the output signal to fall between min and max.
+limit3:: (((limit3))) Limit the output signal to fall between min and max.
   Limit its slew rate to less than maxv per second.
   Limit its second derivative to less than MaxA per second squared.
   footnote:[When the input is a position, this means that the 'position',
   'velocity', and 'acceleration' are limited.]
 
-maj3:: (((maj3)))Compute the majority of 3 inputs.
+maj3:: (((maj3))) Compute the majority of 3 inputs.
 
-scale:: (((scale)))Applies a scale and offset to its input.
+scale:: (((scale))) Applies a scale and offset to its input.
 
 === Type conversion
 
-conv_bit_s32:: (((conv_bit_s32)))Convert a value from bit to s32.
+conv_bit_s32:: (((conv_bit_s32))) Convert a value from bit to s32.
 
-conv_bit_u32:: (((conv_bit_u32)))Convert a value from bit to u32.
+conv_bit_u32:: (((conv_bit_u32))) Convert a value from bit to u32.
 
-conv_float_s32:: (((conv_float_s32)))Convert a value from float to s32.
+conv_float_s32:: (((conv_float_s32))) Convert a value from float to s32.
 
-conv_float_u32:: (((conv_float_u32)))Convert a value from float to u32.
+conv_float_u32:: (((conv_float_u32))) Convert a value from float to u32.
 
-conv_s32_bit:: (((conv_s32_bit)))Convert a value from s32 to bit.
+conv_s32_bit:: (((conv_s32_bit))) Convert a value from s32 to bit.
 
-conv_s32_float:: (((conv_s32_float)))Convert a value from s32 to float.
+conv_s32_float:: (((conv_s32_float))) Convert a value from s32 to float.
 
-conv_s32_u32:: (((conv_s32_u32)))Convert a value from s32 to u32.
+conv_s32_u32:: (((conv_s32_u32))) Convert a value from s32 to u32.
 
-conv_u32_bit:: (((conv_u32_bit)))Convert a value from u32 to bit.
+conv_u32_bit:: (((conv_u32_bit))) Convert a value from u32 to bit.
 
-conv_u32_float:: (((conv_u32_float)))Convert a value from u32 to float.
+conv_u32_float:: (((conv_u32_float))) Convert a value from u32 to float.
 
-conv_u32_s32:: (((conv_u32_s32)))Convert a value from u32 to s32.
+conv_u32_s32:: (((conv_u32_s32))) Convert a value from u32 to s32.
 
 [[sec:Realtime-Components-pilotes]]
 === Hardware Drivers
@@ -211,11 +212,11 @@ serport:: (((serport))) Hardware driver for the digital I/O bits of the 8250 and
 [[sec:Realtime-Components-cinematiques]]
 === Kinematics
 
-kins:: (((kins)))kinematics definitions for LinuxCNC.
+kins:: (((kins))) kinematics definitions for LinuxCNC.
 
-gantrykins:: (((gantrykins)))A kinematics module that maps one axis to multiple joints.
+gantrykins:: (((gantrykins))) A kinematics module that maps one axis to multiple joints.
 
-genhexkins:: (((genhexkins)))Gives six degrees of freedom in position and orientation (XYZABC).
+genhexkins:: (((genhexkins))) Gives six degrees of freedom in position and orientation (XYZABC).
   The location of the motors is defined at compile time.
 
 genserkins:: (((genserkins))) Kinematics that can model a general serial-link manipulator with up to
@@ -243,7 +244,7 @@ scarakins:: (((scarakins))) Kinematics for SCARA-type robots.
 
 at_pid:: (((at_pid))) Proportional/integral/derivative controller with auto tuning.
 
-pid:: Proportional/integral/derivative controller. <<sec:pid,Description>>
+pid:: (((pid))) Proportional/integral/derivative controller. <<sec:pid,Description>>
 
 pwmgen:: (((pwmgen))) Software PWM/PDM generation. <<sec:pwmgen,Description>>
 
@@ -326,7 +327,7 @@ tristate_bit:: (((tristate_bit))) Place a signal on an I/O pin only when enabled
 tristate_float:: (((tristate_float))) Place a signal on an I/O pin only when enabled, similar to a tristate
   buffer in electronics.
 
-watchdog:: (((watchdog)))Monitor one to thirty-two inputs for a 'heartbeat'.
+watchdog:: (((watchdog))) Monitor one to thirty-two inputs for a 'heartbeat'.
 
 == HAL API calls
 

--- a/docs/src/hal/hal-examples.adoc
+++ b/docs/src/hal/hal-examples.adoc
@@ -155,9 +155,9 @@ The following figure shows the result when the X axis is moving at 15
 IPM in the minus direction. Notice that we can get the absolute value
 from either the abs.0.out pin or the X-IPM signal.
 
-[[cap:hal-velocity-example]](((HAL Velocity example)))
-//.HAL: Velocity example
-image:images/velocity-01.png["Velocity Example Screenshot"]
+[[cap:hal-velocity-example]]
+.HAL: Velocity Example(((HAL:Velocity example)))
+image::images/velocity-01.png["HAL: Velocity Example",align="center"]
 
 == Soft Start Details
 

--- a/docs/src/hal/halmodule.adoc
+++ b/docs/src/hal/halmodule.adoc
@@ -75,9 +75,8 @@ microseconds, no matter what).
 h = hal.component("passthrough")
 ----
 
-The component itself is created by a call to the constructor
-'hal.component'. The arguments are the HAL component name and
-(optionally) the
+The component itself is created by a call to the constructor 'hal.component'.
+The arguments are the HAL component name and (optionally) the
 prefix used for pin and parameter names. If the prefix is not
 specified, the component name is used.
 
@@ -171,36 +170,44 @@ writing files) must be done to complete the shutdown process.
 
 === component_exists
 
-Does the specified component exist at this time. +
-Example: +
-hal.component_exists("testpanel") +
+Does the specified component exist at this time. Example:
+
+----
+hal.component_exists("testpanel")
+----
 
 === component_is_ready
 
-Is the specified component ready at this time. +
-Example: +
-hal.component_is_ready("testpanel") +
+Is the specified component ready at this time. Example:
+
+----
+hal.component_is_ready("testpanel")
+----
 
 === get_msg_level
 
-Get the current Realtime msg level. +
+Get the current Realtime msg level.
 
 === set_msg_level
 
 set the current Realtime msg level. +
-used for debugging information. +
+used for debugging information.
 
 === connect
 
-Connect a pin to a signal. +
-example: +
+Connect a pin to a signal. Example:
+
+----
 hal.connect("pinname","signal_name")
+----
 
 === get_value
 
-read a pin, param or signal directly. +
-example: +
+read a pin, param or signal directly. Example:
+
+----
 value = hal.get_value("iocontrol.0.emc-enable-in") +
+----
 
 === get_info_pins()
 
@@ -215,6 +222,7 @@ pinDirection1 = listOfDicts[0].get('DIRECTION')
 ----
 
 === get_info_signals()
+
 returns a list of dicts of all system signals.
 
 [source,python]
@@ -238,60 +246,92 @@ paramValue1 = listOfDicts[0].get('VALUE')
 
 === new_signal
 
-Create a New signal of the type specified. Example: +
+Create a New signal of the type specified. Example:
+
+----
 hal.new_sig("signalname",hal.HAL_BIT)
+----
 
 === pin_has_writer
 
 Does the specified pin have a driving pin connected. +
-Returns True or False. +
+Returns True or False.
+
+----
 h.in.pin_has_writer()
+----
 
 === get_name
+
 Get the HAL object name +
-h.in.get_name() +
 return a string
 
+----
+h.in.get_name()
+----
+
 === get_type
+
 Get the HAL object's type +
-h.in.get_type() +
 returns an integer
+
+----
+h.in.get_type()
+----
 
 === get_dir
+
 Get the HAL object direction type +
-h.in.get_dir() +
 returns an integer
 
+----
+h.in.get_dir()
+----
+
 === get
-get the HAL object value +
+
+get the HAL object value
+
+----
 h.in.get()
+----
 
 === set
-set the HAL object value +
+
+set the HAL object value
+
+----
 h.out.set(10)
+----
 
 === is_pin
+
 Is the object a pin or parameter? +
-h.in.is_pin() +
 returns bool
+
+----
+h.in.is_pin()
+----
 
 === sampler_base
 
-TODO +
+TODO
 
 === stream_base
 
-TODO +
+TODO
 
 === stream
 
-TODO +
+TODO
 
 === set_p
 
-Set a pin value of any pin in the HAL system. +
-example: +
+Set a pin value of any pin in the HAL system. Example:
+
+----
 hal.set_p("pinname","10") +
+----
 
 == Constants
 
@@ -416,7 +456,6 @@ This shows ways to get the pin value and information.
         # this can be called outside the function
         print(self.testPin.get())
 ----
-
 
 == Project ideas
 

--- a/docs/src/hal/halshow.adoc
+++ b/docs/src/hal/halshow.adoc
@@ -54,7 +54,7 @@ you might see with some file browsers. At the right is a tabbed notebook with
 tabs for show and watch.
 
 [[cap:halshow-layout]]
-//.Halshow Layout
+.The Halshow Layout
 image::images/halshow-1.png["Halshow Layout",align="center"]
 
 The tree shows all of the major parts of a HAL. In front of each is a
@@ -69,7 +69,7 @@ Expand Signals; and Erase Watch. (Note that Erase Watch erases 'all'
 previously set watches, you cannot erase just one watch.)
 
 [[fig:halshow-show-tab]]
-//.Show Tab
+.Show Tab
 image::images/halshow-3.png["Show Tab",align="center"]
 
 == HAL Show Area
@@ -131,6 +131,9 @@ position, i.e., acceleration. We first need to load a HAL component named
 ddt, add it to the servo thread, then connect it to the position pin
 of a joint. Once that is done we can find the output of the
 differentiator in halscope. So let's go. (Yes, I looked this one up.)
+
+[NOTE]
+The message output when ddt is loaded doesn't prevent it from running.
 
 ----
 loadrt ddt
@@ -195,7 +198,7 @@ position in the thread. The following figure shows the state of halshow
 after this command has been issued.
 
 [[fig:halshow-addf-command]]
-//.Addf command
+.Addf command
 image::images/halshow-2.png["Addf command",align="center"]
 
 Next we need to connect ddt to something. But how do we know
@@ -276,7 +279,7 @@ the corresponding pin has to be unlinked from the signal. That can be done by
 right-click on the signal name and select "Unlink pin", see <<cap:watch-tab-context-menu>>.
 
 [[fig:halshow-watch-tab]](((Halshow: Watch Tab)))
-//.Watch Tab 
+.The Watch Tab
 image:images/halshow-4.png["Watch Tab",align="center"]
 
 Watch displays bit type (binary) values using colored circles
@@ -293,7 +296,7 @@ increments of distance. If you've used IO_Show in LinuxCNC, the watch page
 in halshow can be set up to watch a parport much as IO_Show did.
 
 [[cap:watch-tab-context-menu]]
-//.Watch Tab context menu
+.The Watch Tab context menu
 image:images/halshow-5.png["Watch Tab context menu",align="center"]
 
 // vim: set syntax=asciidoc:

--- a/docs/src/hal/halshow.adoc
+++ b/docs/src/hal/halshow.adoc
@@ -54,7 +54,7 @@ you might see with some file browsers. At the right is a tabbed notebook with
 tabs for show and watch.
 
 [[cap:halshow-layout]]
-.The Halshow Layout
+.Halshow Layout
 image::images/halshow-1.png["Halshow Layout",align="center"]
 
 The tree shows all of the major parts of a HAL. In front of each is a
@@ -69,8 +69,8 @@ Expand Signals; and Erase Watch. (Note that Erase Watch erases 'all'
 previously set watches, you cannot erase just one watch.)
 
 [[fig:halshow-show-tab]]
-.Show Tab
-image::images/halshow-3.png["Show Tab",align="center"]
+.Halshow: Show Tab
+image::images/halshow-3.png["Halshow: Show Tab",align="center"]
 
 == HAL Show Area
 
@@ -278,9 +278,9 @@ side. Pins that are linked to a signal have disabled buttons. To set these value
 the corresponding pin has to be unlinked from the signal. That can be done by
 right-click on the signal name and select "Unlink pin", see <<cap:watch-tab-context-menu>>.
 
-[[fig:halshow-watch-tab]](((Halshow: Watch Tab)))
-.The Watch Tab
-image:images/halshow-4.png["Watch Tab",align="center"]
+[[fig:halshow-watch-tab]]
+.Halshow: Watch Tab(((Halshow: Watch Tab)))
+image::images/halshow-4.png["Halshow: Watch Tab",align="center"]
 
 Watch displays bit type (binary) values using colored circles
 representing LEDs. They show as dark red when a bit signal or pin is
@@ -296,7 +296,7 @@ increments of distance. If you've used IO_Show in LinuxCNC, the watch page
 in halshow can be set up to watch a parport much as IO_Show did.
 
 [[cap:watch-tab-context-menu]]
-.The Watch Tab context menu
-image:images/halshow-5.png["Watch Tab context menu",align="center"]
+.Halshow: Watch Tab Context Menu
+image::images/halshow-5.png["Halshow: Watch Tab Context Menu",align="center"]
 
 // vim: set syntax=asciidoc:

--- a/docs/src/hal/haltcl.adoc
+++ b/docs/src/hal/haltcl.adoc
@@ -21,7 +21,7 @@ ini files.  Haltcl files are identified in the the HAL section of ini files
 [HAL]
 HALFILE = conventional_file.hal
 HALFILE = tcl_based_file.tcl
------
+----
 
 With appropriate care, .hal and .tcl files can be intermixed.
 
@@ -29,7 +29,6 @@ With appropriate care, .hal and .tcl files can be intermixed.
 
 The halcmd language used in .hal files has a simple syntax that is actually a
 subset of the more powerful general-purpose tcl scripting language.
-
 
 == Haltcl Commands
 
@@ -61,7 +60,6 @@ halcmd   haltcl
 gets     hal gets
 list     hal list
 ....
-
 
 == Haltcl Inifile variables
 
@@ -102,7 +100,7 @@ MAX_VELOCITY = 4
 ----
 
 is expressed as   [JOINT_0]MAX_VELOCITY  in .hal files for halcmd +
-and as          $::JOINT_0(MAX_VELOCITY) in .tcl files for haltcl +
+and as            $::JOINT_0(MAX_VELOCITY) in .tcl files for haltcl.
 
 Because inifiles can repat the same ITEM in the same SECTION multiple times,
 $::SECTION(ITEM) is actually a Tcl list of each individual value.
@@ -241,7 +239,6 @@ capability is useful for testing and for standalone hal applications.
 ----
 $ halrun -T haltclfile.tcl
 ----
-
 
 == Haltcl Distribution Examples (sim)
 

--- a/docs/src/hal/intro.adoc
+++ b/docs/src/hal/intro.adoc
@@ -112,8 +112,8 @@ hardware to LinuxCNC. See the
 <<sec:halui-remote-start,Remote Start Example>>
 section in the HAL UI Examples documentation.
 
-.Remote Start Example Schema
-image::images/remote-start.png["Remote Start Example"]
+.Remote Start Example (Schema)
+image::images/remote-start.png["Remote Start Example Schema"]
 
 The traditional hardware design as described above ends at the edge of
 the main control. Outside the control are a bunch of relatively simple
@@ -221,13 +221,13 @@ Type:: (((HAL Type)))
   have the same restrictions, which are based upon their type. Both pins
   and signals have types, and signals can only be connected to pins of
   the same type. Currently there are 4 types, as follows:
-
++
 - bit - a single TRUE/FALSE or ON/OFF value
 - float - a 64 bit floating point value, with approximately 53 bits of
-resolution and over 1000 bits of dynamic range.
+  resolution and over 1000 bits of dynamic range.
 - u32 - a 32 bit unsigned integer, legal values are 0 to 4,294,967,295
 - s32 - a 32 bit signed integer, legal values are -2,147,483,647 to
-+2,147,483,647
+  +2,147,483,647
 
 Function:: (((HAL:Function)))
   Real hardware components tend to

--- a/docs/src/hal/parallel-port.adoc
+++ b/docs/src/hal/parallel-port.adoc
@@ -26,7 +26,7 @@ used as an input.
 .HAL and Open Collectors
 
 [NOTE]
-===========================================================
+====
 HAL cannot automatically determine if the 'x' mode bidirectional pins are
 actually open collectors (OC). If they are not, they cannot be used as inputs,
 and attempting to drive them LOW from an external source can damage the
@@ -44,7 +44,7 @@ open collector gates (e.g., 74LS05).
 
 On some computers, BIOS settings may affect whether 'x' mode can be
 used. 'SPP' mode is most likely to work.
-===========================================================
+====
 
 No other combinations are supported, and a port cannot be changed from input to
 output once the driver is installed.
@@ -102,7 +102,6 @@ address,  such as 0x278 or 0x378 which are typically configured in the BIOS. The
 line, or in a kernel message after running `sudo modprobe -a parport_pc`.
 There is no default address, so if `<config-string>` does not contain at least one
 address, it is an error.
-
 
 [[fig:parport-block-diag]]
 .Parport block diagram(((Parport block diag)))
@@ -232,10 +231,10 @@ physical pin is high.
 
 * 'parport.<p>.pin-<n>-out-invert' (bit) Inverts an output pin.
 * 'parport.<p>.pin-<n>-out-reset' (bit) (only for 'out' pins) TRUE if this
-pin should be reset when the '-reset' function is executed.
+  pin should be reset when the '-reset' function is executed.
 * parport.<p>.reset-time' (U32) The time (in nanoseconds)
-between a pin is set by 'write' and reset by the 'reset' function if it
-is enabled.
+  between a pin is set by 'write' and reset by the 'reset' function if it
+  is enabled.
 
 The '-invert'  parameter determines whether an output pin is active
 high or active
@@ -248,16 +247,12 @@ setting the HAL '-out' pin TRUE will drive the physical pin low.
 
 * 'parport.<p>.read' (funct) Reads physical input pins of port
   '<portnum>' and updates HAL '-in' and '-in-not' pins.
-
 * 'parport.read-all' (funct) Reads physical input pins of all ports
   and updates HAL '-in' and '-in-not' pins.
-
 * 'parport.<p>.write' (funct) Reads HAL '-out' pins of port
   '<p>' and updates that port's physical output pins.
-
 * 'parport.write-all' (funct) Reads HAL '-out' pins of all ports
   and updates all physical output pins.
-
 * 'parport.<p>.reset' (funct) Waits until 'reset-time' has
   elapsed since the associated 'write', then resets pins to values
   indicated by '-out-invert' and '-out-invert' settings. 'reset' must be

--- a/docs/src/hal/rtcomps.adoc
+++ b/docs/src/hal/rtcomps.adoc
@@ -21,6 +21,7 @@ step type '0', (step and direction). The second is for step type '1'
 control, and the third one shows velocity mode. Control mode and step type
 are set independently, and any combination can be selected.
 
+[[fig:stepgen-block-diagram]]
 .Step Pulse Generator Block Diagram position mode(((Stepgen Block Diagram)))
 image::images/stepgen-block-diag.png[align="center"]
 
@@ -136,6 +137,7 @@ generated pulse train.
 Step generator supports 15 different _step sequences_:
 
 .Step Type 0
+
 Step type 0 is the standard step and direction type. When configured for
 step type 0, there are four extra parameters that determine the exact
 timing of the step and direction signals. In the following figure
@@ -185,16 +187,17 @@ patterns as a function of the state counter. The maximum frequency is
 will be lowered if it is above the limit.
 
 .Two-and-Three-Phase Step Types(((Two and Three Phase)))
-image::images/stepgen-type2-4.png[align="center"]
+image::images/stepgen-type2-4.png["Step Types: Two-and-Three-Phase",align="center"]
 
 .Four-Phase Step Types(((Four Phase)))
-image::images/stepgen-type5-10.png[align="center"]
+image::images/stepgen-type5-10.png["Step Types: Four-Phase",align="center"]
 
 .Five-Phase Step Types(((Five Phase)))
-image::images/stepgen-type11-14.png["Five-Phase Step Types",align="center"]
+image::images/stepgen-type11-14.png["Step Types: Five-Phase",align="center"]
 
 [[sub:stepgen-functions]]
-.Functions(((Hal stepgen Functions)))
+=== Functions(((Hal stepgen Functions)))
+
 The component exports three functions. Each function acts on all of
 the step pulse generators - running different generators in different
 threads is not supported.
@@ -259,7 +262,8 @@ PWM generators starts at 0.
 unloadrt pwmgen
 ----
 
-.PWMgen Output Types
+=== PWMgen Output Types
+
 The PWM generator supports three different 'output types'.
 
 * 'Output type 0' - PWM output pin only. Only positive commands are accepted,
@@ -275,7 +279,8 @@ The PWM generator supports three different 'output types'.
   commands, the PWM signal appears on the down output, and the up output
   remains false. Output type 2 is suitable for driving most H-bridges.
 
-.PWMgen Pins
+=== PWMgen Pins
+
 Each PWM generator will have the following pins:
 
 * '(float) pwmgen.<chan>.value' - Command value, in arbitrary units.
@@ -294,7 +299,8 @@ output type selected:
 * '(bit) pwmgen.<chan>.down' - PWM/PDM output for negative input value
   (output type 2 only).
 
-.PWMgen Parameters
+=== PWMgen Parameters
+
 * '(float) pwmgen.<chan>.scale' - Scaling factor to convert 'value'
   from arbitrary units to duty cycle. For example if scale is set to 4000
   and the input value passed to the pwmgen.<chan>.value is 4000 then it will
@@ -318,7 +324,8 @@ output type selected:
 * '(float) pwmgen.<chan>.curr-dc' - Current duty cycle - after all
   limiting and rounding (read only).
 
-.PWMgen Functions
+=== PWMgen Functions
+
 The component exports two functions. Each function acts on all of the
 PWM generators - running different generators in different threads is
 not supported.
@@ -356,8 +363,9 @@ second or 50 us between counts.
 The Encoder Counter Block Diagram is a block diagram of one channel of an
 encoder counter.
 
+[[fig:encoder-block-diagram]]
 .Encoder Counter Block Diagram(((Encoder Block Diagram)))
-//image::images/encoder-block-diag.png[align="center"]
+image::images/encoder-block-diag.png[align="center"]
 
 .Loading Encoder
 ----
@@ -377,7 +385,8 @@ of a specific counter. The first counter is number 0.
 halcmd: unloadrt encoder
 ----
 
-.Encoder Pins
+=== Encoder Pins
+
 * 'encoder.<chan>.counter-mode' (bit, I/O) (default: FALSE) - Enables
   counter mode. When true, the
   counter counts each rising edge of the phase-A input, ignoring the
@@ -454,13 +463,14 @@ halcmd: unloadrt encoder
   only counts once per full cycle. In counter-mode, this parameter is
   ignored. The 1x mode is useful for some jogwheels.
 
-.Encoder Parameters
+=== Encoder Parameters
+
 * 'encoder.<chan>.capture-position.time (s32, RO)'
 * 'encoder.<chan>.capture-position.tmax (s32, RW)'
 * 'encoder.<chan>.update-counters.time (s32, RO)'
 * 'encoder.<chan>.update-counter.tmax (s32, RW)'
 
-.Encoder Functions
+=== Encoder Functions
 
 The component exports two functions. Each function acts on all of the
 encoder counters - running different counters in different threads is
@@ -508,7 +518,8 @@ cluttering the pin list.
 halcmd: unloadrt pid
 ----
 
-.PID Pins
+=== PID Pins
+
 The three most important pins are
 
 * '(float) pid.<loopnum>.command' - The desired position, as
@@ -577,7 +588,8 @@ additional pins will be exported:
 * '(float) pid.<loopnum>.commandD' - Derivative of the command.
 * '(float) pid.<loopnum>.commandDD' - 2nd derivative of the command.
 
-.PID Functions
+=== PID Functions
+
 The component exports one function for each PID loop. This function
 performs all the calculations needed for the loop. Since each loop has
 its own function, individual loops can be included in different threads
@@ -613,7 +625,8 @@ defined by MAX_CHAN in sim_encoder.c).
 halcmd: unloadrt sim-encoder
 ----
 
-.Sim-encoder Pins
+=== Sim-encoder Pins
+
 * '(float) sim-encoder.<chan-num>.speed' - The speed command for the
   simulated shaft.
 * '(bit) sim-encoder.<chan-num>.phase-A' - Quadrature output.
@@ -622,18 +635,20 @@ halcmd: unloadrt sim-encoder
 
 When '.speed' is positive, '.phase-A' leads '.phase-B'.
 
-.Sim-encoder Parameters
+=== Sim-encoder Parameters
+
 * '(u32) sim-encoder.<chan-num>.ppr' - Pulses Per Revolution.
 * '(float) sim-encoder.<chan-num>.scale' - Scale Factor for 'speed'.
-The default is 1.0, which means that 'speed' is in revolutions per
-second. Change to 60 for RPM, to 360 for
-degrees per second, 6.283185 for radians per seconed, etc.
+  The default is 1.0, which means that 'speed' is in revolutions per
+  second. Change to 60 for RPM, to 360 for
+  degrees per second, 6.283185 for radians per seconed, etc.
 
 Note that pulses per revolution is not the same as counts per
 revolution. A pulse is a complete quadrature cycle. Most encoder
 counters will count four times during one complete cycle.
 
-.Sim-encoder Functions
+=== Sim-encoder Functions
+
 The component exports two functions. Each function affects all
 simulated encoders.
 
@@ -655,9 +670,9 @@ halcmd: loadrt debounce cfg=<config-string>
 ----
 
 <config-string>:: Is a series of comma separated decimal integers.
-Each number installs
-a group of identical debounce filters, the number determines how many
-filters are in the group.
+  Each number installs
+  a group of identical debounce filters, the number determines how many
+  filters are in the group.
 
 .Loading debounce Example
 ----
@@ -682,13 +697,15 @@ filter 0.
 halcmd: unloadrt debounce
 ----
 
-.Debounce Pins
+=== Debounce Pins
+
 Each individual filter has two pins.
 
 * '(bit) debounce.<G>.<F>.in' - Input of filter '<F>' in group '<G>'.
 * '(bit) debounce.<G>.<F>.out' - Output of filter '<F>' in group '<G>'.
 
-.Debounce Parameters
+=== Debounce Parameters
+
 Each group of filters has one parameterfootnote:[Each individual
 filter also has an internal state variable. There is a
 compile time switch that can export that variable as a parameter. This
@@ -703,7 +720,7 @@ doesn't filter anything. As 'delay' increases, longer and longer
 glitches are rejected. If 'delay' is 4, all glitches less than or
 equal to four thread periods will be rejected.
 
-.Debounce Functions
+=== Debounce Functions
 
 Each group of filters has one function, which updates all the filters
 in that group 'simultaneously'. Different groups of filters can be
@@ -723,19 +740,20 @@ halcmd: loadrt siggen [num_chan=<chans>]
 ----
 
 <chans>:: is the number of signal generators that you want to install.
-If 'numchan' is not specified, one signal generator will be installed.
-The maximum
-number of generators is 16 (as defined by MAX_CHAN in siggen.c). Each
-generator is completely independent. In the following descriptions,
+  If 'numchan' is not specified, one signal generator will be installed.
+  The maximum
+  number of generators is 16 (as defined by MAX_CHAN in siggen.c). Each
+  generator is completely independent. In the following descriptions,
 <chan>:: is the number of a specific signal generator (the numbers
-start at 0).
+  start at 0).
 
 .Unloading siggen
 ----
 halcmd: unloadrt siggen
 ----
 
-.Siggen Pins
+=== Siggen Pins
+
 Each generator has five output pins.
 
 * '(float) siggen.<chan>.sine' - Sine wave output.
@@ -760,12 +778,14 @@ For example, if 'siggen.0.amplitude' is 1.0 and 'siggen.0.offset' is
 is 2.5 and 'siggen.0.offset' is 10.0, then the outputs will swing from
 7.5 to 12.5.
 
-.Siggen Parameters
+=== Siggen Parameters
+
 None. footnote:[Prior to version 2.1, frequency, amplitude, and offset
 were parameters. They were changed to pins to allow control by other
 components.]
 
-.Siggen Functions
+=== Siggen Functions
+
 * '(funct) siggen.<chan>.update' - Calculates new values for all five outputs.
 
 [[sec:lut5]]

--- a/docs/src/hal/tutorial.adoc
+++ b/docs/src/hal/tutorial.adoc
@@ -564,7 +564,7 @@ In this example we will use the _velocity_ control type from the `stepgen`
 component.
 
 ----
-halrun
+halrun:
 halcmd: loadrt stepgen step_type=0,0 ctrl_type=v,v
 halcmd: loadrt siggen
 halcmd: loadrt threads name1=fast fp1=0 period1=50000 name2=slow period2=1000000
@@ -983,7 +983,7 @@ only. For larger adjustments the offset button should be used.
 
 [[fig:halscope-vertical-adjustment]]
 .Vertical Adjustment
-image::images/halscope-07.png["Vertical Adjustment", align="center"]
+image::images/halscope-07.png["Vertical Adjustment",align="center"]
 
 The large _Selected Channel_ button at the bottom indicates that channel 1 is
 currently selected channel and that it matches the _X-vel_ signal.

--- a/docs/src/ladder/ladder-intro.adoc
+++ b/docs/src/ladder/ladder-intro.adoc
@@ -78,9 +78,9 @@ The most common components of ladder are contacts (inputs), these
 usually are either NC (normally closed) or NO (normally open), and
 coils (outputs).
 
- - the NO contact image:images/ladder_action_load.png[]
- - the NC contact image:images/ladder_action_loadbar.png[]
- - the coil (output) image:images/ladder_action_out.png[]
+- the NO contact image:images/ladder_action_load.png[]
+- the NC contact image:images/ladder_action_loadbar.png[]
+- the coil (output) image:images/ladder_action_out.png[]
 
 Of course there are many more components to a full ladder language,
 but understanding these will help you grasp the overall concept.
@@ -91,7 +91,7 @@ outputs and other), which get evaluated left to right.
 
 This example is the simplest rung:
 
-image:images/example_link_contact_coil.png[align="center"]
+image::images/example_link_contact_coil.png[align="center"]
 
 The input on the left, B0, a normally open contact, is connected to the
 coil (output) on the right, Q0. Now imagine a voltage gets applied to the
@@ -120,7 +120,7 @@ connect it across the B0 'pushbutton' contact from our earlier example.
 
 Let's take a look at it:
 
-image:images/example_link_contact_coil2.png[align="center"]
+image::images/example_link_contact_coil2.png[align="center"]
 
 As before, when the user presses pushbutton B0, coil Q0 comes on.
 And when coil Q0 comes on, switch Q0 comes on. Now the interesting
@@ -145,7 +145,7 @@ interrupt the power to coil Q0. So let's add a normally-closed
 
 Here's how that would look:
 
-image:images/example_link_contact_coil3.png[align="center"]
+image::images/example_link_contact_coil3.png[align="center"]
 
 Now we have added 'off' or 'stop' pushbutton B1. If the user
 pushes it, contact from the rung to the coil is broken.

--- a/docs/src/lathe/lathe-user.adoc
+++ b/docs/src/lathe/lathe-user.adoc
@@ -66,20 +66,21 @@ angle of each orientation and info on FRONTANGLE and BACKANGLE.
 
 The FRONTANGLE and BACKANGLE are clockwise starting at a line parallel to Z+.
 
+.Lathe Tool Orientations
 image::images/tool-positions_en.svg["Lathe Tool Orientations",align="center"]
 
 In AXIS the following figures show what the Tool Positions look like, as
 entered in the tool table.
 
 [[fig:Outil-Positions-1-2-3-4]]
-.Tool Positions 1, 2, 3 & 4(((Outils en positions 1, 2, 3 et 4)))
+.Tool Positions 1, 2, 3 & 4(((Tool Positions 1, 2, 3 & 4)))
 image:images/tool-pos-1_en.svg["Tool Position 1"]
 image:images/tool-pos-2_en.svg["Tool Position 2"]
 image:images/tool-pos-3_en.svg["Tool Position 3"]
 image:images/tool-pos-4_en.svg["Tool Position 4"]
 
 [[fig:Outil-Positions-5-6-7-8]]
-.Tool Positions 5, 6, 7 & 8(((Outils en positions 5, 6, 7 et 8)))
+.Tool Positions 5, 6, 7 & 8(((Tool Positions 5, 6, 7 & 8)))
 image:images/tool-pos-5_en.svg["Tool Position 5"]
 image:images/tool-pos-6_en.svg["Tool Position 6"]
 image:images/tool-pos-7_en.svg["Tool Position 7"]
@@ -248,7 +249,8 @@ the programmed path unless cutter comp is in effect. In the following
 figures you can see how the control point does not follow the tool edge
 as you might assume.
 
-image::images/control-point_en.svg["Control Point",align="center"]
+.Control point
+image::images/control-point_en.svg["Control point",align="center"]
 
 === Cutting Angles without Cutter Comp
 
@@ -298,7 +300,7 @@ amount of material will be left from the radius of the tool. To finish
 a face cut to the center of a part you have to program the tool to go
 past center at least the nose radius of the tool.
 
-image::images/radius-4_en.svg["Face Cut Image",align="center"]
+image::images/radius-4_en.svg["Face Cut",align="center"]
 
 === Using Cutter Comp
 

--- a/docs/src/lathe/lathe-user.adoc
+++ b/docs/src/lathe/lathe-user.adoc
@@ -17,24 +17,24 @@ See the <<cha:ini-configuration,INI Configuration>> section for more details.
 
 To set up AXIS for Lathe Mode.
 
----------------------------------------
+----
 [DISPLAY]
 
 # Tell the Axis Display our machine is a lathe.
 LATHE = TRUE
----------------------------------------
+----
 
 Lathe Mode in Axis does not set your default plane to G18 (XZ). You
 must program that in the preamble of each G-code file or
 (better) add it to your ini file, like this:
 
----------------------------------------
+----
 [RS274NGC]
 
 # G-code modal codes (modes) that the interpreter is initialized with
 # on startup
 RS274NGC_STARTUP_CODE = G18 G20 G90
----------------------------------------
+----
 
 If your using Gmoccapy then see the
 <<gmoccapy:lathe-section,the Gmoccapy Lathe section>>.
@@ -141,7 +141,8 @@ A typical session might be:
 . Set the current tool with 'Tn M6 G43' where 'n' is the tool number.
 . Select the Z axis in the Manual Control window.
 . Bring the tool close to the control surface.
-. Using a cylinder move the Z away from the control surface until the cylinder just passes between the tool and the control surface.
+. Using a cylinder move the Z away from the control surface until the
+  cylinder just passes between the tool and the control surface.
 . Select Touch Off and pick Tool Table and set the position to 0.0.
 . Repeat for each tool using the same cylinder.
 

--- a/docs/src/motion/kinematics.adoc
+++ b/docs/src/motion/kinematics.adoc
@@ -116,7 +116,7 @@ axis letters used.
 
 It gets a bit more complicated if the machine is missing one or more of the
 axis letters.  The problems of omitted axis letters is addressed by using the
-'coordinates=' module parameter with the trivkins module.  Joint numbers are
+'coordinates=' module parameter with the trivkins module. Joint numbers are
 assigned consecutively to each coordinate specified.  A lathe can be described
 with 'coordinates=xz' The joint assignments will then be:
 
@@ -130,7 +130,7 @@ axis letters. footnote:[ Historically, the trivkins module did not support the
 'coordinates=' parameter so lathe configs were often configured as XYZ
 machines.  The unused Y axis was configured to 1) home immediately, 2) use a
 simple loopback to connect its position command hal pin to its position
-feedback hal pin, and 3) hidden in gui displays.   Numerous sim configs use
+feedback hal pin, and 3) hidden in gui displays. Numerous sim configs use
 these methods in order to share common hal files.]
 
 The 'trivkins' kinematics module also allows the same coordinate to be specified
@@ -187,27 +187,27 @@ to Cartesian coordinates (Dx, Dy) and vice-versa.
 
 To transform from joint space into Cartesian space we will use some
 trigonometry rules (the right triangles determined by the points (0,0),
-(Dx,0), (Dx,Dy) and the triangle (Dx,0), (Bx,0) and (Dx,Dy).
+(Dx,0), (Dx,Dy) and the triangle (Dx,0), (Bx,0) and (Dx,Dy)).
 
 We can easily see that:
 
-image:images/kinematics-math-01.png[align="center"],
+image::images/kinematics-math-01.png[align="center"]
 
 likewise:
 
-image:images/kinematics-math-02.png[align="center"]
+image::images/kinematics-math-02.png[align="center"]
 
 If we subtract one from the other we will get:
 
-image:images/kinematics-math-03.png[align="center"]
+image::images/kinematics-math-03.png[align="center"]
 
 and therefore:
 
-image:images/kinematics-math-04.png[align="center"]
+image::images/kinematics-math-04.png[align="center"]
 
 From there we calculate:
 
-image:images/kinematics-math-05.png[align="center"]
+image::images/kinematics-math-05.png[align="center"]
 
 ////////////////////////////////////////////////////////////////////
 we can easily see that latexmath:[$AD^{2}=x^{2}+y^{2}$], likewise
@@ -258,7 +258,7 @@ image::images/kinematics-math-07.png[align="left"]
 latexmath::[\[AD=\sqrt{x^{2}+y^{2}}\]]
 
 latexmath::[\[BD=\sqrt{(Bx-x)^{2}+y^{2}}\]]
-////////////////////////////////////////////////
+/////////////////////////////////////////////////
 
 or translated to actual code:
 
@@ -266,7 +266,7 @@ or translated to actual code:
 double x2 = pos->tran.x * pos->tran.x;
 double y2 = pos->tran.y * pos->tran.y;
 joints[0] = sqrt(x2 + y2);
-joints[1] = sqrt(Bx - pos->tran.x)*(Bx - pos->tran.x) + y2);
+joints[1] = sqrt((Bx - pos->tran.x)*(Bx - pos->tran.x) + y2);
 return 0;
 ----
 
@@ -361,4 +361,3 @@ modifications are somewhat more complicated.
 
 See 'millturn.comp' as an example of a switchable kinematic
 module that was created using the 'userkins.comp' template.
-

--- a/docs/src/motion/pid-theory.adoc
+++ b/docs/src/motion/pid-theory.adoc
@@ -4,7 +4,6 @@
 [[cha:pid-tuning]]
 = PID Tuning(((PID Tuning)))
 
-
 == PID Controller
 
 A proportional-integral-derivative controller (PID controller) is a

--- a/docs/src/user/user-concepts.adoc
+++ b/docs/src/user/user-concepts.adoc
@@ -41,7 +41,7 @@ For more information on the Trajectory Panner ini options see the
 <<sec:traj-section,Trajectory Section>> in the INI chapter.
 
 [[sub:path-following]]
-=== Path Following(((Path Following)))
+=== Path Following(((Trajectory Planning:Path Following)))
 
 A less straightforward problem is that of path following. When you
 program a corner in G Code, the trajectory planner can do several
@@ -63,7 +63,7 @@ enough to reach maximum velocity on a machine with low acceleration and
 no path tolerance specified, you can get a fairly round corner.
 
 [[sub:programming-the-planner]]
-=== Programming the Planner(((Programming the Planner)))
+=== Programming the Planner(((Trajectory Planning:Programming the Planner)))
 
 The trajectory control commands are as follows:
 
@@ -133,11 +133,11 @@ the next move. The bottom plot shows the effect of the Naive Cam
 Detector to combine the moves and do a better job of keeping the
 velocity as planned.
 
-//.Naive CAM Detector
+.Naive CAM Detector
 image::images/naive-cam.png["Naive CAM Detector",align="center"]
 
 [[sub:planning-moves]]
-=== Planning Moves(((Planning Moves)))
+=== Planning Moves(((Trajectory Planning:Planning Moves)))
 
 Make sure moves are 'long enough' to suit your machine/material.
 Principally because of the rule that the machine will never move at
@@ -313,13 +313,13 @@ reversed, +X will be on the right of the table and -X on the left. This
 inversion does not change anything from the point of view of the direction of
 movement of the tool.
 
-//.Typical Mill Configuration
-image::images/mill-diagram_en.svg["Mill Configuration",align="center"]
+.Typical Mill Configuration
+image::images/mill-diagram_en.svg["Typical Mill Configuration",align="center"]
 
 The following diagram shows a typical lathe showing direction of travel
 of the tool and limit switches.
 
-//.Typical Lathe Configuration
-image::images/lathe-diagram_en.svg["Lathe Configuration",align="center"]
+.Typical Lathe Configuration
+image::images/lathe-diagram_en.svg["Typical Lathe Configuration",align="center"]
 
 // vim: set syntax=asciidoc:

--- a/docs/src/user/user-concepts.adoc
+++ b/docs/src/user/user-concepts.adoc
@@ -106,7 +106,7 @@ Blending without tolerance:: The controlled point will touch each specified
   distance from the end point of the move is as large as it needs to be to
   keep up the best contouring feed.
 
-Naive Cam Detector:: Successive G1 moves that involve only the XYZ axes
+Naive CAM Detector:: Successive G1 moves that involve only the XYZ axes
   that deviate less than Q- from a straight line are merged into a single
   straight line. This merged movement replaces the individual G1 movements
   for the purposes of blending with tolerance. Between successive movements,

--- a/docs/src/user/user-intro.adoc
+++ b/docs/src/user/user-intro.adoc
@@ -32,7 +32,7 @@ complete system:
 The below illustration is a simple block diagram showing what a typical 3-axis, CNC mill with stepper
 motors might look like:
 
-//.Simple LinuxCNC Controlled Machine
+.Simple LinuxCNC Controlled Machine
 image::images/whatstep1.png["Simple LinuxCNC Controlled Machine",align="center"]
 
 A computer running LinuxCNC sends a sequence of pulses via the parallel port to the stepper drives, each of
@@ -103,41 +103,41 @@ AXIS:: <<cha:axis-gui,AXIS>>, the standard keyboard GUI interface. This is also 
   Configuration Wizard is used to create a desktop icon launcher:
 
 [[fig:axis-graphical-interface]]
-//.AXIS graphical interface
-image::../gui/images/axis.png["Axis, the standard keyboard GUI interface",align="center"]
+.AXIS, the standard keyboard GUI interface
+image::../gui/images/axis.png["AXIS, the standard keyboard GUI interface",align="center"]
 
 Touchy:: <<cha:touchy-gui,Touchy>>, a touch screens GUI:
 
 [[fig:touchy-graphical-interface]]
-//.Touchy graphical interface
+.Touchy, a touch screen GUI
 image::../gui/images/touchy.png["Touchy, a touch screen GUI",align="center"]
 
 Gscreen:: <<cha:gscreen,Gscreen>>, a user-configurable touch screen GUI:
 
 [[fig:gscreen-graphical-interface]]
-//.Gscreen graphical interface
+.Gscreen, a configurable base touch screen GUI
 image::../gui/images/gscreen-mill.png["Gscreen, a configurable base touch screen GUI",align="center"]
 
 GMOCCAPY:: <<cha:gmoccapy,GMOCCAPY>>, a touch screen GUI based on Gscreen. GMOCCAPY is also designed to work equally
   well in applications where a keyboard and mouse are the preferred methods of controlling the GUI:
 
 [[fig:gmoccapy-graphical-interface]]
-//.GMOCCAPY graphical interface
-image::../gui/images/gmoccapy_3_axis.png["gmoccapy, a touch screen GUI based on Gscreen",align="center"]
+.GMOCCAPY, a touch screen GUI based on Gscreen
+image::../gui/images/gmoccapy_3_axis.png["GMOCCAPY, a touch screen GUI based on Gscreen",align="center"]
 
 NGCGUI:: <<cha:ngcgui,NGCGUI>>, a subroutine GUI that provides wizard-style programming of G code. NGCGUI may be
   run as a standalone program or embedded into another GUI as a series of tabs. The following screen shot
   shows NGCGUI embedded into Axis:
 
 [[fig:ngcgui-graphical-interface-into-axis]]
-//.NGCGUI graphical interface integrated into Axis
-image::../gui/images/ngcgui.png["NGCGUI graphical interface integrated into Axis",align="center"]
+.NGCGUI, a graphical interface integrated into AXIS
+image::../gui/images/ngcgui.png["NGCGUI, a graphical interface integrated into AXIS",align="center"]
 
 TkLinuxCNC:: <<sec:tklinuxcnc-intro,TkLinuxCNC>>, another interface based on Tcl/Tk.
   Once the most popular interface after AXIS.
 
 [[fig:tklinuxcnc-gui]]
-//.TkLinuxCNC graphical interface
+.TkLinuxCNC graphical interface
 image::images/tklinuxcnc_fr.png["TkLinuxCNC graphical interface",align="center"]
 
 Xemc:: an X-Window program
@@ -159,16 +159,16 @@ PyVCP:: <<cha:pyvcp,'PyVCP'>>, a Python-based virtual control panel that can be 
   indicator or the Emergency Stop output signal, and has a simple no-frills appearance. This makes it an
   excellent choice if the user wants to add a Virtual Control Panel with minimal fuss.
 
-//.PyVCP Example Embedded Into AXIS GUI
-image::../gui/images/axis-pyvcp.png["PyVCP with Axis",align="center"]
+.PyVCP Example Embedded Into AXIS GUI
+image::../gui/images/axis-pyvcp.png["PyVCP embedded into Axis",align="center"]
 
 GladeVCP:: <<cha:glade-vcp,'GladeVCP'>>, a Glade-based virtual control panel that can be added to the Axis or Touchy
   GUIs. GladeVCP has the advantage over PyVCP in that it is not limited to the display or control of HAL
   virtual signals, but can include other external interfaces outside LinuxCNC such as window or network
   events. GladeVCP is also more flexible in how it may be configured to appear on the GUI:
 
-//.GladeVCP Example Embedded Into AXIS GUI
-image::../gui/images/axis-gladevcp.png["GladeVCP with Axis",align="center"]
+.GladeVCP Example Embedded Into AXIS GUI
+image::../gui/images/axis-gladevcp.png["GladeVCP embedded into Axis",align="center"]
 
 == Languages
 

--- a/docs/src/user/user-intro.adoc
+++ b/docs/src/user/user-intro.adoc
@@ -57,40 +57,40 @@ For example, if the Stepper Configuration Wizard was used to create a setup for 
 illustrated above entitled 'My_CNC', the folders created by the wizard would typically contain the
 following files:
 
-* Folder: My_CNC
-** My_CNC.ini
-*** The INI file contains all the basic hardware information regarding the operation of the CNC mill such
-    as the number of steps each stepper motor must turn to complete one full revolution, the maximum rate at
-    which each stepper may operate at, the limits of travel of each axis or the configuration and behaviour of
-    limit switches on each axis.
-** My_CNC.hal
-*** This HAL file contains information that tells LinuxCNC how to link the internal virtual signals to
-    physical connections beyond the computer. For example, specifying pin 4 on the parallel port to send out
-    the Z axis step direction signal, or directing LinuxCNC to cease driving the X axis motor when a limit
-    switch is triggered on parallel port pin 13.
-** custom.HAL
-*** Customisations to the mill configuration beyond the scope of the wizard may be performed by including
-    further links to other virtual points within LinuxCNC in this HAL file. When starting a LinuxCNC session,
-    this file is read and processed before the GUI is loaded. An example may include initiating Modbus
-    communications to the spindle motor so that it is confirmed as operational before the GUI is displayed.
-** custom_postgui.hal
-*** The custom_postgui HAL file allows further customisation of LinuxCNC, but differs from custom.HAL in
-    that it is processed after the GUI is displayed. For example, after establishing Modbus communications to
-    the spindle motor in custom.hal, LinuxCNC can use the custom_postgui file to link the spindle speed readout
-    from the motor drive to a bargraph displayed on the GUI.
-** postgui_backup.hal
-*** This is provided as a backup copy of the custom_postgui.hal file to allow the user to quickly restore a
-    previously-working postgui HAL configuration. This is especially useful if the user wants to run the
-    Configuration Wizard again under the same 'My_CNC' name in order to modify some parameters of the mill.
-    Saving the mill configuration in the Wizard will overwrite the existing custom_postgui file while leaving
-    the postgui_backup file untouched.
-** tool.tbl
-*** A tool table file contains a parameterised list of any cutting tools used by the mill. These parameters
-    can include cutter diameter and length, and is used to provide a catalogue of data that tells LinuxCNC how
-    to compensate its motion for different sized tools within a milling operation.
-* Folder: nc_files
-*** The nc_files folder is provided as a default location to store the G-code programs used to drive the
-    mill. It also includes a number of subfolders with G-code examples.
+* *Folder: `My_CNC`*
+** *`My_CNC.ini`* +
+   The INI file contains all the basic hardware information regarding the operation of the CNC mill such
+   as the number of steps each stepper motor must turn to complete one full revolution, the maximum rate at
+   which each stepper may operate at, the limits of travel of each axis or the configuration and behaviour of
+   limit switches on each axis.
+** *`My_CNC.hal`* +
+   This HAL file contains information that tells LinuxCNC how to link the internal virtual signals to
+   physical connections beyond the computer. For example, specifying pin 4 on the parallel port to send out
+   the Z axis step direction signal, or directing LinuxCNC to cease driving the X axis motor when a limit
+   switch is triggered on parallel port pin 13.
+** *`custom.HAL`* +
+   Customisations to the mill configuration beyond the scope of the wizard may be performed by including
+   further links to other virtual points within LinuxCNC in this HAL file. When starting a LinuxCNC session,
+   this file is read and processed before the GUI is loaded. An example may include initiating Modbus
+   communications to the spindle motor so that it is confirmed as operational before the GUI is displayed.
+** *`custom_postgui.hal`* +
+   The custom_postgui HAL file allows further customisation of LinuxCNC, but differs from custom.HAL in
+   that it is processed after the GUI is displayed. For example, after establishing Modbus communications to
+   the spindle motor in custom.hal, LinuxCNC can use the custom_postgui file to link the spindle speed readout
+   from the motor drive to a bargraph displayed on the GUI.
+** *`postgui_backup.hal`* +
+   This is provided as a backup copy of the custom_postgui.hal file to allow the user to quickly restore a
+   previously-working postgui HAL configuration. This is especially useful if the user wants to run the
+   Configuration Wizard again under the same 'My_CNC' name in order to modify some parameters of the mill.
+   Saving the mill configuration in the Wizard will overwrite the existing custom_postgui file while leaving
+   the postgui_backup file untouched.
+** *`tool.tbl`* +
+   A tool table file contains a parameterised list of any cutting tools used by the mill. These parameters
+   can include cutter diameter and length, and is used to provide a catalogue of data that tells LinuxCNC how
+   to compensate its motion for different sized tools within a milling operation.
+* *Folder: `nc_files`* +
+  The nc_files folder is provided as a default location to store the G-code programs used to drive the
+  mill. It also includes a number of subfolders with G-code examples.
 
 [[sec:graphical-user-interfaces]]
 == Graphical User Interfaces(((Graphical User Interfaces)))


### PR DESCRIPTION
Final PR of (formating) fixes to English documentation after massive French documentation resync (coming next).

This has just been rebased so it should merge without (major) issue.

With the exception of a couple of files (like GladeVCP's) which were awfully formatted and thus deeply changed, this is all blank lines, indentation, index tag location, etc. fixes.

Please review as much as you can and merge. Next on my side is rebasing my docs/fr_migration branch upon this and check sync again. Then make a PR for it.

Last, I'll create a docs/es_migration_final branch from my docs/fr_migration to finally have the all thre languages synced !

Final step will most probably be a final round of anchors and build fixes directly in docs-devel once everything merged and rebased on master.

I'd better have made non breaking PRs but that seem difficult without being able to build selected language docs with the path I took.