### PR TITLE
Only link to HTML translations when they exist

### DIFF
--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -456,10 +456,12 @@ objects/index.incl: $(GENERATED_MANPAGES) objects/var-MAN_HTML_TARGETS $(DOC_SRC
 
 $(DOC_DIR)/html/%/index.html: $(DOC_SRCDIR)/index_%.tmpl ../VERSION $(DOC_SRCDIR)/index.foot
 	cat $(filter-out ../VERSION, $^) | \
-		sed "s/@VERSION@/`cat ../VERSION`/" > $@	
+		sed "s/@VERSION@/`cat ../VERSION`/" | \
+		if [ "yes" != "$(BUILD_DOCS_TRANSLATED)" ]; then sed '/@TRANSLATIONS@/,/@ENDTRANSLATIONS@/d' ; else grep -Ev '@(END)?TRANSLATIONS@'; fi > $@
 
 $(DOC_DIR)/html/index.html: $(DOC_SRCDIR)/index.tmpl objects/index.incl $(DOC_SRCDIR)/index.foot ../VERSION $(DOC_SRCDIR)/Submakefile
-	(cat $(DOC_SRCDIR)/index.tmpl objects/index.incl $(DOC_SRCDIR)/index.foot) | sed "s/@VERSION@/`cat ../VERSION`/" > $@	
+	(cat $(DOC_SRCDIR)/index.tmpl objects/index.incl $(DOC_SRCDIR)/index.foot) | sed "s/@VERSION@/`cat ../VERSION`/"  | \
+		if [ "yes" != "$(BUILD_DOCS_TRANSLATED)" ]; then sed '/@TRANSLATIONS@/,/@ENDTRANSLATIONS@/d' ; else grep -Ev '@(END)?TRANSLATIONS@'; fi > $@
 
 $(DOC_SRCDIR)/%.pdf: $(DOC_SRCDIR)/%.adoc svgs_made_from_dots .adoc-images-stamp
 	$(ECHO) Building $@

--- a/docs/src/index.tmpl
+++ b/docs/src/index.tmpl
@@ -91,10 +91,13 @@ function setup_page(){
 <h3>LinuxCNC version <strong>@VERSION@</strong></h3>
 
 <div style="margin-top: 0em; margin-bottom: 1em; line-height: 150%">
-<p>Translated Documents <a href="es/index.html">Espa&ntilde;ol</a>  *  
-<a href="fr/index.html">Fran&ccedil;ais</a>
+@TRANSLATIONS@
+<p>Translated Documents <a href="index.html">English</a>  *
+<a href="es/index.html">Espa&ntilde;ol</a>  *
+<a href="fr/index.html">Fran&ccedil;ais</a> *
 <a href="zh_CN/index.html">中文</a>
 </p>
+@ENDTRANSLATIONS@
 <p><a href="http://linuxcnc.org">LinuxCNC Home Page</a>  *  
 <a href="http://wiki.linuxcnc.org/cgi-bin/wiki.pl">Wiki Community</a>  *  
 <a href="gcode.html">G-Code Quick Reference</a></p>


### PR DESCRIPTION
Adjusted index.html template to only include links to translated
editions when translations are generated.  This avoid broken
links in the English HTML when po4a is not found.