### PR TITLE
packaging: Fix build with no-docs

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -40,7 +40,7 @@ Build-Depends:
     tk@TCLTK_VERSION@-dev,
     yapps2
 Build-Depends-Indep:
-    @DOC_DEPENDS@
+    @DOC_DEPENDS@,
 Standards-Version: 4.6.0
 Vcs-Browser: https://github.com/LinuxCNC/linuxcnc
 Vcs-Git: https://github.com/LinuxCNC/linuxcnc.git


### PR DESCRIPTION
This line becomes empty when we build with no-docs, and triggers the syntax
error. The added comma will fix this.

Introduced here 183ce12975459114cc32dc45cd10dcd22924e972 when Build-Depends-Indep
and @DOC_DEPENDS@ was split into two separate lines.