### PR TITLE
Make latency-histogram available as Linux menu entry

### DIFF
--- a/share/applications/linuxcnc-latency-histogram.desktop.in
+++ b/share/applications/linuxcnc-latency-histogram.desktop.in
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=
+Type=Application
+Exec=@EMC2_LATENCY_HISTOGRAM_SCRIPT@
+Icon=@EMC2_ICON@
+X-GNOME-DocPath=
+Terminal=false
+Name=Latency Histogram@EMC2_SUFFIX@
+Comment=Show histogram of your machine's latency
+StartupNotify=false
+Categories=Science;X-CNC;

--- a/src/Makefile
+++ b/src/Makefile
@@ -296,6 +296,7 @@ INFILES = \
 	../share/menus/CNC.menu \
 	../share/applications/linuxcnc.desktop \
 	../share/applications/linuxcnc-latency.desktop \
+	../share/applications/linuxcnc-latency-histogram.desktop \
 	../scripts/linuxcnc_var \
 	../scripts/halcmd_twopass \
 	../scripts/runtests \
@@ -597,6 +598,7 @@ MENUS = ../share/menus/CNC.menu \
     ../share/desktop-directories/cnc.directory \
     ../share/applications/linuxcnc.desktop \
     ../share/applications/linuxcnc-latency.desktop \
+    ../share/applications/linuxcnc-latency-histogram.desktop \
 
 install-menus install-menu: $(MENUS)
 	mkdir -p $(HOME)/.config/menus/applications-merged

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -675,6 +675,7 @@ fe () {
 
 if test "xyes" = "x$RUN_IN_PLACE"; then
     EMC2_LATENCY_SCRIPT=$EMC2_HOME/scripts/latency-test
+    EMC2_LATENCY_HISTOGRAM_SCRIPT=$EMC2_HOME/scripts/latency-histogram
     EMC2_SCRIPT=$EMC2_HOME/scripts/linuxcnc
     EMC2_SUFFIX=" (run-in-place)"
     EMC2_ICON=$EMC2_HOME/linuxcncicon.png
@@ -1700,6 +1701,7 @@ AC_CONFIG_FILES(../tcl/linuxcnc.tcl)
 AC_CONFIG_FILES(../lib/python/nf.py)
 AC_CONFIG_FILES([../scripts/linuxcncmkdesktop], [chmod +x ../scripts/linuxcncmkdesktop])
 AC_CONFIG_FILES(../share/applications/linuxcnc-latency.desktop)
+AC_CONFIG_FILES(../share/applications/linuxcnc-latency-histogram.desktop)
 AC_CONFIG_FILES(../share/applications/linuxcnc.desktop)
 AC_CONFIG_FILES(../share/desktop-directories/linuxcnc-cnc.directory)
 AC_CONFIG_FILES(../share/desktop-directories/linuxcnc-ref.directory)


### PR DESCRIPTION
This provide a XDG menu entry for latency-histogram alongside the
latency-test program

Solves Debian bug #1013911.