### PR TITLE
Fix soft limit calculation when using G43.1

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1854,10 +1854,10 @@ def run_warn():
         machine_limit_min, machine_limit_max = soft_limits()
         for i in range(3): # Does not enforce angle limits
             if not(s.axis_mask & (1<<i)): continue
-            if o.canon.min_extents_notool[i] < machine_limit_min[i]:
+            if o.canon.min_extents_notool[i] + to_internal_linear_unit(o.last_tool_offset[i]) < machine_limit_min[i]:
                 warnings.append(_("Program exceeds machine minimum on axis %s")
                     % "XYZABCUVW"[i])
-            if o.canon.max_extents_notool[i] > machine_limit_max[i]:
+            if o.canon.max_extents_notool[i] + to_internal_linear_unit(o.last_tool_offset[i]) > machine_limit_max[i]:
                 warnings.append(_("Program exceeds machine maximum on axis %s")
                     % "XYZABCUVW"[i])
     if warnings:


### PR DESCRIPTION
As discussed in this forum thread:
https://forum.linuxcnc.org/20-g-code/44244-g43-1-dynamic-tool-length-measurement-program-exceeds-machine-maximum-on-axis?start=10#227198

When using G43.1 Tool Length Offset, Axis will wrongly display a warning about exceeding the soft limits.
This PR adds the tool offset to the limits calculation so this warning wont be displayed anymore if not needed (It still will if it actually exceeds the limit).