### PR TITLE
Fix weird message

### DIFF
--- a/src/emc/usr_intf/pncconf/pncconf.py
+++ b/src/emc/usr_intf/pncconf/pncconf.py
@@ -926,7 +926,7 @@ PNCconf will use internal firmware data"%self._p.FIRMDIR),True)
                             raise UserWarning
             except :
                 print(i,j,boardnum)
-                self.warning_dialog(_("It seems data in this file is from too old of a version of PNCConf to continue.\n."),True)
+                self.warning_dialog(_("It seems data in this file is from too old of a version of PNCConf to continue."),True)
                 return True
         else:
             dialog.destroy()


### PR DESCRIPTION
I noticed this because a translation update gave an error due to a mismatched final newline.
```
Compiling localized message catalog ../share/locale/zh_CN/LC_MESSAGES/linuxcnc.mo
po/zh_CN.po:11771: 'msgid' and 'msgstr' entries do not both end with '\n'
```
I was not able to determine a reason to have the trailing newline or the trailing full stop, so I removed them.