### PR TITLE
tool_probe_m6 fix wrong param for emccanon.GET_EXTERNAL_POSITION_X()

### DIFF
--- a/nc_files/remap_lib/python-stdglue/stdglue.py
+++ b/nc_files/remap_lib/python-stdglue/stdglue.py
@@ -586,7 +586,7 @@ def tool_probe_m6(self, **words):
         yield INTERP_EXECUTE_FINISH
 
         # record current position; probably should record every axis
-        self.params[4990] = emccanon.GET_EXTERNAL_POSITION_X()
+        self.params[4999] = emccanon.GET_EXTERNAL_POSITION_X()
         self.params[4998] = emccanon.GET_EXTERNAL_POSITION_Y()
         self.params[4997] = emccanon.GET_EXTERNAL_POSITION_Z()
 


### PR DESCRIPTION
was set to `self.params[4990] = emccanon.GET_EXTERNAL_POSITION_X()`

But was used later as 
```
            # return to recorded tool change position
            self.execute("G53 G0 Z[#4997]")
            yield INTERP_EXECUTE_FINISH
            self.execute("G53 G0 X[#4999] Y[#4998]")
```
