### PR TITLE
Add support for compiling with python3.11

### DIFF
--- a/src/m4/ax_python.m4
+++ b/src/m4/ax_python.m4
@@ -55,7 +55,7 @@
 AC_DEFUN([AX_PYTHON],
 [AC_MSG_CHECKING(for python build information)
 AC_MSG_RESULT([])
-for python in python3.10 python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
+for python in python3.11 python3.10 python3.9 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
 AC_CHECK_PROGS(PYTHON_BIN, [$python])
 ax_python_bin=$PYTHON_BIN
 if test x$ax_python_bin != x; then


### PR DESCRIPTION
Fixes build error on Fedora:
 checking for python build information...
 checking for python3.10... no
 checking for python3.9... no
 checking for python3.8... no
 checking for python3.7... no
 checking for python3.6... no
 checking for python3.5... no
 checking for python3.4... no
 checking for python3.3... no
 checking for python3.2... no
 checking for python3.1... no
 checking for python3.0... no
 checking for python2.7... no
 checking for python2.6... no
 checking for python2.5... no
 checking for python2.4... no
 checking for python2.3... no
 checking for python2.2... no
 checking for python2.1... no
 checking for python... no
   results of the Python check:
     Binary:      no
     Library:     no
     Include Dir: no
 checking for ... no
 checking for python... no
 configure: error: Cannot find python in your system path

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>