### PR TITLE
Added comment to at_pid(9) about the status and incompatibility

### DIFF
--- a/docs/man/man9/at_pid.9
+++ b/docs/man/man9/at_pid.9
@@ -8,6 +8,10 @@ at_pid \- proportional/integral/derivative controller with auto tuning
 
 
 .SH DESCRIPTION
+\fBNOTE:\fR This component is no longer pin for pin compatible with
+the pid component.  The at_pid component seen no development since
+2011 while the pid component has been extended with more features.
+.P
 \fBat_pid\fR is a classic Proportional/Integral/Derivative controller,
 used to control position or speed feedback loops for servo motors and
 other closed-loop applications.


### PR DESCRIPTION
The at_pid component have seen no development since 2011, and
is no longer compatible with the pid component.