### PR TITLE
halui.axis.L.pos-relative: Fix misleading documentation

### DIFF
--- a/docs/src/gui/halui.adoc
+++ b/docs/src/gui/halui.adoc
@@ -223,7 +223,7 @@ L = axis letter (xyzabcuvw)
 * 'halui.axis.L.is-selected' (bit out) - status pin that axis L is selected
 * 'halui.axis.L.pos-commanded' (float out) - Commanded axis position in machine coordinates
 * 'halui.axis.L.pos-feedback' float out) - Feedback axis position in machine coordinates
-* 'halui.axis.L.pos-relative' (float out) - Commanded axis position in relative coordinates
+* 'halui.axis.L.pos-relative' (float out) - Feedback axis position in relative coordinates
 
 === Axis Jogging
 


### PR DESCRIPTION
Just a small documentation fix.

The `motion` manpage currently says that `halui.axis.?.pos-relative` gives the commanded position. However the code and actual behavior shows that it in fact gives the actual (feedback) position. I think it also makes more sense to give the feedback position in most cases, as this is usually used for DRO.

https://github.com/LinuxCNC/linuxcnc/blob/bdc7dcf3841fc76b96abf8a94464cf40d415b73b/src/emc/usr_intf/halui.cc#L2241-L2245

![image](https://user-images.githubusercontent.com/922265/177768757-4335e705-8e23-4d7a-88a1-09a16543fe8c.png)
