### PR TITLE
LCNC 2.8 STARTUP CODE for Gmoccapy

### DIFF
--- a/src/emc/usr_intf/pncconf/build_INI.py
+++ b/src/emc/usr_intf/pncconf/build_INI.py
@@ -109,6 +109,7 @@ class INI:
         print >>file
         print >>file, "[RS274NGC]"
         print >>file, "PARAMETER_FILE = linuxcnc.var"
+        print >>file, "RS274NGC_STARTUP_CODE = G17 G21 G40 G43H0 G54 G64P0.005 G80 G90 G94 G97 M5 M9"
 
         #base_period = self.d.ideal_period()
 


### PR DESCRIPTION
gmoccapy can't cope when it lacks a START UP CODE. So I added him. I took the specific text of the STAR UP CODE from here:
/linuxcnc/configs/sim/gmoccapy/gmoccapy.ini

https://forum.linuxcnc.org/gmoccapy/43087-new-file-button-dont-work#215162