### PR TITLE
Add cross references between bit logic and pid related man pages

### DIFF
--- a/docs/man/man9/at_pid.9
+++ b/docs/man/man9/at_pid.9
@@ -226,3 +226,6 @@ the deadband.  This was not done because it would cause a step in the transfer
 function equal to the size of the deadband.  People who prefer that behavior are
 welcome to add a parameter that will change the behavior, or to write their own
 version of \fBat_pid\fR. However, the default behavior should not be changed.
+
+.SH SEE ALSO
+\fBat_pid\fR(9)

--- a/docs/man/man9/pid.9
+++ b/docs/man/man9/pid.9
@@ -231,3 +231,6 @@ situations that negative FF gains make sense, but in general all gains
 should be positive.  If some output is in the wrong direction, negating
 gains to fix it is a mistake; set the scaling correctly elsewhere
 instead.
+
+.SH SEE ALSO
+\fBat_pid\fR(9)

--- a/src/hal/components/and2.comp
+++ b/src/hal/components/and2.comp
@@ -14,7 +14,11 @@ Otherwise,
 ;
 function _ nofp;
 see_also """
-\\fBlogic\\fR(9)
+\\fBlogic\\fR(9),
+\\fBlut5\\fR(9),
+\\fBnot\\fR(9),
+\\fBor2\\fR(9),
+\\fBxor2\\fR(9).
 """;
 license "GPL";
 ;;

--- a/src/hal/components/logic.comp
+++ b/src/hal/components/logic.comp
@@ -28,6 +28,13 @@ The number of input pins, usually from 2 to 16
 Outputs can be combined, for example 2 + 256 + 1024 = 1282 converted to hex
 would be 0x502 and would have two inputs and have both `xor' and `and' outputs.
 """;
+see_also """
+\\fBand2\\fR(9),
+\\fBlut5\\fR(9),
+\\fBnot\\fR(9),
+\\fBor2\\fR(9),
+\\fBxor2\\fR(9)
+""";
 license "GPL";
 ;;
 FUNCTION(_) {

--- a/src/hal/components/lut5.comp
+++ b/src/hal/components/lut5.comp
@@ -134,6 +134,13 @@ _
 .TE
 \\}
 """;
+see_also """
+\\fBand\\fR(9),
+\\fBlogic\\fR(9),
+\\fBnot\\fR(9),
+\\fBor2\\fR(9),
+\\fBxor2\\fR(9).
+""";
 license "GPL";
 ;;
 

--- a/src/hal/components/not.comp
+++ b/src/hal/components/not.comp
@@ -2,6 +2,13 @@ component not "Inverter";
 pin in bit in;
 pin out bit out;
 function _ nofp;
+see_also """
+\\fBand2\\fR(9),
+\\fBlogic\\fR(9),
+\\fBlut5\\fR(9),
+\\fBor2\\fR(9),
+\\fBxor2\\fR(9).
+""";
 license "GPL";
 ;;
 FUNCTION(_) { out = ! in; }

--- a/src/hal/components/xor2.comp
+++ b/src/hal/components/xor2.comp
@@ -15,7 +15,11 @@ Otherwise,
 \\fBout=FALSE\\fR""";
 function _ nofp;
 see_also """
-\\fBlogic\\fR(9)
+\\fBand2\\fR(9),
+\\fBlogic\\fR(9),
+\\fBlut5\\fR(9),
+\\fBnot\\fR(9),
+\\fBor2\\fR(9).
 """;
 license "GPL";
 ;;


### PR DESCRIPTION
Link between and2, logic, lut5, not and xor2, as well as at_pid
and pid.