### PR TITLE
Rephrase halcomple man header to quiet down po4a

### DIFF
--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -887,8 +887,8 @@ def document(filename, outfilename):
     print("""
 .\\"*******************************************************************
 .\\"
-.\\" This file was generated with halcompile.g.
-.\\" Modify the source file %s.
+.\\" This file was extracted from %s using halcompile.g.
+.\\" Modify the source file.
 .\\"
 .\\"*******************************************************************
 """ % filename, file=f)


### PR DESCRIPTION
This avoid the message from po4a suggesting to translate the
source instead of the generated file, which is not an option in this
case as po4a do not support the hal component format.