### PR TITLE
Indent second line of adoc dot list to quiet down po4a

### DIFF
--- a/docs/src/gui/gstat.adoc
+++ b/docs/src/gui/gstat.adoc
@@ -483,7 +483,7 @@ General message should be used a sparsely as reasonable because all object conne
 It uses a python dict for communication. +
 The dict should include and be checked for a unique id  keyname pair: +
 * ID: 'UNIQUE_ID_CODE' +
-The dict usually has more keyname pair - it depends on implementation. +
+  The dict usually has more keyname pair - it depends on implementation. +
 
 *forced-update* :: '(returns None)' -
 intended to be sent when one wishes to initialize or arbitrarily update an object. +


### PR DESCRIPTION
This avoid a message from po4a noting that the line is really part of
the dot list above, even thought it is missing the recommended
indentation.  Also make the text sligthly more visually appealing.