### PR TITLE
Added runtests option -u to skip test requiring sudo access

### DIFF
--- a/scripts/runtests.in
+++ b/scripts/runtests.in
@@ -46,6 +46,7 @@ export RUNTESTS="$(readlink -f $0)"
 NUM=0
 FAIL=0; FAIL_NAMES=""
 XFAIL=0
+SKIP=0
 VERBOSE=0
 
 clean () {
@@ -126,7 +127,16 @@ run_tests () {
 	testdir=$(dirname $testname)
 	if [ -e $testdir/skip ]; then
 	    if ! [ -x $testdir/skip ] || ! $testdir/skip; then
-		echo "Skipping test: $testdir" 1>&2
+		echo "Skipping disabled test: $testdir" 1>&2
+		SKIP=$(($SKIP+1))
+		continue
+	    fi
+	fi
+	if $NOSUDO && [ -e $testdir/control ] && \
+		grep Restrictions: $testdir/control | grep -q sudo; then
+	    if ! [ -x $testdir/skip ] || ! $testdir/skip; then
+		echo "Skipping sudo test: $testdir" 1>&2
+		SKIP=$(($SKIP+1))
 		continue
 	    fi
 	fi
@@ -204,7 +214,7 @@ run_tests () {
     done < $TMPDIR/alltests
 
     SUCC=$((NUM-FAIL-XFAIL))
-    echo "Runtest: $NUM tests run, $SUCC successful, $FAIL failed + $XFAIL expected"
+    echo "Runtest: $NUM tests run, $SUCC successful, $FAIL failed + $XFAIL expected, $SKIP skipped"
     if [ $FAIL -ne 0 ]; then
 	echo "Failed: $FAIL_NAMES"
 	exit 1;
@@ -227,6 +237,10 @@ Usage:
     $P -c tests
 	Remove temporary files from an earlier test run.
 
+    $P -u
+        Only run tests that require normal user access.  Skip tests
+        requiring root or sudo.
+
     $P -v
         Show stdout and stderr (normally it's hidden).
 EOF
@@ -234,12 +248,14 @@ EOF
 
 CLEAN_ONLY=0
 NOCLEAN=0
+NOSUDO=false
 STOP=0
 PRINT=0
-while getopts cnvsph opt; do
+while getopts cnuvsph opt; do
     case "$opt" in
     c) CLEAN_ONLY=1 ;;
     n) NOCLEAN=1 ;;
+    u) NOSUDO=true ;;
     v) VERBOSE=1 ;;
     s) STOP=1 ;;
     p) PRINT=1 ;;

--- a/tests/README
+++ b/tests/README
@@ -29,6 +29,12 @@ can be run by executing (from the top emc2 directory)
 	scripts/runtests tests
 A subset of the tests can also be run:
 	scripts/runtests tests/xyz tests/a*
+
+To only run the tests that do not require root or sudo access, use the
+-u option:
+
+	scripts/runtests -u tests
+
 The directories named on the commandline are searched recursively for
 'test.hal' or 'test.sh' files, and a directory with such a file is
 assumed to contain a regression test or a functional test.
@@ -93,3 +99,11 @@ and see if it indicates success.
 
 The test passes if the command "checkresult actual" returns a shell
 success value (exit code 0).  Otherwise, the test fails.
+
+Tests requiring root or sudo access are flagged by creating a file
+named control in the test directory, with the 'sudo' flag in the
+Restrictions field:
+
+  Restrictions: sudo
+
+Other restrictions might be added in the future

--- a/tests/halcompile/personalities_mod/control
+++ b/tests/halcompile/personalities_mod/control
@@ -1,0 +1,1 @@
+Restrictions: sudo

--- a/tests/halcompile/relative-header-user/control
+++ b/tests/halcompile/relative-header-user/control
@@ -1,0 +1,1 @@
+Restrictions: sudo

--- a/tests/module-loading/rtapi-app-main-fails/control
+++ b/tests/module-loading/rtapi-app-main-fails/control
@@ -1,0 +1,1 @@
+Restrictions: sudo

--- a/tests/realtime-math/control
+++ b/tests/realtime-math/control
@@ -1,0 +1,1 @@
+Restrictions: sudo

--- a/tests/rtapi-shmem/control
+++ b/tests/rtapi-shmem/control
@@ -1,0 +1,1 @@
+Restrictions: sudo

--- a/tests/symbols.0/control
+++ b/tests/symbols.0/control
@@ -1,0 +1,1 @@
+Restrictions: sudo

--- a/tests/symbols.1/control
+++ b/tests/symbols.1/control
@@ -1,0 +1,1 @@
+Restrictions: sudo

--- a/tests/uspace/spawnv-root/control
+++ b/tests/uspace/spawnv-root/control
@@ -1,0 +1,1 @@
+Restrictions: sudo


### PR DESCRIPTION
This make it easier for non-privileged users to run tests automatically.

The tests requiring sudo are flagged using a mechanism inspired by
the autopkgtest system in Debian, where a control file contain
information about the test.  All tests requiring sudo get a
'sudo' flag in the Restrictions field there.

Also add reporting on number of skipped tests at the end.