### PR TITLE
Fix duplicate listing of "emc" in list of subdirectories

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -160,7 +160,7 @@ SUBDIRS := \
     emc/usr_intf/gremlin emc/usr_intf/gscreen emc/usr_intf/pyui emc/usr_intf/qtvcp \
     emc/usr_intf/gmoccapy emc/usr_intf/qtplasmac emc/usr_intf/mdro\
     emc/usr_intf emc/nml_intf emc/task emc/iotask emc/kinematics emc/tp emc/canterp \
-    emc/motion emc/ini emc/rs274ngc emc/sai emc emc/pythonplugin \
+    emc/motion emc/ini emc/rs274ngc emc/sai emc/pythonplugin \
     emc/motion-logger \
     emc/tooldata \
     emc \


### PR DESCRIPTION
This fixes the non-fatal build diagnostic
```
emc/Submakefile:4: warning: overriding recipe for target '../include/linuxcnc.h'
emc/Submakefile:4: warning: ignoring old recipe for target '../include/linuxcnc.h'
```