### PR TITLE
Make motion/g0/ test failures easier to spot using error: prefix

### DIFF
--- a/tests/motion/g0/checkresult
+++ b/tests/motion/g0/checkresult
@@ -79,7 +79,7 @@ for line in lines:
 
 # verify that X starts at 0.000000
 if samples[0][1] != 0.000000:
-    print("sample 0: X starts at %.6f, not at 0.000000" % samples[0][1])
+    print("error: sample 0: X starts at %.6f, not at 0.000000" % samples[0][1])
     sys.exit(1)
 
 print("line 0: X starts at 0.000000")
@@ -111,15 +111,15 @@ for i in range(i, len(samples)):
 
     # i hate floating point
     if ((accel_ipc2 * cycles_per_second) - max_acceleration_ipspc) > 0.0000001: 
-        print("line %d: detected accel constraint violation!" % i)
-        print("detected accel %.6f i/c^2 (%.6f i/s^2)" % (accel_ipc2, (accel_ipc2 * cycles_per_second * cycles_per_second)))
-        print("max accel %.6f i/s^2)" % max_acceleration_ips2)
+        print("error: line %d: detected accel constraint violation!" % i)
+        print("error: detected accel %.6f i/c^2 (%.6f i/s^2)" % (accel_ipc2, (accel_ipc2 * cycles_per_second * cycles_per_second)))
+        print("error: max accel %.6f i/s^2)" % max_acceleration_ips2)
         sys.exit(1)
 
     if (new_v_ipc - max_velocity_ipc) > 0.0000001:
-        print("line %d: detected vel constraint violation!" % i)
-        print("detected vel %.6f i/c (%.6f i/s)" % (new_v_ipc, new_v_ipc * cycles_per_second))
-        print("max vel %.6f i/c (%.6f i/s)" % (max_velocity_ipc, max_velocity_ips))
+        print("error: line %d: detected vel constraint violation!" % i)
+        print("error: detected vel %.6f i/c (%.6f i/s)" % (new_v_ipc, new_v_ipc * cycles_per_second))
+        print("error: max vel %.6f i/c (%.6f i/s)" % (max_velocity_ipc, max_velocity_ips))
         sys.exit(1)
 
     if accel_ipc2 == 0:
@@ -130,8 +130,8 @@ for i in range(i, len(samples)):
 
 # verify highest seen accel is very close to max accel
 if abs(max_acceleration_ipspc - (highest_seen_accel_ipc2 * cycles_per_second)) > 0.0000001:
-    print("accel only reached %.6f i/c^2 (%.6f i/s^2)" % (highest_seen_accel_ipc2, (highest_seen_accel_ipc2 * cycles_per_second * cycles_per_second)))
-    print("max accel is %.6f i/s^2" % max_acceleration_ips2)
+    print("error: accel only reached %.6f i/c^2 (%.6f i/s^2)" % (highest_seen_accel_ipc2, (highest_seen_accel_ipc2 * cycles_per_second * cycles_per_second)))
+    print("error: max accel is %.6f i/s^2" % max_acceleration_ips2)
     sys.exit(1)
 
 print("    accel reached but did not exceed 1/2 of max accel of %.6f i/s^2" % max_acceleration_ips2)
@@ -169,20 +169,20 @@ for i in range(i, len(samples)):
 
     # i hate floating point
     if ((accel_ipc2 * cycles_per_second) - max_acceleration_ipspc) > 0.0000001: 
-        print("line %d: detected accel constraint violation!" % i)
-        print("detected accel %.6f i/c^2 (%.6f i/s^2)" % (accel_ipc2, accel_ipc2 * cycles_per_second * cycles_per_second))
-        print("max accel %.6f i/s^2)" % max_acceleration_ips2)
+        print("error: line %d: detected accel constraint violation!" % i)
+        print("error: detected accel %.6f i/c^2 (%.6f i/s^2)" % (accel_ipc2, accel_ipc2 * cycles_per_second * cycles_per_second))
+        print("error: max accel %.6f i/s^2)" % max_acceleration_ips2)
         sys.exit(1)
 
     if (new_v_ipc - max_velocity_ipc) > 0.0000001:
-        print("line %d: detected vel constraint violation!" % i)
-        print("detected vel %.6f i/c (%.6f i/s)" % (new_v_ipc, new_v_ipc * cycles_per_second))
-        print("max vel %.6f i/c (%.6f i/s)" % (max_velocity_ipc, max_velocity_ips))
+        print("error: line %d: detected vel constraint violation!" % i)
+        print("error: detected vel %.6f i/c (%.6f i/s)" % (new_v_ipc, new_v_ipc * cycles_per_second))
+        print("error: max vel %.6f i/c (%.6f i/s)" % (max_velocity_ipc, max_velocity_ips))
         sys.exit(1)
 
     if new_v_ipc < -0.0000001:
-        print("line %d: detected vel undershoot!" % i)
-        print("detected vel %.6f i/c (%.6f i/s)" % (new_v_ipc, new_v_ipc * cycles_per_second))
+        print("error: line %d: detected vel undershoot!" % i)
+        print("error: detected vel %.6f i/c (%.6f i/s)" % (new_v_ipc, new_v_ipc * cycles_per_second))
         sys.exit(1)
 
     if new_v_ipc == 0:
@@ -193,8 +193,8 @@ for i in range(i, len(samples)):
 
 # verify highest seen accel is very close to max accel
 if abs(max_acceleration_ipspc + (highest_seen_accel_ipc2 * cycles_per_second)) > 0.0000001:
-    print("accel only reached %.6f i/c^2 (%.6f i/s^2)" % (highest_seen_accel_ipc2, (highest_seen_accel_ipc2 * cycles_per_second * cycles_per_second)))
-    print("max accel is %.6f i/s^2" % max_acceleration_ips2)
+    print("error: accel only reached %.6f i/c^2 (%.6f i/s^2)" % (highest_seen_accel_ipc2, (highest_seen_accel_ipc2 * cycles_per_second * cycles_per_second)))
+    print("error: max accel is %.6f i/s^2" % max_acceleration_ips2)
     sys.exit(1)
 
 print("    decel reached but did not exceed 1/2 of max accel of %.6f i/s^2" % max_acceleration_ips2)
@@ -202,7 +202,7 @@ print("    decel reached but did not exceed 1/2 of max accel of %.6f i/s^2" % ma
 
 # verify X stopped at 1.000000
 if samples[i][1] != 1.000000:
-    print("line %d: X stopped at %.6f, not at 1.000000!" % (i, samples[i][1]))
+    print("error: line %d: X stopped at %.6f, not at 1.000000!" % (i, samples[i][1]))
     sys.exit(1)
 
 print("    X reached target of 1.0000")
@@ -211,7 +211,7 @@ print("    X reached target of 1.0000")
 # verify X doesn't move from now on
 for i in range(i, len(samples) - 1):
     if samples[i][1] != samples[i+1][1]:
-        print("line %d: X moved!" % i)
+        print("error: line %d: X moved!" % i)
         sys.exit(1)
 
 


### PR DESCRIPTION
This make  it easier to spot the problem when running it from the
github CI, as well as making it possible to search for 'error:'
in the test log.