### PR TITLE
Print stderr message if pthread_setname_np() fail

### DIFF
--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -105,6 +105,9 @@ static void set_namef(const char *fmt, ...) {
     va_end(ap);
 
     int res = pthread_setname_np(pthread_self(), buf);
+    if (res) {
+        fprintf(stderr, "pthread_setname_np() failed for %s: %d\n", buf, res);
+    }
     free(buf);
 }
 


### PR DESCRIPTION
This get rid of this compile time warning:

Compiling rtapi/uspace_rtapi_app.cc
rtapi/uspace_rtapi_app.cc: In function ‘void {anonymous}::set_namef(const char*, ...)’:
rtapi/uspace_rtapi_app.cc:107:9: warning: unused variable ‘res’ [-Wunused-variable]
  107 |     int res = pthread_setname_np(pthread_self(), buf);
      |         ^~~