### PR TITLE
Correct string length handling in strlimcpy in halcmd.c

### DIFF
--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -678,10 +678,10 @@ static int strip_comments ( char *buf )
 
 */
 static int strlimcpy(char **dest, char *src, int srclen, int *destspace) {
-    if (*destspace < srclen) {
+    if (*destspace < srclen+1) {
 	return -1;
     } else {
-	strncpy(*dest, src, srclen);
+	strncpy(*dest, src, *destspace);
 	(*dest)[srclen] = '\0';
 	srclen = strlen(*dest);		/* use the actual number of bytes copied */
 	*destspace -= srclen;


### PR DESCRIPTION
The strlen value is the string length, often fetched from strlen(),
which return the number of characters in the string, excluding the
terminal NUL character.  To have room to copy the string into *dest,
the *destspace available must be strlen+1, not strlen, to also have
room for the NUL at the end.  Setting NUL explicitly will not be
needed in the case srclen reflect the real length of str, but if srclen
is smaller than the real length of str, will will ensure the string
is always NUL terminated.  Pass *destspace instead of strlen+1 to
strncpy() ensure the actual target size limit is used no matter what
the content of srclen is.