### PR TITLE
Made tests/motion/g0 more robust and got rid of race condition

### DIFF
--- a/tests/motion/g0/checkresult
+++ b/tests/motion/g0/checkresult
@@ -86,9 +86,13 @@ print("line 0: X starts at 0.000000")
 
 
 # find where X starts moving (X is the second column, column 1)
-i = 0
-while samples[i][1] == samples[i+1][1]:
-    i += 1
+for i in range(0, len(samples) - 1):
+    if samples[i][1] != samples[i+1][1]:
+        break
+
+if len(samples) == i+2:
+    print("error: no acceleration detected, did linuxcnc take too long to start moving?")
+    sys.exit(1)
 
 print("line %d: accel phase starts" % i)
 
@@ -100,7 +104,7 @@ print("line %d: accel phase starts" % i)
 highest_seen_accel_ipc2 = 0
 old_accel_ipc2 = 0
 old_v_ipc = 0
-for i in range(i, len(samples)):
+for i in range(i, len(samples) - 1):
 
     new_v_ipc = samples[i+1][1] - samples[i][1]
     accel_ipc2 = new_v_ipc - old_v_ipc
@@ -141,7 +145,7 @@ print("line %d: entering cruise phase, vel=%.6f i/s, max_accel = %.6f i/s^2" % (
 
 # now i is the first sample of the cruise phase
 # wait for vel to drop again
-for i in range(i, len(samples)):
+for i in range(i, len(samples) - 1):
     new_v_ipc = samples[i+1][1] - samples[i][1]
 
     if abs(new_v_ipc - old_v_ipc) > 0.0000001:
@@ -158,7 +162,7 @@ print("line %d: decel phase starting, old_v=%.6f i/s, new_v=%.6f i/s" % (i, old_
 # verify decel phase stops when vel == 0
 highest_seen_accel_ipc2 = 0
 old_accel_ipc2 = 0
-for i in range(i, len(samples)):
+for i in range(i, len(samples) - 1):
 
     new_v_ipc = samples[i+1][1] - samples[i][1]
     accel_ipc2 = new_v_ipc - old_v_ipc

--- a/tests/motion/g0/test.sh
+++ b/tests/motion/g0/test.sh
@@ -3,16 +3,31 @@
 #export PATH=$PATH:$EMC2_HOME/tests/helpers
 #source $EMC2_HOME/tests/helpers/test-functions.sh
 
+wait_for_pin() {
+    pin="$1"
+    value="$2"
+    maxwait=10 # seconds
+    while [ 0 -lt $maxwait ] \
+      && [ "$value" != "$(halcmd -s show pin $pin | awk '{print $4}')" ]; do
+        sleep 1
+	maxwait=$(($maxwait -1))
+    done
+    if [ 0 -eq $maxwait ] ; then
+	echo "error: waiting for pin $pin timed out"
+	kill $linuxcncpid
+	kill $samplerpid
+	exit 1
+    fi
+}
+
 linuxcnc motion-test.ini &
+linuxcncpid=$!
 
-# let linuxcnc come up
-sleep 4 
+wait_for_pin motion.in-position TRUE
 
-(
-    echo starting to capture data
-    halsampler -t -n 20000 >| result.halsamples
-    echo finished capturing data
-) &
+echo starting to capture data
+halsampler -t >| result.halsamples &
+samplerpid=$!
 
 (
     echo hello EMC mt 1.0
@@ -26,21 +41,27 @@ sleep 4
     echo set home 1
     echo set home 2
 
-    # give linuxcnc a second to home
-    sleep 1.0
+    # Wait for homing to complete
+    wait_for_pin motion.is-all-homed TRUE
 
     echo set mode mdi
-    echo set mdi g0x1
+    dist=1
+    echo set mdi g0x$dist
 
-    # give linuxcnc a half second to move
-    sleep 0.5
+    # Wait for movement to complete
+    wait_for_pin joint.0.pos-fb $dist
+    wait_for_pin joint.0.in-position TRUE
+    wait_for_pin joint.1.in-position TRUE
 
     echo shutdown
 ) | nc localhost 5007
 
+kill $samplerpid
+wait $samplerpid
+echo finished capturing data
 
 # wait for linuxcnc to finish
-wait
+wait $linuxcncpid
 
 exit 0
 


### PR DESCRIPTION
Adjusted test.sh to make sure halsampler run until all instructions are sent
via port 5007 to linuxcncrsh.  Now wait for explicite process IDs of halsampler
and linuxcnc to make sure neither terminated before test is over.  Added more
checks in checkresults, and made sure it give more sensible error messages
if no acceleration is detected (instead of raising out of bound exceptions.
Replaced random sleep periods with code to wait for pins to signal startup,
homing and move is completed.