### PR TITLE
interpeter - add INI paremeters to set peck distance/count

### DIFF
--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -541,7 +541,11 @@ The maximum number of `USER_M_PATH` directories is defined at compile time (typ:
   Allow to clear the G92 offset automatically when config start-up.
 * `DISABLE_FANUC_STYLE_SUB = 0` (Default: 0)
   If there is reason to disable Fanuc subroutines set it to 1.
-
+* 'PARAMETER_G73_PECK_CLEARANCE = .020' (default: Metric machine: 1mm, imperial machine: .050 inches)
+  Chip breaking back-off distance in machine units
+* 'PARAMETER_G83_PECK_CLEARANCE = .020' (default: Metric machine: 1mm, imperial machine: .050 inches)
+  Clearance distance from last feed depth when machine rapids back to bottom of hole, in machine units.
+ 
 [NOTE]
 ====
 The above six options were controlled by the `FEATURES` bitmask in versions of LinuxCNC prior to 2.8.

--- a/src/emc/rs274ngc/interp_cycles.cc
+++ b/src/emc/rs274ngc/interp_cycles.cc
@@ -154,9 +154,7 @@ int Interp::convert_cycle_g83(block_pointer block,
      Thanks to Billy Singleton for pointing it out... */
   CHKS((delta <= 0.0), NCE_NEGATIVE_OR_ZERO_Q_VALUE_USED);
 
-  rapid_delta = _setup.parameter_drill_cycle_chip_break_distance;
-  if (_setup.length_units == CANON_UNITS_MM)
-    rapid_delta = (rapid_delta * 25.4);
+  rapid_delta = _setup.parameter_g83_peck_clearence;;
 
   for (current_depth = (r - delta);
        current_depth > bottom_z; current_depth = (current_depth - delta)) {
@@ -212,24 +210,16 @@ int Interp::convert_cycle_g73(block_pointer block,
 {
   double current_depth;
   double rapid_delta;
-  int count = 0;
   /* Moved the check for negative Q values here as a sign
      may be used with user defined M functions
      Thanks to Billy Singleton for pointing it out... */
   CHKS((delta <= 0.0), NCE_NEGATIVE_OR_ZERO_Q_VALUE_USED);
 
-  rapid_delta = _setup.parameter_drill_cycle_chip_break_distance;
-  if (_setup.length_units == CANON_UNITS_MM)
-    rapid_delta = (rapid_delta * 25.4);
+  rapid_delta = _setup.parameter_g73_peck_clearence;
 
   for (current_depth = (r - delta);
     current_depth > bottom_z; current_depth = (current_depth - delta)) {
-    count ++;
     cycle_feed(block, plane, x, y, current_depth);
-    if (count == _setup.parameter_g73_peck_till_clear_count) {
-        cycle_traverse(block, plane, x, y, r);
-        count = 0;
-    }
     cycle_traverse(block, plane, x, y, current_depth + rapid_delta);
   }
   cycle_feed(block, plane, x, y, bottom_z);

--- a/src/emc/rs274ngc/interp_cycles.cc
+++ b/src/emc/rs274ngc/interp_cycles.cc
@@ -154,7 +154,7 @@ int Interp::convert_cycle_g83(block_pointer block,
      Thanks to Billy Singleton for pointing it out... */
   CHKS((delta <= 0.0), NCE_NEGATIVE_OR_ZERO_Q_VALUE_USED);
 
-  rapid_delta = G83_RAPID_DELTA;
+  rapid_delta = _setup.parameter_drill_cycle_chip_break_distance;
   if (_setup.length_units == CANON_UNITS_MM)
     rapid_delta = (rapid_delta * 25.4);
 
@@ -212,19 +212,24 @@ int Interp::convert_cycle_g73(block_pointer block,
 {
   double current_depth;
   double rapid_delta;
-
+  int count = 0;
   /* Moved the check for negative Q values here as a sign
      may be used with user defined M functions
      Thanks to Billy Singleton for pointing it out... */
   CHKS((delta <= 0.0), NCE_NEGATIVE_OR_ZERO_Q_VALUE_USED);
 
-  rapid_delta = G83_RAPID_DELTA;
+  rapid_delta = _setup.parameter_drill_cycle_chip_break_distance;
   if (_setup.length_units == CANON_UNITS_MM)
     rapid_delta = (rapid_delta * 25.4);
 
   for (current_depth = (r - delta);
-       current_depth > bottom_z; current_depth = (current_depth - delta)) {
+    current_depth > bottom_z; current_depth = (current_depth - delta)) {
+    count ++;
     cycle_feed(block, plane, x, y, current_depth);
+    if (count == _setup.parameter_g73_peck_till_clear_count) {
+        cycle_traverse(block, plane, x, y, r);
+        count = 0;
+    }
     cycle_traverse(block, plane, x, y, current_depth + rapid_delta);
   }
   cycle_feed(block, plane, x, y, bottom_z);

--- a/src/emc/rs274ngc/interp_cycles.cc
+++ b/src/emc/rs274ngc/interp_cycles.cc
@@ -154,7 +154,7 @@ int Interp::convert_cycle_g83(block_pointer block,
      Thanks to Billy Singleton for pointing it out... */
   CHKS((delta <= 0.0), NCE_NEGATIVE_OR_ZERO_Q_VALUE_USED);
 
-  rapid_delta = _setup.parameter_g83_peck_clearence;;
+  rapid_delta = _setup.parameter_g83_peck_clearance;;
 
   for (current_depth = (r - delta);
        current_depth > bottom_z; current_depth = (current_depth - delta)) {
@@ -215,7 +215,7 @@ int Interp::convert_cycle_g73(block_pointer block,
      Thanks to Billy Singleton for pointing it out... */
   CHKS((delta <= 0.0), NCE_NEGATIVE_OR_ZERO_Q_VALUE_USED);
 
-  rapid_delta = _setup.parameter_g73_peck_clearence;
+  rapid_delta = _setup.parameter_g73_peck_clearance;
 
   for (current_depth = (r - delta);
     current_depth > bottom_z; current_depth = (current_depth - delta)) {

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -50,9 +50,6 @@ inline int round_to_int(T x) {
     return (int)std::nearbyint(x);
 }
 
-/* how far above hole bottom for rapid return, in inches */
-#define G83_RAPID_DELTA 0.010
-
 /* nested remap: a remapped code is found in the body of a subroutine
  * which is executing on behalf of another remapped code
  * example: a user G-code command executes a tool change
@@ -791,8 +788,8 @@ struct setup
   int tool_change_at_g30;
   int tool_change_quill_up;
   int tool_change_with_spindle_on;
-  double parameter_drill_cycle_chip_break_distance;
-  int parameter_g73_peck_till_clear_count;
+  double parameter_g73_peck_clearence;
+  double parameter_g83_peck_clearence;
   int a_axis_wrapped;
   int b_axis_wrapped;
   int c_axis_wrapped;

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -788,8 +788,8 @@ struct setup
   int tool_change_at_g30;
   int tool_change_quill_up;
   int tool_change_with_spindle_on;
-  double parameter_g73_peck_clearence;
-  double parameter_g83_peck_clearence;
+  double parameter_g73_peck_clearance;
+  double parameter_g83_peck_clearance;
   int a_axis_wrapped;
   int b_axis_wrapped;
   int c_axis_wrapped;

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -791,6 +791,8 @@ struct setup
   int tool_change_at_g30;
   int tool_change_quill_up;
   int tool_change_with_spindle_on;
+  double parameter_drill_cycle_chip_break_distance;
+  int parameter_g73_peck_till_clear_count;
   int a_axis_wrapped;
   int b_axis_wrapped;
   int c_axis_wrapped;

--- a/src/emc/rs274ngc/interpmodule.cc
+++ b/src/emc/rs274ngc/interpmodule.cc
@@ -816,17 +816,17 @@ static inline int get_tool_change_with_spindle_on(Interp &interp)  {
 static inline void set_tool_change_with_spindle_on(Interp &interp, int value)  {
     interp._setup.tool_change_with_spindle_on = value;
 }
-static inline double get_parameter_g73_peck_clearence (Interp &interp)  {
-    return interp._setup.parameter_g73_peck_clearence;
+static inline double get_parameter_g73_peck_clearance (Interp &interp)  {
+    return interp._setup.parameter_g73_peck_clearance;
 }
-static inline void set_parameter_g73_peck_clearence(Interp &interp, double value)  {
-    interp._setup.parameter_g73_peck_clearence = value;
+static inline void set_parameter_g73_peck_clearance(Interp &interp, double value)  {
+    interp._setup.parameter_g73_peck_clearance = value;
 }
-static inline double get_parameter_g83_peck_clearence (Interp &interp)  {
-    return interp._setup.parameter_g83_peck_clearence;
+static inline double get_parameter_g83_peck_clearance (Interp &interp)  {
+    return interp._setup.parameter_g83_peck_clearance;
 }
-static inline void set_parameter_g83_peck_clearence(Interp &interp, double value)  {
-    interp._setup.parameter_g83_peck_clearence = value;
+static inline void set_parameter_g83_peck_clearance(Interp &interp, double value)  {
+    interp._setup.parameter_g83_peck_clearance = value;
 }
 
 BOOST_PYTHON_MODULE(interpreter) {
@@ -1019,8 +1019,8 @@ BOOST_PYTHON_MODULE(interpreter) {
 	.add_property("tool_change_quill_up", &get_tool_change_quill_up, &set_tool_change_quill_up)
 	.add_property("tool_change_with_spindle_on", &get_tool_change_with_spindle_on,
              &set_tool_change_with_spindle_on)
-	.add_property("parameter_g73_peck_clearence", &get_parameter_g73_peck_clearence, &set_parameter_g73_peck_clearence)
-    .add_property("parameter_g83_peck_clearence", &get_parameter_g83_peck_clearence, &set_parameter_g83_peck_clearence)
+	.add_property("parameter_g73_peck_clearance", &get_parameter_g73_peck_clearance, &set_parameter_g73_peck_clearance)
+    .add_property("parameter_g83_peck_clearance", &get_parameter_g83_peck_clearance, &set_parameter_g83_peck_clearance)
 
 	.add_property( "params",
 		       bp::make_function( &param_wrapper,

--- a/src/emc/rs274ngc/interpmodule.cc
+++ b/src/emc/rs274ngc/interpmodule.cc
@@ -810,11 +810,23 @@ static inline int get_tool_change_quill_up (Interp &interp)  {
 static inline void set_tool_change_quill_up(Interp &interp, int value)  {
     interp._setup.tool_change_quill_up = value;
 }
-static inline int get_tool_change_with_spindle_on (Interp &interp)  {
+static inline int get_tool_change_with_spindle_on(Interp &interp)  {
     return interp._setup.tool_change_with_spindle_on;
 }
 static inline void set_tool_change_with_spindle_on(Interp &interp, int value)  {
     interp._setup.tool_change_with_spindle_on = value;
+}
+static inline double get_parameter_g73_peck_clearence (Interp &interp)  {
+    return interp._setup.parameter_g73_peck_clearence;
+}
+static inline void set_parameter_g73_peck_clearence(Interp &interp, double value)  {
+    interp._setup.parameter_g73_peck_clearence = value;
+}
+static inline double get_parameter_g83_peck_clearence (Interp &interp)  {
+    return interp._setup.parameter_g83_peck_clearence;
+}
+static inline void set_parameter_g83_peck_clearence(Interp &interp, double value)  {
+    interp._setup.parameter_g83_peck_clearence = value;
 }
 
 BOOST_PYTHON_MODULE(interpreter) {
@@ -1007,6 +1019,8 @@ BOOST_PYTHON_MODULE(interpreter) {
 	.add_property("tool_change_quill_up", &get_tool_change_quill_up, &set_tool_change_quill_up)
 	.add_property("tool_change_with_spindle_on", &get_tool_change_with_spindle_on,
              &set_tool_change_with_spindle_on)
+	.add_property("parameter_g73_peck_clearence", &get_parameter_g73_peck_clearence, &set_parameter_g73_peck_clearence)
+    .add_property("parameter_g83_peck_clearence", &get_parameter_g83_peck_clearence, &set_parameter_g83_peck_clearence)
 
 	.add_property( "params",
 		       bp::make_function( &param_wrapper,

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -839,6 +839,8 @@ int Interp::init()
   _setup.tool_change_at_g30 = 0;
   _setup.tool_change_quill_up = 0;
   _setup.tool_change_with_spindle_on = 0;
+  _setup.parameter_drill_cycle_chip_break_distance = .010;
+  _setup.parameter_g73_peck_till_clear_count = 0;
   _setup.a_axis_wrapped = 0;
   _setup.b_axis_wrapped = 0;
   _setup.c_axis_wrapped = 0;
@@ -907,6 +909,11 @@ int Interp::init()
               _setup.c_indexer_jnum = atol(inistring);
           }
           inifile.Find(&_setup.orient_offset, "ORIENT_OFFSET", "RS274NGC");
+          inifile.Find(&_setup.parameter_drill_cycle_chip_break_distance, "PARAMETER_DRILL_CYCLE_CHIP_BREAK_DISTANCE", "RS274NGC");
+          if(NULL != (inistring = inifile.Find("PARAMETER_G73_PECK_TILL_CLEAR_COUNT", "RS274NGC")))
+          {
+              _setup.parameter_g73_peck_till_clear_count = atoi(inistring);
+          }
 
           inifile.Find(&_setup.debugmask, "DEBUG", "EMC");
 

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -841,11 +841,11 @@ int Interp::init()
   _setup.tool_change_quill_up = 0;
   _setup.tool_change_with_spindle_on = 0;
   if (_setup.length_units == CANON_UNITS_INCHES) {
-      _setup.parameter_g73_peck_clearence = .050;
-      _setup.parameter_g83_peck_clearence = .050;
+      _setup.parameter_g73_peck_clearance = .050;
+      _setup.parameter_g83_peck_clearance = .050;
    } else{
-      _setup.parameter_g73_peck_clearence = 1;
-      _setup.parameter_g83_peck_clearence = 1;
+      _setup.parameter_g73_peck_clearance = 1;
+      _setup.parameter_g83_peck_clearance = 1;
     }
   _setup.a_axis_wrapped = 0;
   _setup.b_axis_wrapped = 0;
@@ -915,8 +915,8 @@ int Interp::init()
               _setup.c_indexer_jnum = atol(inistring);
           }
           inifile.Find(&_setup.orient_offset, "ORIENT_OFFSET", "RS274NGC");
-          inifile.Find(&_setup.parameter_g73_peck_clearence, "PARAMETER_G73_PECK_CLEARENCE", "RS274NGC");
-          inifile.Find(&_setup.parameter_g83_peck_clearence, "PARAMETER_G83_PECK_CLEARENCE", "RS274NGC");
+          inifile.Find(&_setup.parameter_g73_peck_clearance, "PARAMETER_G73_PECK_CLEARANCE", "RS274NGC");
+          inifile.Find(&_setup.parameter_g83_peck_clearance, "PARAMETER_G83_PECK_CLEARANCE", "RS274NGC");
 
           inifile.Find(&_setup.debugmask, "DEBUG", "EMC");
 

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -833,14 +833,20 @@ int Interp::init()
   INIT_CANON();
 
   iniFileName = getenv("INI_FILE_NAME");
-
+  _setup.length_units = GET_EXTERNAL_LENGTH_UNIT_TYPE();
+  
   // the default log file
   _setup.loggingLevel = 0;
   _setup.tool_change_at_g30 = 0;
   _setup.tool_change_quill_up = 0;
   _setup.tool_change_with_spindle_on = 0;
-  _setup.parameter_drill_cycle_chip_break_distance = .010;
-  _setup.parameter_g73_peck_till_clear_count = 0;
+  if (_setup.length_units == CANON_UNITS_INCHES) {
+      _setup.parameter_g73_peck_clearence = .050;
+      _setup.parameter_g83_peck_clearence = .050;
+   } else{
+      _setup.parameter_g73_peck_clearence = 1;
+      _setup.parameter_g83_peck_clearence = 1;
+    }
   _setup.a_axis_wrapped = 0;
   _setup.b_axis_wrapped = 0;
   _setup.c_axis_wrapped = 0;
@@ -909,11 +915,8 @@ int Interp::init()
               _setup.c_indexer_jnum = atol(inistring);
           }
           inifile.Find(&_setup.orient_offset, "ORIENT_OFFSET", "RS274NGC");
-          inifile.Find(&_setup.parameter_drill_cycle_chip_break_distance, "PARAMETER_DRILL_CYCLE_CHIP_BREAK_DISTANCE", "RS274NGC");
-          if(NULL != (inistring = inifile.Find("PARAMETER_G73_PECK_TILL_CLEAR_COUNT", "RS274NGC")))
-          {
-              _setup.parameter_g73_peck_till_clear_count = atoi(inistring);
-          }
+          inifile.Find(&_setup.parameter_g73_peck_clearence, "PARAMETER_G73_PECK_CLEARENCE", "RS274NGC");
+          inifile.Find(&_setup.parameter_g83_peck_clearence, "PARAMETER_G83_PECK_CLEARENCE", "RS274NGC");
 
           inifile.Find(&_setup.debugmask, "DEBUG", "EMC");
 
@@ -1082,7 +1085,6 @@ int Interp::init()
       }
   }
 
-  _setup.length_units = GET_EXTERNAL_LENGTH_UNIT_TYPE();
   USE_LENGTH_UNITS(_setup.length_units);
   GET_EXTERNAL_PARAMETER_FILE_NAME(filename, LINELEN);
   if (filename[0] == 0)


### PR DESCRIPTION
peck distance for g73/g83
peck count for g73
g73 does short pecks to break chips.
If count is >0, it will fully retract to clear chips every 'count'
 number of pecks

[RS274NGC]
PARAMETER_DRILL_CYCLE_CHIP_BREAK_DISTANCE = .020
PARAMETER_G73_PECK_TILL_CLEAR_COUNT = 2