### PR TITLE
Re-enable tests/motion-logger/startup-gcode-abort and make it more robust

### DIFF
--- a/tests/motion-logger/startup-gcode-abort/expected.motion-logger.in
+++ b/tests/motion-logger/startup-gcode-abort/expected.motion-logger.in
@@ -76,6 +76,7 @@ SET_AXIS_VEL_LIMIT axis=2 vel=4
 SET_AXIS_ACC_LIMIT axis=2, acc=1000
 SET_AXIS_LOCKING_JOINT axis=2, locking_joint=-1
 
+SET_SPINDLE_PARAMS, 1.00e+99, 0.00e+00, -1.00e+99, 0.00e+00
 JOG_ABORT joint=0
 JOG_ABORT joint=1
 JOG_ABORT joint=2
@@ -108,23 +109,8 @@ JOINT_UNHOME joint=-2
 FREE
 
 #
-# Now Task is done with its internal immediate startup and starts
-# draining the interp_list.
-#
-# emctask_start() called emcTaskPlanInit(), which initialized the
-# Interpreter, enqueueing Canon commands on interp_list.
-#
-
-SET_TERM_COND termCond=2, tolerance=0
-
-# This is the [RS274NGC]RS274NGC_STARTUP_CODE, up to but not going past
-# the very long dwell
-
-SET_LINE x=-1, y=-2, z=-3, a=0, b=0, c=0, u=0, v=0, w=0, id=2, motion_type=1, vel=4.98888, ini_maxvel=4.98888, acc=1247.22, turn=-1
-
-#
-# Task has fully booted!  It's now in Estop, in Manual, and ready to
-# receive commands from the UIs.
+# Task is now got the 'motion.in-position' pin visible, and is
+# accepting abort calls from the UI.
 #
 
 #

--- a/tests/motion-logger/startup-gcode-abort/test-ui.py
+++ b/tests/motion-logger/startup-gcode-abort/test-ui.py
@@ -3,11 +3,13 @@
 import linuxcnc
 import sys
 import time
-
+import hal
 
 #
 # connect to LinuxCNC
 #
+
+comp = hal.component('hal-watcher')
 
 c = linuxcnc.command()
 s = linuxcnc.stat()
@@ -15,10 +17,19 @@ e = linuxcnc.error_channel()
 
 
 #
-# Immediately abort!  Github Issue #49 
+# Immediately abort once linuxcnc is ready!  Github Issue #49
 #
 
-time.sleep(1)
+
+# Wait for (any) HAL pin to show up when LinuxCNC is initialized
+waitlimit = 300
+while 0 < waitlimit:
+    try:
+        waiting = 'TRUE' != hal.get_value('motion.in-position')
+    except RuntimeError:
+        break
+    time.sleep(0.1)
+    waitlimit -= 1
 
 print("UI abort")
 sys.stdout.flush()


### PR DESCRIPTION
Instead of using 'sleep(1)' to guess if linuxcnc is ready to take
instructions from the UI, look for the 'motion.in-position' pin
to show up in hal and abort just after this.  This make sure the
abort happen earlier in the startup process, and hopefully ensure
that the test succeed every time.