### PR TITLE
hal: fix various typos

### DIFF
--- a/src/hal/classicladder/README.txt
+++ b/src/hal/classicladder/README.txt
@@ -140,7 +140,7 @@ For using Classic Ladder as it is, you need :
    * Linux
    * Gtk version 2
 
-I personnaly used the following distribution : Mandriva 2006.
+I personally used the following distribution : Mandriva 2006.
 
 In a console :
 type make if you want to recompile the sources.

--- a/src/hal/classicladder/classicladder.c
+++ b/src/hal/classicladder/classicladder.c
@@ -115,7 +115,7 @@ void display_help (void)
 	       "   --nogui            do not create a GUI, only load a configuration\n"
 	       "   --config=filename  initialize modbus master I/O & load config file-( deprecated- use --modmaster)\n"
 	       "   --modmaster        initialize modbus master I/O ( modbus config is loaded with other objects )\n"
-	       "   --modslave         initialize modbus slave I/O (TCP only- B and W variables accesable\n"
+	       "   --modslave         initialize modbus slave I/O (TCP only- B and W variables accessible\n"
 	       "   --modbus_port=portnumber  used for modbus slave using TCP ( ethernet )\n"
 	       "   --debug            sets the RTAPI debuglevel for printing debug messages\n"
 	       "Please also note that the classicladder realtime module must be loaded first\n"

--- a/src/hal/components/homecomp.comp
+++ b/src/hal/components/homecomp.comp
@@ -138,7 +138,7 @@ static void custom_read_homing_in_pins(int njoints)
         addr = &(custom_joint_home_data->custom_jhd[jno]);
         customH[jno].request_custom_homing = *(addr->request_custom_homing); // IN
 
-        // echo for verificaion:
+        // echo for verification:
         customH[jno].is_custom_homing = customH[jno].request_custom_homing;
     }
 }

--- a/src/hal/components/stepgen.c
+++ b/src/hal/components/stepgen.c
@@ -64,7 +64,7 @@
     No step type uses all five, and only those which will be used are
     exported to HAL.  The values of these parameters are in nano-seconds,
     so no recalculation is needed when changing thread periods.  In
-    the timing diagrams that follow, they are identfied by the
+    the timing diagrams that follow, they are identified by the
     following numbers:
 
     (1): 'stepgen.n.steplen' = length of the step pulse

--- a/src/hal/drivers/hal_ppmc.c
+++ b/src/hal/drivers/hal_ppmc.c
@@ -23,7 +23,7 @@
 *		optional DAC or digital outs installed.
 *               timestamp works the same way, for UPC boards of rev 4
 *               or higher that have the timestamp feature.
-*               enc_clock specifes a 3-digit hex value, where the 1st is a
+*               enc_clock specifies a 3-digit hex value, where the 1st is a
 *               code of 1,2, 5 or 10 to indicate an encoder clock rate of 1, 2.5, 5 or 10 MHz.
 *               The following 2 digits work as above, bus and board address.
 *               Only rev 4 and above PPMC encoder boards have this clock select feature.
@@ -140,7 +140,7 @@ RTAPI_MP_ARRAY_INT(epp_dir, MAX_BUS, "EPP is commanded port direction");
                                 /* only available with rev 2 and above FPGA config */
 #define ENCLOAD     0x00	/* EPP address to write into first byte of preset */
 				/* register for channels 0 - 3 */
-// following regs for new UPC with encoder count timesamp feature
+// following regs for new UPC with encoder count timestamp feature
 #define ENCTS       0x10        /* timestamp low byte for axis 0 */
 #define ENCTS1      0x11        /* timestamp high byte for axis 0 */
 #define ENCTB       0x18        /* timebase low byte */

--- a/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
@@ -80,7 +80,7 @@ struct hm2_lowlevel_io_struct {
     // examples), it is useful to divide the work of the bulk reads which occur
     // every servo cycle into up to three groups:
     //   * queuing the reads -- the buffer must point to storage which is stable
-    //     thrugh the eventual receive_queued_reads call
+    //     through the eventual receive_queued_reads call
     //   * actually requesting the queued reads
     //   * actually receiving the read result and storing it in the buffer given in the
     //     queue_read call

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -108,7 +108,7 @@ static int init_hal_data(void);
     This is done to improve realtime performance.  'shmalloc_up()'
     is used to allocate data that will be accessed by realtime
     code, while 'shmalloc_dn()' is used to allocate the much
-    larger structures that are accessed only occaisionally during
+    larger structures that are accessed only occasionally during
     init.  This groups all the realtime data together, improving
     cache performance.
 */

--- a/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
+++ b/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
@@ -154,7 +154,7 @@ MB_BYTE_TIMEOUT_MS=500
 #using the same name.
 HAL_TX_NAME=remoteIOcfg
 
-#OPTIONAL: Maximum update rate in HZ. Defaults to 0.0 (0.0 = as soon as available = infinit).
+#OPTIONAL: Maximum update rate in HZ. Defaults to 0.0 (0.0 = as soon as available = infinite).
 #NOTE: This is a maximum rate and the actual rate may be lower.
 #If you want to calculate it in ms use (1000 / required_ms).
 #Example: 100 ms = MAX_UPDATE_RATE=10.0, because 1000.0 ms / 100.0 ms = 10.0 Hz

--- a/src/hal/user_comps/mb2hal/mb2hal_init.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_init.c
@@ -290,7 +290,7 @@ retCode parse_transaction_section(const int mb_tx_num)
     DBG(gbl.init_dbg, "[%s] [%s] [%d]", section, tag, this_mb_tx->mb_tx_nelem);
 
     tag = "MAX_UPDATE_RATE"; //optional
-    this_mb_tx->cfg_update_rate = 0; //default: 0=infinit
+    this_mb_tx->cfg_update_rate = 0; //default: 0=infinite
     if (iniFindDouble(gbl.ini_file_ptr, tag, section, &this_mb_tx->cfg_update_rate) != 0) { //not found
         if (mb_tx_num > 0) { //previous value?
             if (strcasecmp(this_mb_tx->cfg_link_type_str, gbl.mb_tx[mb_tx_num-1].cfg_link_type_str) == 0) {

--- a/src/hal/user_comps/mitsub_vfd.py
+++ b/src/hal/user_comps/mitsub_vfd.py
@@ -18,7 +18,7 @@
 #    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # user space component for controlling a misubishi inverter over the serial port using rs485 standard
-# specifcally the A500 F500 E500 A500 D700 E700 F700 series - others may work or need adjustment
+# specifically the A500 F500 E500 A500 D700 E700 F700 series - others may work or need adjustment
 # tested on A500 E500 and E700
 # I referenced manual 'communication option reference manual' and A500 technical manual for 500 series.
 # 'Fr-A700 F700 E700 D700 technical manual' for the 700 series

--- a/src/hal/user_comps/xhc-whb04b-6/main.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/main.cc
@@ -85,7 +85,7 @@ static int printUsage(const char* programName, const char* deviceName, bool isEr
         << "MPG + jogwheel changes the feed override. Each tick will increment/decrement the feed override.\n"
         << "\n"
         << " -B, \n"
-        << "    Big Step modee: "
+        << "    Big Step mode: "
         << "Add 5mm and 10mm to feed selector.\n"
         << "\n"
 

--- a/src/hal/utils/bitfile.c
+++ b/src/hal/utils/bitfile.c
@@ -252,7 +252,7 @@ static int write_chunk(int fd, struct bitfile_chunk *ch)
     /* write tag and length */
     rv = write(fd, hdrbuf, len_len+1);
     if ( rv != len_len+1 ) {
-	errmsg(__func__,"writing headerr: %s", ch->tag, strerror(errno));
+	errmsg(__func__,"writing header: %s", ch->tag, strerror(errno));
 	return -1;
     }
     /* write chunk content */

--- a/src/hal/utils/halcmd_commands.c
+++ b/src/hal/utils/halcmd_commands.c
@@ -2798,7 +2798,7 @@ int do_help_cmd(char *command)
     } else if (strcmp(command, "newinst") == 0) {
 	printf("newinst modname instname\n");
 	printf("  Creates another instance of previously loaded module\n" );
-	printf("  'modname', nameing it 'instname'.\n");
+	printf("  'modname', naming it 'instname'.\n");
 #endif
     } else if (strcmp(command, "unload") == 0) {
 	printf("unload compname\n");

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -693,7 +693,7 @@ static int doLinkpp(char *first_pin_name, char *second_pin_name, connectionRecTy
     rtapi_mutex_give(&(hal_data->mutex));
     
     /* check that both pins have the same type, 
-       don't want ot create a sig, which after that won't be useful */
+       don't want to create a sig, which after that won't be useful */
     if (first_pin->type != second_pin->type) {
       snprintf(errorStr, sizeof(errorStr), "HAL:%d: ERROR: pins '%s' and '%s' not of the same type", 
 	  linenumber, first_pin_name, second_pin_name);


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.ts,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es -L ans,ba,bulle,componentes,doubleclick,dout,dum,fo,halp,ihs,inout,parm,parms,ro,ser,te,ue,wille,wonte`