### PR TITLE
configs: fix various typos

### DIFF
--- a/configs/attic/demo_mazak/demo_mazak.ini
+++ b/configs/attic/demo_mazak/demo_mazak.ini
@@ -103,7 +103,7 @@ MAX_LINEAR_ACCELERATION = 20.0
 
 [EMCIO]
 # change tools in the upper left corner of the table
-# to avoid hitting the vise or workpiece with the tool
+# to avoid hitting the vice or workpiece with the tool
 TOOL_CHANGE_POSITION = -13.75 7.5 -0.022
 # Name of IO controller program, e.g., io
 EMCIO =     io

--- a/configs/sim/axis/moveoff/moveoff_display_7.xml
+++ b/configs/sim/axis/moveoff/moveoff_display_7.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- this is an example, the values are not
-likelly to be suitable for a real machine
+likely to be suitable for a real machine
 -->
 <pyvcp>
   <vbox>

--- a/configs/sim/axis/orphans/iocontrol-removed/python/customtask.py
+++ b/configs/sim/axis/orphans/iocontrol-removed/python/customtask.py
@@ -296,7 +296,7 @@ class CustomTask(emctask.Task,UserFuncs):
         self.io.tool.toolTable[pocket].backangle = backangle
         self.io.tool.toolTable[pocket].offset = offset
 
-        if debug(): print("new tool enttry: ",str(self.io.tool.toolTable[pocket]))
+        if debug(): print("new tool entry: ",str(self.io.tool.toolTable[pocket]))
 
         if self.io.tool.toolInSpindle  == toolno:
             self.io.tool.toolTable[0] = self.io.tool.toolTable[pocket]

--- a/configs/sim/axis/orphans/pysubs/customtask.py
+++ b/configs/sim/axis/orphans/pysubs/customtask.py
@@ -290,7 +290,7 @@ class CustomTask(emctask.Task,UserFuncs):
         self.io.tool.toolTable[pocket].backangle = backangle
         self.io.tool.toolTable[pocket].offset = offset
 
-        if debug(): print("new tool enttry: ",str(self.io.tool.toolTable[pocket]))
+        if debug(): print("new tool entry: ",str(self.io.tool.toolTable[pocket]))
 
         if self.io.tool.toolInSpindle  == toolno:
             self.io.tool.toolTable[0] = self.io.tool.toolTable[pocket]

--- a/configs/sim/axis/vismach/5axis/bridgemill/5axis.ini
+++ b/configs/sim/axis/vismach/5axis/bridgemill/5axis.ini
@@ -72,7 +72,7 @@ TOOL_TABLE = 5axis.tbl
 [KINS]
 # Note: Supported coordinates are XYZBCW but the W coordinate
 #       motion is incorporated into the X,Y,Z axes.
-#       Use of the W coordinate requies a joint (5)
+#       Use of the W coordinate requires a joint (5)
 #       in order to allow display of W values.
 #       Use immediate homing for this joint (JOINT_5)
 # Note: 5axiskins is misnomer

--- a/configs/sim/axis/xhc-hb04/README
+++ b/configs/sim/axis/xhc-hb04/README
@@ -134,7 +134,7 @@ Note: halui MDI commands are defined in a [HALUI] stanza:
 MDI_COMMAND = G0 X0 Y0 Z0
 MDI_COMMAND = M101
 
-The commands are assigned to pins (Type=bit, Dir=IN) named halui.mdi-command-nn whre
+The commands are assigned to pins (Type=bit, Dir=IN) named halui.mdi-command-nn where
 nn corresponds to their ordered appearance beginning with nn=00.  (man halui for more information)
 ----------------------------------
 A application named monitor-xhc-hb04 is included to monitor disconnects and reconnects of the pendant.  This script runs in the background and will pop up a message when the pendant is disconnected or reconnected.  Usage is optional; if used it is specified with ini file entry:

--- a/configs/sim/gmoccapy/gmoccapy_plasma/plasma.py
+++ b/configs/sim/gmoccapy/gmoccapy_plasma/plasma.py
@@ -2,7 +2,7 @@
 # -*- coding:UTF-8 -*-
 """
     This file will control some options of the gmoccapy plasma screen
-    and demonstrats at the same time the possibilities you have introducing
+    and demonstrates at the same time the possibilities you have introducing
     your own handler files and functions to that screen, showing the
     possibilities to modify the layout and behavior
 

--- a/configs/sim/gmoccapy/gmoccapy_plasma/signals.py
+++ b/configs/sim/gmoccapy/gmoccapy_plasma/signals.py
@@ -2,7 +2,7 @@
 # -*- coding:UTF-8 -*-
 """
     This file will control some options of the gmoccapy plasma screen
-    and demonstrats at the same time the possibilities you have introducing
+    and demonstrates at the same time the possibilities you have introducing
     your own handler files and functions to that screen, showing the
     possibilities to modify the layout and behavior
 

--- a/configs/sim/gmoccapy/lathe_configs/README
+++ b/configs/sim/gmoccapy/lathe_configs/README
@@ -33,7 +33,7 @@ However it only works for whole numbers: 100/2 will become 50 but
 3.14149/2 is interpreted as 3 and 14 thousand halves so won't work.
 
 Notes on adding your own cycles:
-Greate a new G-code subroutine in the same format as the existing ones.
+Create a new G-code subroutine in the same format as the existing ones.
 In Glade add a new tab to the 'tabs1' notebook and give it a name matching
 the new cycle.
 Edit the action button (inside an eventbox) to call the new G-code sub.

--- a/configs/sim/gmoccapy/lathe_configs/lathemacro.ui
+++ b/configs/sim/gmoccapy/lathe_configs/lathemacro.ui
@@ -2532,7 +2532,7 @@
                     <property name="height_request">20</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="tooltip_markup" translatable="yes">&lt;!--1084,672--&gt;Finish Diamter</property>
+                    <property name="tooltip_markup" translatable="yes">&lt;!--1084,672--&gt;Finish Diameter</property>
                     <property name="halign">start</property>
                     <property name="valign">start</property>
                     <property name="invisible_char">●</property>

--- a/configs/sim/gmoccapy/plasma_config/plasma.py
+++ b/configs/sim/gmoccapy/plasma_config/plasma.py
@@ -2,7 +2,7 @@
 # -*- coding:UTF-8 -*-
 """
     This file will control some options of the gmoccapy plasma screen
-    and demonstrats at the same time the possibilities you have introducing
+    and demonstrates at the same time the possibilities you have introducing
     your own handler files and functions to that screen, showing the
     possibilities to modify the layout and behavior
 

--- a/configs/sim/gmoccapy/plasma_config/signals.py
+++ b/configs/sim/gmoccapy/plasma_config/signals.py
@@ -2,7 +2,7 @@
 # -*- coding:UTF-8 -*-
 """
     This file will control some options of the gmoccapy plasma screen
-    and demonstrats at the same time the possibilities you have introducing
+    and demonstrates at the same time the possibilities you have introducing
     your own handler files and functions to that screen, showing the
     possibilities to modify the layout and behavior
 

--- a/configs/sim/qtvcp_screens/qtdragon/qtdragon.ini
+++ b/configs/sim/qtvcp_screens/qtdragon/qtdragon.ini
@@ -37,8 +37,8 @@ LOG_FILE = qtdragon.log
 TOOL_EDITOR = tooledit
 CONFIRM_EXIT = True
 
-MESSAGE_BOLDTEXT = Critical and Persistant
-MESSAGE_TEXT = This is a persistant dialog test
+MESSAGE_BOLDTEXT = Critical and Persistent
+MESSAGE_TEXT = This is a persistent dialog test
 MESSAGE_DETAILS = There seems to be something wrong\n You must fix it to clear message
 MESSAGE_TYPE = nonedialog
 MESSAGE_PINNAME = nonedialogtest

--- a/configs/sim/qtvcp_screens/woodpecker/woodpecker_postgui.hal
+++ b/configs/sim/qtvcp_screens/woodpecker/woodpecker_postgui.hal
@@ -57,7 +57,7 @@ net jogSelecty        axis.y.jog-enable      woodpecker.jog.wheel.y
 net jogSelectz        axis.z.jog-enable      woodpecker.jog.wheel.z
 net jogSelecta        axis.a.jog-enable     woodpecker.jog.wheel.a
 
-net jogIncrement      woodpecker.jog.wheel.incement
+net jogIncrement      woodpecker.jog.wheel.increment
 net jogIncrement      axis.x.jog-scale       axis.y.jog-scale      axis.z.jog-scale    axis.a.jog-scale 
 
 net btn_probesim     motion.probe-input      woodpecker.probesim_button  woodpecker.hal_led_probe

--- a/configs/sim/qtvcp_screens/woodpecker/woodpecker_postgui_ya.hal
+++ b/configs/sim/qtvcp_screens/woodpecker/woodpecker_postgui_ya.hal
@@ -47,6 +47,6 @@ net jogSelecty        axis.y.jog-enable      woodpecker.jog.wheel.y
 net jogSelectz        axis.z.jog-enable      woodpecker.jog.wheel.z
 net jogSelecta        axis.a.jog-enable     woodpecker.jog.wheel.a
 
-net jogIncrement      woodpecker.jog.wheel.incement
+net jogIncrement      woodpecker.jog.wheel.increment
 net jogIncrement      axis.x.jog-scale       axis.y.jog-scale      axis.z.jog-scale
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.ts,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es -L ans,ba,bulle,componentes,doubleclick,dout,dum,fo,halp,ihs,inout,parm,parms,ro,ser,te,ue,wille,wonte`