### PR TITLE
lib/python: fix various typos

### DIFF
--- a/lib/python/gladevcp/builtin-panels/versa-probe/versa_probe_screen.py
+++ b/lib/python/gladevcp/builtin-panels/versa-probe/versa_probe_screen.py
@@ -22,7 +22,7 @@ import os                   # needed to get the paths and directories
 import hal_glib             # needed to make our own hal pins
 import gtk.glade
 import sys                  # handle system calls
-import linuxcnc             # to get our own error sytsem
+import linuxcnc             # to get our own error system
 import gladevcp
 import time
 import math
@@ -560,7 +560,7 @@ class ProbeScreenClass:
         # move Z to start point up
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f" % xres
         if self.gcode(s) == -1:
             return
@@ -589,7 +589,7 @@ class ProbeScreenClass:
         # move Z to start point up
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 Y%f" % yres
         if self.gcode(s) == -1:
             return
@@ -618,7 +618,7 @@ class ProbeScreenClass:
         # move Z to start point up
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f" % xres
         if self.gcode(s) == -1:
             return
@@ -647,7 +647,7 @@ class ProbeScreenClass:
         # move Z to start point up
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 Y%f" % yres
         if self.gcode(s) == -1:
             return
@@ -700,7 +700,7 @@ class ProbeScreenClass:
         # move Z to start point up
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f Y%f" % (xres,yres)
         if self.gcode(s) == -1:
             return
@@ -750,7 +750,7 @@ class ProbeScreenClass:
         # move Z to start point up
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f Y%f" % (xres,yres)
         if self.gcode(s) == -1:
             return
@@ -801,7 +801,7 @@ class ProbeScreenClass:
         # move Z to start point up
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f Y%f" % (xres,yres)
         if self.gcode(s) == -1:
             return
@@ -852,7 +852,7 @@ class ProbeScreenClass:
         # move Z to start point up
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f Y%f" % (xres,yres)
         if self.gcode(s) == -1:
             return
@@ -949,7 +949,7 @@ class ProbeScreenClass:
         ymres=float(a[1])-0.5*self.spbtn1_probe_diam.get_value()
         self.lb_probe_ym.set_text( "%.4f" % ymres )
         self.lenght_y()
-        # find, show and move to finded  point
+        # find, show and move to found point
         ycres=0.5*(ypres+ymres)
         self.lb_probe_yc.set_text( "%.4f" % ycres )
         diam=0.5*((xmres-xpres)+(ymres-ypres))
@@ -958,7 +958,7 @@ class ProbeScreenClass:
         # move Z to start point up
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 Y%f" % ycres
         if self.gcode(s) == -1:
             return
@@ -1010,7 +1010,7 @@ class ProbeScreenClass:
         # move Z to start point
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f Y%f" % (xres,yres)
         if self.gcode(s) == -1:
             return
@@ -1056,7 +1056,7 @@ class ProbeScreenClass:
         # move Z to start point
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f Y%f" % (xres,yres)
         if self.gcode(s) == -1:
             return
@@ -1103,7 +1103,7 @@ class ProbeScreenClass:
         # move Z to start point
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f Y%f" % (xres,yres)
         if self.gcode(s) == -1:
             return
@@ -1149,7 +1149,7 @@ class ProbeScreenClass:
         # move Z to start point
         if self.z_clearance_up() == -1:
             return
-        # move to finded  point
+        # move to found point
         s = "G1 X%f Y%f" % (xres,yres)
         if self.gcode(s) == -1:
             return
@@ -1229,7 +1229,7 @@ class ProbeScreenClass:
         ypres=float(a[1])+0.5*self.spbtn1_probe_diam.get_value()
         self.lb_probe_yp.set_text( "%.4f" % ypres )
         self.lenght_y()
-        # find, show and move to finded  point
+        # find, show and move to found point
         ycres=0.5*(ymres+ypres)
         self.lb_probe_yc.set_text( "%.4f" % ycres )
         diam=0.5*((xpres-xmres)+(ypres-ymres))

--- a/lib/python/gladevcp/offsetpage_widget.py
+++ b/lib/python/gladevcp/offsetpage_widget.py
@@ -343,7 +343,7 @@ class OffsetPage(Gtk.VBox):
         else:
             tmpl = lambda s: self.imperial_text_template % s
 
-        # allow 'name' columnn text to be arbitrarily changed
+        # allow 'name' column text to be arbitrarily changed
         if col == 10:
             self.store[row][14] = new_text
             return

--- a/lib/python/gladevcp/speedcontrol.py
+++ b/lib/python/gladevcp/speedcontrol.py
@@ -56,7 +56,7 @@ class SpeedControl(Gtk.VBox, _HalSpeedControlBase):
                             allowed values are 0.001, 99999.0
                             default is 100.0
     increment   = float   : sets the applied increment per mouse click,
-                            -1 means 100 increments fom min to max
+                            -1 means 100 increments from min to max
     inc_speed   = integer : Sets the timer delay for the increment speed holding pressed the buttons
                             allowed values are 20 to 300
                             default is 100

--- a/lib/python/gladevcp/xembed.py
+++ b/lib/python/gladevcp/xembed.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # vim: sts=4 sw=4 et
 """
-XEmbed helper functions to allow correct embeding inside Axis
+XEmbed helper functions to allow correct embedding inside Axis
 """
 
 import gi

--- a/lib/python/plasmac/sector.py
+++ b/lib/python/plasmac/sector.py
@@ -78,10 +78,10 @@ def preview(Conv, fTmp, fNgc, fNgcBkp, \
     if error:
         return error
     if radius == 0:
-        msg = _('RADIUS canot be zero')
+        msg = _('RADIUS cannot be zero')
         error += '{}\n\n'.format(msg)
     if sAngle == 0:
-        msg = _('SEC ANGLE canot be zero')
+        msg = _('SEC ANGLE cannot be zero')
         error += '{}\n\n'.format(msg)
     if error:
         return error

--- a/lib/python/pyngcgui.py
+++ b/lib/python/pyngcgui.py
@@ -391,7 +391,7 @@ def find_positional_parms(s):
                 dvalue = int(dvalue)
             if r.group(4): comment = r.group(4)
         if n > 4:
-            print('find_positional_parametrs unexpected n>4',s,)
+            print('find_positional_parameters unexpected n>4',s,)
             comment = r.group(4)
         if comment is None:
             print('find_positional_parameters:NOCOMMENT') # can't happen
@@ -3357,7 +3357,7 @@ class SaveSection():
                     # example: 246 chars observed for
                     #  qpex --> the call to qpocket uses many named parms
                     # hardcoded for # config.h.in #define LINELEN 255
-                    # hardcoded 252 empiracally determined
+                    # hardcoded 252 empirically determined
                     if len(theline) >= 252:
                         theline = line
                     self.sdata.append(theline)

--- a/lib/python/qtvcp/lib/message.py
+++ b/lib/python/qtvcp/lib/message.py
@@ -222,9 +222,9 @@ if __name__ == '__main__':
 
     dialoge = LcncDialog()
     e = QPushButton(w)
-    e.setText("Show critical\n persistant message!")
+    e.setText("Show critical\n persistent message!")
     e.move(10, 120)
-    e.clicked.connect(lambda data: m.showDialog(dialoge, 'This is a Critical persistant message',
+    e.clicked.connect(lambda data: m.showDialog(dialoge, 'This is a Critical persistent message',
                       details='There seems to be something wrong\n You must fix it to clear message', icon=m.CRITICAL,
                       display_type=LcncDialog.NONE,return_callback = callreturn, nblock=True))
 

--- a/lib/python/qtvcp/lib/qt_ngcgui/ngcgui.py
+++ b/lib/python/qtvcp/lib/qt_ngcgui/ngcgui.py
@@ -277,7 +277,7 @@ class SubFile():
                         self.flag_error("Parm {} exceeds maximum limit of {}".format(pparm, self.g_max_parm))
                     self.min_num = min
                     self.max_num = max
-                # blanks required for this, use original line not tranlated line
+                # blanks required for this, use original line not translated line
                 name, pnum, dvalue, comment = find_positional_parms(orig_line)
                 if name:
                     self.ndict[pnum] = (name, dvalue, comment)
@@ -742,13 +742,13 @@ class NgcGui(QtWidgets.QWidget):
         return(ct)
 
     def warp_info_frame(self, newLayout):
-        """ Convience function to move the info frame to another layout"""
+        """ Convenience function to move the info frame to another layout"""
         newLayout.addWidget(self.frame_info)
         # is this enough?
         self.frame_info.setMaximumWidth(500)
 
     def warp_tabs_frame(self, newLayout):
-        """ Convience function to move the tabs frame to another layout"""
+        """ Convenience function to move the tabs frame to another layout"""
         newLayout.addWidget(self.frame_tabs)
 
 ##################

--- a/lib/python/qtvcp/lib/toolbar_actions.py
+++ b/lib/python/qtvcp/lib/toolbar_actions.py
@@ -694,7 +694,7 @@ class ToolBarActions():
                 return
 
         # are we past 5 files? remove the lowest
-        # else update cuurrent number
+        # else update current number
         if self.recentNum > self.maxRecent:
             widget.removeAction(alist[self.maxRecent])
         else:

--- a/lib/python/qtvcp/plugins/actionbutton_plugin.py
+++ b/lib/python/qtvcp/plugins/actionbutton_plugin.py
@@ -689,7 +689,7 @@ class ActionButtonDialog(QtWidgets.QDialog):
         self.diam = QtWidgets.QWidget()
         hbox = QtWidgets.QHBoxLayout()
         hbox.setContentsMargins(0, 0, 0, 0)
-        label = QtWidgets.QLabel('Round Diamter')
+        label = QtWidgets.QLabel('Round Diameter')
         self.diamSpinBox = QtWidgets.QDoubleSpinBox()
         self.diamSpinBox.setRange(2, 100)
         self.diamSpinBox.setDecimals(1)
@@ -1108,7 +1108,7 @@ class ActionButtonDialog(QtWidgets.QDialog):
             # set widget option
             formWindow.cursor().setProperty(winProperty + '_action',
                                             QtCore.QVariant(True))
-        # set status data fom combo box
+        # set status data from combo box
         # we read all data from combo and set each property to its
         # current dialog state (ie. selected is true, all others false)
         for i in range(1, self.statusCombo.count()):

--- a/lib/python/qtvcp/widgets/action_button.py
+++ b/lib/python/qtvcp/widgets/action_button.py
@@ -13,7 +13,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-# Action buttons are used to change linuxcnc behaivor do to button pushing.
+# Action buttons are used to change linuxcnc behavior do to button pushing.
 # By making the button 'checkable' in the designer editor,
 # the button will toggle.
 # In the designer editor, it is possible to select what the button will do.

--- a/lib/python/qtvcp/widgets/action_button_round.py
+++ b/lib/python/qtvcp/widgets/action_button_round.py
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 
 # This is an extension of action buttons to show a round button image.
-# Action buttons are used to control linuxcnc behaivor by pressing.
+# Action buttons are used to control linuxcnc behavior by pressing.
 # By making the button 'checkable' in the designer editor,
 # the button will toggle.
 # In the designer editor, it is possible to select what the button will do.

--- a/lib/python/qtvcp/widgets/dialog_widget.py
+++ b/lib/python/qtvcp/widgets/dialog_widget.py
@@ -528,7 +528,7 @@ class ToolDialog(LcncDialog, GeometryMixin):
             self.changed.set(False)
 
     # process callback for 'change-button' HAL pin
-    # hide the message dialog or destop notify message
+    # hide the message dialog or desktop notify message
     def external_acknowledge(self, state):
         #print('external acklnowledge: {}'.format(state))
         if state:

--- a/lib/python/tooldb.py
+++ b/lib/python/tooldb.py
@@ -139,7 +139,7 @@ def tooldb_tools(tool_list):
 
 def tooldb_loop():
     """Loop forever:
-       1) send startup acknowlegment
+       1) send startup acknowledgment
        2) read line from stdino
        3) parse line
              execute command if valid


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.ts,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es -L ans,ba,bulle,componentes,doubleclick,dout,dum,fo,halp,ihs,inout,parm,parms,ro,ser,te,ue,wille,wonte`