### PR TITLE
Add missing debian/copyright description of GPL-3+.

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -503,6 +503,23 @@ License: LGPL-2.1+
  On Debian systems, the complete text of the GNU Lesser General Public
  License version 2.1 can be found in '/usr/share/common-licenses/LGPL-2.1'.
 
+License: GPL-3+
+ This package is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>
+ .
+ On Debian systems, the complete text of the GNU General
+ Public License version 2 can be found in "/usr/share/common-licenses/GPL-3".
+
 License: MIT
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This get rid of a lintian warning.