### PR TITLE
Remove more generated files in the clean target

### DIFF
--- a/debian/rules.in
+++ b/debian/rules.in
@@ -60,7 +60,7 @@ endif
 override_dh_auto_clean:
 	dh_auto_clean
 	py3clean .
-	if [ -r src/Makefile.inc -a -r src/config.status ]; then cd src && $(MAKE) clean -s; fi
+	if [ -r src/Makefile.inc -a -r src/config.status ]; then cd src && $(MAKE) clean modclean -s; fi
 	rm -f Makefile.inc
 	rm -f src/config.log src/config.status
 	rm -f $(for i in $(find . -name "*.in"); do basename $i .in; done)

--- a/src/Makefile
+++ b/src/Makefile
@@ -316,7 +316,7 @@ default: $(INFILES)
 # is listed here.  Note that due to $(INCLUDE), defined above, the include
 # files in the source tree are the ones used when building linuxcnc.  The copy
 # in ../include is used when building external components of linuxcnc.
-HEADERS := \
+SRCHEADERS := \
     emc/linuxcnc.h \
     emc/ini/emcIniFile.hh \
     emc/ini/iniaxis.hh \
@@ -439,7 +439,7 @@ HEADERS := \
 
 # the "headers" target installs all the header files in ../include
 .PHONY: headers
-HEADERS := $(patsubst %,../include/%,$(foreach h,$(HEADERS),$(notdir $h)))
+HEADERS := $(patsubst %,../include/%,$(foreach h,$(SRCHEADERS),$(notdir $h)))
 headers: $(HEADERS)
 
 # install header files as part of the build
@@ -503,7 +503,11 @@ pythonclean:
 	find . -name __pycache__ | xargs -r rm -r
 python: $(PYTARGETS)
 userspace: python
-clean: docclean pythonclean cscopeclean
+inclean:
+	$(RM) $(INFILES)
+headersclean:
+	$(RM) $(HEADERS)
+clean: docclean pythonclean cscopeclean inclean headersclean
 
 # This is the gateway into the crazy world of "kbuild", the linux 2.6 system
 # for building kernel modules.	Other kernel module build styles need to be


### PR DESCRIPTION
Remove scripts generated by configure, headers copied into include/.
Make sure the Debian build also uses modclean to remove shared
libraries generated by the build.