### PR TITLE
AXIS: Add [DISPLAY] PREVIEW_TIMEOUT setting.

### DIFF
--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -305,6 +305,7 @@ User Manual.
   If the update time is not set right the screen can become unresponsive or very jerky.
   A value of 100ms (0.1 seconds) is a common setting though a range of 50 - 200ms (.05 - .2 seconds) may be useable.
   An under powered CPU may see improvement with a longer setting. Usually the default is fine.
+* 'PREVIEW_TIMEOUT = 5' - Timeout (in seconds) for loading graphical preview of G-code. Currently AXIS only.
 
 [NOTE]
 The following [DISPLAY] items are used by GladeVCP, see the

--- a/docs/src/gui/axis.adoc
+++ b/docs/src/gui/axis.adoc
@@ -37,13 +37,23 @@ For more information on INI file settings that can change how AXIS
 works see the <<sub:ini:sec:display,Display Section>> of the INI
 Configuration Chapter.
 
-Adjust the response rate of the GUI in milliseconds. Typical 100, useable range 50 - 200 +
+* 'CYCLE_TIME' - Adjust the response rate of the GUI in milliseconds. Typical 100, useable range 50 - 200 +
 (will accept time in seconds (.05 -.2) for legacy reasons - milliseconds preferred to match other screens).
-
++
 [source,{ini}]
 ----
 [DISPLAY]
 CYCLE_TIME = 100
+----
+
+* 'PREVIEW_TIMEOUT' - Set timeout in seconds for loading G-code preview.
+If parsing the G-code lasts longer than this, a notice is shown and only the initial part of the program
+is drawn in the graphical display. Specifying 0 or leaving the setting out results in no timeout.
++
+[source,{ini}]
+----
+[DISPLAY]
+PREVIEW_TIMEOUT = 5
 ----
 
 === A Typical Session


### PR DESCRIPTION
Previously AXIS would freeze when loading a G-code file that takes very
long to execute and/or never terminates. This commit adds an optional
timeout that stops the loading of preview and shows a notice.

Retains old behavior if the .ini file setting is not specified.

--

I've been hitting this problem especially with NativeCAM.
If one sets some parameters such as step down to 0 by mistake, AXIS just freezes.

Example .ngc file with infinite loop for testing:

    o100 do
    o100 while [1 LT 2]

Example .ini configuration:

    [DISPLAY]
    PREVIEW_TIMEOUT = 5.0