### PR TITLE
Duplicate Strings gmoccapy.pot and linuxcnc.pot

### DIFF
--- a/src/emc/usr_intf/gmoccapy/Submakefile
+++ b/src/emc/usr_intf/gmoccapy/Submakefile
@@ -3,9 +3,6 @@ GMOCCAPY_MODULES = dialogs getiniinfo notification player preferences widgets
 PYTARGETS += ../bin/gmoccapy ../lib/python/gmoccapy/__init__.py $(patsubst %,../lib/python/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
 	../share/gmoccapy/gmoccapy.glade 
 
-#PYI18NSRCS += emc/usr_intf/gmoccapy/gmoccapy.py $(patsubst %,emc/usr_intf/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
-#	emc/usr_intf/gmoccapy/gmoccapy.glade 
-
 ../lib/python/gmoccapy/__init__.py:
 	@mkdir -p ../lib/python/gmoccapy
 	@touch $@

--- a/src/emc/usr_intf/gmoccapy/Submakefile
+++ b/src/emc/usr_intf/gmoccapy/Submakefile
@@ -3,8 +3,8 @@ GMOCCAPY_MODULES = dialogs getiniinfo notification player preferences widgets
 PYTARGETS += ../bin/gmoccapy ../lib/python/gmoccapy/__init__.py $(patsubst %,../lib/python/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
 	../share/gmoccapy/gmoccapy.glade 
 
-PYI18NSRCS += emc/usr_intf/gmoccapy/gmoccapy.py $(patsubst %,emc/usr_intf/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
-	emc/usr_intf/gmoccapy/gmoccapy.glade 
+#PYI18NSRCS += emc/usr_intf/gmoccapy/gmoccapy.py $(patsubst %,emc/usr_intf/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
+#	emc/usr_intf/gmoccapy/gmoccapy.glade 
 
 ../lib/python/gmoccapy/__init__.py:
 	@mkdir -p ../lib/python/gmoccapy


### PR DESCRIPTION
The same Strings were generated to gmoccapy.pot and linuxcnc.pot
I inspired here:
https://github.com/LinuxCNC/linuxcnc/pull/542/files

This FIX needs to be done only for branche 2.8. It already exists in the master version.