### PR TITLE
Update remap.adoc

### DIFF
--- a/docs/src/remap/remap.adoc
+++ b/docs/src/remap/remap.adoc
@@ -416,7 +416,7 @@ any extra parameters present.
 Note that RS274NGC rules still apply - for instance you may use axis
 words (eg X,Y,Z) only in the context of a G-code.
 
-`ABCDEFGHIJKMPQRSTUVWXYZ`::
+`ABCDEFHIJKPQRSTUVWXYZ`::
   Defines a required word parameter: an uppercase letter specifies that
   the corresponding word *must*
   be present in the current block. The word`s value will be
@@ -425,7 +425,7 @@ words (eg X,Y,Z) only in the context of a G-code.
   present in the argspec, it will be passed as positional
   parameter, see below.
 
-`abcdefghijkmpqrstuvwxyz`::
+`abcdefhijkpqrstuvwxyz`::
   Defines an optional word parameter: a lowercase letter specifies that
   the corresponding word *may* be present in the current block.
   If the word is present, the word's value will be


### PR DESCRIPTION
Both the "M/m" and "G/g" argspec words are not currently supported by interp_remap.cc. These should be removed from the argspec description as they are not passed to the called remapping code. Either that or the interp_remap.cc should be fixed.