### PR TITLE
Use xdg-open consistently in deb packages and fix lintian overrides

### DIFF
--- a/debian/control.docs.in
+++ b/debian/control.docs.in
@@ -28,7 +28,7 @@ Package: linuxcnc-doc-es
 Provides: linuxcnc-doc
 Architecture: all
 Depends: ${misc:Depends}
-Recommends: mailcap
+Recommends: xdg-utils
 Suggests: pdf-viewer
 Description: controlador de movimiento para máquinas CNC y robots (Español).
  LinuxCNC es EMC (controlador de máquina mejorado) que proporciona

--- a/debian/extras/usr/share/applications/linuxcnc-gcoderef_es.desktop
+++ b/debian/extras/usr/share/applications/linuxcnc-gcoderef_es.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Exec=/usr/bin/x-www-browser /usr/share/doc/linuxcnc/gcode_es.html
+Exec=xdg-open /usr/share/doc/linuxcnc/gcode_es.html
 Icon=linuxcnc_es
 X-GNOME-DocPath=
 Terminal=false

--- a/debian/linuxcnc-doc-es.lintian-overrides
+++ b/debian/linuxcnc-doc-es.lintian-overrides
@@ -1,4 +1,3 @@
-#  mailcap providing /usr/bin/see was added as a recommendation to the package
-linuxcnc-doc-es: desktop-command-not-in-package usr/share/applications/linuxcnc-documentation_es.desktop usr/bin/see
-linuxcnc-doc-es: desktop-command-not-in-package usr/share/applications/linuxcnc-gcoderef_es.desktop usr/bin/x-www-browser
-linuxcnc-doc-es: desktop-command-not-in-package usr/share/applications/linuxcnc-gettingstarted_es.desktop usr/bin/see
+linuxcnc-doc-es: desktop-command-not-in-package usr/share/applications/linuxcnc-documentation_es.desktop xdg-open
+linuxcnc-doc-es: desktop-command-not-in-package usr/share/applications/linuxcnc-gettingstarted_es.desktop xdg-open
+linuxcnc-doc-es: desktop-command-not-in-package usr/share/applications/linuxcnc-gcoderef_es.desktop xdg-open

--- a/debian/linuxcnc-doc-zh-cn.lintian-overrides
+++ b/debian/linuxcnc-doc-zh-cn.lintian-overrides
@@ -1,2 +1,1 @@
-# The application /usr/bin/see is provided by the package mailcap that was added as a recommendation
-linuxcnc-doc-zh-cn: desktop-command-not-in-package usr/share/applications/linuxcnc-gettingstarted_zh_CN.desktop usr/bin/see
+linuxcnc-doc-zh-cn: desktop-command-not-in-package usr/share/applications/linuxcnc-gettingstarted_zh_CN.desktop xdg-open


### PR DESCRIPTION
Instead of using both xdg-open and x-www-browser depending on
package, use only one of them.  Picked xdg-open after consulting

Drop irrelevant overrides and insert correct ones refering to xdg-open.