### PR TITLE
Make pncconf and stepconf XDG menu entries also available for run-in-place

### DIFF
--- a/share/applications/linuxcnc-pncconf.desktop.in
+++ b/share/applications/linuxcnc-pncconf.desktop.in
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Exec=/usr/bin/stepconf
+Exec=@EMC2_BIN_DIR@/pncconf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
-Name=Stepconf Wizard
-Comment=Stepper Configuration Wizard
+Comment=Configuration Wizard For Mesa I/O Cards
 StartupNotify=false
 Categories=Utility;Engineering;X-CNC;
+Name=LinuxCNC Pncconf Wizard
 Keywords=cnc;linuxcnc;cncprog;cncconfig;

--- a/share/applications/linuxcnc-stepconf.desktop.in
+++ b/share/applications/linuxcnc-stepconf.desktop.in
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Exec=/usr/bin/pncconf
+Exec=@EMC2_BIN_DIR@/stepconf
 Icon=linuxcncicon
 X-GNOME-DocPath=
 Terminal=false
-Comment=Configuration Wizard For Mesa I/O Cards
+Name=Stepconf Wizard
+Comment=Stepper Configuration Wizard
 StartupNotify=false
 Categories=Utility;Engineering;X-CNC;
-Name=LinuxCNC Pncconf Wizard
 Keywords=cnc;linuxcnc;cncprog;cncconfig;

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -695,7 +695,7 @@ else
     EMC2_HOME=${prefix}
     EMC2_BIN_DIR=${prefix}/bin
     EMC2_LATENCY_SCRIPT=$EMC2_BIN_DIR/latency-test
-    EMC2_LATENCY_HISTOGRAM_SCRIPT=$EMC2_BIN_DIR/scripts/latency-histogram
+    EMC2_LATENCY_HISTOGRAM_SCRIPT=$EMC2_BIN_DIR/latency-histogram
     EMC2_SCRIPT=$EMC2_BIN_DIR/linuxcnc
     EMC2_SUFFIX=""
     EMC2_ICON=linuxcncicon
@@ -1704,6 +1704,8 @@ AC_CONFIG_FILES(../lib/python/nf.py)
 AC_CONFIG_FILES([../scripts/linuxcncmkdesktop], [chmod +x ../scripts/linuxcncmkdesktop])
 AC_CONFIG_FILES(../share/applications/linuxcnc-latency.desktop)
 AC_CONFIG_FILES(../share/applications/linuxcnc-latency-histogram.desktop)
+AC_CONFIG_FILES(../share/applications/linuxcnc-pncconf.desktop)
+AC_CONFIG_FILES(../share/applications/linuxcnc-stepconf.desktop)
 AC_CONFIG_FILES(../share/applications/linuxcnc.desktop)
 AC_CONFIG_FILES(../share/desktop-directories/linuxcnc-cnc.directory)
 AC_CONFIG_FILES(../share/desktop-directories/linuxcnc-ref.directory)


### PR DESCRIPTION
Moved Debian specific .desktop files to share/applications/.

Also fixes typo in EMC2_LATENCY_HISTOGRAM_SCRIPT.