### PR TITLE
docs: add note to obsolete property 'FEATURES'

### DIFF
--- a/docs/src/config/ini-config.txt
+++ b/docs/src/config/ini-config.txt
@@ -615,9 +615,21 @@ Allow to clear the G92 offset automatically when config start-up.
 * 'DISABLE_FANUC_STYLE_SUB = 0' Default 0
 If there is reason to disable Fanuc subroutines set it to 1.
 
-[NOTE] The above six options were controlled by the 'FEATURES' bitmask
+[NOTE]
+====
+The above six options were controlled by the 'FEATURES' bitmask
 in versions of LinuxCNC prior to 2.8. This INI tag will no longer
-work.
+work. +
+For reference:
+----
+FEATURES & 0x1  -> RETAIN_G43
+FEATURES & 0x2  -> OWORD_NARGS
+FEATURES & 0x4  -> INI_VARS
+FEATURES & 0x8  -> HAL_PIN_VARS
+FEATURES & 0x10 -> NO_DOWNCASE_OWORD
+FEATURES & 0x20 -> OWORD_WARNONLY
+----
+====
 
 [NOTE]
 [WIZARD]WIZARD_ROOT is a valid search path but the Wizard has not been fully


### PR DESCRIPTION
I think it would be good to see what this parameter was about in the past versions.
