### PR TITLE
Use exec instead of exit $? in tests

### DIFF
--- a/tests/hal-link-unlink/test.sh
+++ b/tests/hal-link-unlink/test.sh
@@ -3,6 +3,4 @@
 $REALTIME start
 python3 hallink.py
 
-$REALTIME stop
-
-exit $?
+exec $REALTIME stop

--- a/tests/halui/shared-test.sh
+++ b/tests/halui/shared-test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-linuxcnc -r halui.ini
-exit $?
+exec linuxcnc -r halui.ini
 

--- a/tests/interp/mdi-oword-m66/test.sh
+++ b/tests/interp/mdi-oword-m66/test.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-linuxcnc -r interp.ini
-exit $?
-
+exec linuxcnc -r interp.ini

--- a/tests/interp/oword-mdi-sub-update/test.sh
+++ b/tests/interp/oword-mdi-sub-update/test.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-linuxcnc -r interp.ini
-exit $?
-
+exec linuxcnc -r interp.ini

--- a/tests/interp/pymove/test.sh
+++ b/tests/interp/pymove/test.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-rs274 -i test.ini -n 0 -g test.ngc 2>&1
-exit $?
+exec rs274 -i test.ini -n 0 -g test.ngc 2>&1

--- a/tests/interp/python-self/test.sh
+++ b/tests/interp/python-self/test.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 export PYTHONUNBUFFERED=1
-rs274  -i test.ini -n 0 -g test.ngc 2>&1
-exit $?
+exec rs274  -i test.ini -n 0 -g test.ngc 2>&1

--- a/tests/interp/sequence-number/test.sh
+++ b/tests/interp/sequence-number/test.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-rs274 -n 0 -i test.ini -g test.ngc
-exit $?
+exec rs274 -n 0 -i test.ini -g test.ngc

--- a/tests/interp/subroutine-return/test.sh
+++ b/tests/interp/subroutine-return/test.sh
@@ -3,6 +3,4 @@
 cp -f orig.ngc test.ngc
 cp -f subs/orig-sub.ngc subs/sub.ngc
 
-linuxcnc -r interp.ini
-exit $?
-
+exec linuxcnc -r interp.ini

--- a/tests/interp/value-returned/test.sh
+++ b/tests/interp/value-returned/test.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-rs274 -i test.ini -n 0 -g test.ngc 2>&1
-exit $?
+exec rs274 -i test.ini -n 0 -g test.ngc 2>&1

--- a/tests/io-startup/shared-test.sh
+++ b/tests/io-startup/shared-test.sh
@@ -3,6 +3,4 @@
 rm -f tool.tbl
 cp tool.tbl.original tool.tbl
 
-linuxcnc -r test.ini
-exit $?
-
+exec linuxcnc -r test.ini

--- a/tests/lathe/test.sh
+++ b/tests/lathe/test.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-linuxcnc -r lathe.ini
-exit $?
-
+exec linuxcnc -r lathe.ini

--- a/tests/motion/jogwheel-axis/test.sh
+++ b/tests/motion/jogwheel-axis/test.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-linuxcnc -r motion-test.ini
-exit $?
-
+exec linuxcnc -r motion-test.ini

--- a/tests/motion/jogwheel-joint/test.sh
+++ b/tests/motion/jogwheel-joint/test.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-linuxcnc -r motion-test.ini
-exit $?
-
+exec linuxcnc -r motion-test.ini

--- a/tests/remap/introspect/test.sh
+++ b/tests/remap/introspect/test.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 export PYTHONUNBUFFERED=1
-rs274 -i test.ini -n 0 -g test.ngc 2>&1
-exit $?
+exec rs274 -i test.ini -n 0 -g test.ngc 2>&1

--- a/tests/remap/oword-pycall/test.sh
+++ b/tests/remap/oword-pycall/test.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 export PYTHONUNBUFFERED=1
-rs274 -t test.tbl -i test.ini -n 0 -g test.ngc 2>&1
-exit $?
+exec rs274 -t test.tbl -i test.ini -n 0 -g test.ngc 2>&1

--- a/tests/remap/predefined-named-params/test.sh
+++ b/tests/remap/predefined-named-params/test.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 export PYTHONUNBUFFERED=1
-rs274 -i test.ini -n 0 -g test.ngc 2>&1
-exit $?
+exec rs274 -i test.ini -n 0 -g test.ngc 2>&1

--- a/tests/remap/variable-injection/test.sh
+++ b/tests/remap/variable-injection/test.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-rs274 -i test.ini -g test.ngc 2>&1
-exit $?
+exec rs274 -i test.ini -g test.ngc 2>&1

--- a/tests/tlo/test.sh
+++ b/tests/tlo/test.sh
@@ -3,6 +3,4 @@
 cp -f simpockets.tbl.original simpockets.tbl
 rm -f sim.var
 
-linuxcnc -r g43-test.ini
-exit $?
-
+exec linuxcnc -r g43-test.ini

--- a/tests/toolchanger/m61/test.sh
+++ b/tests/toolchanger/m61/test.sh
@@ -2,6 +2,4 @@
 
 cp -f ../simpockets.tbl.original simpockets.tbl
 
-linuxcnc -r m61-test.ini
-exit $?
-
+exec linuxcnc -r m61-test.ini


### PR DESCRIPTION
Before this change, the shell process will linger around to extract the
exit value, only to return it to the parent process, and after
this change the task is left to the kernel and one less
process is used during testing.  This is a very small optimisation
of the tests to gut down the number of lines and reduce the resources
spend during testing.