### PR TITLE
rtai: don't unload rtai kernel modules

### DIFF
--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -103,7 +103,7 @@ CheckConfig(){
         MODULES_UNLOAD="$MOD $MODULES_UNLOAD"
     done
     case $RTPREFIX in
-    *rtai*)
+    (*rtai*)
         MODULES_LOAD="$MODULES_LOAD $RTLIB_DIR/rtapi$MODULE_EXT $RTLIB_DIR/hal_lib$MODULE_EXT"
         MODULES_UNLOAD="hal_lib rtapi $MODULES_UNLOAD"
         SHM_DEV=/dev/rtai_shm

--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -107,6 +107,9 @@ CheckConfig(){
         MODULES_LOAD="$MODULES_LOAD $RTLIB_DIR/rtapi$MODULE_EXT $RTLIB_DIR/hal_lib$MODULE_EXT"
         MODULES_UNLOAD="hal_lib rtapi $MODULES_UNLOAD"
         SHM_DEV=/dev/rtai_shm
+	;;
+    (*)
+        MODULES_UNLOAD=
     esac
 }
 
@@ -161,7 +164,9 @@ CheckMem(){
 Load(){
     CheckKernel
     for MOD in $MODULES_LOAD ; do
-        $INSMOD $MOD || return $?
+	if ! [ -d /sys/module/`basename $MOD .ko` ]; then
+		$INSMOD $MOD || return $?
+	fi
     done
     if [ "$DEBUG" != "" ] && [ -w /proc/rtapi/debug ] ; then
         echo "$DEBUG" > /proc/rtapi/debug

--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -105,7 +105,7 @@ CheckConfig(){
     case $RTPREFIX in
     (*rtai*)
         MODULES_LOAD="$MODULES_LOAD $RTLIB_DIR/rtapi$MODULE_EXT $RTLIB_DIR/hal_lib$MODULE_EXT"
-        MODULES_UNLOAD="hal_lib rtapi $MODULES_UNLOAD"
+        MODULES_UNLOAD="hal_lib rtapi"
         SHM_DEV=/dev/rtai_shm
 	;;
     (*)

--- a/src/Makefile
+++ b/src/Makefile
@@ -612,7 +612,7 @@ install:
 
 MENUS = ../share/menus/CNC.menu \
     ../share/desktop-directories/cnc.directory
-install-menus install-menu: $(MENUS) $(XDGDESKTOP)
+rip-install-menus rip-install-menu: $(MENUS) $(XDGDESKTOP)
 	mkdir -p $(HOME)/.config/menus/applications-merged
 	cp $< $(HOME)/.config/menus/applications-merged
 else

--- a/src/rtapi/rtai_rtapi.c
+++ b/src/rtapi/rtai_rtapi.c
@@ -774,7 +774,6 @@ static int task_delete(int task_id)
     if (rtapi_data->task_count == 0) {
 	if (rtapi_data->timer_running != 0) {
 	    stop_rt_timer();
-	    rt_free_timers();
 	    rtapi_data->timer_period = 0;
 	    max_delay = DEFAULT_MAX_DELAY;
 	    rtapi_data->timer_running = 0;


### PR DESCRIPTION
A rather long time ago now, we found that there was a low probability chance of a full system crash when unloading linuxcnc on rtai systems, as reported here: https://mail.rtai.org/pipermail/rtai/2020-June/028122.html -- any record of the specific oops seems to have gone missing, but I believed it was specific to unloading the rtai modules.

From what I recall, the chance of lockup seemed to be higher on a vm than on bare metal, but I definitely produced the minimized test case that Andy posted and verified it on real, non-emulated hardware.

This is one of the factors that led to us de-emphasizing rtai based builds, because we couldn't reliably test them on buildbot.

Anyway, I was musing on the fact that at least uspace doesn't actually require these modules to be unloaded between runs, as far as I knew. So anyway, this patch removes the module unloading steps from the realtime script for both uspace+rtapi and kmod+rtapi.

uspace+rtai and kmod+rtai both ran 'halrun test.hal' of tests/abs.0 over 30k times each with no full-system crash.

The original reproducer (unloading rtai_sched) crashed at ~500 cycles in the VM.

This test setup details: host is debian bullseye on ryzen 5700u using kvm virtualization, guest is debian bullseye with 4 cores, 4GB RAM, kernel 4.19.195-RTAI

About "uspace+rtai", which is not the mode that most people use linuxcnc and rtai in: Personally, for a number of reasons I'd like to end up promoting this mode over the old "kmod+rtai" mode if/as we bring back rtai kernel support, but that's contingent on the realtime performance on hardware actually being at par with the older system.

(Short version of the argument: Crashing within kernel modules can easily take down the whole system; uspace+rtai is more forgiving.  No need to make special math libraries for kernel space. the possibility of making "uspace+rtai" a very small deb that augments the regular uspace deb, rather than two separate builds)