### PR TITLE
Made sure 'to_python(unsigned u)' only compare with LONG_MAX when needed

### DIFF
--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -39,8 +39,7 @@ PyObject *to_python(bool b) {
     return PyBool_FromLong(b);
 }
 
-PyObject *to_python(unsigned u) {
-    if(u < LONG_MAX) return PyLong_FromLong(u);
+PyObject *to_python(unsigned int u) {
     return PyLong_FromUnsignedLong(u);
 }
 


### PR DESCRIPTION
As LONG_MAX is larger than any value representable by unsigned (int)
on most platforms, the test in the method do not make sense on these.
Only compare with LONG_MAX on platforms where sizeof(int) == sizeof(long)
and skip that code in the more common case where sizeof(int) < sizeof(long).

Get rid of warning discovered with clang.