### PR TITLE
Make sure get_speed_override() return value

### DIFF
--- a/src/emc/rs274ngc/interpmodule.cc
+++ b/src/emc/rs274ngc/interpmodule.cc
@@ -306,8 +306,8 @@ static inline bool get_probe_flag (Interp &interp)  {
 static inline void set_probe_flag(Interp &interp, bool value)  {
     interp._setup.probe_flag = value;
 }
-static inline bool get_speed_override (Interp &interp)  {
-    return interp._setup.speed_override;
+static inline bool get_speed_override (Interp &interp, int spindle)  {
+    return interp._setup.speed_override[spindle];
 }
 static inline void set_speed_override(Interp &interp, int spindle, bool value)  {
     interp._setup.speed_override[spindle] = value;


### PR DESCRIPTION
The method do not return the override value, but always true.  It
need information on which spindle to return value for, similar
to set_speed_override, to give a sensible value.

Fixes this warning from building with clang:

emc/rs274ngc/interpmodule.cc:310:26: warning: address of array 'interp._setup.speed_override' will always evaluate to 'true' [-Wpointer-bool-conversion]
    return interp._setup.speed_override;
    ~~~~~~ ~~~~~~~~~~~~~~^~~~~~~~~~~~~~