### PR TITLE
Make sure C++ delete is operating on correct class

### DIFF
--- a/src/libnml/buffer/rem_msg.hh
+++ b/src/libnml/buffer/rem_msg.hh
@@ -23,6 +23,7 @@
 #define REM_MSG_HH
 
 
+class NML;
 class CMS_DIAGNOSTICS_INFO;
 struct CMS_HEADER;
 
@@ -82,7 +83,7 @@ struct REMOTE_BLOCKING_READ_REQUEST:public REMOTE_CMS_REQUEST {
     /* to this client */
     long timeout_millis;	/* Milliseconds for blocking_timeout or -1 to 
 				   wait forever */
-    void *_nml;
+    NML *_nml;
     void *_data;
     void *_reply;
 };

--- a/src/libnml/nml/nml_srv.cc
+++ b/src/libnml/nml/nml_srv.cc
@@ -70,7 +70,7 @@ NML_SERVER::NML_SERVER(NML * _nml, int _set_to_master):CMS_SERVER()
 	    } else {
 		rcs_print_error
 		    ("NML_SERVER:(ERROR) ProcessType was REMOTE.\n");
-		_nml = (NML *) NULL;
+		_nml = NULL;
 	    }
 	} else {
 	    rcs_print_error("NML_SERVER:(ERROR) cms was NULL.\n");
@@ -127,7 +127,7 @@ NML_SERVER_LOCAL_PORT::~NML_SERVER_LOCAL_PORT()
     if (NULL != nml && !local_channel_reused) {
 	delete nml;
     }
-    nml = (NML *) NULL;
+    nml = NULL;
     cms = (CMS *) NULL;
 }
 
@@ -194,7 +194,7 @@ REMOTE_READ_REPLY *NML_SERVER_LOCAL_PORT::blocking_read(REMOTE_READ_REQUEST *
 	(REMOTE_BLOCKING_READ_REQUEST *) _req;
     breq->_nml = new NML(nml, 1, -1);
 
-    NML *nmlcopy = (NML *) breq->_nml;
+    NML *nmlcopy = breq->_nml;
     if (NULL == nmlcopy) {
 	rcs_print_error("NMLserver:blocking_read: NML object is NULL.\n");
 	return ((REMOTE_READ_REPLY *) NULL);


### PR DESCRIPTION
The breq->_nml pointer is of type void*, while C++ delete expect a
object pointer.  The object assigned to _nml is of class NML, so
cast to (NML*) before deleting it.

Discovered by building with clang.