### PR TITLE
Fix use-after-free in sendkeys.c

### DIFF
--- a/src/hal/user_comps/sendkeys.c
+++ b/src/hal/user_comps/sendkeys.c
@@ -107,8 +107,8 @@ int init(int argc, char* argv[]){
                     v1 = realloc(codes, (index + 1) * sizeof(int));
                     v2 = realloc(pins, (index + 1) * sizeof(int));
                     if (!v1 || !v2) {
-                        free(codes);
-                        free(pins);
+                        free(v1 ? v1 : codes);
+                        free(v2 ? v2 : pins);
                         rtapi_print_msg(RTAPI_MSG_ERR, "sendkeys.N.keycode error\n");
                         return -ENOMEM;
                     } else {


### PR DESCRIPTION
Fixes the following warnings reported by gcc 12.1.1:

 hal/user_comps/sendkeys.c: In function ‘init’:
 hal/user_comps/sendkeys.c:110:25: warning: pointer ‘codes’ may be used after ‘realloc’ [-Wuse-after-free]
   110 |                         free(codes);
       |                         ^~~~~~~~~~~
 hal/user_comps/sendkeys.c:107:26: note: call to ‘realloc’ here
   107 |                     v1 = realloc(codes, (index + 1) * sizeof(int));
       |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 hal/user_comps/sendkeys.c:111:25: warning: pointer ‘pins’ may be used after ‘realloc’ [-Wuse-after-free]
   111 |                         free(pins);
       |                         ^~~~~~~~~~
  hal/user_comps/sendkeys.c:108:26: note: call to ‘realloc’ here
   108 |                     v2 = realloc(pins, (index + 1) * sizeof(int));
       |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>