### PR TITLE
Reorder documentation index

### DIFF
--- a/docs/html/index.css
+++ b/docs/html/index.css
@@ -3,7 +3,7 @@ list-style-type: none;
 margin-top: 0;
 margin-bottom: 0;
 }
-h3 {
+h1,h2 {
   text-align: center;
 }
 body {

--- a/docs/po4a.cfg
+++ b/docs/po4a.cfg
@@ -82,6 +82,7 @@
 [type: AsciiDoc_def] src/gui/axis.adoc $lang:src/$lang/gui/axis.adoc
 [type: AsciiDoc_def] src/gui/filter-programs.adoc $lang:src/$lang/gui/filter-programs.adoc
 [type: AsciiDoc_def] src/gui/gladevcp.adoc $lang:src/$lang/gui/gladevcp.adoc
+[type: AsciiDoc_def] src/gui/gladevcp-libraries.adoc $lang:src/$lang/gui/gladevcp-libraries.adoc
 [type: AsciiDoc_def] src/gui/gmoccapy.adoc $lang:src/$lang/gui/gmoccapy.adoc
 [type: AsciiDoc_def] src/gui/gscreen.adoc $lang:src/$lang/gui/gscreen.adoc
 [type: AsciiDoc_def] src/gui/gstat.adoc $lang:src/$lang/gui/gstat.adoc

--- a/docs/src/Master_Developer.adoc
+++ b/docs/src/Master_Developer.adoc
@@ -14,6 +14,7 @@ include::common/overleaf.adoc[]
 
 :leveloffset: 1
 
+include::hal/general-ref.adoc[]
 include::code/code-notes.adoc[]
 include::code/nml-messages.adoc[]
 include::code/style-guide.adoc[]

--- a/docs/src/Master_Documentation.adoc
+++ b/docs/src/Master_Documentation.adoc
@@ -3,38 +3,34 @@
 :date: {sys: LANG=C date --date="@$(dpkg-parsechangelog --file ../debian/changelog -S timestamp)" '+%d %b %Y'}
 :ascii-ids:
 :masterdir: {indir}
-:revdate: 2021-10-28
+:revdate: 2021-10-28 
 LinuxCNC V{lversion}, {date}
 ============================
 
-= Contents
-
 :leveloffset: 0
-
-= About LinuxCNC
+= Getting Started & Configuration
 
 :leveloffset: 1
-
-= Introduction
-
-image::common/images/emc2-intro.png[]
-
-include::common/overleaf.adoc[]
-
-= LinuxCNC History
-
-include::common/emc-history.adoc[]
-
-:leveloffset: 0
-
-= Using LinuxCNC
-
-:leveloffset: 1
-
-= General Info
+= Getting Started with LinuxCNC
 
 :leveloffset: 2
+include::getting-started/about-linuxcnc.adoc[]
 
+include::getting-started/system-requirements.adoc[]
+
+include::getting-started/getting-linuxcnc.adoc[]
+
+include::getting-started/running-linuxcnc.adoc[]
+
+include::getting-started/updating-linuxcnc.adoc[]
+
+include::common/linux-faq.adoc[]
+
+
+:leveloffset: 1
+= General User Information
+
+:leveloffset: 2
 include::user/user-foreword.adoc[]
 
 include::user/user-intro.adoc[]
@@ -45,33 +41,179 @@ include::user/starting-linuxcnc.adoc[]
 
 include::gcode/machining-center.adoc[]
 
-include::getting-started/running-linuxcnc.adoc[]
-
-include::config/stepconf.adoc[]
-
-include::config/pncconf.adoc[]
-
-include::common/linux-faq.adoc[]
-
 include::lathe/lathe-user.adoc[]
 
 include::plasma/plasma-cnc-primer.adoc[]
 
-:leveloffset: 1
 
+:leveloffset: 1
+= Configuration Wizards
+
+:leveloffset: 2
+include::config/stepconf.adoc[]
+
+include::config/pncconf.adoc[]
+
+
+:leveloffset: 1
+= Configuration
+
+:leveloffset: 2
+include::config/integrator-concepts.adoc[]
+
+include::install/latency-test.adoc[]
+
+include::motion/tweaking-steppers.adoc[]
+
+include::config/ini-config.adoc[]
+
+include::config/ini-homing.adoc[]
+
+include::config/iov2.adoc[]
+
+include::config/lathe-config.adoc[]
+
+include::config/stepper-quickstart.adoc[]
+
+include::config/stepper.adoc[]
+
+include::config/stepper-diagnostics.adoc[]
+
+
+:leveloffset: 1
+= HAL (Hardware Abstraction Layer)
+
+:leveloffset: 2
+include::hal/intro.adoc[]
+
+include::hal/basic-hal.adoc[]
+
+include::hal/twopass.adoc[]
+
+include::hal/tutorial.adoc[]
+
+include::hal/hal-examples.adoc[]
+
+include::config/core-components.adoc[]
+
+include::hal/components.adoc[]
+
+include::hal/rtcomps.adoc[]
+
+include::hal/comp.adoc[]
+
+include::hal/haltcl.adoc[]
+
+include::hal/halmodule.adoc[]
+
+include::hal/canonical-devices.adoc[]
+
+include::hal/tools.adoc[]
+
+
+:leveloffset: 1
+= Hardware Drivers
+
+:leveloffset: 2
+include::hal/parallel-port.adoc[]
+
+include::drivers/ax5214h.adoc[]
+
+include::drivers/gm.adoc[]
+
+include::drivers/gs2.adoc[]
+
+include::drivers/hostmot2.adoc[]
+
+include::drivers/mb2hal.adoc[]
+
+include::drivers/mitsub-vfd.adoc[]
+
+include::drivers/motenc.adoc[]
+
+include::drivers/opto22.adoc[]
+
+include::drivers/pico-ppmc.adoc[]
+
+include::drivers/pluto-p.adoc[]
+
+include::drivers/pmx485.adoc[]
+
+include::drivers/servo-to-go.adoc[]
+
+include::drivers/shuttle.adoc[]
+
+include::drivers/vfs11.adoc[]
+
+
+:leveloffset: 1
+= Hardware Examples
+
+:leveloffset: 2
+include::examples/pci-parallel-port.adoc[]
+
+include::examples/spindle.adoc[]
+
+include::examples/mpg.adoc[]
+
+include::examples/gs2-example.adoc[]
+
+
+
+:leveloffset: 1
+= ClassicLadder
+
+:leveloffset: 2
+include::ladder/ladder-intro.adoc[]
+
+include::ladder/classic-ladder.adoc[]
+
+include::ladder/ladder-examples.adoc[]
+
+
+:leveloffset: 1
+= Advanced Topics
+
+:leveloffset: 2
+include::motion/kinematics.adoc[]
+
+include::motion/dh-parameters.adoc[]
+
+include::motion/5-axis-kinematics.adoc[]
+
+include::motion/switchkins.adoc[]
+
+include::motion/pid-theory.adoc[]
+
+include::remap/remap.adoc[]
+
+include::config/moveoff.adoc[]
+
+include::code/rs274.adoc[]
+
+include::motion/external-offsets.adoc[]
+
+include::tooldatabase/tooldatabase.adoc[]
+
+
+:leveloffset: 0
+= Usage
+
+:leveloffset: 1
 = User Interfaces
 
 :leveloffset: 2
-
 include::gui/axis.adoc[]
 
 include::gui/gmoccapy.adoc[]
 
-include::gui/ngcgui.adoc[]
-
 include::gui/touchy.adoc[]
 
 include::gui/gscreen.adoc[]
+
+include::gui/qtdragon.adoc[]
+
+include::gui/ngcgui.adoc[]
 
 include::gui/tklinuxcnc.adoc[]
 
@@ -79,13 +221,16 @@ include::plasma/qtplasmac.adoc[]
 
 include::gui/mdro.adoc[]
 
-:leveloffset: 1
 
-= Programming
+:leveloffset: 1
+= G-code Programming
 
 :leveloffset: 2
-
 include::gcode/coordinates.adoc[]
+
+include::gcode/tool-compensation.adoc[]
+
+include::gui/tooledit.adoc[]
 
 include::gcode/overview.adoc[]
 
@@ -99,75 +244,24 @@ include::gcode/other-code.adoc[]
 
 include::examples/gcode.adoc[]
 
-include::gcode/rs274ngc.adoc[]
-
 include::gui/image-to-gcode.adoc[]
 
-:leveloffset: 1
+include::gcode/rs274ngc.adoc[]
 
-= Tool Compensation
-
-:leveloffset: 2
-
-include::gcode/tool-compensation.adoc[]
-
-include::gui/tooledit.adoc[]
-
-:leveloffset: 0
-
-= Configuration
 
 :leveloffset: 1
-
-= General Info
-
-:leveloffset: 2
-
-include::config/integrator-concepts.adoc[]
-
-include::install/latency-test.adoc[]
-
-include::motion/tweaking-steppers.adoc[]
-
-include::config/stepper-diagnostics.adoc[]
-
-:leveloffset: 1
-
-= Configuration
+= Virtual Control Panels
 
 :leveloffset: 2
-
-include::config/stepper-quickstart.adoc[]
-
-include::config/ini-config.adoc[]
-
-include::config/ini-homing.adoc[]
-
-include::config/iov2.adoc[]
-
-include::config/lathe-config.adoc[]
-
-include::remap/remap.adoc[]
-
-include::config/moveoff.adoc[]
-
-include::config/stepper.adoc[]
-
-:leveloffset: 1
-
-= Control Panels
-
-:leveloffset: 2
-
 include::gui/pyvcp.adoc[]
 
 include::gui/pyvcp-examples.adoc[]
 
 include::gui/gladevcp.adoc[]
 
-include::gui/qtvcp.adoc[]
+include::gui/gladevcp-libraries.adoc[]
 
-:leveloffset: 3
+include::gui/qtvcp.adoc[]
 
 include::gui/qtvcp-vcp-panels.adoc[]
 
@@ -183,149 +277,46 @@ include::gui/qtvcp-code-snippets.adoc[]
 
 include::gui/qtvcp-development.adoc[]
 
-:leveloffset: 1
 
-= User Interfaces
+:leveloffset: 1
+= User Interface Programming
 
 :leveloffset: 2
-
 include::gui/panelui.adoc[]
+
+include::gui/filter-programs.adoc[]
 
 include::gui/halui.adoc[]
 
 include::hal/halui-examples.adoc[]
 
-include::gui/vismach.adoc[]
-
 include::config/python-interface.adoc[]
 
 include::gui/gstat.adoc[]
 
-:leveloffset: 1
-
-= Drivers
-
-:leveloffset: 2
-
-include::hal/parallel-port.adoc[]
-
-include::drivers/ax5214h.adoc[]
-
-include::drivers/gs2.adoc[]
-
-include::drivers/hostmot2.adoc[]
-
-include::drivers/motenc.adoc[]
-
-include::drivers/mb2hal.adoc[]
-
-include::drivers/opto22.adoc[]
-
-include::drivers/pico-ppmc.adoc[]
-
-include::drivers/pluto-p.adoc[]
-
-include::drivers/pmx485.adoc[]
-
-include::drivers/servo-to-go.adoc[]
-
-include::drivers/shuttle.adoc[]
-
-include::drivers/gm.adoc[]
-
-include::drivers/vfs11.adoc[]
-
-:leveloffset: 1
-
-= Driver Examples
-
-:leveloffset: 2
-
-include::examples/pci-parallel-port.adoc[]
-
-include::examples/spindle.adoc[]
-
-include::examples/mpg.adoc[]
-
-include::examples/gs2-example.adoc[]
-
-:leveloffset: 1
-
-= PLC
-
-:leveloffset: 2
-
-include::ladder/ladder-intro.adoc[]
-
-include::ladder/classic-ladder.adoc[]
-
-include::ladder/ladder-examples.adoc[]
-
-:leveloffset: 1
-
-= HAL
-
-:leveloffset: 2
-
-include::hal/intro.adoc[]
-
-include::hal/basic-hal.adoc[]
-
-include::hal/twopass.adoc[]
-
-include::hal/tutorial.adoc[]
-
-include::hal/general-ref.adoc[]
-
-include::config/core-components.adoc[]
-
-include::hal/canonical-devices.adoc[]
-
-include::hal/tools.adoc[]
-
-include::hal/halshow.adoc[]
-
-include::hal/components.adoc[]
-
-include::hal/rtcomps.adoc[]
-
-include::hal/hal-examples.adoc[]
-
-include::hal/comp.adoc[]
-
-include::hal/haltcl.adoc[]
-
-include::hal/halmodule.adoc[]
+include::gui/vismach.adoc[]
 
 
 :leveloffset: 0
-
-= Advanced Topics
+= Glossary, Copyright & History
 
 :leveloffset: 1
+= Overleaf
+include::common/overleaf.adoc[]
 
-include::motion/kinematics.adoc[]
-
-include::motion/dh-parameters.adoc[]
-
-include::motion/5-axis-kinematics.adoc[]
-
-include::motion/switchkins.adoc[]
-
-include::motion/pid-theory.adoc[]
-
-include::motion/external-offsets.adoc[]
-
-include::tooldatabase/tooldatabase.adoc[]
-
-include::code/rs274.adoc[]
-
-:leveloffset: 0
-
+:leveloffset: 1
 include::common/glossary.adoc[]
 
+:leveloffset: 1
+= Copyright
+
+:leveloffset: 2
 include::common/gpld-copyright.adoc[]
 
-// = Index
+:leveloffset: 1
+= LinuxCNC History
+
+:leveloffset: 2
+include::common/emc-history.adoc[]
 
 // vim: set syntax=asciidoc:

--- a/docs/src/index.tmpl
+++ b/docs/src/index.tmpl
@@ -88,17 +88,23 @@ function setup_page(){
   <img src="linuxcnc-logo-chips.png" alt="LinuxCNC Logo" width="175"/>
 </div>
 
-<h3>LinuxCNC version <strong>@VERSION@</strong></h3>
+<!-- <h3 align="center">LinuxCNC version <strong>@VERSION@</strong></h3>
+<h2>Documentation</h2> -->
+<h2>LinuxCNC version <strong>@VERSION@</strong> Documentation</h2>
 
 <div style="margin-top: 0em; margin-bottom: 1em; line-height: 150%">
-<p><a href="http://linuxcnc.org">LinuxCNC Home Page</a>  *
-<a href="http://wiki.linuxcnc.org/cgi-bin/wiki.pl">Wiki Community</a>  *
+<p><a href="http://linuxcnc.org">LinuxCNC Home Page</a>  &bull;
+<a href="http://wiki.linuxcnc.org/cgi-bin/wiki.pl">Wiki</a> &bull;
+<a href="https://forum.linuxcnc.org">Forum</a> &bull;
+<a href="https://github.com/LinuxCNC/linuxcnc">Source</a> &bull;
 <a href="gcode.html">G-Code Quick Reference</a></p>
 </div>
 <p><input type="button" value="Expand Documents" id="docExpand" onclick="return toggle_section(this);"/>
    <input type="button" value="Collapse Documents" id="docCollapse" onclick="return toggle_section(this);"/></p>
-<p><a onclick="return toggle('sec0')"><img alt="plus" id="sec0_image" style="border:0; margin-right:5px; vertical-align:middle;" src="plus.png"/>Getting Started with LinuxCNC</a></p>
 
+<h3>Getting Started &amp; Configuration</h3>
+
+<p><a onclick="return toggle('sec0')"><img alt="plus" id="sec0_image" style="border:0; margin-right:5px; vertical-align:middle;" src="plus.png"/>Getting Started with LinuxCNC</a></p>
 <div id="sec0">
 	<ul>
 		<li><a href="getting-started/about-linuxcnc.html">About LinuxCNC</a></li>
@@ -107,14 +113,6 @@ function setup_page(){
 		<li><a href="getting-started/running-linuxcnc.html">Running LinuxCNC</a></li>
 		<li><a href="getting-started/updating-linuxcnc.html">Updating LinuxCNC</a></li>
 		<li><a href="common/linux-faq.html">Linux FAQ</a></li>
-	</ul>
-</div>
-
-<p><a onclick="return toggle('sec1')"><img src="plus.png" style="border:0;margin-right:5px;vertical-align:middle;" id="sec1_image" alt="plus"/>Configuration Wizards</a></p>
-<div id="sec1">
-	<ul>
-		<li><a href="config/stepconf.html" class="tooltips">Stepconf, Parallel Port Stepper Configurator</a></li>
-		<li><a href="config/pncconf.html" class="tooltips">Pncconf, Mesa Hardware Configurator</a></li>
 	</ul>
 </div>
 
@@ -130,6 +128,118 @@ function setup_page(){
 		<li><a href="plasma/plasma-cnc-primer.html">Plasma CNC Primer</a></li>
 	</ul>
 </div>
+
+<p><a onclick="return toggle('sec1')"><img src="plus.png" style="border:0;margin-right:5px;vertical-align:middle;" id="sec1_image" alt="plus"/>Configuration Wizards</a></p>
+<div id="sec1">
+	<ul>
+		<li><a href="config/stepconf.html" class="tooltips">Stepconf, Parallel Port Stepper Configurator</a></li>
+		<li><a href="config/pncconf.html" class="tooltips">Pncconf, Mesa Hardware Configurator</a></li>
+	</ul>
+</div>
+
+<p><a onclick="return toggle('sec5')"><img src="plus.png" alt="plus" style="border:0;margin-right:5px;vertical-align:middle;" id="sec5_image"/>Configuration</a></p>
+<div id="sec5">
+	<ul>
+		<li><a href="config/integrator-concepts.html">Integrator Concepts</a></li>
+		<li><a href="install/latency-test.html">Latency Test</a></li>
+		<li><a href="motion/tweaking-steppers.html">Stepper Tuning</a></li>
+		<li><a href="config/ini-config.html">INI Configuration</a></li>
+		<li><a href="config/ini-homing.html">Homing Configuration</a></li>
+		<li><a href="config/iov2.html">I/O Control V2</a></li>
+		<li><a href="config/lathe-config.html">Lathe Configuration</a></li>
+		<li><a href="config/stepper-quickstart.html">Stepper Quick Start</a></li>
+		<li><a href="config/stepper.html">Stepper Configuration</a></li>
+		<li><a href="config/stepper-diagnostics.html">Stepper Diagnostics</a></li>
+	</ul>
+</div>
+
+<p><a onclick="return toggle('sec11')"><img alt="plus" style="border:0;margin-right:5px;vertical-align:middle;" id="sec11_image" src="plus.png"/>HAL (Hardware Abstraction Layer)</a></p>
+<div id="sec11">
+	<ul>
+		<li><a href="hal/intro.html">HAL Introduction</a></li>
+		<li><a href="hal/basic-hal.html">HAL Basics</a></li>
+		<li><a href="hal/twopass.html">HAL Twopass</a></li>
+		<li><a href="hal/tutorial.html">HAL Tutorial</a></li>
+		<li><a href="hal/hal-examples.html">HAL Examples</a></li>
+		<li><a href="config/core-components.html">HAL Core Components</a></li>
+		<li><a href="hal/components.html">HAL Component List</a></li>
+		<li><a href="hal/rtcomps.html">HAL Component Descriptions</a></li>
+		<li><a href="hal/comp.html">HAL Component Generator</a></li>
+		<li><a href="hal/haltcl.html">HAL TCL Files</a></li>
+		<li><a href="hal/halmodule.html">Creating Userspace Python Components</a></li>
+		<li><a href="hal/canonical-devices.html">Canonical Device Interfaces</a></li>
+		<li><a href="hal/tools.html">HAL Tools</a></li>
+	</ul>
+</div>
+
+<p><a onclick="return toggle('sec8')"><img alt="plus" id="sec8_image" style="border:0;margin-right:5px;vertical-align:middle;" src="plus.png"/>Hardware Drivers</a></p>
+<div id="sec8">
+	<ul>
+		<li><a href="hal/parallel-port.html">Parallel Port Driver</a></li>
+		<li><a href="drivers/ax5214h.html">AX5214H Driver</a></li>
+		<li><a href="drivers/gm.html">General Mechatronics GM6-PCI Driver</a></li>
+		<li><a href="drivers/gs2.html">GS2 Driver</a></li>
+		<li><a href="drivers/hostmot2.html">Mesa HostMot2 Driver</a></li>
+		<li><a href="drivers/mb2hal.html">Modbus to HAL Driver</a></li>
+		<li><a href="drivers/mitsub-vfd.html">Mitsubishi VFD Driver</a></li>
+		<li><a href="drivers/motenc.html">Motenc Driver</a></li>
+		<li><a href="drivers/opto22.html">Opto22 Driver</a></li>
+		<li><a href="drivers/pico-ppmc.html">Pico Drivers</a></li>
+		<li><a href="drivers/pluto-p.html">Pluto P Driver</a></li>
+		<li><a href="drivers/pmx485.html">Powermax Modbus Driver</a></li>
+		<li><a href="drivers/servo-to-go.html">Servo To Go Driver</a></li>
+		<li><a href="drivers/shuttle.html">ShuttleXpress and ShuttlePRO Driver</a></li>
+		<li><a href="drivers/vfs11.html">VFS11 Driver</a></li>
+	</ul>
+</div>
+
+<p><a onclick="return toggle('sec10')"><img src="plus.png" alt="plus" style="border:0;margin-right:5px;vertical-align:middle;" id="sec10_image"/>Hardware Examples</a></p>
+<div id="sec10">
+	<ul>
+		<li><a href="examples/pci-parallel-port.html">PCI Parallel Port Example</a></li>
+		<li><a href="examples/spindle.html">Spindle Control Example</a></li>
+		<li><a href="examples/mpg.html">MPG Example</a></li>
+		<li><a href="examples/gs2-example.html">GS2 Example</a></li>
+	</ul>
+</div>
+
+<p><a onclick="return toggle('sec9')"><img alt="plus" style="border:0;margin-right:5px;vertical-align:middle;" id="sec9_image" src="plus.png"/>ClassicLadder</a></p>
+<div id="sec9">
+
+	<ul>
+		<li>ClassicLadder is a software PLC (Programmable Logic Controller) built into LinuxCNC.</li>
+		<li><a href="ladder/ladder-intro.html">ClassicLadder Introduction</a></li>
+		<li><a href="ladder/classic-ladder.html">ClassicLadder Programming</a></li>
+		<li><a href="ladder/ladder-examples.html">ClassicLadder Examples</a></li>
+	</ul>
+</div>
+
+<p><a onclick="return toggle('sec12')"><img alt="plus" id="sec12_image" style="border:0;margin-right:5px;vertical-align:middle;" src="plus.png"/>Advanced Topics</a></p>
+<div id="sec12">
+	<ul>
+		<li><a href="motion/kinematics.html">Kinematics</a></li>
+		<li><a href="motion/dh-parameters.html">DH Parameters</a></li>
+		<li><a href="motion/5-axis-kinematics.html">5-Axis-Kinematics</a></li>
+		<li><a href="motion/switchkins.html">Switchable Kinematics</a></li>
+		<li><a href="motion/pid-theory.html">PID theory</a></li>
+		<li><a href="remap/remap.html">Remap: Extending LinuxCNC</a></li>
+		<li><a href="config/moveoff.html">Moveoff Component</a></li>
+		<li><a href="code/rs274.html">Stand Alone Interpreter</a></li>
+		<li><a href="motion/external-offsets.html">External Offsets</a></li>
+		<li><a href="tooldatabase/tooldatabase.html">Tool Database Interface</a></li>
+	</ul>
+</div>
+
+<p><a onclick="return toggle('sec13')"><img src="plus.png" alt="plus" id="sec13_image" style="border:0;margin-right:5px;vertical-align:middle;"/>Integrator Information</a></p>
+<div id="sec13">
+	<ul>
+		<li><a href="integrator/steppers.html">Stepper Information</a></li>
+		<li><a href="integrator/stepper-timing.html">Stepper Drive Timing</a></li>
+		<li><a href="integrator/wiring.html">Best Wiring Practices</a></li>
+	</ul>
+</div>
+
+<h3>Usage</h3>
 
 <p><a onclick="return toggle('sec3')"><img alt="plus" id="sec3_image" style="border:0;margin-right:5px;vertical-align:middle;" src="plus.png"/>User Interfaces</a></p>
 <div id="sec3">
@@ -163,21 +273,7 @@ function setup_page(){
 	</ul>
 </div>
 
-<p><a onclick="return toggle('sec5')"><img src="plus.png" alt="plus" style="border:0;margin-right:5px;vertical-align:middle;" id="sec5_image"/>Configuration</a></p>
-<div id="sec5">
-	<ul>
-		<li><a href="config/integrator-concepts.html">Integrator Concepts</a></li>
-		<li><a href="install/latency-test.html">Latency Test</a></li>
-		<li><a href="motion/tweaking-steppers.html">Stepper Tuning</a></li>
-		<li><a href="config/ini-config.html">INI Configuration</a></li>
-		<li><a href="config/ini-homing.html">Homing Configuration</a></li>
-		<li><a href="config/iov2.html">I/O Control V2</a></li>
-		<li><a href="config/lathe-config.html">Lathe Configuration</a></li>
-		<li><a href="config/stepper-quickstart.html">Stepper Quick Start</a></li>
-		<li><a href="config/stepper.html">Stepper Configuration</a></li>
-		<li><a href="config/stepper-diagnostics.html">Stepper Diagnostics</a></li>
-	</ul>
-</div>
+<h3>Customization &amp; Development</h3>
 
 <p><a onclick="return toggle('sec6')"><img src="plus.png" alt="plus" id="sec6_image" style="border:0;margin-right:5px;vertical-align:middle;"/>Virtual Control Panels</a></p>
 <div id="sec6">
@@ -210,91 +306,6 @@ function setup_page(){
 	</ul>
 </div>
 
-<p><a onclick="return toggle('sec8')"><img alt="plus" id="sec8_image" style="border:0;margin-right:5px;vertical-align:middle;" src="plus.png"/>Hardware Drivers</a></p>
-<div id="sec8">
-	<ul>
-		<li><a href="hal/parallel-port.html">Parallel Port Driver</a></li>
-		<li><a href="drivers/ax5214h.html">AX5214H Driver</a></li>
-		<li><a href="drivers/gm.html">General Mechatronics GM6-PCI Driver</a></li>
-		<li><a href="drivers/gs2.html">GS2 Driver</a></li>
-		<li><a href="drivers/hostmot2.html">Mesa HostMot2 Driver</a></li>
-		<li><a href="drivers/mb2hal.html">Modbus to HAL Driver</a></li>
-		<li><a href="drivers/mitsub-vfd.html">Mitsubishi VFD Driver</a></li>
-		<li><a href="drivers/motenc.html">Motenc Driver</a></li>
-		<li><a href="drivers/opto22.html">Opto22 Driver</a></li>
-		<li><a href="drivers/pico-ppmc.html">Pico Drivers</a></li>
-		<li><a href="drivers/pluto-p.html">Pluto P Driver</a></li>
-		<li><a href="drivers/pmx485.html">Powermax Modbus Driver</a></li>
-		<li><a href="drivers/servo-to-go.html">Servo To Go Driver</a></li>
-		<li><a href="drivers/shuttle.html">ShuttleXpress and ShuttlePRO Driver</a></li>
-		<li><a href="drivers/vfs11.html">VFS11 Driver</a></li>
-	</ul>
-</div>
-
-<p><a onclick="return toggle('sec9')"><img alt="plus" style="border:0;margin-right:5px;vertical-align:middle;" id="sec9_image" src="plus.png"/>ClassicLadder</a></p>
-<div id="sec9">
-ClassicLadder is a software PLC (Programmable Logic Controller) built
-into LinuxCNC.
-	<ul>
-		<li><a href="ladder/ladder-intro.html">ClassicLadder Introduction</a></li>
-		<li><a href="ladder/classic-ladder.html">ClassicLadder Programming</a></li>
-		<li><a href="ladder/ladder-examples.html">ClassicLadder Examples</a></li>
-	</ul>
-</div>
-
-<p><a onclick="return toggle('sec10')"><img src="plus.png" alt="plus" style="border:0;margin-right:5px;vertical-align:middle;" id="sec10_image"/>Hardware Examples</a></p>
-<div id="sec10">
-	<ul>
-		<li><a href="examples/pci-parallel-port.html">PCI Parallel Port Example</a></li>
-		<li><a href="examples/spindle.html">Spindle Control Example</a></li>
-		<li><a href="examples/mpg.html">MPG Example</a></li>
-		<li><a href="examples/gs2-example.html">GS2 Example</a></li>
-	</ul>
-</div>
-
-<p><a onclick="return toggle('sec11')"><img alt="plus" style="border:0;margin-right:5px;vertical-align:middle;" id="sec11_image" src="plus.png"/>HAL (Hardware Abstraction Layer)</a></p>
-<div id="sec11">
-	<ul>
-		<li><a href="hal/intro.html">HAL Introduction</a></li>
-		<li><a href="hal/basic-hal.html">HAL Basics</a></li>
-		<li><a href="hal/twopass.html">HAL Twopass</a></li>
-		<li><a href="hal/tutorial.html">HAL Tutorial</a></li>
-		<li><a href="hal/hal-examples.html">HAL Examples</a></li>
-		<li><a href="config/core-components.html">HAL Core Components</a></li>
-		<li><a href="hal/components.html">HAL Component List</a></li>
-		<li><a href="hal/rtcomps.html">HAL Component Descriptions</a></li>
-		<li><a href="hal/comp.html">HAL Component Generator</a></li>
-		<li><a href="hal/haltcl.html">HAL TCL Files</a></li>
-		<li><a href="hal/halmodule.html">Creating Userspace Python Components</a></li>
-		<li><a href="hal/canonical-devices.html">Canonical Device Interfaces</a></li>
-		<li><a href="hal/tools.html">HAL Tools</a></li>
-	</ul>
-</div>
-
-<p><a onclick="return toggle('sec12')"><img alt="plus" id="sec12_image" style="border:0;margin-right:5px;vertical-align:middle;" src="plus.png"/>Advanced Topics</a></p>
-<div id="sec12">
-	<ul>
-		<li><a href="motion/kinematics.html">Kinematics</a></li>
-		<li><a href="motion/dh-parameters.html">DH Parameters</a></li>
-		<li><a href="motion/5-axis-kinematics.html">5-Axis-Kinematics</a></li>
-		<li><a href="motion/switchkins.html">Switchable Kinematics</a></li>
-		<li><a href="motion/pid-theory.html">PID theory</a></li>
-		<li><a href="remap/remap.html">Remap: Extending LinuxCNC</a></li>
-		<li><a href="config/moveoff.html">Moveoff Component</a></li>
-		<li><a href="code/rs274.html">Stand Alone Interpreter</a></li>
-		<li><a href="motion/external-offsets.html">External Offsets</a></li>
-		<li><a href="tooldatabase/tooldatabase.html">Tool Database Interface</a></li>
-	</ul>
-</div>
-
-<p><a onclick="return toggle('sec13')"><img src="plus.png" alt="plus" id="sec13_image" style="border:0;margin-right:5px;vertical-align:middle;"/>Integrator Information</a></p>
-<div id="sec13">
-	<ul>
-		<li><a href="integrator/steppers.html">Stepper Information</a></li>
-		<li><a href="integrator/stepper-timing.html">Stepper Drive Timing</a></li>
-		<li><a href="integrator/wiring.html">Best Wiring Practices</a></li>
-	</ul>
-</div>
 
 <p><a onclick="return toggle('sec14')"><img src="plus.png" id="sec14_image" style="border:0;margin-right:5px;vertical-align:middle;" alt="plus"/>Developer Information</a></p>
 <div id="sec14">

--- a/docs/src/index.tmpl
+++ b/docs/src/index.tmpl
@@ -320,6 +320,8 @@ function setup_page(){
 	</ul>
 </div>
 
+<h3>General Information</h3>
+
 <p><a onclick="return toggle('sec15')"><img src="plus.png" alt="plus" id="sec15_image" style="border:0;margin-right:5px;vertical-align:middle;"/>Glossary, Copyright, History &amp; Overview</a></p>
 	<div id="sec15">
 	<ul>


### PR DESCRIPTION
Like mentioned in #1914.
Now also adapted the PDF version.
See http://buildbot.linuxcnc.org/doc/scratch/v2.9.0~pre0~1914-reorder-documentation~da5be815b/ for a preview.

Closes #1914 