### PR TITLE
hal: fix typo in variable name

### DIFF
--- a/src/hal/components/deadzone.comp
+++ b/src/hal/components/deadzone.comp
@@ -1,6 +1,6 @@
 component deadzone "Return the center if within the threshold";
 param rw float center = 0.0 "The center of the dead zone";
-param rw float threshhold = 1.0 "The dead zone is \\fBcenter\\fR \\(+- (\\fBthreshhold\\fR/2)";
+param rw float threshold = 1.0 "The dead zone is \\fBcenter\\fR \\(+- (\\fBthreshold\\fR/2)";
 pin in float in;
 pin out float out;
 
@@ -9,7 +9,7 @@ function _ "Update \\fBout\\fR based on \\fBin\\fR and the parameters.";
 license "GPL";
 ;;
 FUNCTION(_) {
-    double th2 = threshhold / 2;
+    double th2 = threshold / 2;
     double lo = center - th2;
     double hi = center + th2;
     double in_ = in;


### PR DESCRIPTION
substitute 'threshold' for 'threshhold'