### PR TITLE
docs: Master_Developer.adoc blank lines b/w includes

### DIFF
--- a/docs/src/Master_Developer.adoc
+++ b/docs/src/Master_Developer.adoc
@@ -15,13 +15,21 @@ include::common/overleaf.adoc[]
 :leveloffset: 1
 
 include::hal/general-ref.adoc[]
+
 include::code/code-notes.adoc[]
+
 include::code/nml-messages.adoc[]
+
 include::code/style-guide.adoc[]
+
 include::code/building-linuxcnc.adoc[]
+
 include::code/adding-configs.adoc[]
+
 include::code/contributing-to-linuxcnc.adoc[]
+
 include::common/glossary.adoc[]
+
 include::common/gpld-copyright.adoc[]
 
 // vim: set syntax=asciidoc:


### PR DESCRIPTION
this is to comply with https://docs.asciidoctor.org/asciidoc/latest/directives/include/#include-syntax