### PR TITLE
Revert "Duplicate Strings gmoccapy.pot and linuxcnc.pot"

### DIFF
--- a/src/emc/usr_intf/gmoccapy/Submakefile
+++ b/src/emc/usr_intf/gmoccapy/Submakefile
@@ -3,6 +3,9 @@ GMOCCAPY_MODULES = dialogs getiniinfo notification player preferences widgets
 PYTARGETS += ../bin/gmoccapy ../lib/python/gmoccapy/__init__.py $(patsubst %,../lib/python/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
 	../share/gmoccapy/gmoccapy.glade 
 
+PYI18NSRCS += emc/usr_intf/gmoccapy/gmoccapy.py $(patsubst %,emc/usr_intf/gmoccapy/%.py,$(GMOCCAPY_MODULES)) \
+	emc/usr_intf/gmoccapy/gmoccapy.glade 
+
 ../lib/python/gmoccapy/__init__.py:
 	@mkdir -p ../lib/python/gmoccapy
 	@touch $@


### PR DESCRIPTION
Reverts LinuxCNC/linuxcnc#1896

It is very frustrating to see that you now splited the gmoccapy translation in two pot files.

gmoccapy.glade is the main screen from gmoccapy! It is no widget it is the main screen!!
All the effort I have done to translate the GUI in different languages has become now much more complicated. I explained all at the beginning of this discussion why I did all the thinks.

I agree that it should not be in both submake files, but IT BELOGNGS TO GMOCCAPY not to linuxcnc.

As I am still out of time I hope someone will revert this change, otherwise I will do that as soon as I have time.

Norbert 