### PR TITLE
Halshow: add buttons for signals

### DIFF
--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -867,7 +867,7 @@ proc watchHAL {which} {
     set ::watchlist_len [llength $::watchlist]
     set i $::watchlist_len
     set label [lindex [split $which +] end]
-
+    set labelcolor black
      # check if pin or param is writable
      # var writable: 1=yes, 0=no, -1=writable but connected to signal
     set writable 0
@@ -887,16 +887,18 @@ proc watchHAL {which} {
         if {[lindex $showret 8] == "RW"} {
             set writable 1
         }
+        set labelcolor #6e3400
     } elseif {$vartype == "sig"} {
         # puts stderr "return $showret, found: [string first "<==" $showret 0]"
         # check if signal has no writers
         if {[string first "<==" $showret 0] < 0} {
             set writable 1
         }
+        set labelcolor blue3
     }
 
     $::cisp create text $::col1_width [expr $i * 20 + 13] -text $label \
-            -anchor w -tag $label
+            -anchor w -tag $label -fill $labelcolor
     set canvaswidth [winfo width $::cisp]
     if {$type == "bit"} {
         $::cisp create oval 10 [expr $i * 20 + 5] 25 [expr $i * 20 + 20] \

--- a/tcl/bin/halshow.tcl
+++ b/tcl/bin/halshow.tcl
@@ -869,9 +869,11 @@ proc watchHAL {which} {
     set label [lindex [split $which +] end]
 
      # check if pin or param is writable
+     # var writable: 1=yes, 0=no, -1=writable but connected to signal
     set writable 0
     set showret [join [hal show $vartype $label] " "]
     if {$vartype == "pin"} {
+        # check if pin is input
         if {[string index [lindex $showret 9] 0] == "I"} {
             # check if signals are connected to pin
             if {[string first "==" [lindex $showret 12] 0] < 0} {
@@ -881,7 +883,14 @@ proc watchHAL {which} {
             }
         }
     } elseif {$vartype == "param"} {
+        # check if parameter is writable
         if {[lindex $showret 8] == "RW"} {
+            set writable 1
+        }
+    } elseif {$vartype == "sig"} {
+        # puts stderr "return $showret, found: [string first "<==" $showret 0]"
+        # check if signal has no writers
+        if {[string first "<==" $showret 0] < 0} {
             set writable 1
         }
     }
@@ -893,26 +902,38 @@ proc watchHAL {which} {
         $::cisp create oval 10 [expr $i * 20 + 5] 25 [expr $i * 20 + 20] \
             -fill lightgray -tag oval$i
         if {$writable == 1} {
-            canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 48] \
-                [expr {$i * 20 + 4}] 24 17 "Set" [list hal_setp $label 1] 1
-            canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 20] \
-                [expr {$i * 20 + 4}] 24 17 "Clr" [list hal_setp $label 0] 1
+            if {$vartype == "sig"} {
+                canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 48] \
+                    [expr {$i * 20 + 4}] 24 17 "Set" [list hal_sets $label 1] 1
+                canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 20] \
+                    [expr {$i * 20 + 4}] 24 17 "Clr" [list hal_sets $label 0] 1
+            } else {
+                canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 48] \
+                    [expr {$i * 20 + 4}] 24 17 "Set" [list hal_setp $label 1] 1
+                canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 20] \
+                    [expr {$i * 20 + 4}] 24 17 "Clr" [list hal_setp $label 0] 1
+            }
         } elseif {$writable == -1} {
             canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 48] \
-                [expr $i * 20 + 4] 24 17 "Set" [list hal_setp $label 1] 0
+                [expr $i * 20 + 4] 24 17 "Set" [] 0
             canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 20] \
-                [expr $i * 20 + 4] 24 17 "Clr" [list hal_setp $label 0] 0
+                [expr $i * 20 + 4] 24 17 "Clr" [] 0
         }
     } else {
         $::cisp create text 10 [expr $i * 20 + 12] -text "" \
             -anchor w -tag text$i
 
         if {$writable == 1} {
-            canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 48] \
-                [expr $i * 20 + 4] 52 17 "Set val" [list setValue $label] 1
+            if {$vartype == "sig"} {
+                canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 48] \
+                    [expr $i * 20 + 4] 52 17 "Set val" [list setsValue $label] 1
+            } else {
+                canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 48] \
+                    [expr $i * 20 + 4] 52 17 "Set val" [list setpValue $label] 1
+            }
         } elseif {$writable == -1} {
             canvasbutton::canvasbutton $::cisp [expr $canvaswidth - 48] \
-                [expr $i * 20 + 4] 52 17 "Set val" [list setValue $label] 0
+                [expr $i * 20 + 4] 52 17 "Set val" [] 0
         }
     }
     if {$i > 1} {$::cisp create line 10 [expr $i * 20 + 3] [expr $canvaswidth - 52] \
@@ -988,16 +1009,28 @@ proc hal_setp {label val} {
     eval hal "setp $label $val"
 }
 
+proc hal_sets {label val} {
+    eval hal "sets $label $val"
+}
+
 proc copyName {label} {
     clipboard clear
     clipboard append $label
 }
 
-proc setValue {label} {
+proc setpValue {label} {
     set val [eval hal "getp $label"]
     set val [entrybox $val [msgcat::mc "Set"] $label]
     if {$val != "cancel"} {
         eval hal "setp $label $val"
+    }
+}
+
+proc setsValue {label} {
+    set val [eval hal "gets $label"]
+    set val [entrybox $val [msgcat::mc "Set"] $label]
+    if {$val != "cancel"} {
+        eval hal "sets $label $val"
     }
 }
 


### PR DESCRIPTION
This adds buttons for signals as well if they don't have any writers connected to.

i also added different colours for pins, parameters and signals.
I am not sure if this isn't received as too colourful or if other colours would fit better.
Just let me know.
Currently black=pins, blue=signals, red=parameters:

![grafik](https://user-images.githubusercontent.com/67957916/189541650-2e213653-8917-48a4-a8ad-c9c41aed2de3.png)

Furthermore an option "--noprefs" was added in 965fffe06dfb28eb2914a8c8e8670774411ee6f0 (requested by @dngarrett)