### PR TITLE
Add styleColorMarkerBackground to qtvcp gcode_editor to allow set from stylesheet

### DIFF
--- a/lib/python/qtvcp/widgets/gcode_editor.py
+++ b/lib/python/qtvcp/widgets/gcode_editor.py
@@ -332,11 +332,6 @@ class EditorBase(QsciScintilla):
     def markerBackgroundColor(self):
         return self._styleMarkerBackgroundColor
 
-#    def set_markerBackgroundColor(self):
-#        self._styleMarkerBackgroundColor = color
-#        self.setMarkerBackgroundColor(QColor(color), self.CURRENT_MARKER_NUM)
-
-
     # must set lexer paper background color _and_ editor background color it seems
     def set_background_color(self, color):
         self.SendScintilla(QsciScintilla.SCI_STYLESETBACK, QsciScintilla.STYLE_DEFAULT, QColor(color))

--- a/lib/python/qtvcp/widgets/gcode_editor.py
+++ b/lib/python/qtvcp/widgets/gcode_editor.py
@@ -231,6 +231,7 @@ class EditorBase(QsciScintilla):
     _styleBackgroundColor = QColor("#000000")
     _styleSelectionForegroundColor = QColor("#ffffff")
     _styleSelectionBackgroundColor = QColor("#000000")
+    _styleMarkerBackgroundColor = QColor("yellow")
 
     def __init__(self, parent=None):
         super(EditorBase, self).__init__(parent)
@@ -262,7 +263,7 @@ class EditorBase(QsciScintilla):
         # Gcode highlight line
         self.currentHandle = self.markerDefine(QsciScintilla.Background,
                           self.CURRENT_MARKER_NUM)
-        self.setMarkerBackgroundColor(QColor("yellow"),
+        self.setMarkerBackgroundColor(self.markerBackgroundColor(),
                                       self.CURRENT_MARKER_NUM)
 
         # user Highlight line
@@ -327,6 +328,14 @@ class EditorBase(QsciScintilla):
 
     def backgroundColor(self):
         return self._styleBackgroundColor
+
+    def markerBackgroundColor(self):
+        return self._styleMarkerBackgroundColor
+
+#    def set_markerBackgroundColor(self):
+#        self._styleMarkerBackgroundColor = color
+#        self.setMarkerBackgroundColor(QColor(color), self.CURRENT_MARKER_NUM)
+
 
     # must set lexer paper background color _and_ editor background color it seems
     def set_background_color(self, color):
@@ -500,6 +509,13 @@ class EditorBase(QsciScintilla):
     def setColorBackground(self, value):
         self.setBackgroundColor(value)
     styleColorBackground = pyqtProperty(QColor, getColorBackground, setColorBackground)
+
+    def getColorMarkerBackground(self):
+        return self.markerBackgroundColor()
+    def setColorMarkerBackground(self, value):
+        self.setMarkerBackgroundColor(QColor(value), self.CURRENT_MARKER_NUM)
+        self._styleMarkerBackgroundColor = QColor(value)
+    styleColorMarkerBackground = pyqtProperty(QColor, getColorMarkerBackground, setColorMarkerBackground)
 
     def getFont0(self):
         return self.lexer.font(0)

--- a/share/qtvcp/screens/qtdragon_hd/argentium.qss
+++ b/share/qtvcp/screens/qtdragon_hd/argentium.qss
@@ -460,6 +460,7 @@ EditorBase {
     qproperty-styleColorMarginText: #00aaff; /* margin line numbers */
     qproperty-styleFontMargin: "Lato Heavy, 10 ";
     qproperty-styleColorBackground: #202020;
+    qproperty-styleColorMarkerBackground: #505050;	/* Current Line Marker Background */
     qproperty-styleColor0: #e0e0e0; /* digit characters */
     qproperty-styleColor1: #00eeee; /* comments */
     qproperty-styleColor2: #e0e0e0; /* alphabetic characters */

--- a/share/qtvcp/screens/qtdragon_hd/dark_grey.qss
+++ b/share/qtvcp/screens/qtdragon_hd/dark_grey.qss
@@ -465,6 +465,7 @@ EditorBase {
     qproperty-styleColorMarginText: #E0E0E0; /* margin line numbers */
     qproperty-styleFontMargin: "Lato Heavy, 10 ";
     qproperty-styleColorBackground: #303030;
+    qproperty-styleColorMarkerBackground: #505050; /* Current Line Marker Background */
     qproperty-styleColor0: #9ad58d; /* digit characters */
     qproperty-styleColor1: #9ad58d; /* comments */
     qproperty-styleColor2: #9ad58d; /* alphabetic characters */


### PR DESCRIPTION
added styleColorMarkerBackground in qtvcp gcode_editor to set current line marker bg color from stylesheet. Updated argentinium.qss and dark_grey.qss in qtdragon_hd to use this style for better readability