### PR TITLE
build mesa_uart on uspace

### DIFF
--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -12,6 +12,7 @@ COMP_MANPAGES := $(patsubst hal/components/%.comp, ../docs/man/man9/%.9, $(COMPS
 ifeq ($(BUILD_SYS),uspace)
 COMP_DRIVERS += hal/drivers/serport.comp
 COMP_DRIVERS += hal/drivers/mesa_7i65.comp
+COMP_DRIVERS += hal/drivers/mesa_uart.comp
 else
 COMP_DRIVERS := $(wildcard hal/drivers/*.comp)
 endif


### PR DESCRIPTION
Was there a specific reason why `mesa_uart.comp `was not added to the build when building for uspace?
