### PR TITLE
Update links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ for such compliance.
 [Weblate]: https://hosted.weblate.org/projects/linuxcnc/
 [Website]: https://linuxcnc.org/
 
-[Ｄｏｃｕｍｅｎｔａｔｉｏｎ]: http://linuxcnc.org/docs/stable/html/
-[Ｉｎｓｔａｌｌ]: http://linuxcnc.org/docs/stable/html/getting-started/getting-linuxcnc.html
-[Ｂｕｉｌｄ]: http://linuxcnc.org/docs/stable/html/code/building-linuxcnc.html
+[Ｄｏｃｕｍｅｎｔａｔｉｏｎ]: http://linuxcnc.org/docs/2.9/html/
+[Ｉｎｓｔａｌｌ]: http://linuxcnc.org/docs/2.9/html/getting-started/getting-linuxcnc.html
+[Ｂｕｉｌｄ]: http://linuxcnc.org/docs/2.9/html/code/building-linuxcnc.html
 [License]: COPYING

--- a/README_es.md
+++ b/README_es.md
@@ -22,4 +22,4 @@ La traduccion al español de este software queda adherida a este descargo y a la
 
 Consulte el archivo 'docs/src/code/building-linuxcnc.txt' para obtener información sobre cómo construir y ejecutar el software, o vea:
 
-http://linuxcnc.org/docs/devel/html/code/building-linuxcnc.html
+http://linuxcnc.org/docs/2.9/html/code/building-linuxcnc.html

--- a/configs/by_interface/mesa/hm2-servo/hm2-servo.hal
+++ b/configs/by_interface/mesa/hm2-servo/hm2-servo.hal
@@ -15,7 +15,7 @@
 # sudo ln -s $HOME/emc2-sandbox/src/hal/drivers/mesa-hostmot2/firmware /lib/firmware/hm2
 #
 # See also:
-# <http://www.linuxcnc.org/docs/devel/html/man/man9/hostmot2.9.html#config%20modparam>
+# <http://www.linuxcnc.org/docs/2.9/html/man/man9/hostmot2.9.html#config%20modparam>
 # and http://wiki.linuxcnc.org/cgi-bin/emcinfo.pl?HostMot2
 #
 # #####################################################################

--- a/configs/by_interface/mesa/hm2-stepper/hm2-stepper.hal
+++ b/configs/by_interface/mesa/hm2-stepper/hm2-stepper.hal
@@ -15,7 +15,7 @@
 # sudo ln -s $HOME/emc2-sandbox/src/hal/drivers/mesa-hostmot2/firmware /lib/firmware/hm2
 #
 # See also:
-# <http://www.linuxcnc.org/docs/devel/html/man/man9/hostmot2.9.html#config%20modparam>
+# <http://www.linuxcnc.org/docs/2.9/html/man/man9/hostmot2.9.html#config%20modparam>
 # and http://wiki.linuxcnc.org/cgi-bin/emcinfo.pl?HostMot2
 #
 # #####################################################################

--- a/configs/by_interface/mesa/plasma-5i20/plasma-5i20.hal
+++ b/configs/by_interface/mesa/plasma-5i20/plasma-5i20.hal
@@ -4,7 +4,7 @@
 # sudo ln -s $HOME/emc2-sandbox/src/hal/drivers/mesa-hostmot2/firmware /lib/firmware/hm2
 #
 # See also:
-# <http://www.linuxcnc.org/docs/devel/html/man/man9/hostmot2.9.html#config%20modparam>
+# <http://www.linuxcnc.org/docs/2.9/html/man/man9/hostmot2.9.html#config%20modparam>
 # and http://wiki.linuxcnc.org/cgi-bin/emcinfo.pl?HostMot2
 #
 # #####################################################################

--- a/configs/sim/axis/remap/README
+++ b/configs/sim/axis/remap/README
@@ -21,7 +21,7 @@ python-stdglue contains embedded Python code supporting the above examples. This
 common_nc_subs: this contains reset_state.ngc, which should be called from ON_ABORT procedure.  Note that it is in particular important to reset the modal state after a failed remap procedure because this can lead to susequent failures (e.g. bug ID 3437928).  The demos use their own on_abort sub and call reset_state.
 
 Remapping Documentation:
-  http://www.linuxcnc.org/docs/devel/html/remap/structure.html
+  http://www.linuxcnc.org/docs/2.9/html/remap/structure.html
 
 see also:
   http://wiki.linuxcnc.org/cgi-bin/emcinfo.pl?RemappingStatus

--- a/configs/sim/axis/remap/README_es
+++ b/configs/sim/axis/remap/README_es
@@ -21,7 +21,7 @@ python-stdglue contiene código Python incrustado que admite los ejemplos anteri
 common_nc_subs: contiene reset_state.ngc, que debe llamarse desde el procedimiento ON_ABORT. Tenga en cuenta que es particularmente importante restablecer el estado modal después de un procedimiento de reasignación fallido porque esto puede conducir a fallas posteriores (por ejemplo, ID de error 3437928). Las demostraciones usan su propio sub on_abort y llaman a reset_state.
 
 Reasignación de documentación:
-  http://www.linuxcnc.org/docs/devel/html/remap/structure.html
+  http://www.linuxcnc.org/docs/2.9/html/remap/structure.html
 
 ver también:
   http://wiki.linuxcnc.org/cgi-bin/emcinfo.pl?RemappingStatus

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,7 +1,7 @@
 ---
 Bug-Database: https://github.com/LinuxCNC/linuxcnc/issues
 Bug-Submit: https://github.com/LinuxCNC/linuxcnc/issues/new
-Documentation: http://linuxcnc.org/docs/2.8/html/
+Documentation: http://linuxcnc.org/docs/2.9/html/
 Repository-Browse: https://github.com/LinuxCNC/linuxcnc
 Reference:
  - Author: Ronald Lumia

--- a/docs/man/man1/image-to-gcode.1
+++ b/docs/man/man1/image-to-gcode.1
@@ -33,7 +33,7 @@ image-to-gcode \- converts bitmap images to G-code
 brightness of each pixel as a Z-height. 
 
 Detailed docs:
-http://linuxcnc.org/docs/stable/html/gui/image-to-gcode.html
+http://linuxcnc.org/docs/2.9/html/gui/image-to-gcode.html
 
 .SH "SEE ALSO"
 \fBLinuxCNC(1)\fR

--- a/docs/man/man1/qtplasmac-cfg2prefs.1
+++ b/docs/man/man1/qtplasmac-cfg2prefs.1
@@ -35,7 +35,7 @@ configuration to a QtPlasmaC configuration.
 .SH "SEE ALSO"
 See the QtPlasmaC section of the LinuxCNC Documentation for more information.
 
-http://linuxcnc.org/docs/devel/html/plasma/qtplasmac.html#qt_modify-config
+http://linuxcnc.org/docs/2.9/html/plasma/qtplasmac.html#qt_modify-config
 .SH AUTHOR
 Phillip Carter
 .SH LICENSE

--- a/docs/man/man1/qtplasmac-materials.1
+++ b/docs/man/man1/qtplasmac-materials.1
@@ -36,7 +36,7 @@ The file can be created by text entry or by importing text from a CAM tool file.
 .SH "SEE ALSO"
 See the QtPlasmaC section of the LinuxCNC Documentation for more information.
 
-http://linuxcnc.org/docs/devel/html/plasma/qtplasmac.html#_material_converter
+http://linuxcnc.org/docs/2.9/html/plasma/qtplasmac.html#_material_converter
 .SH AUTHOR
 Phillip Carter
 .SH LICENSE

--- a/docs/man/man1/qtplasmac-plasmac2qt.1
+++ b/docs/man/man1/qtplasmac-plasmac2qt.1
@@ -34,7 +34,7 @@ qtplasmac-plasmac2qt is a Python script for migrating from PlasmaC to QtPlasmac.
 .SH "SEE ALSO"
 See the QtPlasmaC section of the LinuxCNC Documentation for more information.
 
-http://linuxcnc.org/docs/devel/html/plasma/qtplasmac.html#qt_modify-config
+http://linuxcnc.org/docs/2.9/html/plasma/qtplasmac.html#qt_modify-config
 .SH AUTHOR
 Phillip Carter
 .SH LICENSE

--- a/docs/man/man1/qtplasmac-setup.1
+++ b/docs/man/man1/qtplasmac-setup.1
@@ -35,7 +35,7 @@ package to run in place and vice-versa.
 .SH "SEE ALSO"
 See the QtPlasmaC section of the LinuxCNC Documentation for more information.
 
-http://linuxcnc.org/docs/devel/html/plasma/qtplasmac.html#_change_type_of_linuxcnc_installation
+http://linuxcnc.org/docs/2.9/html/plasma/qtplasmac.html#_change_type_of_linuxcnc_installation
 .SH AUTHOR
 Phillip Carter
 .SH LICENSE

--- a/docs/src/man/man1/xhc-whb04b-6.1.adoc
+++ b/docs/src/man/man1/xhc-whb04b-6.1.adoc
@@ -402,7 +402,7 @@ MDI_COMMAND=(debug,macro16)
 
 Exercise caution if using copy and paste of this example code from the online web docs.
 Certain characters are incompatibly encoded by the web site (minus becomes em-dash).
-It is safer to copy and paste from https://raw.githubusercontent.com/LinuxCNC/linuxcnc/2.8/src/hal/user_comps/xhc-whb04b-6/example-configuration.md[].
+It is safer to copy and paste from https://raw.githubusercontent.com/LinuxCNC/linuxcnc/2.9/src/hal/user_comps/xhc-whb04b-6/example-configuration.md[].
 
 ----
 #

--- a/lib/python/pyngcgui.py
+++ b/lib/python/pyngcgui.py
@@ -511,7 +511,7 @@ def spath_from_inifile(fname):
         return []
     ini = linuxcnc.ini(fname)
     homedir = os.path.dirname(os.path.realpath(fname))
-    # http://www.linuxcnc.org/docs/devel/html/config/ini_config.html
+    # http://www.linuxcnc.org/docs/2.9/html/config/ini_config.html
     l = []
     p = ini.find('DISPLAY','PROGRAM_PREFIX')
     if p:

--- a/nc_files/comp311.ngc
+++ b/nc_files/comp311.ngc
@@ -1,6 +1,6 @@
 (this is the program describing entry moves for)
 (radius compensation in Figure 3 of the Handbook)
-(http://linuxcnc.org/docs/2.7/html/gcode/tool-compensation.html)
+(http://linuxcnc.org/docs/2.9/html/gcode/tool-compensation.html)
 
 g20 f60
 

--- a/share/qtvcp/screens/qtdragon/qtdragon_handler.py
+++ b/share/qtvcp/screens/qtdragon/qtdragon_handler.py
@@ -132,7 +132,7 @@ class HandlerClass:
 <body>
 <h1>Setup Tab</h1>
 <p>If you select a file with .html as a file ending, it will be shown here..</p>
-<li><a href="http://linuxcnc.org/docs/devel/html/">Documents online</a></li>
+<li><a href="http://linuxcnc.org/docs/2.9/html/">Documents online</a></li>
 <li><a href="file://%s">Local files</a></li>
 <img src="file://%s" alt="lcnc_swoop" />
 <hr />

--- a/share/qtvcp/screens/woodpecker/woodpecker_handler.py
+++ b/share/qtvcp/screens/woodpecker/woodpecker_handler.py
@@ -144,7 +144,7 @@ class HandlerClass:
 <body>
 <h1>Setup Tab</h1>
 <p>If you select a file with .html as a file ending, it will be shown here..</p>
-<li><a href="http://linuxcnc.org/docs/devel/html/">Documents online</a></li>
+<li><a href="http://linuxcnc.org/docs/2.9/html/">Documents online</a></li>
 <li><a href="file://">Local files</a></li>
 <img src="file://%s" alt="lcnc_swoop" />
 <hr />

--- a/src/emc/ini/update_ini.py
+++ b/src/emc/ini/update_ini.py
@@ -67,7 +67,7 @@ if dialogs:
                            "This version of LinuxCNC separates the concepts of Axes and "
                            "Joints which necessitates changes to the INI and HAL files. "
                            "The changes required are described here:\n"
-                           "http://linuxcnc.org/docs/devel/html/ in the section "
+                           "http://linuxcnc.org/docs/2.9/html/ in the section "
                            "'Getting Started with LinuxCNC' -> 'Updating LinuxCNC'\n"
                            "The [EMC]VERSION data in your INI file indicates that your "
                            "configuration requires update.\n"


### PR DESCRIPTION
Is everyone fine with that if all links in the docs which are pointing to 
http://linuxcnc.org/docs/html/* are changed to 
http://linuxcnc.org/docs/2.9/html/* ?
(This is mostly the case in links in the man pages.)

This allows us to reference always the correct version of the docs.
