### PR TITLE
gmoccapy: fix error on creating file when RS274NGC_STARTUP_CODE is not set

### DIFF
--- a/src/emc/usr_intf/gmoccapy/getiniinfo.py
+++ b/src/emc/usr_intf/gmoccapy/getiniinfo.py
@@ -448,7 +448,7 @@ class GetIniInfo:
     def get_RS274_start_code(self):
         temp = self.inifile.find("RS274NGC", "RS274NGC_STARTUP_CODE")
         if not temp:
-            return False
+            temp = ""
         return  temp
 
     def get_user_messages(self):

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -4749,8 +4749,6 @@ class gmoccapy(object):
     def on_btn_new_clicked(self, widget, data=None):
         tempfilename = os.path.join(_TEMPDIR, "temp.ngc")
         content = self.get_ini_info.get_RS274_start_code()
-        if content == None:
-            content = " "
         content += "\n\n\n\nM2"
         gcodefile = open(tempfilename, "w")
         gcodefile.write(content)


### PR DESCRIPTION
Reported here: https://forum.linuxcnc.org/gmoccapy/46944-error-when-creating-new-program

@gmoccapy are you ok with this simplification?