### PR TITLE
Changed to regular format for man page cross references.

### DIFF
--- a/docs/man/man1/moveoff_gui.1
+++ b/docs/man/man1/moveoff_gui.1
@@ -235,4 +235,4 @@ moveoff component are located in:
 .br
    configs/sim/touchy/ngcgui    (touchy-ui)
 
-man page for the moveoff component:\fBmoveoff\fR(9)
+See also \fBmoveoff\fR(9) for details on the component.

--- a/docs/man/man3/hm2_pktuart_read.3hm2
+++ b/docs/man/man3/hm2_pktuart_read.3hm2
@@ -68,6 +68,7 @@ Numeric values of the HM2_PKTUART_ error codes are defined in src/hal/drivers/me
 
 .SH SEE ALSO
 .TP
-.B man hm2_pktuart_setup, man hm2_pktuart_send
+\fBhm2_pktuart_setup\fR(3hm2), \fBhm2_pktuart_send\fR(3hm2)
+
 .TP
 See src/hal/drivers/mesa_pktgyro_test.comp for an example usage.

--- a/docs/man/man3/hm2_pktuart_send.3hm2
+++ b/docs/man/man3/hm2_pktuart_send.3hm2
@@ -47,6 +47,6 @@ Numeric values of HM2_PKTUART_ error codes are defined in src/hal/drivers/mesa-h
 
 
 .SH SEE ALSO
-.B man hm2_pktuart_setup, man hm2_pktuart_read
+\fBhm2_pktuart_setup\fR(3hm2), \fBhm2_pktuart_read\fR(3hm2)
 .TP
 See src/hal/drivers/mesa_pktgyro_test.comp for an example usage.

--- a/docs/man/man3/hm2_pktuart_setup.3hm2
+++ b/docs/man/man3/hm2_pktuart_setup.3hm2
@@ -95,7 +95,7 @@ txclear!=1 or rxclear!=1 lets the corresponding registers unchanged.
 Returns 0 on success and -1 or -EINVAL on failure. 
 
 .SH SEE ALSO
-.B man hm2_pktuart_send, man hm2_pktuart_read
+\fBhm2_pktuart_send\fR(3hm2), \fBhm2_pktuart_read\fR(3hm2)
 .TP
 See src/hal/drivers/mesa_pktgyro_test.comp for an example usage. 
 

--- a/docs/man/man3/hm2_uart_read.3hm2
+++ b/docs/man/man3/hm2_uart_read.3hm2
@@ -30,5 +30,6 @@ bytes) and "data" needs to be at least that large or undefined mayhem will ensue
 Returns the number of bytes read on success and \-1 on failure.
 
 .SH SEE ALSO
-man hm2_uart_setup, man hm2_uart_send
+\fBhm2_uart_setup\fR(3hm2), \fBhm2_uart_send\fR(3hm2)
+.TP
 See src/hal/drivers mesa_uart.comp for an example usage.

--- a/docs/man/man3/hm2_uart_send.3hm2
+++ b/docs/man/man3/hm2_uart_send.3hm2
@@ -30,5 +30,6 @@ It should be used inside a function in a realtime or userspace HAL component.
 Returns the number of bytes sent on success and \-1 on failure.
 
 .SH SEE ALSO
-man hm2_uart_setup, man hm2_uart_read
+\fBhm2_uart_setup\fR(3hm2), \fBhm2_uart_read\fR(3hm2)
+.TP
 See src/hal/drivers mesa_uart.comp for an example usage.

--- a/docs/man/man3/hm2_uart_setup.3hm2
+++ b/docs/man/man3/hm2_uart_setup.3hm2
@@ -58,5 +58,6 @@ To change bitrate without altering mode settings send \-1 to both modes.
 Returns0 on success and \-1 on failure 
 
 .SH SEE ALSO
-man hm2_uart_send, man hm2_uart_read
+\fBhm2_uart_send\fR(3hm2), \fBhm2_uart_read\fR(3hm2)
+.TP
 See src/hal/drivers mesa_uart.comp for an example usage.

--- a/docs/man/man9/gantrykins.9
+++ b/docs/man/man9/gantrykins.9
@@ -10,11 +10,5 @@ the kinstype parameter set for KINEMATICS_BOTH.  Example:
 .PP
   loadrt trivkins coordinates=xyyz \fBkinstypes=BOTH\fR
 
-For more information:
-
-$ man \-s 9 trivkins
-
-
-
-
-
+.SH SEE ALSO
+\fBtrivkins\fR(9)

--- a/docs/man/man9/gentrivkins.9
+++ b/docs/man/man9/gentrivkins.9
@@ -4,11 +4,6 @@
 
 gentrivkins \- \fBSuperseded\fR by the general purpose \fBtrivkins\fR kinematics module.
 
-For more information:
+.SH SEE ALSO
 
-$ man -s 9 trivkins
-
-
-
-
-
+\fBtrivkins\fR(9)

--- a/docs/man/man9/hostmot2.9
+++ b/docs/man/man9/hostmot2.9
@@ -1202,7 +1202,7 @@ The driver auto-detects the connected hardware port, channel and device type.
 Devices can be connected in any order to any active channel of an active port.
 (see the config modparam definition above).
 
-For full details of the smart-serial devices see \fBman sserial\fR.
+For full details of the smart-serial devices see \fBsserial\fR(9).
 
 .SS BSPI
 The BSPI (Buffered SPI) driver is unusual in that it does not create any HAL
@@ -1210,11 +1210,12 @@ pins. Instead the driver exports a set of functions that can be used by a sub-dr
 for the attached hardware. Typically these would be written in the "comp"
 
 pre-processing language: see http://linuxcnc.org/docs/html/hal/comp.html or man
-halcompile for further details. See man mesa_7i65 and the source of mesa_7i65.comp for
+halcompile for further details. See mesa_7i65(9) and the source of mesa_7i65.comp for
 details of a typical sub-driver.
-See man hm2_bspi_setup_chan, man hm2_bspi_write_chan, man hm2_tram_add_bspi_frame,
-man hm2_allocate_bspi_tram, man hm2_bspi_set_read_function and
-man hm2_bspi_set_write_function for the exported functions.
+See hm2_bspi_setup_chan(3hm2), hm2_bspi_write_chan(3hm2),
+hm2_tram_add_bspi_frame(3hm2), hm2_allocate_bspi_tram(3hm2),
+hm2_bspi_set_read_function(3hm2) and hm2_bspi_set_write_function(3hm2)
+for the exported functions.
 
 The names of the available channels are printed to standard output during the
 driver loading process and take the form
@@ -1225,10 +1226,10 @@ The UART driver also does not create any HAL pins, instead it declares two
 simple read/write functions and a setup function to be utilised by user-written
 code.  Typically this would be written in the "comp"
 pre-processing language: see http://linuxcnc.org/docs/html/hal/comp.html or man
-halcompile for further details. See man mesa_uart and the source of mesa_uart.comp for
+halcompile for further details. See mesa_uart(9) and the source of mesa_uart.comp for
 details of a typical sub-driver.
-See man hm2_uart_setup_chan, man hm2_uart_send, man hm2_uart_read and man
-hm2_uart_setup.
+See hm2_uart_setup_chan(3hm2), hm2_uart_send(3hm2),
+hm2_uart_read(3hm2) and hm2_uart_setup(3hm2).
 
 The names of the available uart channels are printed to standard output during the
 driver loading process and take the form
@@ -1639,7 +1640,7 @@ internal state to the syslog, and set the pin back to False.
 
 .SS Setting up Smart Serial devices
 
-See man setsserial for the current way to set smart-serial eeprom parameters.
+See setsserial(9) for the current way to set smart-serial eeprom parameters.
 
 .SH FUNCTIONS
 .TP
@@ -1695,18 +1696,12 @@ it is better to use the synchronous hm2dpll triggering function.
 
 .SH SEE ALSO
 
-hm2_pci(9)
-.br
-hm2_eth(9)
-.br
-hm2_spi(9)
-.br
-hm2_rpspi(9)
-.br
-hm2_7i43(9)
-.br
-hm2_7i90(9)
-.br
+\fBhm2_pci\fR(9),
+\fBhm2_eth\fR(9),
+\fBhm2_spi\fR(9),
+\fBhm2_rpspi\fR(9),
+\fBhm2_7i43\fR(9),
+\fBhm2_7i90\fR(9)
 
 Mesa's documentation for the Anything I/O boards, at
 .UR

--- a/docs/man/man9/kins.9
+++ b/docs/man/man9/kins.9
@@ -499,5 +499,5 @@ agree with the default ordering expected by it (XYZBCW
 The HAL component \fBuserkins.comp\fR is a template for making
 kinematic modules using the halcompile tool.  The unmodified
 template supports an identity xyz configuration that uses
-3 joints.  See the \fBuserkins\fR man page for more info.
+3 joints.  See \fBuserkins\fR(9) for more info.
 

--- a/src/hal/components/clarke2.comp
+++ b/src/hal/components/clarke2.comp
@@ -9,7 +9,7 @@ two of the three are needed to completely define the current or voltage.
 \\fBclarke2\\fR assumes that the sum is zero, so it only uses phases A and
 B of the input.  Since the H (homopolar) output will always be zero in
 this case, it is not generated.""";
-see_also """\\fBclarke3\\fR for the general case, \\fBclarkeinv\\fR for
+see_also """\\fBclarke3\\fR(9) for the general case, \\fBclarkeinv\\fR(9) for
 the inverse transform.""";
 pin in float a;
 pin in float b "first two phases of three phase input";

--- a/src/hal/components/clarke3.comp
+++ b/src/hal/components/clarke3.comp
@@ -6,7 +6,7 @@ if the three phases don't sum to zero).\n.P\n\\fBclarke3\\fR implements
 the general case of the transform, using all three phases.  If the
 three phases are known to sum to zero, see \\fBclarke2\\fR for a
 simpler version.""";
-see_also """\\fBclarke2\\fR for the 'a+b+c=0' case, \\fBclarkeinv\\fR for
+see_also """\\fBclarke2\\fR(9) for the 'a+b+c=0' case, \\fBclarkeinv\\fR(9) for
 the inverse transform.""";
 pin in float a;
 pin in float b;

--- a/src/hal/components/clarkeinv.comp
+++ b/src/hal/components/clarkeinv.comp
@@ -2,7 +2,7 @@ component clarkeinv "Inverse Clarke transform";
 description """The inverse Clarke transform can be used rotate a 
 vector quantity and then translate it from Cartesian coordinate
 system to a three phase system (three components 120 degrees apart).""";
-see_also """\\fBclarke2\\fR and \\fBclarke3\\fR for the forward transform.""";
+see_also """\\fBclarke2\\fR(9) and \\fBclarke3\\fR(9) for the forward transform.""";
 pin in float x;
 pin in float y "cartesian components of input";
 pin in float h "homopolar component of input (usually zero)";


### PR DESCRIPTION
Man page viewers like khelp are able to convert hostmot2(9) into a link to the hostmot2 manual page, while they do not understand 'man hostmot2' or similar notation.  Thus, converted references to the regular fomat used in manual pages.