### PR TITLE
Fix GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ["debian:buster", "debian:bullseye", "debian:bookworm", "debian:sid"]
+        image: ["debian:buster", "debian:bullseye", "debian:bookworm"]
     container:
       image: ${{ matrix.image }}
       # IPC_OWNER is needed for shmget IPC_CREAT
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: ["debian:buster", "debian:bullseye", "debian:bookworm", "debian:sid"]
+        image: ["debian:buster", "debian:bullseye", "debian:bookworm"]
     container:
       image: ${{ matrix.image }}
       # IPC_OWNER is needed for shmget IPC_CREAT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,10 +100,10 @@ jobs:
       run: |
         set -e
         set -x
-        apt-get --yes --quiet install --no-install-recommends gpg software-properties-common
+        apt-get --yes --quiet install --no-install-recommends gpg
         gpg --homedir="${PWD}/gnupg" --output /etc/apt/trusted.gpg.d/linuxcnc-deb-archive.gpg --export 3CB9FD148F374FEF
         DIST=$(echo ${{matrix.image}} | cut -d : -f 2)
-        add-apt-repository "deb http://linuxcnc.org $DIST base"
+        echo "deb http://linuxcnc.org $DIST base" >> /etc/apt/sources.list
         apt-get --quiet update
 
     - name: Build architecture-specific Debian packages
@@ -174,10 +174,10 @@ jobs:
       run: |
         set -e
         set -x
-        apt-get --yes --quiet install gpg software-properties-common
+        apt-get --yes --quiet install gpg
         gpg --homedir="${PWD}/gnupg" --output /etc/apt/trusted.gpg.d/linuxcnc-deb-archive.gpg --export 3CB9FD148F374FEF
         DIST=$(echo ${{matrix.image}} | cut -d : -f 2)
-        add-apt-repository "deb http://linuxcnc.org $DIST base"
+        echo "deb http://linuxcnc.org $DIST base" >> /etc/apt/sources.list
         apt-get --quiet update
 
     - name: Build architecture-independent Debian packages


### PR DESCRIPTION
This makes our Github Actions CI work again, by (sadly) not trying to build on Debian Unstable/Sid.

These are the bugs in Debian Unstable preventing us from building:
* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1020893
* https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1008735

Not sure what the best way forward here is.  It's really important that we test our build on Debian Unstable (since that's what our "official" debian packages must target), but I really don't like having our CI totally stop for a week or whatever when Sid breaks.

As far as I know there's no way to mark a build as "failed, but let's keep going anyway":  https://docs.github.com/en/actions/creating-actions/setting-exit-codes-for-actions#about-exit-codes