### PR TITLE
Add workaround for broken lsb_release in current Debian Sid/Bookworm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,13 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
+        case "${{matrix.image}}" in
+            debian:sid|debian:bookworm)
+                exit 0
+                ;;
+            *)
+                ;;
+        esac
         set -e
         set -x
         apt-get --yes --quiet install --no-install-recommends gpg software-properties-common
@@ -172,6 +179,13 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
+        case "${{matrix.image}}" in
+            debian:sid|debian:bookworm)
+                exit 0
+                ;;
+            *)
+                ;;
+        esac
         set -e
         set -x
         apt-get --yes --quiet install gpg software-properties-common

--- a/debian/configure
+++ b/debian/configure
@@ -55,7 +55,15 @@ done
 
 DISTRIB_NAME=
 if [ "$(command -v lsb_release)" != "" ] || [ "$(which lsb_release)" != "" ]; then
-    DISTRIB_NAME="$(lsb_release -s -i)-$(lsb_release -s -r)"
+    ID="$(lsb_release --short --id)"
+    RELEASE="$(lsb_release --short --release)"
+    # Workaround for broken lsb_release, <URL: https://bugs.debian.org/1008735 >
+    case "$RELEASE" in
+      n/a)
+        RELEASE=unstable
+        ;;
+    esac
+    DISTRIB_NAME="$ID-$RELEASE"
 elif [ -f /etc/lsb-release ]; then
     source /etc/lsb-release
     DISTRIB_NAME=$DISTRIB_ID-$DISTRIB_RELEASE

--- a/debian/update-dch-from-git
+++ b/debian/update-dch-from-git
@@ -26,9 +26,17 @@ if [ "$NEW_DEB_VERSION" = "$DEB_VERSION" ]; then
     exit 0
 fi
 
+# Workaround until <URL: https://bugs.debian.org/1008735 > in lsb_release is fixed.
+CODENAME="$(lsb_release --codename --short)"
+case "$CODENAME" in
+  n/a)
+    CODENAME=unstable
+    ;;
+esac
+
 set -e
 (
-echo "linuxcnc ($NEW_DEB_VERSION) $(lsb_release -cs); urgency=low"
+echo "linuxcnc ($NEW_DEB_VERSION) $CODENAME; urgency=low"
 echo
 git log --pretty=format:"  * %w(72,0,6)%s" $GIT_TAG..
 echo


### PR DESCRIPTION
No longer add linuxcnc.org APT repo for unstable and bookworm builds and add override to debian/configure and update-dch-from-git to get sid/bookworms building until <URL: https://bugs.debian.org/1008735 > is fixed.