### PR TITLE
Tooledit: Correct data type and validate input for orientation + warn if out of range

### DIFF
--- a/lib/python/gladevcp/tooledit_gtk.glade
+++ b/lib/python/gladevcp/tooledit_gtk.glade
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="2.18"/>
+  <requires lib="gtk+" version="3.0"/>
   <!-- interface-naming-policy project-wide -->
   <object class="GtkListStore" id="liststore1">
     <columns>
@@ -49,17 +49,19 @@
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
     <child>
-      <object class="GtkVBox" id="tooledit_box">
+      <object class="GtkBox" id="tooledit_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
         <child>
           <object class="GtkNotebook" id="tool_offset_notebook">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <child>
-              <object class="GtkVBox" id="vbox1">
+              <object class="GtkBox" id="vbox1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="all_window">
                     <property name="visible">True</property>
@@ -286,7 +288,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkHButtonBox" id="buttonbox">
+                  <object class="GtkButtonBox" id="buttonbox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="layout_style">center</property>

--- a/lib/python/gladevcp/tooledit_gtk.glade
+++ b/lib/python/gladevcp/tooledit_gtk.glade
@@ -35,7 +35,7 @@
       <!-- column-name back -->
       <column type="gchararray"/>
       <!-- column-name orient -->
-      <column type="gchararray"/>
+      <column type="gint"/>
       <!-- column-name comments -->
       <column type="gchararray"/>
     </columns>

--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -561,7 +561,7 @@ class ToolEdit(Gtk.VBox):
                 i += 1
                 if colnum + i < len(columns):
                     if columns[colnum + i].props.visible:
-                        renderer = columns[colnum + i].get_cell_renderers()
+                        renderer = columns[colnum + i].get_cells()
                         if renderer[0].props.editable:
                             next_column = columns[colnum + i]
                             cont = False
@@ -569,7 +569,7 @@ class ToolEdit(Gtk.VBox):
                 else:
                     i = 1
                     while cont2:
-                        renderer = columns[i].get_cell_renderers()
+                        renderer = columns[i].get_cells()
                         if renderer[0].props.editable:
                             next_column = columns[i]
                             cont2 = False
@@ -578,7 +578,7 @@ class ToolEdit(Gtk.VBox):
                     cont = False
 
             if keyname == 'Right':
-                renderer = columns[colnum].get_cell_renderers()
+                renderer = columns[colnum].get_cells()
                 if type(focuschild) is Gtk.Entry:
                     self.col_editted(renderer[0], path, treeview.get_focus_child().props.text, colnum, filter)
             GLib.timeout_add(50,
@@ -594,7 +594,7 @@ class ToolEdit(Gtk.VBox):
                 i -= 1
                 if colnum + i > 0:
                     if columns[colnum + i].props.visible:
-                        renderer = columns[colnum + i].get_cell_renderers()
+                        renderer = columns[colnum + i].get_cells()
                         if renderer[0].props.editable:
                             next_column = columns[colnum + i]
                             cont = False
@@ -602,7 +602,7 @@ class ToolEdit(Gtk.VBox):
                 else:
                     i = -1
                     while cont2:
-                        renderer = columns[i].get_cell_renderers()
+                        renderer = columns[i].get_cells()
                         if renderer[0].props.editable:
                             next_column = columns[i]
                             cont2 = False
@@ -610,7 +610,7 @@ class ToolEdit(Gtk.VBox):
                             i -= 1
                     cont = False
 
-            renderer = columns[colnum].get_cell_renderers()
+            renderer = columns[colnum].get_cells()
             if type(focuschild) is Gtk.Entry:
                 self.col_editted(renderer[0], path, treeview.get_focus_child().props.text, colnum, filter)
             GLib.timeout_add(50,

--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -226,7 +226,7 @@ class ToolEdit(Gtk.VBox):
         except:
             print(_("tooledit_widget error: cannot select tool number"),toolnumber)
 
-    def add(self,widget,data=[1,0,0,'0','0','0','0','0','0','0','0','0','0','0','0','0',"comment"]):
+    def add(self,widget,data=[1,0,0,'0','0','0','0','0','0','0','0','0','0','0','0',0,"comment"]):
         self.model.append(data)
         self.num_of_col +=1
 
@@ -234,6 +234,17 @@ class ToolEdit(Gtk.VBox):
     def set_filename(self,filename):
         self.toolfile = filename
         self.reload(None)
+
+    def warning_dialog(self, line_number):
+        message = _("Error in tool table line {0} in column ").format(line_number) + _("Orientation") + \
+            _(".\nValid range is 0 - 9.")
+        dialog = Gtk.MessageDialog(self.wTree.get_object("window1"),
+            Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            Gtk.MessageType.ERROR, Gtk.ButtonsType.OK,
+            message)
+        dialog.show()
+        dialog.run()
+        dialog.destroy()
 
         # Reload the tool file into display
     def reload(self,widget):
@@ -247,10 +258,14 @@ class ToolEdit(Gtk.VBox):
             return
         logfile = open(self.toolfile, "r").readlines()
         self.toolinfo = []
+        line_number = 0
         for rawline in logfile:
             # strip the comments from line and add directly to array
             # if index = -1 the delimiter ; is missing - clear comments
             index = rawline.find(";")
+            # skip lines beginning with a semicolon
+            if index == 0:
+                continue
             comment =''
             if not index == -1:
                 comment = (rawline[index+1:])
@@ -258,7 +273,8 @@ class ToolEdit(Gtk.VBox):
                 line = rawline.rstrip(comment)
             else:
                 line = rawline
-            array = [0,0,0,'0','0','0','0','0','0','0','0','0','0','0','0','0',comment]
+            line_number += 1
+            array = [0,0,0,'0','0','0','0','0','0','0','0','0','0','0','0',0,comment]
             toolinfo_flag = False
             # search beginning of each word for keyword letters
             # offset 0 is the checkbutton so ignore it
@@ -278,11 +294,21 @@ class ToolEdit(Gtk.VBox):
                                 array[offset]= int(word.lstrip(i))
                             except:
                                 print(_("Tooledit widget int error"))
+                        elif offset == 15:
+                            try:
+                                # Accept also float for 'orientation' for backward compatibility
+                                value = int(float(word.lstrip(i)))
+                                array[offset] = value
+                                if value not in range(10):
+                                    self.warning_dialog(line_number)
+                                    break
+                            except:
+                                print(_("Tooledit widget float error"))
                         else:
                             try:
                                 array[offset]= locale.format("%10.4f", float(word.lstrip(i)))
                             except:
-                                print(_("Tooledit_widget float error"))
+                                print(_("Tooledit widget float error"))
                         break
             if toolinfo_flag:
                 self.toolinfo = array
@@ -292,16 +318,26 @@ class ToolEdit(Gtk.VBox):
         # Note we have to save the float info with a decimal even if the locale uses a comma
     def save(self,widget):
         if self.toolfile == None:return
+        liststore = self.model
+        # pre check before saving the file
+        # if not done before, the file will be saved only until the erroneous line and the rest will be lost
+        line_number = 0
+        for row in liststore:
+            values = [ value for value in row ]
+            line_number += 1
+            if values[15] > 9:
+                self.warning_dialog(line_number)
+                return
+
         file = open(self.toolfile, "w")
         #print self.toolfile
-        liststore = self.model
         for row in liststore:
             values = [ value for value in row ]
             #print values
             line = ""
             for num,i in enumerate(values):
                 if num == 0: continue
-                elif num in (1,2): # tool# pocket#
+                elif num in (1,2,15): # tool#, pocket#, orientation
                     line = line + "%s%d "%(KEYWORDS[num], i)
                 elif num == 16: # comments
                     test = i.strip()
@@ -421,15 +457,24 @@ class ToolEdit(Gtk.VBox):
         elif filter == 'tool':
             (store_path,) = self.tool_filter.convert_path_to_child_path(path)
             path = store_path
-        
+
         if col in(1,2):
             try:
                 self.model[path][col] = int(new_text)
             except:
                 pass
-        elif col in range(3,16):
+        # validate input for float columns
+        elif col in range(3,15):
             try:
                 self.model[path][col] = locale.format("%10.4f",locale.atof(new_text))
+            except:
+                pass
+        # validate input for orientation: check if int and valid range
+        elif col == 15:
+            try:
+                value = int(new_text)
+                if value in range(10):
+                    self.model[path][col] = value
             except:
                 pass
         elif col == 16:


### PR DESCRIPTION
I corrected the data type to int and changed the tool table to allow only input from 0-9.
When a wrong value is in the tool table (orientation in degree) a warning is popping up and saving will not be allowed until a valid value is entered.
I am not sure if this is a bit too overdone to create a dialog for this rare case.
I also could throw an exception that would be shown in the general exception dialog...

Resolves #1773