### PR TITLE
Mb2hal: add version number for backward compatibilty

### DIFF
--- a/docs/man/man1/mb2hal.1
+++ b/docs/man/man1/mb2hal.1
@@ -103,9 +103,9 @@ m = HAL_TX_NAME or transaction number if not set, n = element number (NELEMENTS)
 .br
 Example: 
 .br
-mb2hal.00.01.<type> (transaction=00, second register=01 (00 is the first one))
+mb2hal.00.01.int (TRANSACTION_00, second register)
 .br
-mb2hal.TxName.01.<type> (HAL_TX_NAME=TxName, second register=01 (00 is the first one))
+mb2hal.readStatus.01.bit (HAL_TX_NAME=readStatus, first bit)
 
 .SH AUTHOR
 Victor Rocco

--- a/docs/src/drivers/mb2hal.adoc
+++ b/docs/src/drivers/mb2hal.adoc
@@ -65,8 +65,8 @@ m|INIT_DEBUG | Integer | No | Debug level of init and INI file parsing. +
 2 = OK confirmation messages +
 3 = debugging messages +
 4 = maximum debugging messages (only in transactions) +
-m|HAL_MODULE_NAME | String | No | HAL module (component) name. Defaults
-to "mb2hal".
+m|VERSION | String | No | Version number in the format N.N[NN]. Defaults to 1.0.
+m|HAL_MODULE_NAME | String | No | HAL module (component) name. Defaults to "mb2hal".
 m|SLOWDOWN | Float | No | Insert a delay of "FLOAT seconds" between
 transactions in order to not to have a lot of logging and facilitate the debugging.
 Useful when using `DEBUG=3` (NOT `INIT_DEBUG=3`).
@@ -195,7 +195,18 @@ include::mb2hal_HOWTO.ini[]
 == Pins
 
 [NOTE]
-[yellow yellow-background]#Yellow# = New in LinuxCNC 2.9
+====
+[yellow yellow-background]#Yellow# = New in MB2HAL 1.1 (LinuxCNC 2.9)
+To use these new features you have to set `VERSION = 1.1`
+
+m = Value of `HAL_TX_NAME` if set or transaction number +
+n = element number (`NELEMENTS`) or name from `PIN_NAMES`
+
+Example:
+
+* `mb2hal.00.01.int` (TRANSACTION_00, second register)
+* `mb2hal.readStatus.01.bit` (HAL_TX_NAME=readStatus, first bit)
+====
 
 === [yellow-background]#fnct_01_read_coils#
 
@@ -243,15 +254,5 @@ let the other open (read as 0).
 
 Both pin values are added and limited to 65535 (UINT16_MAX). Use one and
 let the other open (read as 0).
-
-==========================
-m = `HAL_TX_NAME` or transaction number if not set, n = element number
-(`NELEMENTS`) or name from `PIN_NAMES`
-
-Example:
-
-* `mb2hal.00.01.<type>` (transaction=00, second register=01 (00 is the first one))
-* `mb2hal.TxName.01.<type>` (HAL_TX_NAME=TxName, second register=01 (00 is the first one))
-==========================
 
 // vim: set syntax=asciidoc:

--- a/src/hal/user_comps/mb2hal/LogBook.txt
+++ b/src/hal/user_comps/mb2hal/LogBook.txt
@@ -24,6 +24,8 @@
  * USA.
  */
 
+2022-10-14:
+    - Version 1.1: Added version number for backward compatibility with old pin names
 2021-01-17:
     - Added Pins:
       . added bit-inv (invert bit) output for fnct_02_read_discrete_inputs and fnct_01_read_coils

--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -400,10 +400,11 @@ retCode get_tx_connection(const int this_mb_tx_num, int *ret_connected)
 
 void set_init_gbl_params()
 {
-    gbl.hal_mod_name = "mb2hal"; //until readed in config file
+    gbl.hal_mod_name = "mb2hal"; //until read in config file
     gbl.hal_mod_id   = -1;
-    gbl.init_dbg     = debugERR; //until readed in config file
-    gbl.slowdown     = 0;        //until readed in config file
+    gbl.init_dbg     = debugERR; //until read in config file
+    gbl.version      = 1000;     //defaults to 1000 (= 1.000) if not set
+    gbl.slowdown     = 0;        //until read in config file
     gbl.mb_tx_fncts[mbtxERR]                         = "";
     gbl.mb_tx_fncts[mbtx_01_READ_COILS]              = "fnct_01_read_coils";
     gbl.mb_tx_fncts[mbtx_02_READ_DISCRETE_INPUTS]    = "fnct_02_read_discrete_inputs";

--- a/src/hal/user_comps/mb2hal/mb2hal.h
+++ b/src/hal/user_comps/mb2hal/mb2hal.h
@@ -139,7 +139,8 @@ typedef struct {
     FILE *ini_file_ptr;
     char *ini_file_path;
     //INI config, common section
-    int    init_dbg;
+    int   init_dbg;
+    int   version;
     double slowdown;
     //HAL related
     int   hal_mod_id;

--- a/src/hal/user_comps/mb2hal/mb2hal.h
+++ b/src/hal/user_comps/mb2hal/mb2hal.h
@@ -42,14 +42,14 @@ typedef enum { linkRTU,
              } link_type_t;
 
 typedef enum { mbtxERR,
-               mbtx_01_READ_COILS,
                mbtx_02_READ_DISCRETE_INPUTS,
                mbtx_03_READ_HOLDING_REGISTERS,
                mbtx_04_READ_INPUT_REGISTERS,
-               mbtx_05_WRITE_SINGLE_COIL,
                mbtx_06_WRITE_SINGLE_REGISTER,
                mbtx_15_WRITE_MULTIPLE_COILS,
                mbtx_16_WRITE_MULTIPLE_REGISTERS,
+               mbtx_01_READ_COILS,
+               mbtx_05_WRITE_SINGLE_COIL,
                mbtxMAX
              } mb_tx_fnct; //modbus transaction code
 typedef enum { debugSILENT, debugERR, debugOK, debugDEBUG, debugMAX

--- a/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
+++ b/src/hal/user_comps/mb2hal/mb2hal_HOWTO.ini
@@ -18,6 +18,12 @@
 # 4 = maximum debugging messages (only in transactions).
 INIT_DEBUG=3
 
+#OPTIONAL: Set to 1.1 to enable the new functions:
+# - fnct_01_read_coils
+# - fnct_05_write_single_coil
+# - changed pin names (see https://linuxcnc.org/docs/2.9/html/drivers/mb2hal.html#_pins).
+VERSION=1.1
+
 #OPTIONAL: HAL module (component) name. Defaults to "mb2hal".
 HAL_MODULE_NAME=mb2hal
 
@@ -101,11 +107,11 @@ FIRST_ELEMENT=0
 PIN_NAMES=cycle_start,stop,feed_hold
 
 #REQUIRED: Modbus transaction function code (see www.modbus.org specifications).
-#    fnct_01_read_coils               (01 = 0x01)
+#    fnct_01_read_coils               (01 = 0x01) (new in 1.1)
 #    fnct_02_read_discrete_inputs     (02 = 0x02)
 #    fnct_03_read_holding_registers   (03 = 0x03)
 #    fnct_04_read_input_registers     (04 = 0x04)
-#    fnct_05_write_single_coil        (05 = 0x05)
+#    fnct_05_write_single_coil        (05 = 0x05) (new in 1.1)
 #    fnct_06_write_single_register    (06 = 0x06)
 #    fnct_15_write_multiple_coils     (15 = 0x0F)
 #    fnct_16_write_multiple_registers (16 = 0x10)

--- a/src/hal/user_comps/mb2hal/mb2hal_hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_hal.c
@@ -101,30 +101,49 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
         switch (mb_tx->mb_tx_fnct) {
         case mbtx_05_WRITE_SINGLE_COIL:
         case mbtx_15_WRITE_MULTIPLE_COILS:
-            if (0 != hal_pin_bit_newf(HAL_IN, mb_tx->bit + pin_counter, gbl.hal_mod_id,
-                                      "%s.bit", hal_pin_name)) {
-                ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
-                    mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
-                return retERR;
+            if(gbl.version < 1001){
+                if (0 != hal_pin_bit_newf(HAL_IN, mb_tx->bit + pin_counter, gbl.hal_mod_id,
+                                        "%s", hal_pin_name)) {
+                    ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
+                        mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                    return retERR;
+                }
+            } else {
+                if (0 != hal_pin_bit_newf(HAL_IN, mb_tx->bit + pin_counter, gbl.hal_mod_id,
+                                        "%s.bit", hal_pin_name)) {
+                    ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
+                        mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                    return retERR;
+                }
             }
             *mb_tx->bit[pin_counter] = 0;
             break;
         case mbtx_01_READ_COILS:
         case mbtx_02_READ_DISCRETE_INPUTS:
-            if (0 != hal_pin_bit_newf(HAL_OUT, mb_tx->bit + pin_counter, gbl.hal_mod_id,
-                                      "%s.bit", hal_pin_name)) {
-                ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
-                    mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
-                return retERR;
+            if (gbl.version < 1001) {
+                if (0 != hal_pin_bit_newf(HAL_OUT, mb_tx->bit + pin_counter, gbl.hal_mod_id,
+                                        "%s", hal_pin_name)) {
+                    ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
+                        mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                    return retERR;
+                }
+                *mb_tx->bit[pin_counter] = 0;
+            } else {
+                if (0 != hal_pin_bit_newf(HAL_OUT, mb_tx->bit + pin_counter, gbl.hal_mod_id,
+                                        "%s.bit", hal_pin_name)) {
+                    ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
+                        mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                    return retERR;
+                }
+                if (0 != hal_pin_bit_newf(HAL_OUT, mb_tx->bit_inv + pin_counter, gbl.hal_mod_id,
+                                        "%s.bit-inv", hal_pin_name)) {
+                    ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
+                        mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                    return retERR;
+                }
+                *mb_tx->bit[pin_counter] = 0;
+                *mb_tx->bit_inv[pin_counter] = 1;
             }
-            if (0 != hal_pin_bit_newf(HAL_OUT, mb_tx->bit_inv + pin_counter, gbl.hal_mod_id,
-                                      "%s.bit-inv", hal_pin_name)) {
-                ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_bit_newf failed",
-                    mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
-                return retERR;
-            }            
-            *mb_tx->bit[pin_counter] = 0;
-            *mb_tx->bit_inv[pin_counter] = 1;
             break;
         case mbtx_04_READ_INPUT_REGISTERS:
         case mbtx_03_READ_HOLDING_REGISTERS:
@@ -157,32 +176,42 @@ retCode create_each_mb_tx_hal_pins(mb_tx_t *mb_tx)
             break;
         case mbtx_06_WRITE_SINGLE_REGISTER:
         case mbtx_16_WRITE_MULTIPLE_REGISTERS:
-            if (0 != hal_pin_float_newf(HAL_IN, mb_tx->float_value + pin_counter, gbl.hal_mod_id,
-                                        "%s.float", hal_pin_name)) {
-                ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_float_newf failed",
-                    mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
-                return retERR;
+            if (gbl.version < 1001) {
+                if (0 != hal_pin_s32_newf(HAL_IN, mb_tx->int_value + pin_counter, gbl.hal_mod_id,
+                                        "%s", hal_pin_name)) {
+                    ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_s32_newf failed",
+                        mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                    return retERR;
+                }
+                *mb_tx->int_value[pin_counter] = 0;
+            } else {
+                if (0 != hal_pin_float_newf(HAL_IN, mb_tx->float_value + pin_counter, gbl.hal_mod_id,
+                                            "%s.float", hal_pin_name)) {
+                    ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_float_newf failed",
+                        mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                    return retERR;
+                }
+                if (0 != hal_pin_s32_newf(HAL_IN, mb_tx->int_value + pin_counter, gbl.hal_mod_id,
+                                        "%s.int", hal_pin_name)) {
+                    ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_s32_newf failed",
+                        mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                    return retERR;
+                }
+                //if (0 != hal_param_float_newf(HAL_RW, mb_tx->scale + pin_counter, gbl.hal_mod_id,
+                //                              "%s.scale", hal_pin_name)) {
+                //    ERR(gbl.init_dbg, "[%d] [%s] [%s]", mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
+                //    return retERR;
+                //}
+                //if (0 != hal_param_float_newf(HAL_RW, mb_tx->offset + pin_counter, gbl.hal_mod_id,
+                //                              "%s.offset", hal_pin_name)) {
+                //    ERR(gbl.init_dbg, "[%d] [%s]", mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name);
+                //    return retERR;
+                //}
+                *mb_tx->float_value[pin_counter] = 0;
+                *mb_tx->int_value[pin_counter] = 0;
+                //mb_tx->scale[pin_counter] = 1;
+                //mb_tx->offset[pin_counter] = 0;
             }
-            if (0 != hal_pin_s32_newf(HAL_IN, mb_tx->int_value + pin_counter, gbl.hal_mod_id,
-                                      "%s.int", hal_pin_name)) {
-                ERR(gbl.init_dbg, "[%d] [%s] [%s] hal_pin_s32_newf failed",
-                    mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
-                return retERR;
-            }
-            //if (0 != hal_param_float_newf(HAL_RW, mb_tx->scale + pin_counter, gbl.hal_mod_id,
-            //                              "%s.scale", hal_pin_name)) {
-            //    ERR(gbl.init_dbg, "[%d] [%s] [%s]", mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name, hal_pin_name);
-            //    return retERR;
-            //}
-            //if (0 != hal_param_float_newf(HAL_RW, mb_tx->offset + pin_counter, gbl.hal_mod_id,
-            //                              "%s.offset", hal_pin_name)) {
-            //    ERR(gbl.init_dbg, "[%d] [%s]", mb_tx->mb_tx_fnct, mb_tx->mb_tx_fnct_name);
-            //    return retERR;
-            //}
-            *mb_tx->float_value[pin_counter] = 0;
-            *mb_tx->int_value[pin_counter] = 0;
-            //mb_tx->scale[pin_counter] = 1;
-            //mb_tx->offset[pin_counter] = 0;
             break;
         default:
             ERR(gbl.init_dbg, "[%d]", mb_tx->mb_tx_fnct);

--- a/src/hal/user_comps/mb2hal/mb2hal_init.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_init.c
@@ -353,7 +353,8 @@ retCode parse_transaction_section(const int mb_tx_num)
                 break;
             }
         }
-        if (this_mb_tx->mb_tx_fnct <= mbtxERR || this_mb_tx->mb_tx_fnct >= mbtxMAX) {
+        int max = gbl.version<1001?mbtx_01_READ_COILS:mbtxMAX;
+        if (this_mb_tx->mb_tx_fnct <= mbtxERR || this_mb_tx->mb_tx_fnct >= max) {
             ERR(gbl.init_dbg, "[%s] [%s] [%s] out of range", section, tag, tmpstr);
             return retERR;
         }

--- a/src/hal/user_comps/mb2hal/mb2hal_init.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_init.c
@@ -89,6 +89,15 @@ retCode parse_common_section()
     iniFindInt(gbl.ini_file_ptr, tag, section, &gbl.init_dbg);
     DBG(gbl.init_dbg, "[%s] [%s] [%d]", section, tag, gbl.init_dbg);
 
+    tag     = "VERSION"; //optional
+    tmpstr = iniFind(gbl.ini_file_ptr, tag, section);
+    if (tmpstr != NULL) {
+        int major, minor;
+        sscanf(tmpstr, "%d.%d", &major, &minor);
+        gbl.version = major*1000 + minor;
+    }
+    DBG(gbl.init_dbg, "[%s] [%s] [%d]", section, tag, gbl.version);
+
     tag    = "HAL_MODULE_NAME"; //optional
     tmpstr = iniFind(gbl.ini_file_ptr, tag, section);
     if (tmpstr != NULL) {

--- a/src/hal/user_comps/mb2hal/mb2hal_modbus.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_modbus.c
@@ -1,5 +1,4 @@
 #include <sys/time.h>
-//#include <stdint.h>
 #include "mb2hal.h"
 
 retCode fnct_01_read_coils(mb_tx_t *this_mb_tx, mb_link_t *this_mb_link)


### PR DESCRIPTION
Some time ago I added some functionality to MB2HAL and therefore changed some pin names (https://github.com/LinuxCNC/linuxcnc/pull/1030, https://linuxcnc.org/docs/2.9/html/drivers/mb2hal.html#_pins).
So this might break a configuration working with 2.8.
To avoid this, this PR adds a version number to the MB2HAL INI file. If this is not set, MB2HAL behaves like before.
If set so 1.1, the new features are "unlocked" and the changed pin names are applied.

f25ed1307a1c083a6cb0a6d5a8227bb011c19f07 is technically not needed to ensure backward compatibility, but as these functions belong to 1.1, they should be available only there.
