### PR TITLE
uspace+rtai: fix priority

### DIFF
--- a/src/rtapi/rtapi_uspace.hh
+++ b/src/rtapi/rtapi_uspace.hh
@@ -71,10 +71,12 @@ struct RtapiApp
 
     RtapiApp(int policy = SCHED_OTHER) : policy(policy), period(0) {}
 
-    int prio_highest();
-    int prio_lowest();
-    int prio_next_higher(int prio);
-    int prio_next_lower(int prio);
+    virtual int prio_highest() const;
+    virtual int prio_lowest() const;
+    int prio_higher_delta() const;
+    int prio_bound(int prio) const;
+    int prio_next_higher(int prio) const;
+    int prio_next_lower(int prio) const;
     long clock_set_period(long int period_nsec);
     int task_new(void (*taskcode)(void*), void *arg,
             int prio, int owner, unsigned long int stacksize, int uses_fp);

--- a/src/rtapi/uspace_rtai.cc
+++ b/src/rtapi/uspace_rtai.cc
@@ -165,6 +165,14 @@ struct RtaiApp : RtapiApp {
     void do_delay(long ns) {
         rt_sleep(nano2count(ns));
     }
+
+    int prio_highest() const {
+        return RT_SCHED_HIGHEST_PRIORITY;
+    }
+
+    int prio_lowest() const {
+        return RT_SCHED_LOWEST_PRIORITY;
+    }
 };
 
 pthread_once_t RtaiApp::key_once;

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -835,37 +835,52 @@ struct rtapi_task *task_array[MAX_TASKS];
 
 /* Priority functions.  Uspace uses POSIX task priorities. */
 
-int RtapiApp::prio_highest()
+int RtapiApp::prio_highest() const
 {
     return sched_get_priority_max(policy);
 }
 
-int RtapiApp::prio_lowest()
+int RtapiApp::prio_lowest() const
 {
   return sched_get_priority_min(policy);
 }
 
-int RtapiApp::prio_next_higher(int prio)
-{
-  /* return a valid priority for out of range arg */
-  if (prio >= rtapi_prio_highest())
-    return rtapi_prio_highest();
-  if (prio < rtapi_prio_lowest())
-    return rtapi_prio_lowest();
-
-  /* return next higher priority for in-range arg */
-  return prio + 1;
+int RtapiApp::prio_higher_delta() const {
+    if(rtapi_prio_highest() > rtapi_prio_lowest()) {
+        return 1;
+    }
+    return -1;
 }
 
-int RtapiApp::prio_next_lower(int prio)
+int RtapiApp::prio_bound(int prio) const {
+    if(rtapi_prio_highest() > rtapi_prio_lowest()) {
+        if (prio >= rtapi_prio_highest())
+            return rtapi_prio_highest();
+        if (prio < rtapi_prio_lowest())
+            return rtapi_prio_lowest();
+    } else {
+        if (prio <= rtapi_prio_highest())
+            return rtapi_prio_highest();
+        if (prio > rtapi_prio_lowest())
+            return rtapi_prio_lowest();
+    }
+    return prio;
+}
+
+int RtapiApp::prio_next_higher(int prio) const
 {
-  /* return a valid priority for out of range arg */
-  if (prio <= rtapi_prio_lowest())
-    return rtapi_prio_lowest();
-  if (prio > rtapi_prio_highest())
-    return rtapi_prio_highest();
-  /* return next lower priority for in-range arg */
-  return prio - 1;
+    prio = prio_bound(prio);
+    if(prio != rtapi_prio_highest())
+        return prio + prio_higher_delta();
+    return prio;
+}
+
+int RtapiApp::prio_next_lower(int prio) const
+{
+    prio = prio_bound(prio);
+    if(prio != rtapi_prio_lowest())
+        return prio - prio_higher_delta();
+    return prio;
 }
 
 int RtapiApp::allocate_task_id()


### PR DESCRIPTION
rtai priority numbers run opposite to pthread priority numbers.

After this change, no threads.0 failures for 1000 tests. Before, failure probability was at least 1 in 50 tests.

Closes: #2098