### PR TITLE
Fix exception in ;py, comment

### DIFF
--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -235,6 +235,8 @@ std::string handle_pyerror()
     bp::object formatted_list, formatted;
 
     PyErr_Fetch(&exc, &val, &tb);
+    PyErr_NormalizeException(&exc, &val, &tb);
+
     bp::handle<> hexc(exc), hval(bp::allow_null(val)), htb(bp::allow_null(tb));
     bp::object traceback(bp::import("traceback"));
     if (!tb) {

--- a/src/emc/sai/driver.cc
+++ b/src/emc/sai/driver.cc
@@ -43,7 +43,7 @@
 InterpBase *pinterp;
 #define interp_new (*pinterp)
 const char *prompt = "READ => ";
-const char *history = "~/.rs274";
+const char *histfile = "~/.rs274";
 #define RS274_HISTORY "RS274_HISTORY"
 
 #define active_settings  interp_new.active_settings
@@ -137,15 +137,15 @@ void initialize_readline ()
     rl_readline_name = "rs274";
  
     if ((s = getenv(RS274_HISTORY)))
-	history = s;
+	histfile = s;
     // tilde-expand 
-    if (wordexp(history, &p, WRDE_SHOWERR|WRDE_UNDEF )) {
+    if (wordexp(histfile, &p, WRDE_SHOWERR|WRDE_UNDEF )) {
 	perror("wordexp");
     } else {
-	history = strdup(p.we_wordv[0]);
+	histfile = strdup(p.we_wordv[0]);
     }
-    if (history)
-	read_history(history);
+    if (histfile)
+	read_history(histfile);
 }
 
 /***********************************************************************/
@@ -186,8 +186,8 @@ int interpret_from_keyboard(  /* ARGUMENTS                 */
 	{
 	    line = readline ( prompt);
 	    if (!line || strcmp (line, "quit") == 0) {
-		if (history)
-		    write_history(history);
+		if (histfile)
+		    write_history(histfile);
 		return 0;
 	    }
 	    if (*line)


### PR DESCRIPTION
The exception must be "normalized".

It's not clear why this changed. the function must be called "[under certain circumstances](https://docs.python.org/3.8/c-api/exceptions.html#c.PyErr_NormalizeException)"     

 Closes #2092

Also fixes a problem where `rs274 -g` would just crash. This is unconnected, but I had hoped I could reproduce the problem just starting the rs274 commandline program instead of running AXIS.