### PR TITLE
packaging: mark linuxcnc-doc-de Multi-Arch: Foreign

### DIFF
--- a/debian/control.docs.in
+++ b/debian/control.docs.in
@@ -1,6 +1,7 @@
 Package: linuxcnc-doc-de
 Provides: linuxcnc-doc
 Architecture: all
+Multi-Arch: foreign
 Depends: ${misc:Depends}
 Recommends: xdg-utils
 Suggests: pdf-viewer


### PR DESCRIPTION
This makes it match the other docs packages.  "Multi-Arch: Foreign" lets this architecture-independent binary package satisfy dependencies of binary packages of other architectures (i.e. in a multi-arch system).