### PR TITLE
qtvcp: add spacer to center buttons in cam_align

### DIFF
--- a/share/qtvcp/panels/cam_align/cam_align.ui
+++ b/share/qtvcp/panels/cam_align/cam_align.ui
@@ -18,6 +18,19 @@
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
        <widget class="ActionButton" name="actionbutton_2">
         <property name="text">
          <string>SET Origin</string>
@@ -164,7 +177,7 @@
      </layout>
     </item>
     <item>
-     <widget class="CamView" name="camview">
+     <widget class="CamView" name="camview" native="true">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
         <horstretch>0</horstretch>


### PR DESCRIPTION
Center buttons and labels to fit also in small frames.


Before:
![image](https://user-images.githubusercontent.com/67957916/200189289-30adb530-b716-4e72-88d6-85c22aa49c71.png)


After:
![Bildschirmfoto_2022-11-06_19-38-29](https://user-images.githubusercontent.com/67957916/200189305-3a6f51fd-d8a4-495a-8a35-02d2325009f6.png)


