### PR TITLE
Fix various typos

### DIFF
--- a/configs/attic/demo_mazak/demo_mazak.hal
+++ b/configs/attic/demo_mazak/demo_mazak.hal
@@ -181,7 +181,7 @@ addf encoder.update-counters        base-thread
 
 # -------------------------------------------------
 
-# Next, create signals with meaningfull names, and attach them to the
+# Next, create signals with meaningful names, and attach them to the
 #  physical pins.  There are a lot of these, so they are broken up
 
 # ---------------------------------------------------
@@ -628,7 +628,7 @@ setp pid.2.maxoutput [JOINT_2]MAX_OUTPUT
 
 # LADDER LOGIC!!!
 #
-# Classic ladder doesn't let you use meaningfull names, so this
+# Classic ladder doesn't let you use meaningful names, so this
 # will be the magic decoder ring
 
 # INPUTS to CL

--- a/configs/sim/axis/vismach/puma/puma_cube.txt
+++ b/configs/sim/axis/vismach/puma/puma_cube.txt
@@ -8,6 +8,6 @@ Usage:
   Ctrl-Home -- Home All
   R ---------- Run
 
-Example gcode (.ngc) files are:
+Example G-code (.ngc) files are:
 ./puma_cube.ngc
 ./puma_seam_weld.ngc

--- a/configs/sim/axis/vismach/puma/puma_cube.txt
+++ b/configs/sim/axis/vismach/puma/puma_cube.txt
@@ -8,6 +8,6 @@ Usage:
   Ctrl-Home -- Home All
   R ---------- Run
 
-Example gocde (.ngc) files are:
+Example gcode (.ngc) files are:
 ./puma_cube.ngc
 ./puma_seam_weld.ngc

--- a/configs/sim/craftsman/screens/gcodes.htm
+++ b/configs/sim/craftsman/screens/gcodes.htm
@@ -744,7 +744,7 @@ G4 does not affect spindle, coolant and any I/O.</p></div>
 <div class="ulist"><ul>
 <li>
 <p>
-the P number is negative or not specifed.
+the P number is negative or not specified.
 </p>
 </li>
 </ul></div>

--- a/configs/sim/qtvcp_screens/qtdragon/qtdragon_hd_postgui.hal
+++ b/configs/sim/qtvcp_screens/qtdragon/qtdragon_hd_postgui.hal
@@ -4,7 +4,7 @@
 loadrt logic names=logic-and personality=0x102
 addf logic-and servo-thread
 
-# load a summing compnent for adding spindle lift and Z compensation
+# load a summing component for adding spindle lift and Z compensation
 loadrt scaled_s32_sums
 addf scaled-s32-sums.0 servo-thread
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -828,7 +828,7 @@ linuxcnc (1:2.7.8) unstable; urgency=medium
 
 linuxcnc (1:2.7.7) unstable; urgency=medium
 
-  * docs: fix example scrips so they work when copied and pasted
+  * docs: fix example scripts so they work when copied and pasted
   * docs: fix minor mux_generic(9) manpage quibbles
 
   * Axis GUI: work around python-tk "True" bug

--- a/docs/man/man9/hostmot2.9
+++ b/docs/man/man9/hostmot2.9
@@ -175,7 +175,7 @@ rates and bit lengths)
 \fBnum_resolvers\fR [optional, default: \-1]
 Only enable the first N resolvers. If N = \-1 then all resolvers are enabled.
 This module does not work with generic resolvers (unlike the encoder module
-which works with any encoder). At the time of writing thex Hostmot2 Resolver
+which works with any encoder). At the time of writing this Hostmot2 Resolver
 function only works with the Mesa 7I49 card.
 .TP
 \fBnum_pwmgens\fR [optional, default: \-1]

--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -369,7 +369,7 @@ See <<cha:gmoccapy,gmoccapy>> document for Gmoccapy details.
 * 'BACK_TOOL_LATHE = 1' - Any non-empty value (including "0") causes axis to use "back tool lathe mode" with inverted X axis.
 * 'FOAM = 1' - Any non-empty value (including "0") causes axis to change the display for foam-cutter mode.
 * 'GEOMETRY = XYZABCUVW' - Controls the *preview* and *backplot* of motion.
-  This item consists of a sequence of axis letters and control characters, optionally preceeded with a "-" sign:
+  This item consists of a sequence of axis letters and control characters, optionally preceded with a "-" sign:
 
 . The letters X, Y, Z specify translation along the named coordinate.
 . The letters A, B, C specify rotation about the corresponding axes X, Y, Z.

--- a/docs/src/gen_complist.py
+++ b/docs/src/gen_complist.py
@@ -55,7 +55,7 @@ def generate_complist(complist_path):
     file2.close()
 
     generate_links(gen_filename, False, True)
-    print('gen_complist: Added {} uncategorized and {} potentially obsolete entrie(s) to hal component list'.format(len(miss_in_list), len(miss_in_man)))
+    print('gen_complist: Added {} uncategorized and {} potentially obsolete entry/entries to hal component list'.format(len(miss_in_list), len(miss_in_man)))
 
 
 def generate_links(filename, create_backup=True, add_descr=False):

--- a/docs/src/gui/gmoccapy.adoc
+++ b/docs/src/gui/gmoccapy.adoc
@@ -203,7 +203,7 @@ path for macros:
 SUBROUTINE_PATH = macros
 ----
 This sets the path to search for macros and other subroutines. Several subroutine
-paths can be separeted ":".
+paths can be separated ":".
 
 Then you just have to add a section like this:
 
@@ -1100,7 +1100,7 @@ You have three options:
 
 The checkboxes allow the user to select if he wants the on board keyboard to be shown immediately,
 when entering the MDI Mode, when entering the offset page, the tooledit widget or when open a program
-in the EDIT mode. The keyboard button on the bottom button list will not be affected by theese settings,
+in the EDIT mode. The keyboard button on the bottom button list will not be affected by these settings,
 so you are able to show or hide the keyboard by pressing the button. The default behavior will be set by
 the checkboxes.
 
@@ -1407,7 +1407,7 @@ Probe velocities::
   commented out in macros/change.ngc, otherwise the user would have to click
   twice on the probe button.)
 --
-// TODO: check if this option is accidently gone in 2.9
+// TODO: check if this option is accidentally gone in 2.9
 // Tool Changer::
 // +
 // --

--- a/docs/src/gui/qtdragon.adoc
+++ b/docs/src/gui/qtdragon.adoc
@@ -324,7 +324,7 @@ will show the keyboard. +
 To hide the keyboard, do one of the following:
 
 - click the MAIN page button
-- The curently selected page button.
+- The currently selected page button.
 - go into AUTO mode
 
 It should be noted that keyboard jogging is disabled when using the virtual

--- a/docs/src/gui/qtvcp-code-snippets.adoc
+++ b/docs/src/gui/qtvcp-code-snippets.adoc
@@ -387,7 +387,7 @@ In Qt Designer:
 * Use Qt Designer's slot editor to use the button signal `clicked(bool)`
   to call form's handler function `toggle_continuous_clicked()`. +
   See <<sub:qtvcp:designer-slots,Using Qt Designer To Add Slots>>
-  section for more informations.
+  section for more information.
 
 Then add this code snippets to the handler file under the `initialized__`
 function:

--- a/docs/src/gui/qtvcp-custom-widgets.adoc
+++ b/docs/src/gui/qtvcp-custom-widgets.adoc
@@ -179,7 +179,7 @@ This LED indicator widget will respond to selectable LinuxCNC controller
 states.
 
 //TODO Link external file for code block content, or as a linked asset to
-//  strip the looong listing as it is detailed chunck by chunk beneath ?
+//  strip the looong listing as it is detailed chunk by chunk beneath ?
 
 [source,python]
 ----
@@ -684,7 +684,7 @@ They would need to be added to `qtvcp/plugins/` +
 Then `qtvcp/plugins/qtvcp_plugin.py` would need to be adjusted to
 _import_ them.
 
-//FIXME split samples bellow in independent py files and simply link them
+//FIXME split samples below in independent py files and simply link them
 //      as they're not documented, or possibly include them if we really
 //      want to have them here in full text
 

--- a/docs/src/gui/qtvcp-development.adoc
+++ b/docs/src/gui/qtvcp-development.adoc
@@ -83,7 +83,7 @@ Finally when QtVCP is asked to shutdown:
 
 == Path Information
 
-When QtVCP loads it collects paths informations.
+When QtVCP loads it collects paths information.
 
 This is available in the handler file's `+__init__()+` function
 as *`path`*:
@@ -154,7 +154,7 @@ should be checked for in the `processed_key_event__` function.
 === Preference File
 
 Some QtVCP widgets use the preference file to record important
-informations.
+information.
 
 This _requires the preference file to be set up early_ in the widget
 initialization process. +

--- a/docs/src/gui/qtvcp-libraries.adoc
+++ b/docs/src/gui/qtvcp-libraries.adoc
@@ -402,7 +402,7 @@ This library *handles tool offset file changes*.
 WARNING: *LinuxCNC doesn't handle third party manipulation of the tool
   file well.*
 
-//FIXME Tools: Objets properties ?
+//FIXME Tools: Objects properties ?
 
 === Helpers
 
@@ -418,12 +418,12 @@ This is a raw list formed _from the system tool file_.
   This will return a Python *tuple of two Python lists of Python lists of
 tool information*:
 +
-* *`[0]`* will be _real tools informations_
-* *`[1]`* will be _wear tools informations_ (tool numbers will be over
+* *`[0]`* will be _real tools information_
+* *`[1]`* will be _wear tools information_ (tool numbers will be over
   10000; Fanuc style tool wear)
 
 +
-By default, adds a blanck tool entry with tool number -99. +
+By default, adds a blank tool entry with tool number -99. +
 You can preload the `newtool` array with tool information.
 
 *`DELETE_TOOLS(_toolnumber_)`*::
@@ -907,7 +907,7 @@ QtVCP searches for the `ScreenOptions` widget first and, if found, calls
 *`+_pref_init()+`*. +
 This will _create the preferences object_ and return it to QtVCP to pass
 to all the widgets and add it to the window object attributes. +
-In this case the preferences object would be accessable from the handler
+In this case the preferences object would be accessible from the handler
 file's `initialized_` method as *`self.w.PREFS_`*.
 
 //FIXME Global or per widget prefs file ?

--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -642,7 +642,7 @@ MDI_COMMAND = G53 G0 Z0;G53 G0 X0 Y0, Goto\nMachn\nZero
 //FIXME add link to Indicated_PushButton section
 Action buttons are subclassed from
 <<sub:qtvcp:widgets:indicatedpushbutton>>[`IndicatedPushButton`]. +
-See the following sections for more informations about:
+See the following sections for more information about:
 
 * <<sub:qtvcp:widgets:indicatedpushbutton:led,LED Indicator option>>
 * <<sub:qtvcp:widgets:indicatedpushbutton:state-enabled,Enabled on State>>
@@ -1084,7 +1084,7 @@ as plasma or some Lathes and have no rotate button assigned.
 |===
 
 *`MouseWheelInvertZoom`* _(bool)_::
-  Determines wether or not to _invert the zoom direction_ when zooming
+  Determines whether or not to _invert the zoom direction_ when zooming
   with the mouse wheel. +
   The following shows an example of how to set this property:
 +
@@ -1737,7 +1737,7 @@ The state options are:
 *`is_neg_limit_tripped`*::
 *`is_pos_limit_tripped`*::
 *`is_limits_tripped`*::
-// end defintion list
+// end definition list
 
 .Properties
 There are properties that can be changed:
@@ -2353,7 +2353,7 @@ actions:
 *`set_all_unchecked()`*::
   Uncheck all selected tools.
 
-.Example for handler file executing aformentioned functions.
+.Example for handler file executing aforementioned functions.
 [source,python]
 ----
 self.w.tooloffsetview.add_tool()

--- a/docs/src/gui/qtvcp.adoc
+++ b/docs/src/gui/qtvcp.adoc
@@ -279,7 +279,7 @@ This file will be read and executed as Python code in the
 *handler file context*.
 
 *Only local functions and local attributes* can be referenced. +
-Global libraries can not be referenced. (usualy seen as all capital
+Global libraries can not be referenced. (usually seen as all capital
 words with no preceding self.) +
 
 What can be used can vary by screen and development cycle.
@@ -888,7 +888,7 @@ By instantiating the libraries here we *create global reference*.
 You can note this by the commands that don't have `self.` in front of
 them.
 
-By convention we _capitalize the names of globaly referenced libraries_.
+By convention we _capitalize the names of globally referenced libraries_.
 
 === HANDLER CLASS Section
 
@@ -1100,7 +1100,7 @@ Save the handler file.
 Now when you load your screen and press the button it should print the
 name of the button in the terminal.
 
-== More Informations
+== More Information
 
 <<cha:qtvcp:panels,QtVCP Builtin Virtual Control Panels>>
 

--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -2233,7 +2233,7 @@ It is possible to use near-end-of-life consumables for piercing and then they ca
 [underline]*Puddle Jump*
 
 *Puddle Jump* is the height that the torch will move to after piercing and prior to moving to *Cut Height* and is expressed as a percentage of *Pierce Height*.
-This allows the torch to clear any puddle of molten material tht may be caused by piercing. The maximum allowable height is 200% of the *Pierce Height*
+This allows the torch to clear any puddle of molten material that may be caused by piercing. The maximum allowable height is 200% of the *Pierce Height*
 
 Setting for *Puddle Jump* are described in <<qt_material,cut parameters>>
 

--- a/lib/python/qtvcp/core.py
+++ b/lib/python/qtvcp/core.py
@@ -260,7 +260,7 @@ class Status(GStat):
     # to call this function
     # but when using MDI subprograms, the subprogram must be the only
     # polling instance.
-    # this is done by blocking the main screen polling untill the
+    # this is done by blocking the main screen polling until the
     # subprogram is done.
     def poll_error(self):
         if self._block_polling: return None

--- a/lib/python/qtvcp/lib/qt_ngcgui/ngcgui.py
+++ b/lib/python/qtvcp/lib/qt_ngcgui/ngcgui.py
@@ -475,7 +475,7 @@ class NgcGui(QtWidgets.QWidget):
 
     ###################################################################
     #Function to automatically add preconfigured NGCGUI files form the Linuxcnc INI as tabs in NGCGUI for QTVCP
-    #The funtion is called by the Ngcgui class constructor and relies on the following INI enteries
+    #The function is called by the Ngcgui class constructor and relies on the following INI entries
     #NGCGUI_SUBFILE : name of the NGCGUI file (including extension) to be automatically loaded
     #NGCGUI_SUBFILE_PATH : path of the directory where the files can be found, relative to the root of the launched Linuxcnc INI
     ###################################################################

--- a/lib/python/qtvcp/lib/qt_ngcgui/ngcgui.ui
+++ b/lib/python/qtvcp/lib/qt_ngcgui/ngcgui.ui
@@ -140,7 +140,7 @@
           <item>
            <widget class="QCheckBox" name="chk_save">
             <property name="toolTip">
-             <string>Aways save when code is finalized</string>
+             <string>Always save when code is finalized</string>
             </property>
             <property name="text">
              <string>Save?</string>

--- a/lib/python/qtvcp/lib/ripper/gcode_ripper.py
+++ b/lib/python/qtvcp/lib/ripper/gcode_ripper.py
@@ -51,7 +51,7 @@
 
     Version 0.11 - Fixed a minor bug that cause a failed file read in rare cases (tries to calculate square root of negative number)
 
-    Version 0.12 - Updated the probe data file reading routine to be less sensitive to file formating
+    Version 0.12 - Updated the probe data file reading routine to be less sensitive to file formatting
                  - Fixed error in probe Z offsets when using an external probe data file
 
     Version 0.13 - Changed "Probe & Cut" to add the "Probe Z Safe" value to the height of the rapid moves ensuring the tool does not crash
@@ -73,12 +73,12 @@
                  - Fixed problem that made the rapid height to high in adjusted g-code because the calculated maximum probe value would never go below zero.
                  - Added option for selecting if all points are probed or just required points
                  - Added option for selecting if probe data is saved when running probe and cut operation
-                 - G-code ripper no longer takes into acount the rapid moved when determining the design size
+                 - G-code ripper no longer takes into account the rapid moved when determining the design size
                  - Changed so G-Code Ripper does not try to load a file on startup.
 
     Version 0.19 - Changed autoprobe safe height calculation with MACH3/4 for "Probe and Cut" Mach was unable to perform the calculated height like LinuxCNC.
 
-    Version 0.20 - Fixed problem that occured when the Z position was not set by a rapid move before and X,Y move when probing.
+    Version 0.20 - Fixed problem that occurred when the Z position was not set by a rapid move before and X,Y move when probing.
                    (It now uses the first Z position in the g-code for the z-safe for probe moves before a z position is specified.)
 
     Version 0.21 - Added option to disable the g-code path display (might speed things up for large g-code files
@@ -222,7 +222,7 @@ def error_message(message):
     root.wait_window(error_report)
     return return_value.get()
 
-#Define cmp_new, cmp replacement for Python 3 compatability
+#Define cmp_new, cmp replacement for Python 3 compatibility
 def cmp_new(A,B):
     if A==B:
         return False
@@ -365,7 +365,7 @@ class Application(Frame):
         self.current_input_file = StringVar()
          
         ###########################################################################
-        #                         INITILIZE VARIABLES                             #
+        #                         INITIALIZE VARIABLES                            #
         #    if you want to change a default setting this is the place to do it   #
         ###########################################################################
         self.show_axis.set(1)
@@ -482,7 +482,7 @@ class Application(Frame):
         self.gpost.set("(G-Code Postamble)")
         
         ##########################################################################
-        ###                     END INITILIZING VARIABLES                      ###
+        ###                     END INITIALIZING VARIABLES                     ###
         ##########################################################################
         self.config_file = "g-code-ripper_config.ngc"
         home_config1 = self.HOME_DIR + "/" + self.config_file
@@ -5294,7 +5294,7 @@ class G_Code_Rip:
                 dz = coordA[2]-LASTZ
 
                 # Check if next point is coincident with the
-                # current point withing the set accuracy
+                # current point within the set accuracy
                 if sqrt((dx+0j).real**2 + (dy+0j).real**2 + (dz+0j).real**2) > self.accuracy and gen_rapids == True:
                     ### Move tool to safe height (z_safe) ###
                     if no_variables==False:
@@ -6125,12 +6125,12 @@ class G_Code_Rip:
             #fmessage(MSG)
             raise ValueError(MSG)
         
-        #################################################################    
+        #################################################################
         ###  While there are still brackets "[...]" keep processing   ###
         #################################################################
         while s != -1:
             ##############################################################
-            ### Find the first occurance of "]" after the current "["  ###
+            ### Find the first occurence of "]" after the current "["  ###
             ##############################################################
             e=-1
             for cnt in range(len(line)-1,s,-1):
@@ -6365,7 +6365,7 @@ class G_Code_Rip:
         return loc
 
     ############################################################################
-    # routine takes an x and a y coords and does a cordinate transformation    #
+    # routine takes an x and a y coords and does a coordinate transformation   #
     # to a new coordinate system at angle from the initial coordinate system   #
     # Returns new x,y tuple                                                    #
     ############################################################################

--- a/scripts/halreport
+++ b/scripts/halreport
@@ -690,9 +690,9 @@ output, input, and io pins (OUT:,IN:,IO:) followed by
 the function name, thread_name, and the addf-order for
 the function.
 
-For critcal signal paths (e.g., pid loops), the signal OUT
+For critical signal paths (e.g., pid loops), the signal OUT
 pin should be numerically lower in order than the order of
-any timing-critcal IN pins for the signal."
+any timing-critical IN pins for the signal."
 
   set ::HR(thread_names) [hal list thread]
   set ::HR(functs)       [hal list funct]
@@ -893,7 +893,7 @@ any timing-critcal IN pins for the signal."
 
   puts $fd "Notes:
 1) Userspace functions are not ordered and are marked \"notRT\".
-2) Most in-tree components important for timing-critcal signal
+2) Most in-tree components important for timing-critical signal
    paths are handled.  When a component is not handled explicitly,
    a function may be tagged as ?-function_name.
 3) When alias pin names are used, the actual pin name is shown

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1163,7 +1163,7 @@ fi
 AC_ARG_ENABLE(build-documentation-translation,
     AS_HELP_STRING(
         [--disable-build-documentation-translation],
-        [Disable building documention in other languages than English.]
+        [Disable building documentation in languages other than English.]
     ),
     [
     case "$enableval" in

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -504,7 +504,7 @@ ver. 2.2.2
 
 ver. 2.2.1
 - if linuxcnc is restarted without shutting down gmoccapy, it was not possible
-  to close gmoccapy (except from comandline with killall -9 gmoccapy
+  to close gmoccapy (except from commandline with killall -9 gmoccapy
   I added a check to status.poll and now a raise SystemExit will be called.
   as this also applies to CombiDRO a added that there too.
   I added gmoccapy to the linuxcnc script to be killed on restart
@@ -566,7 +566,7 @@ ver. 2.1.5
 ver. 2.1.4
 - lathe wear offsets has been displayed by default, IMHO that
   disturbs most users, as the wear offsets do only work with
-  remaped code. That part is only weak documented.
+  remapped code. That part is only weak documented.
 - If the user wants to use wear offsets, he will have to include
   in [DISPLAY] LATHE_WEAR_OFFSETS = 1, otherwise the additional tabs
   will be hidden.
@@ -1833,7 +1833,7 @@ ver. 0.9.1.2
 
 ver. 0.9.1
 - show offsets and show dtg for gremlin are only sensitive if show gremlin DRO 
-  is actice, other behavior makes no sense
+  is active, other behavior makes no sense
 - settings page can be reached now also in estop state
 - desktop notify can be disabled in settings page, makes the gui faster
 - file to load on start up can be selected on settings page

--- a/src/emc/usr_intf/pncconf/pncconf-help/help-basic.txt
+++ b/src/emc/usr_intf/pncconf/pncconf-help/help-basic.txt
@@ -30,7 +30,7 @@ GUI Frontend list:
             -fully supports lathes.
             -is the most developed and used frontend
             -is designed to be used with mouse and keyboard
-            -is tkinter based so intergrates PYVCP panels naturally.
+            -is tkinter based so integrates PYVCP panels naturally.
             -has a graphical window.
             -allows VCP panels integrated on the side or in center tab
 
@@ -39,7 +39,7 @@ GUI Frontend list:
                 minimal physical switches and a MPG wheel.
             -requires cycle-start, abort, and single-step signals and buttons
             -It also requires shared axis MPG jogging to be selected.  
-            -is GTK based so intergrates GLADE VCP panels naturally.
+            -is GTK based so integrates GLADE VCP panels naturally.
             -allows VCP panels integrated in the center Tab
             -has no graphical window
             -look can be changed with custom themes

--- a/src/hal/components/anglejog.comp
+++ b/src/hal/components/anglejog.comp
@@ -137,7 +137,7 @@ static int  ifactor = 0;
         /* and set command to present magnitude to avoid movement when
            next enabled */
         mag_cmd = current_mag;
-        //NOTE: changes allowd only when disabled:
+        //NOTE: changes allowed only when disabled:
         if (!enable_in) {
             static bool gave_msg = 0;
             bool new_ifactor = 0;

--- a/src/hal/drivers/bcm2835.h
+++ b/src/hal/drivers/bcm2835.h
@@ -129,7 +129,7 @@
 /// \version 1.6 Document testing on 2012-07-15-wheezy-raspbian and Occidentalisv01
 ///              Functions bcm2835_gpio_ren(), bcm2835_gpio_fen(), bcm2835_gpio_hen()
 ///               bcm2835_gpio_len(), bcm2835_gpio_aren() and bcm2835_gpio_afen() now
-///               changes only the pin specified. Other pins that were already previoulsy
+///               changes only the pin specified. Other pins that were already previously
 ///               enabled stay enabled.
 ///              Added  bcm2835_gpio_clr_ren(), bcm2835_gpio_clr_fen(), bcm2835_gpio_clr_hen()
 ///                bcm2835_gpio_clr_len(), bcm2835_gpio_clr_aren(), bcm2835_gpio_clr_afen()

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -114,7 +114,7 @@
 
    The use of version codes  means that any subsequent changes to
    the structs will be fully protected, with a clean shutdown and
-   meaningfull error messages in case of a mismatch.
+   meaningful error messages in case of a mismatch.
 */
 
 #define HAL_KEY   0x48414C32	/* key used to open HAL shared memory */


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.ts,*.svg,./.git,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es -L ans,ba,bu,bulle,componentes,doubleclick,dout,dum,extint,fo,halp,ihs,inout,parm,parms,ro,ser,te,tey,ue,wille,wonte`