### PR TITLE
Adjusted scripts/platform-is-supported to not fail on Debian Testing and Unstable

### DIFF
--- a/scripts/platform-is-supported
+++ b/scripts/platform-is-supported
@@ -72,8 +72,13 @@ if os == 'linux':
     except ValueError as e:
         major = release
         minor = "0"
-    release_major = int(major)
-    release_minor = int(minor)
+    try:
+        release_major = int(major)
+        release_minor = int(minor)
+    except ValueError as e:
+	# Debian Unstable and Testing do not have a release number, the value is 'n/a'
+        release_major = 666
+        release_minor = 0
 
     uname = subprocess.check_output(['uname', '-r']).strip()
     kernel_flavor = detect_kernel_flavor(uname)


### PR DESCRIPTION
The Testing Debian distribution only get its version number returned from lsb_release very shortly before the release, so for most of its life it will be set to n/a like it is for Unstable.