### PR TITLE
fix: linuxcncrsh: return PROGRAM NONE if no program is open (2.8)

### DIFF
--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -2041,11 +2041,11 @@ static cmdResponseType getJointHomed(char *s, connectionRecType *context)
 static cmdResponseType getProgram(char *s, connectionRecType *context)
 {
   const char *pProgram = "PROGRAM %s";
-  
-//  snprintf(outBuf, sizeof(outBuf), pProgram, progName);
-//  printf("Program name = %s", emcStatus->task.file[0]);
+
   if (emcStatus->task.file[0] != 0)
     snprintf(context->outBuf, sizeof(context->outBuf), pProgram, emcStatus->task.file);
+  else
+    snprintf(context->outBuf, sizeof(context->outBuf), pProgram, "NONE");
   return rtNoError;
 }
 


### PR DESCRIPTION
a duplicate of this PR: https://github.com/LinuxCNC/linuxcnc/pull/2152 .... targetted to 2.8 as suggested by @andypugh 

I forked the 2.8 branch of `LinuxCNC/linuxcnc` and applied the same change.

---- 

I found the following bug while using `linuxcncrsh`. `get program` does not return `none` if no program is open.

The behavior of `get program` when no program is open is documented as:

```
program
With get, returns the name of the currently opened program, or "none".
```

see:
- https://linuxcnc.org/docs/html/man/man1/linuxcncrsh.1.html
- https://github.com/LinuxCNC/linuxcnc/blob/8afe6e42325af758ff51c238a72b0e89fa25caf2/src/emc/usr_intf/emcrsh.cc#L319

It appears this bug has been present since `emcrsh.cc` was first committed:

https://github.com/LinuxCNC/linuxcnc/blob/bf277a0dd70f9251e2f8150559bdfe613468269d/src/emc/usr_intf/emcrsh.cc#L4140

**steps to reproduce**:
- run a linuxcnc program with `linuxcncrsh`
- connect via telnet & init session
- reference:
    - https://github.com/LinuxCNC/linuxcnc/blob/master/tests/linuxcncrsh/test.sh#L29
    - https://linuxcnc.org/docs/html/man/man1/linuxcncrsh.1.html

`telnet <SOME_IP> 5007`

```
hello EMC adamlouis 1.1
set enable EMCTOO
```

- run `get program`
- run `get program`
- run `get program`
- run `get program`
- run `get estop` (or any other `get *` command `get machine`, get `get joint_pos`, etc)
- run `get program`
- run `get program`
- run `get program`
- run `get program`
- ...

**expected behavior**:

for all commands above:

- `get program` -> `PROGRAM NONE\r\n`
- `get estop` -> `ESTOP ON\r\n`

**actual behavior**:

`get program` --> `\r\n`
`get program` --> `\r\n\r\n`
`get program` --> `\r\n\r\n\r\n`
`get program` --> `\r\n\r\n\r\n`
`get estop` --> `ESTOP ON\r\n`
`get program` --> `ESTOP ON\r\n\r\n`
`get program` --> `ESTOP ON\r\n\r\n\r\n`
`get program` --> `ESTOP ON\r\n\r\n\r\n\r\n`
`get program` --> `ESTOP ON\r\n\r\n\r\n\r\n\r\n`

- `get program` returns the previously executed `get *` command (except at the start, when no other `get` has been run)
- each time `get program` is run while no program is open, an additional new line is added to the response

---

In #2152, @andypugh said:

> This looks like an obvious bug and I think it should be targetted to 2.8 and then merged up.
(I tried just changing the bae here, but it didn't have the required effect)