### PR TITLE
matrixkins: Add calibrated 3-axis kinematics HAL component

### DIFF
--- a/docs/man/man9/kins.9
+++ b/docs/man/man9/kins.9
@@ -22,6 +22,8 @@ For additional information, see the Documents 'Advanced Topics':
 .PP
 .B loadrt lineardeltakins (see separate manpage)
 .PP
+.B loadrt matrixkins
+.PP
 .B loadrt maxkins
 .PP
 .B loadrt pentakins
@@ -320,6 +322,10 @@ https://w.wiki/NcY
 .TP
 .B genserkins.D\-\fIN
 Parameters describing the \fIN\fRth joint's geometry.
+
+.SS matrixkins \- Calibrated kinematics for 3-axis cartesian machines
+Similar to trivkins, but allows calibrating out small imperfections in axis
+alignment. See matrixkins(9) man page for detailed instructions.
 
 .SS maxkins \- 5-axis kinematics example
 Kinematics for Chris Radek's tabletop 5 axis mill named 'max' with tilting

--- a/src/hal/components/matrixkins.comp
+++ b/src/hal/components/matrixkins.comp
@@ -1,0 +1,320 @@
+//   This is a component for LinuxCNC HAL
+//   Copyright 2022 Petteri Aimonen <jpa at git.mail.kapsi.fi>
+//
+//   This program is free software; you can redistribute it and/or
+//   modify it under the terms of version 2 of the GNU General
+//   Public License as published by the Free Software Foundation.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with this program; if not, write to the Free Software
+//   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+component matrixkins "Calibrated kinematics for 3-axis machines";
+
+description
+"""
+The matrixkins component implements custom kinematics for 3-axis
+Cartesian machines that allows compensating minor alignment inaccuracies
+in software.
+
+\\fBKINEMATICS MODEL:\\fR
+
+By default identity matrix is used, which is equal to trivial kinematics:
+
+.nf
+| X_joint |   | 1 0 0 |   | X_axis |
+| Y_joint | = | 0 1 0 | * | Y_axis |
+| Z_joint |   | 0 0 1 |   | Z_axis |
+.fi
+
+Adjusting the calibration matrix allows compensating out many
+mechanical issues, including:
+
+  1. Scale error of each axis.
+  2. Perpendicularity between each pair of axes.
+  3. Parallelism between spindle rotational axis and Z movement.
+  4. Perpendicularity between spindle rotational axis and X/Y movement.
+
+The matrix coefficients are set by parameters C_xx .. C_zz.
+For 3 axis machine, the equations become:
+
+.nf
+X_joint = C_xx * X_axis + C_xy * Y_axis + C_xz * Z_axis
+Y_joint = C_yx * X_axis + C_yy * Y_axis + C_yz * Z_axis
+Z_joint = C_zx * X_axis + C_zy * Y_axis + C_zz * Z_axis
+.fi
+
+If the machine has more than 3 axes, the rest are passed through
+without adjustment.
+
+\\fBCALIBRATION INSTRUCTIONS:\\fR
+
+For a 3 axis milling machine, the following process can be used to accurately
+measure and compensate the mechanical alignment.
+
+Tools required:
+
+  1. Dial indicator that can be mounted on spindle.
+  2. Straight rod that can be mounted on spindle.
+  3. Calipers.
+
+Process:
+
+\\fB1. Head tramming\\fR
+
+Mechanically tram the spindle to the table surface as well as you can.
+The perpendicularity of spindle vs. table cannot be compensated in software,
+and the spindle axis will act as the reference for all further steps.
+
+You can measure the perpendicularity by mounting the dial indicator on
+the spindle. Search for "mill tramming" online for detailed process.
+
+\\fB2. X and Y axis squaring\\fR
+
+Cut octagon out of some rigid material. It is best to cut a roughing path
+first and a thin finishing pass last, to get the best accuracy. Make the
+octagon as large as your calipers can measure. Before unmounting the
+workpiece, mark the X and Y directions on it.
+
+Measure width along X and Y axes. If your axis scales are set correctly,
+they should be identical. If they are not, you can adjust c[0] and c[4] to
+compensate. Note that endmill diameter will affect the actual dimensions
+of the test octagon, but not the ratio between sides.
+
+Measure width along both diagonals.
+If the X and Y axes are square to each other, the readings should be identical.
+
+To compensate, set
+C_xy = (B^2 - A^2) / (2 * A * B)
+where A is the diagonal in X+/Y+ direction and B is the diagonal in X+/Y- direction.
+
+This adjusts Y axis direction while keeping X axis as it was.
+Alternatively you can set C_yx to adjust X axis instead.
+The choice affects alignment with respect to e.g. table slots.
+
+\\fB3. X axis squaring to spindle\\fR
+
+Mount the dial indicator so that it rotates around the spindle axis, like in tramming measurement.
+Mark a spot on the table where the indicator touches when it is in positive X direction from spindle center.
+Zero the dial indicator.
+
+Rotate dial indicator 180 degrees around the spindle.
+Move X axis in positive direction until the indicator touches the same spot.
+Ideally indicator reads 0 again.
+
+To compensate, set
+C_zx = D / X
+where D is the new dial indicator reading, and X is the length moved along X axis.
+
+\\fB4. Y axis squaring to spindle\\fR
+
+Same as step 3, except move the machine in positive Y direction.
+
+To compensate, set
+C_zy = D / Y
+where D is the new dial indicator reading, and Y is the length moved.
+
+\\fB5. Z axis parallelism to spindle in X direction\\fR
+
+Mount straight rod to the spindle.
+Position dial indicator so that it measures horizontally against the positive X side of the rod, close to the spindle.
+
+Spin the spindle by hand to see if there is any runout.
+Zero the dial indicator at the midway position.
+
+Raise Z axis until dial indicator measures close to the bottom end of the rod.
+Spin the spindle by hand and take note of the midway value.
+
+Set
+C_xz = - X / Z
+where X is the dial indicator difference between bottom and top and Z is the amount you raised the Z axis.
+
+\\fB6. Z axis parallelism to spindle in Y direction\\fR
+
+Same as step 5, except measure on the positive Y side of the rod.
+
+Set
+C_yz = - Y / Z
+where Z is the dial indicator difference and Z is the amount you raised the Z axis.
+
+\\fBCONFIGURATION FILES:\\fR
+
+Specify matrixkins in LinuxCNC INI file as:
+
+.nf
+\\fB[KINS]\\fR
+\\fBKINEMATICS=matrixkins\\fR
+.fi
+
+In your HAL configuration file, set the parameters C_xx .. C_zz:
+
+.nf
+\\fB setp matrixkins.C_xx 1 \\fR  # X axis scale
+\\fB setp matrixkins.C_xy 0 \\fR  # Skew Y axis towards X axis
+\\fB setp matrixkins.C_xz 0 \\fR  # Skew Z axis towards X axis
+\\fB setp matrixkins.C_yx 0 \\fR  # Skew X axis towards Y axis
+\\fB setp matrixkins.C_yy 1 \\fR  # Y axis scale
+\\fB setp matrixkins.C_yz 0 \\fR  # Skew Z axis towards Y axis
+\\fB setp matrixkins.C_zx 0 \\fR  # Skew X axis towards Z axis
+\\fB setp matrixkins.C_zy 0 \\fR  # Skew Y axis towards Z axis
+\\fB setp matrixkins.C_zz 1 \\fR  # Z axis scale
+.fi
+
+The parameters can be modified during runtime using halcmd.
+To avoid sudden movements, it is better to turn off machine power before changes.
+
+If recalibration is performed with already existing calibration being in effect,
+the adjustment values should be added to the old values instead of replacing them.
+
+""";
+see_also "kins(9)";
+pin out bit dummy=1; // halcompile requires at least one pin
+license "GPL";
+;;
+
+static struct haldata {
+    hal_float_t C_xx;
+    hal_float_t C_xy;
+    hal_float_t C_xz;
+    hal_float_t C_yx;
+    hal_float_t C_yy;
+    hal_float_t C_yz;
+    hal_float_t C_zx;
+    hal_float_t C_zy;
+    hal_float_t C_zz;
+} *haldata;
+
+static int userkins_setup(void) {
+    int res=0;
+    int comp_id;
+    // this name must be different than the comp name:
+    comp_id = hal_init("matrixkinsdata");
+    if (comp_id < 0) goto error;
+    haldata = hal_malloc(sizeof(struct haldata));
+    if (!haldata) goto error;
+
+    res |= hal_param_float_new("matrixkins.C_xx", HAL_RW, &haldata->C_xx, comp_id);
+    res |= hal_param_float_new("matrixkins.C_xy", HAL_RW, &haldata->C_xy, comp_id);
+    res |= hal_param_float_new("matrixkins.C_xz", HAL_RW, &haldata->C_xz, comp_id);
+    res |= hal_param_float_new("matrixkins.C_yx", HAL_RW, &haldata->C_yx, comp_id);
+    res |= hal_param_float_new("matrixkins.C_yy", HAL_RW, &haldata->C_yy, comp_id);
+    res |= hal_param_float_new("matrixkins.C_yz", HAL_RW, &haldata->C_yz, comp_id);
+    res |= hal_param_float_new("matrixkins.C_zx", HAL_RW, &haldata->C_zx, comp_id);
+    res |= hal_param_float_new("matrixkins.C_zy", HAL_RW, &haldata->C_zy, comp_id);
+    res |= hal_param_float_new("matrixkins.C_zz", HAL_RW, &haldata->C_zz, comp_id);
+
+    haldata->C_xx = haldata->C_yy = haldata->C_zz = 1.0;
+    haldata->C_xy = haldata->C_xz = 0.0;
+    haldata->C_yx = haldata->C_yz = 0.0;
+    haldata->C_zx = haldata->C_zy = 0.0;
+
+    if (res) goto error;
+    hal_ready(comp_id);
+    rtapi_print("*** %s setup ok\n",__FILE__);
+    return 0;
+error:
+    rtapi_print("\n!!! %s setup failed res=%d\n\n",__FILE__,res);
+    return -1;
+}
+
+#include "kinematics.h"
+#include "emcmotcfg.h"
+
+KINS_NOT_SWITCHABLE
+EXPORT_SYMBOL(kinematicsType);
+EXPORT_SYMBOL(kinematicsInverse);
+EXPORT_SYMBOL(kinematicsForward);
+
+KINEMATICS_TYPE kinematicsType()
+{
+static bool is_setup=0;
+    if (!is_setup) userkins_setup();
+    return KINEMATICS_BOTH;
+}
+
+int kinematicsForward(const double *j,
+                      EmcPose * pos,
+                      const KINEMATICS_FORWARD_FLAGS * fflags,
+                      KINEMATICS_INVERSE_FLAGS * iflags)
+{
+    // For forward kinematics (joint to axis position) we
+    // need the inverse of the 3x3 matrix.
+    //
+    // Refer to e.g.
+    // https://ardoris.wordpress.com/2008/07/18/general-formula-for-the-inverse-of-a-3x3-matrix/
+    // https://en.wikipedia.org/wiki/Invertible_matrix#Inversion_of_3_%C3%97_3_matrices
+
+    double a = haldata->C_xx;
+    double b = haldata->C_xy;
+    double c = haldata->C_xz;
+    double d = haldata->C_yx;
+    double e = haldata->C_yy;
+    double f = haldata->C_yz;
+    double g = haldata->C_zx;
+    double h = haldata->C_zy;
+    double i = haldata->C_zz;
+
+    double det = a * (e * i - f * h)
+               - b * (d * i - f * g)
+               + c * (d * h - e * g);
+    double invdet = 1.0 / det;
+
+    // Apply inverse matrix transform to the 3 cartesian coordinates
+    pos->tran.x = invdet * ( (e * i - f * h) * j[0]
+                            +(c * h - b * i) * j[1]
+                            +(b * f - c * e) * j[2]);
+
+    pos->tran.y = invdet * ( (f * g - d * i) * j[0]
+                            +(a * i - c * g) * j[1]
+                            +(c * d - a * f) * j[2]);
+
+    pos->tran.z = invdet * ( (d * h - e * g) * j[0]
+                            +(b * g - a * h) * j[1]
+                            +(a * e - b * d) * j[2]);
+
+    // Pass rest of axes as identity
+    if (EMCMOT_MAX_JOINTS > 3) pos->a = j[3];
+    if (EMCMOT_MAX_JOINTS > 4) pos->b = j[4];
+    if (EMCMOT_MAX_JOINTS > 5) pos->c = j[5];
+    if (EMCMOT_MAX_JOINTS > 6) pos->u = j[6];
+    if (EMCMOT_MAX_JOINTS > 7) pos->v = j[7];
+    if (EMCMOT_MAX_JOINTS > 8) pos->w = j[8];
+
+    return 0;
+}
+
+int kinematicsInverse(const EmcPose * pos,
+                      double *j,
+                      const KINEMATICS_INVERSE_FLAGS * iflags,
+                      KINEMATICS_FORWARD_FLAGS * fflags)
+{
+    double a = haldata->C_xx;
+    double b = haldata->C_xy;
+    double c = haldata->C_xz;
+    double d = haldata->C_yx;
+    double e = haldata->C_yy;
+    double f = haldata->C_yz;
+    double g = haldata->C_zx;
+    double h = haldata->C_zy;
+    double i = haldata->C_zz;
+
+    // Apply matrix transform to the 3 cartesian coordinates
+    j[0] = pos->tran.x * a + pos->tran.y * b + pos->tran.z * c;
+    j[1] = pos->tran.x * d + pos->tran.y * e + pos->tran.z * f;
+    j[2] = pos->tran.x * g + pos->tran.y * h + pos->tran.z * i;
+
+    // Pass rest of axes as identity
+    if (EMCMOT_MAX_JOINTS > 3) j[3] = pos->a;
+    if (EMCMOT_MAX_JOINTS > 4) j[4] = pos->b;
+    if (EMCMOT_MAX_JOINTS > 5) j[5] = pos->c;
+    if (EMCMOT_MAX_JOINTS > 6) j[6] = pos->u;
+    if (EMCMOT_MAX_JOINTS > 7) j[7] = pos->v;
+    if (EMCMOT_MAX_JOINTS > 8) j[8] = pos->w;
+
+    return 0;
+}

--- a/src/hal/components/matrixkins.comp
+++ b/src/hal/components/matrixkins.comp
@@ -189,12 +189,15 @@ static struct haldata {
     hal_float_t C_zz;
 } *haldata;
 
-static int userkins_setup(void) {
+static int matrixkins_setup(void) {
     int res=0;
-    int comp_id;
-    // this name must be different than the comp name:
-    comp_id = hal_init("matrixkinsdata");
+
+    // inherit comp_id from rtapi_main()
     if (comp_id < 0) goto error;
+
+    res = hal_set_unready(comp_id);
+    if (res) goto error;
+
     haldata = hal_malloc(sizeof(struct haldata));
     if (!haldata) goto error;
 
@@ -214,7 +217,10 @@ static int userkins_setup(void) {
     haldata->C_zx = haldata->C_zy = 0.0;
 
     if (res) goto error;
-    hal_ready(comp_id);
+
+    res = hal_ready(comp_id);
+    if (res) goto error;
+
     rtapi_print("*** %s setup ok\n",__FILE__);
     return 0;
 error:
@@ -232,8 +238,8 @@ EXPORT_SYMBOL(kinematicsForward);
 
 KINEMATICS_TYPE kinematicsType()
 {
-static bool is_setup=0;
-    if (!is_setup) userkins_setup();
+    static bool is_setup=0;
+    if (!is_setup) matrixkins_setup();
     return KINEMATICS_BOTH;
 }
 

--- a/tests/matrixkins/README
+++ b/tests/matrixkins/README
@@ -1,0 +1,2 @@
+Tests correct functioning of the matrixkins kinematics
+in both forward and backward direction.

--- a/tests/matrixkins/checkresult
+++ b/tests/matrixkins/checkresult
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0 # test failure is indicated by test.sh exit value

--- a/tests/matrixkins/core_sim.hal
+++ b/tests/matrixkins/core_sim.hal
@@ -1,0 +1,18 @@
+# core HAL config file for simulation
+
+loadrt [KINS]KINEMATICS
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[KINS]JOINTS
+
+# add motion controller functions to servo thread
+addf motion-command-handler servo-thread
+addf motion-controller servo-thread
+
+# create HAL signals for position commands from motion module
+# loop position commands back to motion module feedback
+net Xpos joint.0.motor-pos-cmd => joint.0.motor-pos-fb
+net Ypos joint.1.motor-pos-cmd => joint.1.motor-pos-fb
+net Zpos joint.2.motor-pos-cmd => joint.2.motor-pos-fb
+
+# estop loopback
+net estop-loop iocontrol.0.user-enable-out iocontrol.0.emc-enable-in
+

--- a/tests/matrixkins/test-ui.py
+++ b/tests/matrixkins/test-ui.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+import linuxcnc
+import hal
+
+import math
+import time
+import sys
+import subprocess
+import os
+import signal
+import glob
+import re
+
+def wait_for_linuxcnc_startup(status, timeout=10.0):
+
+    """Poll the Status buffer waiting for it to look initialized,
+    rather than just allocated (all-zero).  Returns on success, throws
+    RuntimeError on failure."""
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        status.poll()
+        if (status.angular_units == 0.0) \
+            or (status.axis_mask == 0) \
+            or (status.cycle_time == 0.0) \
+            or (status.exec_state != linuxcnc.EXEC_DONE) \
+            or (status.interp_state != linuxcnc.INTERP_IDLE) \
+            or (status.inpos == False) \
+            or (status.linear_units == 0.0) \
+            or (status.max_acceleration == 0.0) \
+            or (status.max_velocity == 0.0) \
+            or (status.program_units == 0.0) \
+            or (status.rapidrate == 0.0) \
+            or (status.state != linuxcnc.STATE_ESTOP) \
+            or (status.task_state != linuxcnc.STATE_ESTOP):
+            time.sleep(0.1)
+        else:
+            # looks good
+            return
+
+    # timeout, throw an exception
+    raise RuntimeError("Timeout")
+
+
+c = linuxcnc.command()
+s = linuxcnc.stat()
+e = linuxcnc.error_channel()
+h = hal.component("dummy")
+h.ready()
+
+# Wait for LinuxCNC to initialize itself so the Status buffer stabilizes.
+wait_for_linuxcnc_startup(s)
+
+# Because the kinematics is non-trivial, a homing is needed.
+# HOME_ABSOLUTE_ENCODER = 1 is used in the ini file.
+c.state(linuxcnc.STATE_ESTOP_RESET)
+c.state(linuxcnc.STATE_ON)
+c.home(0)
+c.home(1)
+c.home(2)
+c.wait_complete()
+
+def absdelta(a, b):
+    '''Maximum absolute difference between components of two coordinate points'''
+    return max(abs(a[i] - b[i]) for i in range(len(a)))
+
+def test_coordinate(target, expected):
+    '''Command LinuxCNC to go to 'target' position,
+    and check that actual joint positions given by inverse kinematics
+    match 'expected'. Also check that feedback position given by forward
+    kinematics matches the 'target' point.
+    '''
+    c.mode(linuxcnc.MODE_MDI)
+    c.mdi('G0 X%0.9f Y%0.9f Z%0.9f F1000' % target)
+    c.wait_complete()
+
+    # Read out resulting joint positions to verify kinematics is working correctly.
+    # The delay seems to be needed for trajectory to fully settle, otherwise there is
+    # about 1e-5 error between target and actual position.
+    time.sleep(0.05)
+    s.poll()
+    joints = s.joint_position[:3]
+    joints_feedback = s.joint_actual_position[:3]
+    coord_feedback = s.actual_position[:3]
+
+    print("Target location %s, joints %s, feedback %s" % (target, joints, coord_feedback))
+
+    # Accuracy limit is set to 1e-9 here.
+    # For practical purposes, a numerical accuracy of 1e-6 would be perfectly acceptable.
+    # Current implementation using doubles achieves about 1e-14 precision.
+    maxdelta = 1e-9
+
+    if absdelta(joints, expected) > maxdelta:
+        raise RuntimeError("Error in inverse kinematics: coordinates %s should give joint positions %s, got %s" %
+                           (target, expected, joints))
+
+    if absdelta(coord_feedback, target) > maxdelta:
+        raise RuntimeError("Error in forward kinematics: coordinates %s, feedback joints %s and coord %s" %
+                           (target, joints_feedback, coord_feedback))
+
+# Test the default identity transform
+test_coordinate((0, 0, 0), (0, 0, 0))
+test_coordinate((10, 20, 30), (10, 20, 30))
+test_coordinate((11, 12, 13), (11, 12, 13))
+
+# Test with axis scaling
+hal.set_p('matrixkins.C_xx', "0.99")
+hal.set_p('matrixkins.C_yy', "1.01")
+hal.set_p('matrixkins.C_zz', "1.05")
+test_coordinate((0, 0, 0), (0, 0, 0))
+test_coordinate((10, 20, 30), (10 * 0.99, 20 * 1.01, 30 * 1.05))
+test_coordinate((11, 12, 13), (11 * 0.99, 12 * 1.01, 13 * 1.05))
+hal.set_p('matrixkins.C_xx', "1.00")
+hal.set_p('matrixkins.C_yy', "1.00")
+hal.set_p('matrixkins.C_zz', "1.00")
+
+# Test with X axis skews
+hal.set_p('matrixkins.C_xy', "0.01")
+hal.set_p('matrixkins.C_xz', "0.03")
+test_coordinate((0, 0, 0), (0, 0, 0))
+test_coordinate((10, 20, 30), (10 + 20 * 0.01 + 30 * 0.03, 20, 30))
+test_coordinate((11, 12, 13), (11 + 12 * 0.01 + 13 * 0.03, 12, 13))
+hal.set_p('matrixkins.C_xy', "0.0")
+hal.set_p('matrixkins.C_xz', "0.0")
+
+# Test with Y axis skews
+hal.set_p('matrixkins.C_yx', "0.01")
+hal.set_p('matrixkins.C_yz', "0.03")
+test_coordinate((0, 0, 0), (0, 0, 0))
+test_coordinate((10, 20, 30), (10, 20 + 10 * 0.01 + 30 * 0.03, 30))
+test_coordinate((11, 12, 13), (11, 12 + 11 * 0.01 + 13 * 0.03, 13))
+hal.set_p('matrixkins.C_yx', "0.0")
+hal.set_p('matrixkins.C_yz', "0.0")
+
+# Test with Z axis skews
+hal.set_p('matrixkins.C_zx', "0.01")
+hal.set_p('matrixkins.C_zy', "0.03")
+test_coordinate((0, 0, 0), (0, 0, 0))
+test_coordinate((10, 20, 30), (10, 20, 30 + 0.01 * 10 + 0.03 * 20))
+test_coordinate((11, 12, 13), (11, 12, 13 + 0.01 * 11 + 0.03 * 12))
+hal.set_p('matrixkins.C_zx', "0.0")
+hal.set_p('matrixkins.C_zy', "0.0")
+
+sys.exit(0)
+

--- a/tests/matrixkins/test.ini
+++ b/tests/matrixkins/test.ini
@@ -1,0 +1,105 @@
+[EMC]
+# The version string for this INI file.
+VERSION = 1.1
+
+#DEBUG = 0x0
+DEBUG = 0xffffffff
+
+[DISPLAY]
+DISPLAY = ./test-ui.py
+
+[FILTER]
+#No Content
+
+[RS274NGC]
+PARAMETER_FILE = sim.var
+USER_M_PATH = ./subs
+
+[EMCMOT]
+EMCMOT = motmod
+COMM_TIMEOUT = 4.0
+BASE_PERIOD = 0
+SERVO_PERIOD = 1000000
+
+[TASK]
+TASK = milltask
+CYCLE_TIME = 0.001
+
+[HAL]
+HALUI = halui
+HALFILE = core_sim.hal
+
+[HALUI]
+#No Content
+
+[TRAJ]
+AXES =                  3
+COORDINATES =           X Y Z
+HOME =                  0 0 0
+LINEAR_UNITS =          mm
+ANGULAR_UNITS =         degree
+DEFAULT_LINEAR_VELOCITY =      10
+MAX_LINEAR_ACCELERATION =      1000
+MAX_LINEAR_VELOCITY =          100
+
+[EMCIO]
+EMCIO = io
+CYCLE_TIME = 0.100
+TOOL_TABLE = simpockets.tbl
+TOOL_CHANGE_QUILL_UP = 1
+RANDOM_TOOLCHANGER = 0
+
+[KINS]
+KINEMATICS = matrixkins
+JOINTS = 3
+
+[AXIS_X]
+MIN_LIMIT = -1000
+MAX_LIMIT = 1000
+MAX_VELOCITY = 100
+MAX_ACCELERATION = 1000
+
+[JOINT_0]
+TYPE =             LINEAR
+HOME =             0.000
+HOME_ABSOLUTE_ENCODER = 1
+MAX_VELOCITY =     100
+MAX_ACCELERATION = 1000
+BACKLASH =         0.000
+MIN_LIMIT =        -1000
+MAX_LIMIT =        1000
+FERROR =           0.001
+
+[AXIS_Y]
+MIN_LIMIT = -1000
+MAX_LIMIT = 1000
+MAX_VELOCITY = 100
+MAX_ACCELERATION = 1000
+
+[JOINT_1]
+TYPE =             LINEAR
+HOME =             0.000
+HOME_ABSOLUTE_ENCODER = 1
+MAX_VELOCITY =     100
+MAX_ACCELERATION = 1000
+BACKLASH =         0.000
+MIN_LIMIT =        -1000
+MAX_LIMIT =        1000
+FERROR =           0.001
+
+[AXIS_Z]
+MIN_LIMIT = -1000
+MAX_LIMIT = 1000
+MAX_VELOCITY = 100
+MAX_ACCELERATION = 1000
+
+[JOINT_2]
+TYPE =             LINEAR
+HOME =             0.000
+HOME_ABSOLUTE_ENCODER = 1
+MAX_VELOCITY =     100
+MAX_ACCELERATION = 1000
+BACKLASH =         0.000
+MIN_LIMIT =        -1000
+MAX_LIMIT =        1000
+FERROR =           0.001

--- a/tests/matrixkins/test.sh
+++ b/tests/matrixkins/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rm -f sim.var
+linuxcnc -r test.ini
+


### PR DESCRIPTION
This component allows calibrating away small axis alignment errors in 3-axis cartesian machines.

The component itself should be compatible with most machines.
Dual-axis gantry machine support might be worth adding, but I don't have such a machine myself.

I've documented a generic method that could be used to measure the calibration constants, but it may need adjustment based on machine types and tools available.