### PR TITLE
mb2hal: fix error when PIN_NAMES > 5

### DIFF
--- a/src/hal/user_comps/mb2hal/mb2hal_init.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_init.c
@@ -139,7 +139,7 @@ retCode parse_pin_names(const char * names_string, mb_tx_t *this_mb_tx)
         }
         if(name_count >= name_buf_size)
         {
-            name_count += NAME_ALLOC_SIZE;
+            name_buf_size += NAME_ALLOC_SIZE;
             name_ptrs = realloc(name_ptrs, sizeof(char *) * name_buf_size);
             if(name_ptrs == NULL)
             {


### PR DESCRIPTION
Do you guys agree that this was the intention of the author?

It increases the size of the buffer holding the pin names by steps of `NAME_ALLOC_SIZE` when more pins are defined.

Resolves #2162