### PR TITLE
Reintroduce translation links.

### DIFF
--- a/docs/src/index.tmpl
+++ b/docs/src/index.tmpl
@@ -88,6 +88,28 @@ function setup_page(){
   <img src="linuxcnc-logo-chips.png" alt="LinuxCNC Logo" width="175"/>
 </div>
 
+@TRANSLATIONS@
+<p>Translations:
+<a href="cs/">Czech</a>
+<a href="da/">Dansk</a>
+<a href="de/">Deutch</a>
+<a href="es/">Espa&ntilde;ol</a>
+<a href="fr/">Francés</a>
+<a href="hu/">Hungarian</a>
+<a href="it/">Italian</a>
+<a href="ka/">Georgian</a>
+<a href="nb/">Norsk bokm&aring;l</a>
+<a href="pt/">Portuguese</a>
+<a href="pt_BR/">Brazilian Portuguese</a>
+<a href="ru/">Russian</a>
+<a href="sk/">Slovak</a>
+<a href="tr/">Turkish</a>
+<a href="uk/">Ukrainian</a>
+<a href="vi/">Vietnamese</a>
+<a href="zh_CN/">中文</a>
+</p>
+@ENDTRANSLATIONS@
+
 <!-- <h3 align="center">LinuxCNC version <strong>@VERSION@</strong></h3>
 <h2>Documentation</h2> -->
 <h2>LinuxCNC version <strong>@VERSION@</strong> Documentation</h2>


### PR DESCRIPTION
This make translations easier to find on linuxcnc.org.