### PR TITLE
GMOCCAPY 3.4.1

### DIFF
--- a/docs/src/gui/gmoccapy.adoc
+++ b/docs/src/gui/gmoccapy.adoc
@@ -10,6 +10,7 @@
 :ini: {basebackend@docbook:'':ini}
 :hal: {basebackend@docbook:'':hal}
 :ngc: {basebackend@docbook:'':ngc}
+:css: {basebackend@docbook:'':css}
 
 == Introduction
 
@@ -425,6 +426,69 @@ You can control what is shown and what is hidden on the graphics screen by addin
 <G-code to be hidden>
 (PREVIEW,show)
 ----
+
+=== User Command File
+
+If a file ~/.gmoccapyrc exists, its contents are executed as Python source code just after
+the GUI is displayed. The details of what may be written in the ~/.gmoccapyrc are subject
+to change during the development cycle.
+
+A configuration-specific Python file may be specified with an INI file setting
+[source,{ini}]
+----
+[DISPLAY]
+USER_COMMAND_FILE=filename.py
+----
+If this file is specified, this file is sourced just after the AXIS GUI is displayed
+*instead* of ~/.gmoccapyrc.
+
+
+The following example changes the size of the vertical buttons and changes the order of buttons:
+.Example of .axisrc file
+-----
+self.widgets.vbtb_main.set_size_request(85,-1)
+BB_SIZE = (70, 70) # default = (90, 56)
+self.widgets.tbtn_estop.set_size_request(*BB_SIZE)
+self.widgets.tbtn_on.set_size_request(*BB_SIZE)
+self.widgets.rbt_manual.set_size_request(*BB_SIZE)
+self.widgets.rbt_mdi.set_size_request(*BB_SIZE)
+self.widgets.rbt_auto.set_size_request(*BB_SIZE)
+self.widgets.tbtn_setup.set_size_request(*BB_SIZE)
+self.widgets.tbtn_user_tabs.set_size_request(*BB_SIZE)
+self.widgets.btn_exit.set_size_request(*BB_SIZE)
+
+self.widgets.vbtb_main.remove(self.widgets.tbtn_setup)
+self.widgets.vbtb_main.remove(self.widgets.lbl_time)
+self.widgets.vbtb_main.add(self.widgets.tbtn_setup)
+self.widgets.vbtb_main.add(self.widgets.lbl_time)
+-----
+
+The widget names can the looked up in the /usr/share/gmoccapy.glade file
+
+=== User CSS File
+
+Similar to the User command file it's possible to influence the appearance by cascading style sheets (CSS).
+If a file ~/.gmoccapy_css exists, its contents are loaded into the stylesheet provider and are so beeing applied to the GUI.
+
+A configuration-specific CSS file may be specified with an INI file setting
+[source,{ini}]
+----
+[DISPLAY]
+USER_CSS_FILE=filename.css
+----
+If this file is specified, this file is used *instead* of ~/.gmoccapy_css.
+
+Information what can be controlled by CSS can be found here: link:https://docs.gtk.org/gtk3/css-overview.html[Overview of CSS in GTK]
+
+Here an example how the color of checked buttons can be set to yellow:
+.Example Yellow color for checked buttons
+[source,{css}]
+----
+button:checked {
+    background: rgba(250,230,0,0.8);
+}
+----
+
 
 == HAL Pins
 

--- a/src/emc/usr_intf/gmoccapy/getiniinfo.py
+++ b/src/emc/usr_intf/gmoccapy/getiniinfo.py
@@ -472,3 +472,9 @@ class GetIniInfo:
             print("**** GMOCCAPY GETINIINFO **** \nERROR getting machine units \n"
                   "please check [TRAJ] LINEAR_UNITS for a valid entry, found {0}".format(units))
             return None
+
+    def get_user_command_file(self):
+        temp = self.inifile.find("DISPLAY", "USER_COMMAND_FILE")
+        if temp:
+            print("**** USER_COMMAND_FILE = " + temp)
+        return temp

--- a/src/emc/usr_intf/gmoccapy/getiniinfo.py
+++ b/src/emc/usr_intf/gmoccapy/getiniinfo.py
@@ -478,3 +478,9 @@ class GetIniInfo:
         if temp:
             print("**** USER_COMMAND_FILE = " + temp)
         return temp
+
+    def get_user_css_file(self):
+        temp = self.inifile.find("DISPLAY", "USER_CSS_FILE")
+        if temp:
+            print("**** USER_CSS_FILE = " + temp)
+        return temp

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -7078,7 +7078,6 @@ F12 or $ key does the same</property>
                 <property name="homogeneous">True</property>
                 <child>
                   <object class="GtkButton" id="btn_delete">
-                    <property name="label" translatable="yes">delete MDI</property>
                     <property name="use_action_appearance">False</property>
                     <property name="width_request">90</property>
                     <property name="height_request">56</property>
@@ -7089,6 +7088,15 @@ F12 or $ key does the same</property>
                     <property name="halign">center</property>
                     <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_delete_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Delete
+MDI history</property>
+                        <property name="justify">center</property>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -6292,13 +6292,15 @@ to test your settings.</property>
                 <child>
                   <object class="GtkToggleButton" id="tbtn_estop">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Estop the machine
 [F1]</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_emergency</property>
                     <signal name="toggled" handler="on_tbtn_estop_toggled" swapped="no"/>
                   </object>
@@ -6311,13 +6313,15 @@ to test your settings.</property>
                 <child>
                   <object class="GtkToggleButton" id="tbtn_on">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Turn the machine on/off
 [F2]</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_machine_off</property>
                     <signal name="toggled" handler="on_tbtn_on_toggled" swapped="no"/>
                   </object>
@@ -6330,13 +6334,15 @@ to test your settings.</property>
                 <child>
                   <object class="GtkRadioButton" id="rbt_manual">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">enter manual mode to jog axis by hand or touch off
 [F3]</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_manual</property>
                     <property name="active">True</property>
                     <property name="draw_indicator">False</property>
@@ -6353,13 +6359,15 @@ to test your settings.</property>
                 <child>
                   <object class="GtkRadioButton" id="rbt_mdi">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">enter MDI mode to launch G-code commands
 [F5]</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_mdi</property>
                     <property name="draw_indicator">False</property>
                     <property name="group">rbt_auto</property>
@@ -6375,12 +6383,14 @@ to test your settings.</property>
                 <child>
                   <object class="GtkRadioButton" id="rbt_auto">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">enter auto mode to run programs</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_auto</property>
                     <property name="draw_indicator">False</property>
                     <signal name="pressed" handler="on_rbt_auto_pressed" swapped="no"/>
@@ -6395,12 +6405,14 @@ to test your settings.</property>
                 <child>
                   <object class="GtkToggleButton" id="tbtn_setup">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Enter the settings page, the default code is "123"</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_settings</property>
                     <signal name="toggled" handler="on_tbtn_setup_toggled" swapped="no"/>
                   </object>
@@ -6413,12 +6425,14 @@ to test your settings.</property>
                 <child>
                   <object class="GtkToggleButton" id="tbtn_user_tabs">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">show user tabs</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_user_tabs</property>
                     <signal name="toggled" handler="on_tbtn_user_tabs_toggled" swapped="no"/>
                   </object>
@@ -6458,6 +6472,7 @@ Date</property>
         </child>
         <child>
           <object class="GtkNotebook" id="ntb_button">
+            <property name="height_request">62</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="show_tabs">False</property>
@@ -6471,12 +6486,14 @@ Date</property>
                 <child>
                   <object class="GtkButton" id="btn_homing">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">open homing button list</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_ref_menu</property>
                     <signal name="clicked" handler="on_btn_homing_clicked" swapped="no"/>
                   </object>
@@ -6489,12 +6506,14 @@ Date</property>
                 <child>
                   <object class="GtkButton" id="btn_touch">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">open touch off button list</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_touch_off</property>
                     <signal name="clicked" handler="on_btn_touch_clicked" swapped="no"/>
                   </object>
@@ -6506,7 +6525,7 @@ Date</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_0">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -6520,12 +6539,14 @@ Date</property>
                 <child>
                   <object class="GtkButton" id="btn_tool">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Open the tooleditor page</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_tools</property>
                     <property name="image_position">top</property>
                     <signal name="clicked" handler="on_btn_tool_clicked" swapped="no"/>
@@ -6538,7 +6559,7 @@ Date</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_1">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -6551,7 +6572,7 @@ Date</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_2">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -6567,13 +6588,15 @@ Date</property>
                     <property name="label" translatable="yes">World
 Mode</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Switch motion mode between Joint and World mode
 F12 or $ key does the same</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="toggled" handler="on_tbtn_switch_mode_toggled" swapped="no"/>
                   </object>
                   <packing>
@@ -6584,7 +6607,7 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_replace_mode_btn">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -6597,7 +6620,7 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_3">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -6611,12 +6634,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkToggleButton" id="tbtn_fullsize_preview0">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">make the preview as large as possible</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_fullsize_preview0_open</property>
                     <signal name="toggled" handler="on_tbtn_fullsize_preview_toggled" swapped="no"/>
                   </object>
@@ -6629,12 +6654,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_exit">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Close gmoccapy / leave the program</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_close</property>
                     <signal name="clicked" handler="on_btn_exit_clicked" swapped="no"/>
                   </object>
@@ -6718,12 +6745,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_load">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Load a new program</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_open</property>
                     <signal name="clicked" handler="on_btn_load_clicked" swapped="no"/>
                   </object>
@@ -6736,11 +6765,13 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_reload">
                     <property name="related_action">hal_action_reload</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="use_underline">True</property>
                     <child>
                       <object class="GtkImage" id="img_reload1">
@@ -6759,12 +6790,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_run">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Run the loaded program</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_run</property>
                     <signal name="clicked" handler="on_btn_run_clicked" swapped="no"/>
                   </object>
@@ -6777,12 +6810,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_stop">
                     <property name="related_action">hal_action_stop</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Stop the running program</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_stop</property>
                     <signal name="clicked" handler="on_btn_stop_clicked" swapped="no"/>
                   </object>
@@ -6795,12 +6830,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkToggleButton" id="tbtn_pause">
                     <property name="related_action">hal_tgl_pause</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Pause the running program</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_pause</property>
                     <signal name="toggled" handler="on_tbtn_pause_toggled" swapped="no"/>
                   </object>
@@ -6813,12 +6850,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_step">
                     <property name="related_action">hal_action_step</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Run the  loaded program step by step</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_step</property>
                   </object>
                   <packing>
@@ -6830,12 +6869,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_from_line">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">run the program from a certain line, attention, that is dangerous, because the previous lines will not checked!</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_run_from</property>
                     <signal name="clicked" handler="on_btn_from_line_clicked" swapped="no"/>
                   </object>
@@ -6848,12 +6889,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkToggleButton" id="tbtn_optional_blocks">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Machine or not the optional blocks of the program. If the button is pressed, the optional blocks will not be machined. The button will indicate this by a yellow background.</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_skip_optional_inactive</property>
                     <signal name="toggled" handler="on_tbtn_optional_blocks_toggled" swapped="no"/>
                   </object>
@@ -6866,11 +6909,13 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkToggleButton" id="tbtn_fullsize_preview1">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_fullsize_preview1_open</property>
                     <signal name="toggled" handler="on_tbtn_fullsize_preview_toggled" swapped="no"/>
                   </object>
@@ -6883,12 +6928,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_edit">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Edit the loaded program</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_editor</property>
                     <signal name="clicked" handler="on_btn_edit_clicked" swapped="no"/>
                   </object>
@@ -7033,12 +7080,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_delete">
                     <property name="label" translatable="yes">delete MDI</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">delete MDI history</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_delete_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7049,7 +7098,7 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_4">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7062,7 +7111,7 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_version">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7078,7 +7127,7 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_5">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7093,12 +7142,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_classicladder">
                     <property name="label" translatable="yes">Cl.-ladder</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Open classicladder</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_classicladder_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7111,12 +7162,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_hal_scope">
                     <property name="label" translatable="yes">Hal-Scope</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">launch hal scope</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_hal_scope_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7129,12 +7182,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_status">
                     <property name="label" translatable="yes">Status</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">launch linuxcnc status</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_status_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7147,12 +7202,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_hal_meter">
                     <property name="label" translatable="yes">Hal Meter</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">launch hal meter</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="xalign">0.51999998092651367</property>
                     <signal name="clicked" handler="on_btn_hal_meter_clicked" swapped="no"/>
                   </object>
@@ -7166,12 +7223,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_calibration">
                     <property name="label" translatable="yes">Calibration</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">launch calibration</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_calibration_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7184,12 +7243,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_show_hal">
                     <property name="label" translatable="yes">Halshow</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">opens the show hal tool</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_show_hal_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7221,7 +7282,7 @@ F12 or $ key does the same</property>
                 <property name="homogeneous">True</property>
                 <child>
                   <object class="GtkLabel" id="lbl_space_6">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7235,9 +7296,13 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_reload_edit">
                     <property name="related_action">hal_action_reload</property>
+                    <property name="width_request">90</property>
+                    <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_edit_menu_reload</property>
                     <property name="use_underline">True</property>
                   </object>
@@ -7250,10 +7315,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_save">
                     <property name="related_action">hal_action_save</property>
+                    <property name="width_request">90</property>
+                    <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">save the file using the original name</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_edit_menu_save</property>
                   </object>
                   <packing>
@@ -7265,12 +7334,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_save_as">
                     <property name="related_action">hal_action_saveas</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">save the file with a new name</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_edit_menu_save_as</property>
                   </object>
                   <packing>
@@ -7281,7 +7352,7 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_7">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7294,7 +7365,7 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_8">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7308,12 +7379,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_new">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">clear the edit field and make a new file</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_edit_menu_new</property>
                     <signal name="clicked" handler="on_btn_new_clicked" swapped="no"/>
                   </object>
@@ -7325,7 +7398,7 @@ F12 or $ key does the same</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_9">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7339,12 +7412,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_keyb">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">Show or hide the virtual keyboard</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_edit_menu_keyboard</property>
                     <signal name="clicked" handler="on_btn_show_kbd_clicked" swapped="no"/>
                   </object>
@@ -7357,12 +7432,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_back_edit">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">Go back to main button list</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_edit_menu_close</property>
                     <signal name="clicked" handler="on_btn_back_clicked" swapped="no"/>
                   </object>
@@ -7396,12 +7473,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_delete_tool">
                     <property name="label" translatable="yes">Delete</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">delete selected tool or tools</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_delete_tool_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7414,12 +7493,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_add_tool">
                     <property name="label" translatable="yes">Add</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">add a new tool to tool table</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_add_tool_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7432,12 +7513,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_reload_tooltable">
                     <property name="label" translatable="yes">Reload</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">reload tool table from file</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_reload_tooltable_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7450,12 +7533,14 @@ F12 or $ key does the same</property>
                   <object class="GtkButton" id="btn_apply_tool_changes">
                     <property name="label" translatable="yes">Apply</property>
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">apply the changes you made, G43 will be executed only if it is active G-code</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_apply_tool_changes_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -7467,12 +7552,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_select_tool_by_no">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Select a tool by number</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_select_tool_by_no_clicked" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="img_tool_by_no">
@@ -7490,12 +7577,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_index_tool">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">change tool with the command M61 Q?, no machine move will be done</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_selected_tool_clicked" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="img_index_tool">
@@ -7513,12 +7602,14 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_change_tool">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">change tool to the selected one</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_toolchange</property>
                     <signal name="clicked" handler="on_btn_selected_tool_clicked" swapped="no"/>
                   </object>
@@ -7531,13 +7622,15 @@ F12 or $ key does the same</property>
                 <child>
                   <object class="GtkButton" id="btn_tool_touchoff_x">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">touch off the tool and set the value to the tool table</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_tool_touchoff_clicked" swapped="no"/>
                     <child>
                       <object class="GtkLabel">
@@ -7557,7 +7650,7 @@ tool x</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_hide_tto_x">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7571,13 +7664,15 @@ tool x</property>
                 <child>
                   <object class="GtkButton" id="btn_tool_touchoff_z">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">touch off the tool and set the value to the tool table</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_tool_touchoff_clicked" swapped="no"/>
                     <child>
                       <object class="GtkLabel" id="btn_tool_touchoff_z_label">
@@ -7598,12 +7693,14 @@ tool z</property>
                 <child>
                   <object class="GtkButton" id="btn_back_tool">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Go back to main button list</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_back_tool</property>
                     <signal name="clicked" handler="on_btn_back_clicked" swapped="no"/>
                   </object>
@@ -7637,12 +7734,14 @@ tool z</property>
                 <child>
                   <object class="GtkButton" id="btn_home">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Move to your home directory</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_home</property>
                     <signal name="clicked" handler="on_btn_home_clicked" swapped="no"/>
                   </object>
@@ -7655,12 +7754,14 @@ tool z</property>
                 <child>
                   <object class="GtkButton" id="btn_dir_up">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Move to parent directory</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_dir_up</property>
                     <signal name="clicked" handler="on_btn_dir_up_clicked" swapped="no"/>
                   </object>
@@ -7672,7 +7773,7 @@ tool z</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_10">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7686,12 +7787,14 @@ tool z</property>
                 <child>
                   <object class="GtkButton" id="btn_sel_prev">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Select the previous file</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_sel_prev</property>
                     <property name="image_position">top</property>
                     <signal name="clicked" handler="on_btn_sel_prev_clicked" swapped="no"/>
@@ -7705,12 +7808,14 @@ tool z</property>
                 <child>
                   <object class="GtkButton" id="btn_sel_next">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Select the next file</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_sel_next</property>
                     <property name="image_position">top</property>
                     <signal name="clicked" handler="on_btn_sel_next_clicked" swapped="no"/>
@@ -7724,12 +7829,14 @@ tool z</property>
                 <child>
                   <object class="GtkButton" id="btn_jump_to">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Jump to user defined directory</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_jump_to</property>
                     <property name="image_position">top</property>
                     <signal name="clicked" handler="on_btn_jump_to_clicked" swapped="no"/>
@@ -7742,7 +7849,7 @@ tool z</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_11">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7756,12 +7863,14 @@ tool z</property>
                 <child>
                   <object class="GtkButton" id="btn_select">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">select the highlighted file and return the path</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_select</property>
                     <property name="image_position">top</property>
                     <signal name="clicked" handler="on_btn_select_clicked" swapped="no"/>
@@ -7774,7 +7883,7 @@ tool z</property>
                 </child>
                 <child>
                   <object class="GtkLabel" id="lbl_space_12">
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -7788,12 +7897,14 @@ tool z</property>
                 <child>
                   <object class="GtkButton" id="btn_back_file_load">
                     <property name="use_action_appearance">False</property>
-                    <property name="width_request">85</property>
+                    <property name="width_request">90</property>
                     <property name="height_request">56</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Close without returning a file path</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
                     <property name="image">img_back_file_load</property>
                     <signal name="clicked" handler="on_btn_back_clicked" swapped="no"/>
                   </object>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -155,10 +155,6 @@ class gmoccapy(object):
         gettext.install("gmoccapy", localedir=LOCALEDIR)
 
         # CSS styling
-        screen = Gdk.Screen.get_default()
-        provider = Gtk.CssProvider()
-        style_context = Gtk.StyleContext()
-        style_context.add_provider_for_screen(screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         css = b"""
             button {
                 padding: 0;
@@ -171,7 +167,11 @@ class gmoccapy(object):
                 padding: 8px;
             }
         """
+        screen = Gdk.Screen.get_default()
+        provider = Gtk.CssProvider()
         provider.load_from_data(css)
+        style_context = Gtk.StyleContext()
+        style_context.add_provider_for_screen(screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
         # needed components to communicate with hal and linuxcnc
         self.halcomp = hal.component("gmoccapy")
@@ -530,6 +530,28 @@ class gmoccapy(object):
                 print(tb, file=sys.stderr)
                 self.notification.add_message(_("Error in ") + rcfile + "\n" \
                     + _("Please check the console output."), ALERT_ICON)
+
+        # Custom css file, e.g.:
+        #     button:checked {
+        #         background: rgba(230,230,50,0.8);
+        #     }
+
+        css_file = "~/.gmoccapy_css"
+        user_css_file = self.get_ini_info.get_user_css_file()
+        if user_css_file:
+            css_file = user_css_file
+        css_file = os.path.expanduser(css_file)
+        if os.path.exists(css_file):
+            provider_custom = Gtk.CssProvider()
+            try:
+                provider_custom.load_from_path(css_file)
+                style_context.add_provider_for_screen(screen, provider_custom, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+            except:
+                tb = traceback.format_exc()
+                print(tb, file=sys.stderr)
+                self.notification.add_message(_("Error in ") + css_file + "\n" \
+                    + _("Please check the console output."), ALERT_ICON)
+
 
 
     def _get_ini_data(self):

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -516,6 +516,22 @@ class gmoccapy(object):
         cycle_time = self.get_ini_info.get_cycle_time()
         GLib.timeout_add( cycle_time, self._periodic )  # time between calls to the function, in milliseconds
 
+        # This allows sourcing an user defined file
+        rcfile = "~/.gmoccapyrc"
+        user_command_file = self.get_ini_info.get_user_command_file()
+        if user_command_file:
+            rcfile = user_command_file
+        rcfile = os.path.expanduser(rcfile)
+        if os.path.exists(rcfile):
+            try:
+                exec(compile(open(rcfile, "rb").read(), rcfile, 'exec'))
+            except:
+                tb = traceback.format_exc()
+                print(tb, file=sys.stderr)
+                self.notification.add_message(_("Error in ") + rcfile + "\n" \
+                    + _("Please check the console output."), ALERT_ICON)
+
+
     def _get_ini_data(self):
         self.get_ini_info = getiniinfo.GetIniInfo()
         # get the axis list from INI

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -101,7 +101,7 @@ _BB_LOAD_FILE = 8
 #_BB_HOME_JOINTS will not be used, we will reorder the notebooks to get the correct page shown
 
 # Default button size for bottom buttons
-_DEFAULT_BB_SIZE = (85, 56)
+_DEFAULT_BB_SIZE = (90, 56)
 
 _TEMPDIR = tempfile.gettempdir()  # Now we know where the tempdir is, usually /tmp
 
@@ -768,6 +768,8 @@ class gmoccapy(object):
     def _new_button_with_predefined_image(self, name, size, image = None, image_name = None):
         btn = Gtk.Button()
         btn.set_size_request(*size)
+        btn.set_halign(Gtk.Align.CENTER)
+        btn.set_valign(Gtk.Align.CENTER)
         btn.set_property("name", name)
         try:
             if image:
@@ -791,6 +793,8 @@ class gmoccapy(object):
         image.set_size_request(72,48)
         btn = Gtk.Button.new()
         btn.set_size_request(*_DEFAULT_BB_SIZE)
+        btn.set_halign(Gtk.Align.CENTER)
+        btn.set_valign(Gtk.Align.CENTER)
         btn.set_property("name", name)
         try:
             if filepath:
@@ -962,6 +966,9 @@ class gmoccapy(object):
         lbl.set_visible(True)
         lbl.set_justify(Gtk.Justification.CENTER)
         btn = Gtk.ToggleButton.new()
+        btn.set_size_request(*_DEFAULT_BB_SIZE)
+        btn.set_halign(Gtk.Align.CENTER)
+        btn.set_valign(Gtk.Align.CENTER)
         btn.add(lbl)
         btn.connect("toggled", self.on_tbtn_edit_offsets_toggled)
         btn.set_property("tooltip-text", _("Press to edit the offsets"))
@@ -1020,6 +1027,9 @@ class gmoccapy(object):
             lbl.show()
 
         btn = self.widgets.offsetpage1.wTree.get_object("zero_g92_button")
+        btn.set_size_request(*_DEFAULT_BB_SIZE)
+        btn.set_halign(Gtk.Align.CENTER)
+        btn.set_valign(Gtk.Align.CENTER)
         self.widgets.offsetpage1.buttonbox.remove(btn)
         btn.connect("clicked", self.on_btn_zero_g92_clicked)
         btn.set_property("tooltip-text", _("Press to reset all G92 offsets"))
@@ -1029,6 +1039,9 @@ class gmoccapy(object):
 
         if self.tool_measure_OK:
             btn = Gtk.Button.new_with_label(_(" Block\nHeight"))
+            btn.set_size_request(*_DEFAULT_BB_SIZE)
+            btn.set_halign(Gtk.Align.CENTER)
+            btn.set_valign(Gtk.Align.CENTER)
             btn.connect("clicked", self.on_btn_block_height_clicked)
             btn.set_property("tooltip-text", _("Press to enter new value for block height"))
             btn.set_property("name", "block_height")
@@ -1039,6 +1052,9 @@ class gmoccapy(object):
         lbl.set_visible(True)
         lbl.set_justify(Gtk.Justification.CENTER)
         btn = Gtk.Button.new()
+        btn.set_size_request(*_DEFAULT_BB_SIZE)
+        btn.set_halign(Gtk.Align.CENTER)
+        btn.set_valign(Gtk.Align.CENTER)
         btn.add(lbl)
         btn.connect("clicked", self._on_btn_set_selected_clicked)
         btn.set_property("tooltip-text", _("Press to set the selected coordinate system to be the active one"))
@@ -1253,6 +1269,8 @@ class gmoccapy(object):
             for direction in ["+","-"]:
                 name = "{0}{1}".format(str(axis), direction)
                 btn = Gtk.Button.new_with_label(name.upper())
+                btn.set_halign(Gtk.Align.CENTER)
+                btn.set_valign(Gtk.Align.CENTER)
                 btn.set_property("name", name)
                 btn.connect("pressed", self._on_btn_jog_pressed, name)
                 btn.connect("released", self._on_btn_jog_released, name)
@@ -1272,6 +1290,8 @@ class gmoccapy(object):
             for direction in ["+","-"]:
                 name = "{0}{1}".format(str(joint), direction)
                 btn = Gtk.Button.new_with_label(name.upper())
+                btn.set_halign(Gtk.Align.CENTER)
+                btn.set_valign(Gtk.Align.CENTER)
                 btn.set_property("name", name)
                 btn.connect("pressed", self._on_btn_jog_pressed, name)
                 btn.connect("released", self._on_btn_jog_released, name)
@@ -1328,6 +1348,9 @@ class gmoccapy(object):
                 if len(lbl) > 11:
                     lbl = lbl[0:10] + "\n" + lbl[11:20]
                 btn = Gtk.Button.new_with_label(lbl)
+                btn.set_size_request(*_DEFAULT_BB_SIZE)
+                btn.set_halign(Gtk.Align.CENTER)
+                btn.set_valign(Gtk.Align.CENTER)
                 btn.set_property("name","macro_{0}".format(pos))
             btn.set_property("tooltip-text", _("Press to run macro {0}".format(name)))
             btn.connect("clicked", self._on_btn_macro_pressed, name)

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -163,9 +163,6 @@ class gmoccapy(object):
                 padding: 3px;
                 margin: 1px;
             }
-            #notification_close {
-                padding: 8px;
-            }
         """
         screen = Gdk.Screen.get_default()
         provider = Gtk.CssProvider()

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -83,7 +83,7 @@ sys.excepthook = excepthook
 
 # constants
 #         # gmoccapy  #"
-_RELEASE = " 3.4.0"
+_RELEASE = " 3.4.1"
 _INCH = 0                         # imperial units are active
 _MM = 1                           # metric units are active
 

--- a/src/emc/usr_intf/gmoccapy/notification.py
+++ b/src/emc/usr_intf/gmoccapy/notification.py
@@ -114,7 +114,7 @@ class Notification(Gtk.Window):
         default_style = Gtk.Button().get_style_context()
         pixbuf = icon_theme_helper.load_symbolic_from_icon_theme(self.icon_theme, icon_name, self.icon_size, default_style)
         icon.set_from_pixbuf(pixbuf)
-        hbox.pack_start(icon, False, False, 0)
+        hbox.pack_start(icon, False, False, 3)
         label = Gtk.Label()
         label.set_line_wrap(True)
         label.set_line_wrap_mode(Pango.WrapMode.WORD_CHAR)
@@ -132,6 +132,7 @@ class Notification(Gtk.Window):
             label.set_markup(text)
         else:
             label.set_text(text)
+        label.set_xalign(0)
         hbox.pack_start(label, False, False, 0)
         btn_close = Gtk.Button()
         btn_close.set_name("notification_close")
@@ -307,8 +308,8 @@ def main():
     notification.icon_theme.append_search_path("../../../../share/gmoccapy/icons/") # relative from this file location
     notification.icon_theme.append_search_path("../share/gmoccapy/icons/")
     notification.icon_theme.append_search_path("/usr/share/gmoccapy/icons/")
-    # notification.icon_theme.set_custom_theme("classic")
-    notification.icon_theme.set_custom_theme("material")
+    notification.icon_theme.set_custom_theme("classic")
+    # notification.icon_theme.set_custom_theme("material")
     # notification.icon_theme.set_custom_theme("material-light")
     notification.add_message('This is a warning', 'dialog_warning')
     notification.add_message('Hallo World this is a long string that have a linebreak ', 'dialog_information')

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -1,6 +1,14 @@
-- fixed sensitizing of user tab button on toggling "edit offsets" (#2111)
-- fix error on creating new G-code file when RS274NGC_STARTUP_CODE is not set
-  (#2057)
+ver 3.4.1
+ 
+  New features:
+  - added possibility for sourcing an user defined file (rcfile)
+  - added option to use external CSS file
+
+  Fixes:
+  - some optical fixes (button properties, left align text in notification)
+  - fixed sensitizing of user tab button on toggling "edit offsets" (#2111)
+  - fix error on creating new G-code file when RS274NGC_STARTUP_CODE is not set
+    (#2057)
 
 ver 3.4.0
 


### PR DESCRIPTION
 New:
  - added possibility for sourcing an user command file (rcfile)
  - added option to use external CSS file
  - swapped position of settings button with user tabs button
  (more details about that in the docs-changes)
  
  Fixes:
  - some optical fixes (button properties, left align text in notification)
  - fixed sensitizing of user tab button on toggling "edit offsets" (#2111)
  - fix error on creating new G-code file when RS274NGC_STARTUP_CODE is not set
    (#2057)