### PR TITLE
Debian - netcat build deps

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -33,7 +33,7 @@ Build-Depends:
     libtirpc-dev,
     libusb-1.0-0-dev,
     libxmu-dev,
-    netcat,
+    netcat-traditional | netcat-openbsd | netcat,
     po4a,
     procps,
     psmisc,


### PR DESCRIPTION
Apparently the former netcat package was renamed to netcat-traditional (https://tracker.debian.org/pkg/netcat).