### PR TITLE
fix zombie detection problem with procps 4.0 (sid)

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -592,7 +592,7 @@ function KillTaskWithTimeout() {
     fi
     local NPROCS
     for KILL_PID in $KILL_PIDS ; do
-        if $PS -o comm= $KILL_PID | $GREP -q '<defunct>'; then
+        if $PS -o stat= -o comm= $KILL_PID | $GREP -q '^Z'; then
             echo "Skipping defunct task $KILL_TASK, PID=$KILL_PID" >>$PRINT_FILE
             continue
         fi
@@ -602,7 +602,7 @@ function KillTaskWithTimeout() {
 	# wait and see if it disappears
 	while [ $WAIT -gt 1 ] ; do
 	    # see if it's still alive
-            NPROCS=$($PS -o comm= $KILL_PID | $GREP -v '<defunct>' | wc -l)
+            NPROCS=$($PS -o stat= -o comm= $KILL_PID | $GREP -v '^Z' | wc -l)
             if [ $NPROCS -gt 0 ]; then
 		WAIT=$(($WAIT-1))
 		sleep .1
@@ -618,7 +618,7 @@ function KillTaskWithTimeout() {
 	    # wait and see if it disappears
 	    while [ $WAIT -gt 1 ] ; do
 		# see if it's still alive
-                NPROCS=$($PS -o comm= $KILL_PID | $GREP -v '<defunct>' | wc -l)
+                NPROCS=$($PS -o stat= -o comm= $KILL_PID | $GREP -v '^Z' | wc -l)
                 if [ $NPROCS -gt 0 ]; then
 		    WAIT=$(($WAIT-1))
 		    sleep .1

--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -116,7 +116,7 @@ CheckConfig(){
 CheckStatus(){
     case $RTPREFIX in
     uspace)
-        if [ -z "$($PS -o comm= -C rtapi_app | $GREP -v '<defunct>')" ]; then
+        if [ -z "$($PS -o stat= -o comm= -C rtapi_app | $GREP -v '^Z')" ]; then
             exit 1
         else
             exit 0
@@ -197,13 +197,13 @@ Unload(){
         START=$SECONDS
         local NPROCS
         while [ 5 -gt $((SECONDS-START)) ]; do
-            NPROCS=$(ps -C rtapi_app -o comm= | $GREP -v '<defunct>' | wc -l)
+            NPROCS=$(ps -C rtapi_app -o stat= -o comm= | $GREP -v '^Z' | wc -l)
             if [ $NPROCS -eq 0 ]; then
                 break
             fi
             sleep 0.1
         done
-        NPROCS=$(ps -C rtapi_app -o comm= | $GREP -v '<defunct>' | wc -l)
+        NPROCS=$(ps -C rtapi_app -o stat= -o comm= | $GREP -v '^Z' | wc -l)
         if [ $NPROCS -gt 0 ]; then
             echo "ERROR: rtapi_app failed to die" 1>&2
         fi


### PR DESCRIPTION
This makes our launcher scripts work with both procps 4 (sid) and procps 3 (bookworm and older).