### PR TITLE
Dropped duplicate HOME value from gmoccapy simulated config

### DIFF
--- a/configs/sim/gmoccapy/gmoccapy.ini
+++ b/configs/sim/gmoccapy/gmoccapy.ini
@@ -109,7 +109,6 @@ MAX_ACCELERATION = 1500.0
 
 [JOINT_0]
 TYPE =                          LINEAR
-HOME =                          0.000
 MAX_VELOCITY =                  166
 MAX_ACCELERATION =              1500.0
 BACKLASH = 0.000
@@ -137,7 +136,6 @@ MAX_ACCELERATION = 1500.0
 
 [JOINT_1]
 TYPE =                          LINEAR
-HOME =                          0.000
 MAX_VELOCITY =                  166
 MAX_ACCELERATION =              1500.0
 BACKLASH = 0.000
@@ -164,7 +162,6 @@ MAX_ACCELERATION = 1500.0
 
 [JOINT_2]
 TYPE =                          LINEAR
-HOME =                          0.0
 MAX_VELOCITY =                  166
 MAX_ACCELERATION =              1500.0
 BACKLASH = 0.000


### PR DESCRIPTION
This avoid error message from gmoccapy which is confused when it receive an array as the HOME value instead of a single value.

I kept the non-zero values, as the 0.00 values seem like some leftover default value.

Fixes #2210