### PR TITLE
debian: moved dep source-highlight to build-indep

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -70,7 +70,8 @@ elif [ -f /etc/lsb-release ]; then
 fi
 
 if [ -n "$ENABLE_BUILD_DOCUMENTATION" ]; then
-    DOC_DEPENDS="dblatex (>= 0.2.12),\n    dvipng,\n    graphviz,\n    groff,\n    inkscape,\n    python3-lxml,\n    w3c-linkchecker,\n    xsltproc,\n    texlive-extra-utils,\n    texlive-font-utils,\n    texlive-fonts-recommended,\n    texlive-lang-cyrillic,\n    texlive-lang-european,\n    texlive-lang-french,\n    texlive-lang-german,\n    texlive-lang-polish,\n    texlive-lang-spanish,\n    texlive-latex-recommended,\n    fonts-dejavu"
+    DOC_DEPENDS="dblatex (>= 0.2.12),\n    dvipng,\n    fonts-dejavu,\n    graphviz,\n    groff,\n    inkscape,\n    python3-lxml,\n    source-highlight,\n    texlive-extra-utils,\n    texlive-font-utils,\n    texlive-fonts-recommended,\n    texlive-lang-cyrillic,\n    texlive-lang-european,\n    texlive-lang-french,\n    texlive-lang-german,\n    texlive-lang-polish,\n    texlive-lang-spanish,\n    texlive-latex-recommended,\n    w3c-linkchecker,\n    xsltproc"
+    
 
     case $DISTRIB_NAME in
 	Debian-9)

--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -14,7 +14,6 @@ Build-Depends:
     asciidoc,
     ghostscript,
     imagemagick,
-    source-highlight,
     asciidoc-dblatex,
     autoconf,
     automake,


### PR DESCRIPTION
Asciidoc with its unfortunate bloating recommendation of dbLaTeX is needed for the man pages, but the source-highlighting is only performed for the full documentation. This does not change too much, had hope to achieve a bit more of a reduction, but better than nothing it is.