### PR TITLE
NML: include jjogmode when logging EMC_JOG commands

### DIFF
--- a/src/emc/nml_intf/emc.cc
+++ b/src/emc/nml_intf/emc.cc
@@ -980,6 +980,7 @@ void EMC_JOG_ABS::update(CMS * cms)
     EMC_JOG_CMD_MSG::update(cms);
     cms->update(pos);
     cms->update(vel);
+    cms->update(jjogmode);
 
 }
 
@@ -990,6 +991,7 @@ void EMC_JOG_STOP::update(CMS * cms)
 {
 
     EMC_JOG_CMD_MSG::update(cms);
+    cms->update(jjogmode);
 
 }
 
@@ -1314,6 +1316,7 @@ void EMC_JOG_CONT::update(CMS * cms)
 
     EMC_JOG_CMD_MSG::update(cms);
     cms->update(vel);
+    cms->update(jjogmode);
 
 }
 
@@ -2117,6 +2120,7 @@ void EMC_JOG_INCR::update(CMS * cms)
     EMC_JOG_CMD_MSG::update(cms);
     cms->update(incr);
     cms->update(vel);
+    cms->update(jjogmode);
 
 }
 


### PR DESCRIPTION
I'm really not a fan of CMS/RCS/NML, but replacing it with something modern, standard, and easier to use will be a huge task.