### PR TITLE
task: fail if the user's requested interp can't be loaded

### DIFF
--- a/src/emc/task/emctask.cc
+++ b/src/emc/task/emctask.cc
@@ -443,6 +443,10 @@ int emcTaskPlanInit()
 	if((inistring = inifile.Find("INTERPRETER", "TASK"))) {
 	    pinterp = interp_from_shlib(inistring);
 	    fprintf(stderr, "interp_from_shlib() -> %p\n", pinterp);
+            if (!pinterp) {
+                fprintf(stderr, "failed to load [TASK]INTERPRETER (%s)\n", inistring);
+                return -1;
+            }
 	}
         inifile.Close();
     }


### PR DESCRIPTION
The INI file may override which interpreter Task uses, via [TASK]INTERPRETER.

Before this commit, if the user's specified interpreter failed to load, Task would log a warning but then fall back to using the default interp and continue.

After this commit, if the user's specified interpreter fails to load, Task refuses to start.