### PR TITLE
halcompile: Add command line arguments to provide compile and link flags

### DIFF
--- a/docs/src/hal/comp.adoc
+++ b/docs/src/hal/comp.adoc
@@ -272,15 +272,25 @@ parameters, and functions for `prefix`.
   Its return type is 'void'; it may call 'exit()' if it wishes to terminate rather than create a HAL component
   (e.g., because the commandline arguments were invalid).
 
-* 'option extra_link_args "..."' - (default: "") +
-  This option is ignored if the option 'userspace' (see above) is set to 'no'.
-  When linking a userspace component, the arguments given are inserted in the link line.
-  Note that because compilation takes place in a temporary directory,
-  "-L." refers to the temporary directory and not the directory where the .comp source file resides.
+* 'option extra_link_args "..."' - (default: "")
+   This option is ignored if the option 'userspace' (see above) is set to
+   'no'.  When linking a userspace component, the arguments given are inserted
+   in the link line.  Note that because compilation takes place in a temporary
+   directory, "-L." refers to the temporary directory and not the directory where
+   the .comp source file resides.
+   This option can be set in the halcompile command-line with
+   --extra-link-args="-L.....". This alternative provides a way to set
+   extra flags in cases where the input file is a .c rather than a
+   .comp.
 
-* 'option extra_compile_args "..."' - (default: "") +
-  This option is ignored if the option 'userspace' (see above) is set to 'no'.
-  When compiling a userspace component, the arguments given are inserted in the compiler command line.
+* 'option extra_compile_args "..."' - (default: "")
+   This option is ignored if the option 'userspace' (see above) is set to
+   'no'.  When compiling a userspace component, the arguments given are inserted
+   in the compiler command line.
+   If the input file is a .c file this option can be set in the halcompile
+   command-line with --extra-compile-args="-I.....". This alternative
+   provides a way to set extra flags in cases where the input file is a
+   .c rather than a .comp.
 
 * 'option homemod yes' - (default: no) +
   Module is a custom Homing module loaded using [EMCMOT]HOMEMOD=modulename
@@ -488,7 +498,18 @@ halcompile --compile usrexample.comp
 halcompile --document usrexample.comp
 ----
 
-This only works for '.comp' files, not for '.c' files.
+For some libraries (for example modbus) it might be necessary to add extra
+compiler and linker arguments to enable the compiler to find and link the
+libraries. In the case of .comp files this can be done via "option"
+statements in the .comp file. For .c files this is not possible so the
+--extra-compile-args and --extra-link-args parameters can be used instead.
+As an example, this command line can be used to compile the vfdb_vfd.c
+component out-of-tree.
+----
+halcompile --userspace --install --extra-compile-args="-I/usr/include/modbus" --extra-link-args="-lm -lmodbus -llinuxcncini" vfdb_vfd.c
+----
+NOTE: The effect of using both command-line and in-file extra-args is
+undefined.
 
 == Examples
 

--- a/docs/src/hal/comp.adoc
+++ b/docs/src/hal/comp.adoc
@@ -273,24 +273,18 @@ parameters, and functions for `prefix`.
   (e.g., because the commandline arguments were invalid).
 
 * 'option extra_link_args "..."' - (default: "")
-   This option is ignored if the option 'userspace' (see above) is set to
-   'no'.  When linking a userspace component, the arguments given are inserted
-   in the link line.  Note that because compilation takes place in a temporary
-   directory, "-L." refers to the temporary directory and not the directory where
-   the .comp source file resides.
-   This option can be set in the halcompile command-line with
-   --extra-link-args="-L.....". This alternative provides a way to set
-   extra flags in cases where the input file is a .c rather than a
-   .comp.
+   This option is ignored if the option 'userspace' (see above) is set to 'no'.
+   When linking a userspace component, the arguments given are inserted in the link line.
+   Note that because compilation takes place in a temporary directory,
+   "-L." refers to the temporary directory and not the directory where the .comp source file resides.
+   This option can be set in the halcompile command-line with -extra-link-args="-L.....".
+   This alternative provides a way to set extra flags in cases where the input file is a .c file rather than a .comp file.
 
 * 'option extra_compile_args "..."' - (default: "")
-   This option is ignored if the option 'userspace' (see above) is set to
-   'no'.  When compiling a userspace component, the arguments given are inserted
-   in the compiler command line.
-   If the input file is a .c file this option can be set in the halcompile
-   command-line with --extra-compile-args="-I.....". This alternative
-   provides a way to set extra flags in cases where the input file is a
-   .c rather than a .comp.
+   This option is ignored if the option 'userspace' (see above) is set to 'no'.
+   When compiling a userspace component, the arguments given are inserted in the compiler command line.
+   If the input file is a .c file this option can be set in the halcompile command-line with --extra-compile-args="-I.....".
+   This alternative provides a way to set extra flags in cases where the input file is a .c file rather than a .comp file.
 
 * 'option homemod yes' - (default: no) +
   Module is a custom Homing module loaded using [EMCMOT]HOMEMOD=modulename
@@ -396,18 +390,16 @@ When the item is a conditional item, it is only legal to refer to it when its 'c
 
 == Components with one function
 
-If a component has only one function and the string "FUNCTION" does
-not appear anywhere after ';;', then the portion after ';;' is all
-taken to be the body of the component's single function. See the
-<<code:simple-comp-example,Simple Comp>> for and example of this.
+If a component has only one function and the string "FUNCTION" does not appear anywhere after ';;',
+then the portion after ';;' is all taken to be the body of the component's single function.
+See the <<code:simple-comp-example,Simple Comp>> for an example of this.
 
 == Component Personality
 
 If a component has any pins or parameters with an "if condition" or "[maxsize : condsize]", it is called a component with 'personality'.
 The 'personality' of each instance is specified when the module is loaded. 'Personality' can be used to create pins only when needed.
 For instance, personality is used in the 'logic' component,
-to allow for a variable number of input pins to each logic gate
-and to allow for a selection of any of the basic boolean logic functions 'and', 'or', and 'xor'.
+to allow for a variable number of input pins to each logic gate and to allow for a selection of any of the basic boolean logic functions 'and', 'or', and 'xor'.
 
 The default number of allowed 'personality' items is a compile-time setting (64).
 The default applies to numerous components included in the distribution that are built using halcompile.
@@ -498,18 +490,14 @@ halcompile --compile usrexample.comp
 halcompile --document usrexample.comp
 ----
 
-For some libraries (for example modbus) it might be necessary to add extra
-compiler and linker arguments to enable the compiler to find and link the
-libraries. In the case of .comp files this can be done via "option"
-statements in the .comp file. For .c files this is not possible so the
---extra-compile-args and --extra-link-args parameters can be used instead.
-As an example, this command line can be used to compile the vfdb_vfd.c
-component out-of-tree.
+For some libraries (for example modbus) it might be necessary to add extra compiler and linker arguments to enable the compiler to find and link the libraries.
+In the case of .comp files this can be done via "option" statements in the .comp file.
+For .c files this is not possible so the --extra-compile-args and --extra-link-args parameters can be used instead.
+As an example, this command line can be used to compile the vfdb_vfd.c component out-of-tree.
 ----
 halcompile --userspace --install --extra-compile-args="-I/usr/include/modbus" --extra-link-args="-lm -lmodbus -llinuxcncini" vfdb_vfd.c
 ----
-NOTE: The effect of using both command-line and in-file extra-args is
-undefined.
+NOTE: The effect of using both command-line and in-file extra-args is undefined.
 
 == Examples
 

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -150,7 +150,7 @@ deprmap = {'s32': 'signed', 'u32': 'unsigned'}
 deprecated = ['s32', 'u32']
 
 def initialize():
-    global functions, params, pins, options, comp_name, names, docs, variables
+    global functions, params, pins, comp_name, names, docs, variables
     global modparams, includes
 
     functions = []; params = []; pins = []; options = {}; variables = []
@@ -1120,6 +1120,11 @@ Usage:
 
 Option to set maximum 'personalities' items:
     --personalities=integer_value   (default is %(dflt)d)
+
+Options to add compile and link flags (only for userspace, only for .c files)
+    --extra-compile-args="-I/usr/include/..."
+    --extra-link-args="-l..."
+
 """ % {'name': os.path.basename(sys.argv[0]),'dflt':MAX_PERSONALITIES})
     raise SystemExit(exitval)
 
@@ -1133,15 +1138,17 @@ def main():
     mode = PREPROCESS
     outfile = None
     userspace = False
+    global options
+    options = {}
     try:
         opts, args = getopt.getopt(sys.argv[1:], "Uluijcpdo:h?P:",
                            ['unix', 'install', 'compile', 'preprocess', 'outfile=',
                             'document', 'help', 'userspace', 'install-doc',
                             'view-doc', 'require-license', 'print-modinc',
-                            'personalities='])
+                            'personalities=', "extra-compile-args=",
+                            'extra-link-args='])
     except getopt.GetoptError:
         usage(1)
-
     for k, v in opts:
         if k in ("-U", "--unix"):
             require_unix_line_endings = True
@@ -1173,6 +1180,10 @@ def main():
                 print("MAX_PERSONALITIES=%d"%(MAX_PERSONALITIES))
             except Exception as detail:
                 raise SystemExit("Bad value for -P (--personalities)=",v,"\n",detail)
+        if k in ("--extra-compile-args"):
+            option("extra_compile_args", v)
+        if k in ("--extra-link-args"):
+            option("extra_link_args", v)
         if k in ("-?", "-h", "--help"):
             usage(0)
 

--- a/tests/halcompile/command_line_flags/flags.c
+++ b/tests/halcompile/command_line_flags/flags.c
@@ -1,0 +1,20 @@
+/*
+  flags.c
+  To test command line compiler flags to halcompile
+
+  Copyright (C) 2023 Andy Pugh
+ */
+
+
+#ifndef ULAPI
+#error This is intended as a userspace component only.
+#endif
+
+#include <readline.h>
+
+int main(int argc, char **argv)
+{
+    const char* res;
+    rl_initialize();
+    return 0;
+}

--- a/tests/halcompile/command_line_flags/test.sh
+++ b/tests/halcompile/command_line_flags/test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+if [ -e flags ]
+then
+    rm flags
+fi
+halcompile --userspace --compile flags.c > /dev/null
+if [ -e flags ]
+then
+    echo "No flags, compile succeeded but should fail"
+    exit 1
+fi
+halcompile --userspace --compile --extra-compile-args="-I/usr/include/readline" flags.c > /dev/null
+if [ -e flags ]
+then
+    echo "Linker flags only, compile succeeded but should fail"
+    exit 1
+fi
+halcompile --userspace --compile --extra-link-args="-lm -lreadline" flags.c > /dev/null
+if [ -e flags ]
+then
+    echo "Compiler flags only, compile succeeded but should fail"
+    exit 1
+fi
+halcompile --userspace --compile --extra-compile-args="-I/usr/include/readline" --extra-link-args="-lm -lreadline" flags.c > /dev/null
+if [ -e flags ]
+then
+    rm flags
+    exit 0
+else
+    echo "Compile failed but should succeed"
+    exit 1
+fi
+


### PR DESCRIPTION
It is possible to provide extra compiler and linker flags with "option" lines inside a hal component written in the .comp preprocessor format. However for files written in straight C this does not work. This commit adds --extra-compile-args and --extra-link-args as command-line options to halcompile.
See https://github.com/LinuxCNC/linuxcnc/issues/2204 for more background


Signed-off-by: andypugh <andy@bodgesoc.org>