### PR TITLE
Disabling calls to glBitmap that crash on bookworm

### DIFF
--- a/lib/python/glnav.py
+++ b/lib/python/glnav.py
@@ -62,7 +62,8 @@ def use_pango_font(font, start, count, will_call_prepost=False):
         context.restore()
         w, h = int(w / Pango.SCALE), int(h / Pango.SCALE)
         glNewList(base+i, GL_COMPILE)
-        glBitmap(0, 0, 0, 0, 0, h-d, ''.encode())
+        #FIXME: crashes in debian/bookworm
+        #glBitmap(0, 0, 0, 0, 0, h-d, ''.encode())
         #glDrawPixels(0, 0, 0, 0, 0, h-d, '');
         if not will_call_prepost:
             pango_font_pre()
@@ -73,7 +74,8 @@ def use_pango_font(font, start, count, will_call_prepost=False):
             except Exception as e:
                 print("glnav Exception ",e)
 
-        glBitmap(0, 0, 0, 0, w, -h+d, ''.encode())
+        #FIXME: crashes in debian/bookworm
+        #glBitmap(0, 0, 0, 0, w, -h+d, ''.encode())
         if not will_call_prepost:
             pango_font_post()
         glEndList()


### PR DESCRIPTION
The example code uses `None` as its last argument, which however triggers the same error as presented in https://github.com/LinuxCNC/linuxcnc/issues/1599#issuecomment-1374146728. 

It is unclear to me what the exact effect of the disabled invocation of glBitmap may be. To my eye, AXIS works fine without it.