### PR TITLE
work around a PyOpenGL-vs-Wayland bug on Debian Bookworm

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -22,6 +22,12 @@ if test "xyes" = "x@RUN_IN_PLACE@"; then
     fi
 fi
 
+# This works around a compatibility problem between Bookworm's PyOpenGL
+# and Wayland (https://github.com/LinuxCNC/linuxcnc/issues/2264).
+if [[ -z "${PYOPENGL_PLATFORM}" ]]; then
+    export PYOPENGL_PLATFORM="x11"
+fi
+
 ################################################################################
 # 0. Values that come from configure
 ################################################################################


### PR DESCRIPTION
See <https://github.com/LinuxCNC/linuxcnc/issues/2264> for some details.

I'm not sure what the correct fix is to get our OpenGL stuff to work on Wayland, but this at least works around the immediate issue.