### PR TITLE
document linuxcnc command line options

### DIFF
--- a/docs/src/man/man1/linuxcnc.1.in
+++ b/docs/src/man/man1/linuxcnc.1.in
@@ -28,7 +28,8 @@
 linuxcnc \- LinuxCNC (The Enhanced Machine Controller)
 .SH SYNOPSIS
 .B linuxcnc
-[\fI-v\fR] [\fI-d\fR] [\fIINI file\fR]
+[\fI-h\fR] [\fI-v\fR] [\fI-d\fR] [\fI-r\fR] [\fI-l\fR] [\fI-k\fR] [\fI-t <tpmodulename> [parameters]\fR]
+[\fI-m <homemodulename> [parameters]\fR] [\fI-H <dirname>\fR] [\fIINI file\fR]
 .SH DESCRIPTION
 \fBlinuxcnc\fR is used to start LinuxCNC (The Enhanced Machine Controller). It
 starts the realtime system and then initializes a number of LinuxCNC
@@ -38,7 +39,10 @@ to run. If \fIINI file\fR is not specified, the \fBlinuxcnc\fR script presents
 a graphical wizard to let you choose one.
 .SH OPTIONS
 .TP
-\fB\-v\fR 
+\fB\-h\fR
+Shows the help
+.TP
+\fB\-v\fR
 Be a little bit verbose. This causes the script to print information
 as it works.
 .TP
@@ -47,11 +51,28 @@ Print lots of debug information. All executed commands
 are echoed to the screen. This mode is useful when something is
 not working as it should.
 .TP
+\fB\-r\fR
+Disable redirection of stdout and stderr to ~/linuxcnc_print.txt and
+~/linuxcnc_debug.txt when stdin is not a tty.
+Used when running linuxcnc tests non-interactively.
+.TP
 \fB\-l\fR
 Use the last-used INI file without prompting. This is often a good choice
 for a shortcut command or startup item.
 .TP
-\fBINIFILE\fR
+\fB\-k\fR
+Continue in the presence of errors in HAL files
+.TP
+\fB\-t <tpmodulename> [parameters] \fR
+Specify custom trajectory_planning_module overrides optional INI setting [TRAJ]TPMOD
+.TP
+\fB\-m <homemodulename> [parameters]\fR
+Specify custom homing_module overrides optional INI setting [EMCMOT]HOMEMOD
+.TP
+\fB\-H <dirname>\fR
+Search dirname for HAL files before searching INI directory and system library: $HALLIB_DIR
+.TP
+\fB<INIFILE>\fR
 The INI file is the main piece of a LinuxCNC configuration. It is not the
 entire configuration; there are various other files that go with it
 (NML files, HAL files, TBL files, VAR files). It is, however, the most

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -112,6 +112,10 @@ Usage:
 Options:
     -d: Turn on "debug" mode
     -v: Turn on "verbose" mode
+    -r: Disable redirection of stdout and stderr to ~/linuxcnc_print.txt and
+        ~/linuxcnc_debug.txt when stdin is not a tty.
+        Used when running linuxcnc tests non-interactively.
+    -l: Use the last-used INI file
     -k: Continue in the presence of errors in HAL files
     -t "tpmodulename [parameters]"
             specify custom trajectory_planning_module
@@ -133,29 +137,30 @@ EOF
 ################################################################################
 while getopts "dvlhkrH:t:m:" opt
 do
-	case "$opt" in
-	d)
-		# enable echoing of script and command output
-		if tty -s; then
-		    DEBUG_FILE=/dev/fd/2
-		    echo "Debug mode on" >$DEBUG_FILE
-		fi
-		set -x;;
-	v)
-		# enable printing of verbose messages
-		if tty -s; then
-		    PRINT_FILE=/dev/fd/1
-		    echo "Verbose mode on" >$PRINT_FILE
-		fi;;
-        r)
-                RUNTESTS=yes
-                ;;
-	l)
-		USE_LAST_INIFILE=1;;
-        k)      DASHK=-k;;
-	h)
-		usage
-		exit 0;;
+    case "$opt" in
+    d)
+        # enable echoing of script and command output
+        if tty -s; then
+            DEBUG_FILE=/dev/fd/2
+            echo "Debug mode on" >$DEBUG_FILE
+        fi
+        set -x;;
+    v)
+        # enable printing of verbose messages
+        if tty -s; then
+            PRINT_FILE=/dev/fd/1
+            echo "Verbose mode on" >$PRINT_FILE
+        fi;;
+    r)
+        RUNTESTS=yes
+        ;;
+    l)
+        USE_LAST_INIFILE=1;;
+    k)
+        DASHK=-k;;
+    h)
+        usage
+        exit 0;;
     H)  # -H dirname: prepend dirname to HALLIB_PATH
         if [ -d $OPTARG ]; then
             HALLIB_PATH=$(cd $OPTARG;pwd):$HALLIB_PATH
@@ -175,10 +180,10 @@ do
         # and be located in: $LINUXCNC_RTLIB_DIR
         HOMEMOD=$OPTARG
         ;;
-	*)
-		usage
-		exit 1
-	esac
+    *)
+        usage
+        exit 1
+    esac
 done
 shift $(($OPTIND-1))
 


### PR DESCRIPTION
Documented all command line option of the linuxcnc script in the man page as well as in the help text of the script itself.

I am not sure what the option `-r` does. 

It sets `RUNTESTS=yes` and for my understanding this will result that stdout and stderr are not being written to these files:
```
if [ -z $RUNTESTS ]; then
if ! tty -s; then
    exec 2>> $DEBUG_FILE
    exec >> $PRINT_FILE
fi
fi
```
But when I tested that, it makes no difference.