### PR TITLE
Added man page cross reference between spindle(9) and motion(9).

### DIFF
--- a/docs/man/man9/motion.9
+++ b/docs/man/man9/motion.9
@@ -724,4 +724,4 @@ This manual page is incomplete.
 Identification of pins categorized with \fB(DEBUG)\fR is dubious.
 
 .SH SEE ALSO
-iocontrol(1), milltask(1)
+iocontrol(1), milltask(1), spindle(9)

--- a/src/hal/components/spindle.comp
+++ b/src/hal/components/spindle.comp
@@ -48,6 +48,7 @@ If a spindle encoder is available it is used to tailor the acceleration and dece
 If not the spindle speed is simulated. The component allows for gearboxes with up to 16 gears.
 Each gear has individual control of speeds, acceleration, driver gain and direction.""";
 
+see_also "\\fBmotion\\fR(9)";
 
 pin in unsigned select-gear
 """Select a gear. Must be in the range 0 -> number of available gears -1. If you use this, do not use the select.x input pins.""";


### PR DESCRIPTION
The motion component have some spindle pins, so it would be useful to guide readers between them.