### PR TITLE
docs: add qtvcp options in man page

### DIFF
--- a/docs/man/man1/qtvcp.1
+++ b/docs/man/man1/qtvcp.1
@@ -27,11 +27,70 @@
 qtvcp \- Qt-based virtual control panels
 .SH SYNOPSIS
 .B qtvcp
+[\fIOPTIONS\fR] myfile.ui
 
 .SH DESCRIPTION
 \fBqtvcp\fR is a system for creating user interfaces for LinuxCNC. 
 
 Full documentation at http://linuxcnc.org/docs/html/gui/qtvcp.html
+
+.SH OPTIONS
+.TP
+\fB\-h, --help\fR
+Show this help message and exit.
+.TP
+\fB\-c\fR [\fI<NAME>\fR]
+Set component name to NAME. Default is basename of UI file.
+.TP
+\fB\-a\fR
+Set the window to always be on top.
+.TP
+\fB\-d\fR
+Enable debug output.
+.TP
+\fB\-v\fR
+Enable verbose debug output
+.TP
+\fB\-q\fR
+Enable only error debug output.
+.TP
+\fB\-g\fR [\fI<GEOMETRY>\fR]
+Set geometry WIDTHxHEIGHT+XOFFSET+YOFFSET.
+Values are in pixel units, XOFFSET/YOFFSET is referenced from top left of screen.
+Use -g WIDTHxHEIGHT for just setting size or -g +XOFFSET+YOFFSET for just position.
+
+Example: -g 200x400+0+100.
+.TP
+\fB\-H\fR [\fI<FILE>\fR]
+Execute HAL statements from FILE with halcmd after the
+component is set up and ready.
+.TP
+\fB\-i\fR
+Enable info output.
+.TP
+\fB\-m\fR
+Force panel window to maximize.
+.TP
+\fB\-f\fR
+Force panel window to fullscreen.
+.TP
+\fB\-t\fR [\fI<THEME>\fR]
+Set QT style. Default is system theme.
+.TP
+\fB\-x\fR [\fI<XID>\fR]
+Reparent Qtvcp into an existing window XID instead of creating
+a new top level window.
+.TP
+\fB\--push_xid\fR
+Reparent window into a plug add push the plug xid number to
+standardout.
+.TP
+\fB\-u\fR [\fI<USERMOD>\fR]
+File path of user defined handler file.
+.TP
+\fB\-o\fR [\fI<USEROPTS>\fR]
+Pass USEROPTS strings to handler under self.w.USEROPTIONS_ list
+variable.
 
 .SH "SEE ALSO"
 \fBLinuxCNC(1)\fR

--- a/docs/src/gui/qtvcp.adoc
+++ b/docs/src/gui/qtvcp.adoc
@@ -109,20 +109,27 @@ All `<options>` must appear before `<screen_name>`.
 
 .Options
 
-* `-d` Debugging on
-* `-a` Set window always on top
-* `-c` HAL component name. Default is to use the UI file name.
-* `-g` Geometry: WIDTHxHEIGHT+XOFFSET+YOFFSET. Example:
-  `-g 200x400+0+100`
-* `-m` Maximize window
-* `-f` Fullscreen the window
-* `-t` Theme. Default is system theme
-* `-x` Embed into a X11 window that doesn't support embedding.
+* `-d` Debugging on.
+* `-i` Enable info output.
+* `-v` Enable verbose debug output.
+* `-q` Enable only error debug output.
+* `-a` Set window always on top.
+* `-c NAME` HAL component name. Default is to use the UI file name.
+* `-g GEOMETRY` Set geometry WIDTHxHEIGHT+XOFFSET+YOFFSET. Values are in pixel units,
+XOFFSET/YOFFSET is referenced from top left of screen.
+Use -g WIDTHxHEIGHT for just setting size or -g +XOFFSET+YOFFSET for just position.
+Example: `-g 200x400+0+100`
+* `-H FILE` Execute hal statements from FILE with halcmd after the
+ component is set up and ready.
+* `-m` Maximize window.
+* `-f` Fullscreen the window.
+* `-t THEME` Default is system theme
+* `-x XID` Embed into a X11 window that doesn't support embedding.
 * `--push_xid` Send QtVCP's X11 window id number to standard output; for
   embedding.
-* `-u` File path of a substitute handler file
-* `-o` Pass a string to QtVCP's handler file under `self.w.USEROPTIONS_`
-  list variable. can be multiple -o
+* `-u USERMOD` File path of a substitute handler file.
+* `-o USEROPTS` Pass a string to QtVCP's handler file under `self.w.USEROPTIONS_`
+  list variable. Can be multiple -o.
 
 .<screen_name>
 `<screen_name>` is the _base name of the .ui and _handler.py files_. +

--- a/src/emc/usr_intf/qtvcp/qtvcp.py
+++ b/src/emc/usr_intf/qtvcp/qtvcp.py
@@ -48,7 +48,7 @@ use -g WIDTHxHEIGHT for just setting size or -g +XOFFSET+YOFFSET for just positi
                   , help="reparent window into a plug add push the plug xid number to standardout")
           , Option( '-u', dest='usermod', default="", help='file path of user defined handler file')
           , Option( '-o', dest='useropts', action='append', metavar='USEROPTS', default=[]
-                  , help='pass USEROPTS strings to handler under self.w.USEROPTIONS_ list varible')
+                  , help='pass USEROPTS strings to handler under self.w.USEROPTIONS_ list variable')
           ]
 
 from PyQt5.QtCore import QObject, QEvent, pyqtSignal


### PR DESCRIPTION
Adds the recently added options to the docs and add the options to the man page.