### PR TITLE
Halcompile permissions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1063,6 +1063,7 @@ modules: $(patsubst %.o,../rtlib/%.so,$(obj-m))
 	$(Q)objcopy -j .rtapi_export -O binary objects/$*.tmp objects/$*.sym
 	$(Q)(echo '{ global : '; tr -s '\0' < objects/$*.sym | xargs -r0 printf '%s;\n' | grep .; echo 'local : * ; };') > objects/$*.ver
 	$(Q)$(CC) -shared -Bsymbolic $(LDFLAGS) -Wl,--version-script,objects/$*.ver -o $@ $^ -lm
+	$(Q)chmod -x $@
 
 RTFLAGS += -fno-strict-aliasing -fwrapv
 

--- a/src/Makefile.modinc.in
+++ b/src/Makefile.modinc.in
@@ -121,6 +121,7 @@ $(foreach mod,$(patsubst %.o,%,$(obj-m)),\
 	$(Q)objcopy -j .rtapi_export -O binary $*.tmp $*.sym
 	$(Q)(echo '{ global : '; tr -s '\0' < $*.sym | xargs -r0 printf '%s;\n' | grep .; echo 'local : * ; };') > $*.ver
 	$(Q)$(CC) -shared -Bsymbolic $(LDFLAGS) -Wl,--version-script,$*.ver -o $@ $^ -lm
+	$(Q)chmod -x $@
 endif
 
 ifeq ($(BUILDSYS),normal)

--- a/tests/halcompile/personalities_mod/test.sh
+++ b/tests/halcompile/personalities_mod/test.sh
@@ -1,8 +1,28 @@
 #!/bin/sh
+set -e
+
 DIR=../../../src/hal/components ;# use in-tree components
 halcompile --personalities=2 --install $DIR/lincurve.comp
 halcompile --personalities=2 --install $DIR/logic.comp
 halcompile --personalities=2 --install $DIR/bitslice.comp
+
+# This tells us the expected filename extension ${MODULE_EXT} of realtime
+# modules.
+source "${EMC2_HOME}/scripts/rtapi.conf"
+
+for INSTALLED_FILE in "${EMC2_HOME}"/rtlib/{lincurve,logic,bitslice}"${MODULE_EXT}"; do
+    if [[ ! -f "${INSTALLED_FILE}" ]]; then
+        echo "'halcompile --install' did not install '${INSTALLED_FILE}'"
+        exit 1
+    fi
+
+    MODE=$(stat --printf '%#03a\n' "${INSTALLED_FILE}")
+    if [[ $((MODE & 0111)) != '0' ]]; then
+        echo "installed file '${INSTALLED_FILE}' has incorrect permissions"
+        echo "expected no execute bits, got ${MODE}"
+        exit 1
+    fi
+done
 
 for HAL in *.hal; do
     echo "testing $HAL"

--- a/tests/halcompile/userspace-count-names/test.sh
+++ b/tests/halcompile/userspace-count-names/test.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
+set -e
+
 halcompile --install userspace_count_names.comp
+
+INSTALLED_FILE="${EMC2_HOME}/bin/userspace_count_names"
+if [[ ! -f "${INSTALLED_FILE}" ]]; then
+    echo "'halcompile --install' did not install '${INSTALLED_FILE}'"
+    exit 1
+fi
+
+MODE=$(stat --printf '%#03a\n' "${INSTALLED_FILE}")
+if [[ $((MODE & 0111)) == '0' ]]; then
+    echo "installed file '${INSTALLED_FILE}' has incorrect permissions"
+    echo "expected *some* execute bit, got ${MODE}"
+    exit 1
+fi
 
 for HAL in *.hal; do
     echo "testing $HAL"


### PR DESCRIPTION
This fixes the permissions of `.so` uspace realtime components built by halcompile.  For some reason they come out of gcc executable, which doesn't hurt anything but still isn't right.  This just chmods them after building to turn off the `x` bit.

Also adds checks to existing halcompile tests that verify that "userspace" (non-realtime) components are executable (they are) and realtime components are not executable (they aren't, after this PR).