### PR TITLE
Fix canterp.so installation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -666,7 +666,7 @@ install-docs:
 install-dirs:
 	$(DIR) $(DESTDIR)$(EMC2_RTLIB_DIR) \
 		$(DESTDIR)$(sysconfdir)/linuxcnc $(DESTDIR)$(bindir) $(DESTDIR)$(libdir) \
-		$(DESTDIR)/lib/linuxcnc $(DESTDIR)$(includedir)/linuxcnc \
+		$(DESTDIR)/$(libdir)/linuxcnc $(DESTDIR)$(includedir)/linuxcnc \
 		$(DESTDIR)$(docsdir) $(DESTDIR)$(ncfilesdir) \
 		$(DESTDIR)/etc/X11/app-defaults $(DESTDIR)$(tcldir)/bin \
 		$(DESTDIR)$(tcldir)/scripts \
@@ -731,7 +731,7 @@ install-kernel-indep: install-dirs
 	$(FILE) $(filter ../lib/%.a ../lib/%.so.0,$(TARGETS)) $(DESTDIR)$(libdir)
 	cp --no-dereference $(wildcard ../lib/*.so) $(DESTDIR)$(libdir)
 	-ldconfig $(DESTDIR)$(libdir)
-	$(FILE) ../lib/linuxcnc/canterp.so $(DESTDIR)$(libdir)/linuxcnc
+	$(FILE) ../lib/linuxcnc/canterp.so $(DESTDIR)$(libdir)/linuxcnc/
 	$(FILE) $(HEADERS) $(DESTDIR)$(includedir)/linuxcnc/
 	$(TREE) $(NC_FILES) $(DESTDIR)$(ncfilesdir)
 	$(EXE) ../nc_files/M101 $(DESTDIR)$(ncfilesdir)


### PR DESCRIPTION
Fixes installation of canterp.so (introduced in
c54043254a432d214b296183545c5779d9e1b6cd).

Building rpm packages fails as follows:
    error: Installed (but unpackaged) file(s) found:
        /usr/lib64/linuxcnc

This is a result of mismatch between
  - creating directories using: $(DESTDIR)/lib/linuxcnc

  - installing canterp.so using: $(FILE) ../lib/linuxcnc/canterp.so $(DESTDIR)$(libdir)/linuxcnc

It manifests on systems where "${libdir}" differs from "lib".

Note: this does not fixes loading canterp.so which uses hardcoded path[1].

[1] https://github.com/LinuxCNC/linuxcnc/commit/1f733ebaf9065f5c2304c34168964f8c9605b0dc#diff-e4daea21a6d335db374a201d7386d70ef7ba440ee0d87aa462c87a051be68cffR39

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>