### PR TITLE
Execute LOG commands at runtime

### DIFF
--- a/src/emc/nml_intf/emc.hh
+++ b/src/emc/nml_intf/emc.hh
@@ -334,6 +334,9 @@ extern int emcOperatorText(int id, const char *fmt, ...) __attribute__((format(p
 // print note to operator
 extern int emcOperatorDisplay(int id, const char *fmt, ...) __attribute__((format(printf,2,3)));
 
+// log text to file
+extern int emcLogCmd(int id, const char *text);
+
 // implementation functions for EMC_AXIS types
 
 extern int emcAxisSetUnits(int axis, double units);

--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -49,6 +49,12 @@ class EMC_OPERATOR_ERROR:public RCS_CMD_MSG {
     char error[LINELEN];
 };
 
+
+#define EMC_OPERATOR_TEXT_ID_TEXT       0
+#define EMC_OPERATOR_TEXT_ID_LOGOPEN    1
+#define EMC_OPERATOR_TEXT_ID_LOGAPPEND  2
+#define EMC_OPERATOR_TEXT_ID_LOGCLOSE   3
+#define EMC_OPERATOR_TEXT_ID_LOGWRITE   4
 /**
  * Send a textual information message to the operator.
  * This is similar to EMC_OPERATOR_ERROR message except that the messages are

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -2373,29 +2373,43 @@ void MESSAGE(char *s)
 static FILE *logfile = NULL;
 
 void LOG(char *s) {
-    flush_segments();
-    if(logfile) { fprintf(logfile, "%s\n", s); fflush(logfile); }
-    fprintf(stderr, "LOG(%s)\n", s);
+    EMC_OPERATOR_TEXT log_msg;
 
+    flush_segments();
+    log_msg.id = EMC_OPERATOR_TEXT_ID_LOGWRITE;
+    strncpy(log_msg.text, s, LINELEN);
+    log_msg.text[LINELEN - 1] = 0;
+    interp_list.append(log_msg);
 }
 
 void LOGOPEN(char *name) {
-    if(logfile) fclose(logfile);
-    logfile = fopen(name, "wt");
-    fprintf(stderr, "LOGOPEN(%s) -> %p\n", name, logfile);
+    EMC_OPERATOR_TEXT log_msg;
+
+    flush_segments();
+    log_msg.id = EMC_OPERATOR_TEXT_ID_LOGOPEN;
+    strncpy(log_msg.text, name, LINELEN);
+    log_msg.text[LINELEN - 1] = 0;
+    interp_list.append(log_msg);
 }
 
 void LOGAPPEND(char *name) {
-    if(logfile) fclose(logfile);
-    logfile = fopen(name, "at");
-    fprintf(stderr, "LOGAPPEND(%s) -> %p\n", name, logfile);
+    EMC_OPERATOR_TEXT log_msg;
+
+    flush_segments();
+    log_msg.id = EMC_OPERATOR_TEXT_ID_LOGAPPEND;
+    strncpy(log_msg.text, name, LINELEN);
+    log_msg.text[LINELEN - 1] = 0;
+    interp_list.append(log_msg);
 }
 
 
 void LOGCLOSE() {
-    if(logfile) fclose(logfile);
-    logfile = NULL;
-    fprintf(stderr, "LOGCLOSE()\n");
+    EMC_OPERATOR_TEXT log_msg;
+
+    flush_segments();
+    log_msg.id = EMC_OPERATOR_TEXT_ID_LOGCLOSE;
+    log_msg.text[0] = 0;
+    interp_list.append(log_msg);
 }
 
 void MIST_OFF()


### PR DESCRIPTION
Log commands in G-Code are executed during the interpreted phase.

This changes it so the commands are executed when the program is running.
Like this the timestamps represent the real time and not the time when the G-Code-file was read and interpreted.