### PR TITLE
Make manual tool change more verbose

### DIFF
--- a/src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py
+++ b/src/emc/usr_intf/axis/scripts/hal_manualtoolchange.py
@@ -35,7 +35,7 @@ def stop_polling_hal_in_background():
 
 def do_change(n):
     if n:
-        message = _("Insert tool %d and click continue when ready") % n
+        message = get_tool_change_message(n)
     else:
         message = _("Remove the tool and click continue when ready")
     app.wm_withdraw()
@@ -50,6 +50,54 @@ def do_change(n):
     if r == 0:
         h.changed = True
     app.update()
+
+def get_tool_change_message(n):
+    try:
+        if len(sys.argv) < 2:
+            raise Exception("No .ini-File specified, can't read tool table.")
+        inipath = sys.argv[1]
+        if (not os.path.isabs(inipath)):
+            raise Exception(".ini-File path must be absolute.")
+        inidir = os.path.dirname(inipath)
+        inifile = linuxcnc.ini(inipath)
+        tooltable_file = inifile.find("EMCIO", "TOOL_TABLE")
+        machine_units = inifile.find("TRAJ", "LINEAR_UNITS")
+        # make sure we get an absolute path to the tool table
+        if (tooltable_file != ""):
+            if (not os.path.isabs(tooltable_file)):
+                tooltable_file = os.path.join(inidir, tooltable_file)
+        # load the tool table file
+        tool_info = get_tool_info(tooltable_file, n)
+        diameter = ("%f" % tool_info["diameter"]).rstrip("0").rstrip(".")
+        return _("Insert tool and click continue when ready.\n\nTool number: %(number)s\nDiameter: %(diameter)s%(units)s\nComment: %(comment)s") % ({
+            "number":   n, 
+            "diameter": diameter,
+            "units":    machine_units,
+            "comment":  tool_info["comment"]
+        })
+    except Exception as error:
+        # old style message with just tool number and the error message
+        return "".join((_("Insert tool %d and click continue when ready") % n,
+                        _("\n\nError: %s") % error))
+
+def get_tool_info(file, n):
+    with open(file, "r") as f:
+        for i, line in enumerate(f):
+            tool_data = parse_line(line)
+            if tool_data["number"] == n:
+                return tool_data
+    raise Exception(_("Tool not found."))
+
+def parse_line(line):
+    data = {}
+    parts = line.partition(";")
+    data["comment"] = parts[2]
+    for token in parts[0].upper().split(" "):
+        if (token.startswith("T")):
+            data["number"] = int(token[1:])
+        if (token.startswith("D")):
+            data["diameter"] = float(token[1:])
+    return data
 
 h = hal.component("hal_manualtoolchange")
 h.newpin("number", hal.HAL_S32, hal.HAL_IN)

--- a/src/emc/usr_intf/pncconf/build_HAL.py
+++ b/src/emc/usr_intf/pncconf/build_HAL.py
@@ -789,7 +789,8 @@ class HAL:
                 if not self.d.frontend in (_PD._QTDRAGON,_PD._GMOCCAPY):
                     print(_("#  ---Use external manual tool change dialog---"), file=file)
                     print(file=file)
-                    print("loadusr -W hal_manualtoolchange", file=file)
+                    inifilepath = os.path.join(base, self.d.machinename + ".ini")
+                    print("loadusr -W hal_manualtoolchange {0}".format(inifilepath) , file=file)
                     print("net tool-change-request    =>  hal_manualtoolchange.change", file=file)
                     print("net tool-change-confirmed  <=  hal_manualtoolchange.changed", file=file)
                     print("net tool-number            =>  hal_manualtoolchange.number", file=file)

--- a/src/emc/usr_intf/stepconf/build_HAL.py
+++ b/src/emc/usr_intf/stepconf/build_HAL.py
@@ -307,7 +307,8 @@ class HAL:
         print(file=file)
         if self.d.manualtoolchange:
             if not self.d.select_qtdragon:
-                print("loadusr -W hal_manualtoolchange", file=file)
+                inifilepath = os.path.join(base, self.d.machinename + ".ini")
+                print("loadusr -W hal_manualtoolchange {0}".format(inifilepath) , file=file)
                 print("net tool-change iocontrol.0.tool-change => hal_manualtoolchange.change", file=file)
                 print("net tool-changed iocontrol.0.tool-changed <= hal_manualtoolchange.changed", file=file)
                 print("net tool-number iocontrol.0.tool-prep-number => hal_manualtoolchange.number", file=file)


### PR DESCRIPTION
hal_manualtoolchange.py accepts the ini-file path as an argument in order to read the tooltable-file.

This allows to dialog to display tool diameter and comments.

https://i.imgur.com/MTFFabB.png