### PR TITLE
More consistent indentation of adoc list element lines

### DIFF
--- a/docs/src/gui/gmoccapy.adoc
+++ b/docs/src/gui/gmoccapy.adoc
@@ -126,8 +126,8 @@ PROGRAM_PREFIX = ../../nc_files/
 - _DISPLAY = gmoccapy_ - This tells LinuxCNC to use GMOCCAPY.
 
 - _PREFERENCE_FILE_PATH_ - Gives the location and name of the preferences file to be used.
-In most cases this line will not be needed, it is used by GMOCCAPY to store your settings of the GUI,
-like themes, DRO units, colors, and keyboard settings, etc., see <<gmoccapy:settings-page,settings page>> for more details.
+  In most cases this line will not be needed, it is used by GMOCCAPY to store your settings of the GUI,
+  like themes, DRO units, colors, and keyboard settings, etc., see <<gmoccapy:settings-page,settings page>> for more details.
 +
 [NOTE]
 If no path or file is given, GMOCCAPY will use as default
@@ -149,8 +149,8 @@ If no values are given, MIN will be set to 0.1 and MAX to 1.0.
 
 - _LATHE = 1_ - Set the screen layout to control a lathe.
 - _BACK_TOOL_LATHE = 1_ - Is optional and will switch the X axis in a way you need for a back tool lathe.
-Also the keyboard shortcuts will react in a different way.
-It is allowed with GMOCCAPY to configure a lathe also with additional axes, so you may use also a XZCW config for a lathe.
+  Also the keyboard shortcuts will react in a different way.
+  It is allowed with GMOCCAPY to configure a lathe also with additional axes, so you may use also a XZCW config for a lathe.
 +
 [TIP]
 See also the <<gmoccapy:lathe-section,Lathe Specific Section>>.
@@ -770,7 +770,7 @@ To be able to use a key switch to unlock the settings page, the following
 pin is exported:
 
 - *gmoccapy.unlock-settings* _(bit IN)_ - The settings page is unlocked if the pin is high.
-To use this pin, you need to activate it on the settings page.
+  To use this pin, you need to activate it on the settings page.
 
 === Error/Warning Pins
 
@@ -1487,11 +1487,11 @@ Directories=16x16/actions,24x24/actions,32x32/actions,48x48/actions,scalable/act
 * Comment: A description of your icon theme.
 * Inherits: A icon theme can derive from another icon theme, the default is hicolor.
 * Directories: A comma separated list of all the directories of your icon theme. +
-Each directory usually contains all the icons of the theme in a specific size, for example 16x16/actions should contain all icons with the category "actions" in the size 16x16 pixels as pixel-graphics (e.g. png files).
-A special case is the directory called "scalable/actions", this contains scalable icons not tied to a specific size (e.g. svg files). +
-By supplying different sized versions of the icons,
-we can guarantee a nice looking icon if different sizes and we also have the ability to change the icon according to its size,
-for example a 64x64 px sized icon may contain more details than its 16x16 px version.
+  Each directory usually contains all the icons of the theme in a specific size, for example 16x16/actions should contain all icons with the category "actions" in the size 16x16 pixels as pixel-graphics (e.g. png files).
+  A special case is the directory called "scalable/actions", this contains scalable icons not tied to a specific size (e.g. svg files). +
+  By supplying different sized versions of the icons,
+  we can guarantee a nice looking icon if different sizes and we also have the ability to change the icon according to its size,
+  for example a 64x64 px sized icon may contain more details than its 16x16 px version.
 --
 - For each directory we also have to write a section in the index.theme file:
 +

--- a/docs/src/gui/gstat.adoc
+++ b/docs/src/gui/gstat.adoc
@@ -480,7 +480,7 @@ General message should be used a sparsely as reasonable because all object conne
 It uses a Python dict for communication. +
 The dict should include and be checked for a unique id  keyname pair: +
 * ID: 'UNIQUE_ID_CODE' +
-The dict usually has more keyname pair - it depends on implementation.
+  The dict usually has more keyname pair - it depends on implementation.
 
 *forced-update* :: '(returns None)' -
 intended to be sent when one wishes to initialize or arbitrarily update an object. +

--- a/docs/src/gui/qtdragon.adoc
+++ b/docs/src/gui/qtdragon.adoc
@@ -521,9 +521,9 @@ This is only available in the QtDragon_hd version.
 * There should now be a file in the nc_files folder called {something}-probe-only.ngc. Set the file filter to G-Code Files, navigate to the nc_files directory and load this file.
 * Without changing the offsets, run this program. Make sure the probe tool is installed. When complete, there will be a file in the config directory called 'probe_points.txt'.
 * In Qtdragon_hd press the 'Enable Z Comp' button to enable compensation.
-Look at the status line for indication of success or failure.
-Active compensation will be displayed beside the label: 'Z Level Comp'
-While jogging that display should change based on the compensation component.
+  Look at the status line for indication of success or failure.
+  Active compensation will be displayed beside the label: 'Z Level Comp'
+  While jogging that display should change based on the compensation component.
 
 [NOTE]
 If you use auto raise Z to lift the spindle on pause, you must combine the two

--- a/docs/src/gui/qtvcp-code-snippets.adoc
+++ b/docs/src/gui/qtvcp-code-snippets.adoc
@@ -147,11 +147,11 @@ The function
 
 * creates a Python `dict` with:
 ** *`NAME`* - needs to be set to the _dialogs unique launch name_. +
-`NAME` sets which dialog to request. +
-`ENTRY` or `CALCULATOR` allows entering numbers.
+   `NAME` sets which dialog to request. +
+   `ENTRY` or `CALCULATOR` allows entering numbers.
 //FIXME Is that a user defined unique name or a dialog type ?
 ** *`ID`* - needs to be set to a _unique name that the function supplies_.
-`ID` should be a unique key.
+   `ID` should be a unique key.
 ** *`TITLE`* sets the dialog title.
 ** *Arbitrary data* can be added to the `dict`. The dialog will ignore them but send them back to the return code.
 * Sends the `dict` as a *`dialog-request`* `STATUS` message

--- a/docs/src/gui/qtvcp-vismach.adoc
+++ b/docs/src/gui/qtvcp-vismach.adoc
@@ -160,7 +160,7 @@ part = AsciiOBJ(data="v 0.123 0.234 0.345 1.0 ...")
 ----
 
 - STL model parts are added to the Vismach space in the _same locations as they were created in the STL or OBJ space_,
-ie ideally with a rotational point at their origin.
+  ie ideally with a rotational point at their origin.
 
 [NOTE]
 It is much easier to move while building if the origin of the model is at 

--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -1505,7 +1505,7 @@ These Sound options require `python3-gst1.0` installed.
 ** `BEEP_START`
 
 * *Text-To-Speech* +
-If the _Espeak_ module (`python3-espeak`) is installed, you can use the `SPEAK` entry to pronounce text:
+  If the _Espeak_ module (`python3-espeak`) is installed, you can use the `SPEAK` entry to pronounce text:
 
 * *`SPEAK '_my message_'`*
 

--- a/docs/src/gui/qtvcp.adoc
+++ b/docs/src/gui/qtvcp.adoc
@@ -116,11 +116,11 @@ All `<options>` must appear before `<screen_name>`.
 * `-a` Set window always on top.
 * `-c NAME` HAL component name. Default is to use the UI file name.
 * `-g GEOMETRY` Set geometry WIDTHxHEIGHT+XOFFSET+YOFFSET. Values are in pixel units,
-XOFFSET/YOFFSET is referenced from top left of screen.
-Use -g WIDTHxHEIGHT for just setting size or -g +XOFFSET+YOFFSET for just position.
-Example: `-g 200x400+0+100`
-* `-H FILE` Execute hal statements from FILE with halcmd after the
- component is set up and ready.
+  XOFFSET/YOFFSET is referenced from top left of screen.
+  Use -g WIDTHxHEIGHT for just setting size or -g +XOFFSET+YOFFSET for just position.
+  Example: `-g 200x400+0+100`
+* `-H FILE` Execute hal statements from FILE with halcmd after the component
+  is set up and ready.
 * `-m` Maximize window.
 * `-f` Fullscreen the window.
 * `-t THEME` Default is system theme

--- a/docs/src/install/latency-test.adoc
+++ b/docs/src/install/latency-test.adoc
@@ -219,8 +219,8 @@ BIOS tuning guide is not practical.  In general, some things to try
 tuning in the BIOS are:
 
 * Disable ACPI, APM, and any other power-saving features.  This includes
-anything related to power saving, suspending, CPU sleep states, CPU
-frequency scaling, etc.
+  anything related to power saving, suspending, CPU sleep states, CPU
+  frequency scaling, etc.
 
 * Disable CPU "turbo" mode.
 

--- a/docs/src/man/man1/xhc-whb04b-6.1.adoc
+++ b/docs/src/man/man1/xhc-whb04b-6.1.adoc
@@ -208,11 +208,11 @@ The feed rotary button can serve in
 * Step move x mm
 * MPG override feed/spindle
 * The special position Lead. +
-*Continuous:* In this mode jogging is performed at the selected feed rate. As long the jogwheel turns, the selected axis moves. +
-*Step:* In this mode the machine moves steps * wheel_counts at the currently selected step size and the current set feed rate in machine units.
-If the commanded position is not reached the machine keeps moving even the jogwheel is not turning. +
-*Lead:* Manipulates the spindle override. +
-*MPG:* Manipulates the feedrate override.
+  *Continuous:* In this mode jogging is performed at the selected feed rate. As long the jogwheel turns, the selected axis moves. +
+  *Step:* In this mode the machine moves steps * wheel_counts at the currently selected step size and the current set feed rate in machine units.
+  If the commanded position is not reached the machine keeps moving even the jogwheel is not turning. +
+  *Lead:* Manipulates the spindle override. +
+  *MPG:* Manipulates the feedrate override.
 
 Note:
 As a consequence of 3 modes from manufacturer, switching the feed rotary button back from Lead revert to MPG mode, MPG mode is default mode at startup.

--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -2591,8 +2591,8 @@ All leadins and leadouts are arcs except for *Circles* and *Stars*:
 - If the circle is external then any leadin or leadout will be an arc.
 - If the circle is internal and a *small hole* then any leadin will be perpendicular and there will be no lead out.
 - If the circle is internal and not a *small hole* then any leadin and leadout will be an arc.
-If the leadin has a length greater than half the radius then the leadin will revert to perpendicular and there will be no leadout.
-If the leadout has a length greater than half the radius then there will be no leadout.
+  If the leadin has a length greater than half the radius then the leadin will revert to perpendicular and there will be no leadout.
+  If the leadout has a length greater than half the radius then there will be no leadout.
 
 *Stars:*
 


### PR DESCRIPTION
This get rid of some po4a warnings about inconsistent indentation.