### PR TITLE
Adding function for carousel HAL component

### DIFF
--- a/src/hal/components/carousel.comp
+++ b/src/hal/components/carousel.comp
@@ -138,6 +138,12 @@ param r  signed state = 0 "Current component state";
 param r  bit    homing  = 0 "Shows that homing is in progress. Only used for index mode";
 param r  float  timer "Shows the value of the internal timer";
 param r signed motor-dir "Internal tag for search direction";
+param r  float  timer-cycle "Shows the cycle time";
+param rw float read-time = 0 """Time in seconds for reading Gray, Straight Binary or BCD code after some position is founded. 
+Value for encoder with trigger signal can be 0. Recomended value for encoder without trigger signal can be 0.02""";
+param rw float check-time = 0 """Time in seconds to wait to stop mechanical oscilation of toolchanger in a position.
+Recomended value for unreliable ATC positioning can be 1. Only used in Gray, Straight Binary or BCD code.""";
+param rw float error-time = 3600 "Time in seconds to stop motor in error case";
 
 option count_function;
 option extra_setup;
@@ -291,6 +297,18 @@ FUNCTION(_){
     if (unhome && ! old_unhome) homed = 0;
     old_unhome = unhome;
 
+    // measuring cycle time
+    if (state > 0){
+    timer_cycle += fperiod;}
+    if (state == 9){
+    timer_cycle = 0;}
+
+    // stop motor in error case    
+    if (timer_cycle > error_time){    
+    motor_fwd = 0;
+    motor_rev = 0;
+	}
+
     switch (state){
     case 0: // waiting at start
         motor_dir = 0;
@@ -364,7 +382,39 @@ FUNCTION(_){
             motor_vel = fwd_dc;
             motor_dir = 1;
         }
-        state = 2;
+ 
+        if ((inst_code == 'G' || inst_code == 'B' || inst_code == 'D') ){
+		state = 102;
+		} else {
+		state = 2;
+		}
+   case 102: // leaving position    
+        if ((current_position != 0) && enable) return;
+        state = 103;
+        break;
+   case 103: // finded middle position (0 position)    
+        if ((current_position == 0) && enable) return;
+        state = 104;
+        timer = read_time;
+        break;
+   case 104: // finded some position  
+        if ((current_position != mod_pocket) && enable) return;
+        timer -= fperiod;
+        if (timer > 0) return;
+        motor_fwd = 0;
+        motor_rev = 0;
+        state = 105;
+        timer = check_time;
+        break;
+   case 105: // pause for check correction position
+		timer -= fperiod;
+        if (timer > 0) return;
+        if ((current_position != mod_pocket) && enable){
+		state = 0;
+		} else {
+		state = 2;
+		}	 
+        break;                      
     case 2: // moving
         if ((current_position != mod_pocket) && enable) return;
         if (rev_pulse > 0){


### PR DESCRIPTION
Hello,

I tried use component carousel for encoder without trigger signal: https://forum.linuxcnc.org/24-hal-components/47845-carousel-dont-work-w-o-trigger It did not work. 

So we have a problem when moving from position 9 to 8 and from position 3 to 2. Why is this so:
9 = 2^3+0+0+2^0
8 = 2^3+0+0+0

3 = 0+0+2^1+2^0
2 = 0+0+2^1+0

When I want the revolver, let it turn from position 9 to 8 or from position 3 to 2. Then the engine starts and immediately stops. A situation occurs when, due to manufacturing tolerances, bit ^0 (2^0=1) turns on one millisecond before the rest of the bit, and the program thinks it is already in the position where it should be (but physically it is not) and turns off the rotation relay.

I solved it. I made a modification to the carousel component. The original solution worked in such a way that moving from the first position to the second position was only about checking whether it is already in the correct position. I have several phases. 

The first phase (case 0 and case 1) is the same as it was. ATC is started and the direction of rotation is evaluated.

The second phase (case 102) to leave the first position. I check if the position is already 0 and I don't care how the read position changes. 

In the third phase (case 103), I just check that the position is zero. 

In the fourth phase (case 104), I check that the position has changed to anything else and i make decision, how to continue. Than I am waiting user defined short time (several miliseconds). Than I read code position.  If position is not correct I continue move. If position is correct I continue to next phase. 

In the fifth phase (case 105) I waiting user defined time. It is long time for stabilize mechanical oscilation of toolchanger. Than I check if the position is correct, than I make decision, how to continue. If position is not correct I repeat cycle . If position is correct I continue to next phase.

I needed to make sure that the ATC motor still wouldn't spin when the encoder failed. The Brother TC-211 uses a motor that is not designed for continuous operation. That's why I made the "error_time" parameter. If the ATC cycle length is longer than this parameter, the ATC motor will shut down and the program will hang. The default value of this parameter is 3600s = 1 hour. I don't expect anyone to have a longer cycle ATC. I have this value set to 20 seconds myself.

I would like to ask for help.
1) I would need someone to test these changes on an ATC without an encoder with only indexing. I don't have such an ATC myself, so I can't verify if my changes messed something up.
2) I'm just an amateur programmer, so I need comments about the C language so I don't break any conventions. 
3) I need advice on what else to do in the LinuxuCNC project so as not to break the rules. I guess I'll have to edit the manual? And what else?