### PR TITLE
Fix up several UI problems

### DIFF
--- a/lib/python/gladevcp/hal_graph.py
+++ b/lib/python/gladevcp/hal_graph.py
@@ -191,7 +191,7 @@ class HAL_Graph(Gtk.DrawingArea, _HalWidgetBase):
         ymin, ymax = self.min, self.max
         yticks = self.yticks
         if self.autoscale:
-            tv = map(lambda x: x[1], self.ticks_saved + list(self.ticks))
+            tv = [x[1] for x in self.ticks_saved + list(self.ticks)]
             if tv:
                 ymin, ymax = min(tv), max(tv)
                 ymin -= abs(ymin) * 0.1

--- a/lib/python/gladevcp/hal_graph.py
+++ b/lib/python/gladevcp/hal_graph.py
@@ -166,7 +166,7 @@ class HAL_Graph(Gtk.DrawingArea, _HalWidgetBase):
         w, h = w - 2, h - 2
 
         cr.set_line_width(1)
-        cr.set_source_color(self.bg_color)
+        cr.set_source_rgb(self.bg_color.red, self.bg_color.green, self.bg_color.blue)
         cr.rectangle(0, 0, w, h)
         cr.stroke_preserve()
         cr.fill()
@@ -217,7 +217,7 @@ class HAL_Graph(Gtk.DrawingArea, _HalWidgetBase):
         cr.set_font_size(font_small)
         self.text_at(cr, self.sublabel, w/2, 2.5 * font_large, yalign='top')
 
-        cr.set_source_color(self.fg_color)
+        cr.set_source_rgb(self.fg_color.red, self.fg_color.green, self.fg_color.blue)
 
         if self.ticks_saved:
             self.draw_graph(cr, w, h, ymin, ymax, self.ticks_saved, t2x)

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -23,7 +23,6 @@ import sys, os
 import string
 from OpenGL.GL import *
 from OpenGL.GLU import *
-from OpenGL.GLUT import *
 BASE = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
 sys.path.insert(0, os.path.join(BASE, "lib", "python"))
 

--- a/src/emc/usr_intf/gremlin/gremlin-run
+++ b/src/emc/usr_intf/gremlin/gremlin-run
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
+import gi
+gi.require_version("Gtk","3.0")
+from gi.repository import Gtk
 
 import sys
 import os
-import gtk
 
 import linuxcnc
 from gremlin import Gremlin
@@ -13,7 +15,7 @@ def W(p, k, *args, **kw):
     p.add(w)
     return w
 
-class GremlinApp(gtk.Window):
+class GremlinApp(Gtk.Window):
     def __init__(self, inifile):
         if not inifile:
             inifile = os.environ.get('INI_FILE_NAME', None)
@@ -25,9 +27,9 @@ class GremlinApp(gtk.Window):
         except linuxcnc.error as detail:
             usage('Using filename = %s\n %s' % (inifile,detail))
 
-        gtk.Window.__init__(self)
+        Gtk.Window.__init__(self)
 
-        self.vbox = W(self, gtk.VBox)
+        self.vbox = W(self, Gtk.VBox)
         self.gremlin = W(self.vbox, Gremlin, inifile)
         self.gremlin.set_size_request(400, 400)
 
@@ -35,7 +37,7 @@ class GremlinApp(gtk.Window):
 
         self.show()
     def quit(self, event):
-        gtk.main_quit()
+        Gtk.main_quit()
 
 
 def usage(msg=None):
@@ -57,6 +59,6 @@ def main():
         usage()
 
     g = GremlinApp(inifilename)
-    gtk.main()
+    Gtk.main()
 
 if __name__ == '__main__': raise SystemExit(main())

--- a/src/emc/usr_intf/gremlin/gremlin.py
+++ b/src/emc/usr_intf/gremlin/gremlin.py
@@ -92,6 +92,10 @@ class StatCanon(rs274.glcanon.GLCanon, rs274.interpret.StatMixin):
 
 
 
+# Gtk is not capable of creating a "legacy" or "compatibility" context, which necessitates
+# descending to the GLX API layer to create the required context. This can only be removed
+# someday when the core drawing routines of Gremlin/AXIS are upgraded to modern OpenGL style,
+# a large undertaking.
 
 class Gremlin(Gtk.DrawingArea,rs274.glcanon.GlCanonDraw,glnav.GlNavBase):
     xlib = cdll.LoadLibrary('libX11.so')
@@ -124,18 +128,6 @@ class Gremlin(Gtk.DrawingArea,rs274.glcanon.GlCanonDraw,glnav.GlNavBase):
         configs = GLX.glXChooseFBConfig(self.xdisplay, 0, None, byref(c_int()))
         self.context = GLX.glXCreateContext(self.xdisplay, xvinfo, None, True)
 
-
-#class Gremlin(gtk.gtkgl.widget.DrawingArea, glnav.GlNavBase,
-#              rs274.glcanon.GlCanonDraw):
-#    rotation_vectors = [(1.,0.,0.), (0., 0., 1.)]
-
-#    def __init__(self, inifile):
-#
-#        display_mode = ( gtk.gdkgl.MODE_RGB | gtk.gdkgl.MODE_DEPTH |
-#                         gtk.gdkgl.MODE_DOUBLE )
-#        glconfig = gtk.gdkgl.Config(mode=display_mode)
-
-#        gtk.gtkgl.widget.DrawingArea.__init__(self, glconfig)
         Gtk.DrawingArea.__init__(self)
         glnav.GlNavBase.__init__(self)
         def C(s):
@@ -231,24 +223,14 @@ class Gremlin(Gtk.DrawingArea,rs274.glcanon.GlCanonDraw,glnav.GlNavBase):
         """make cairo context current for drawing"""
         if(not GLX.glXMakeCurrent(self.xdisplay, self.xwindow_id, self.context)):
             print("failed binding opengl context")
-        #glcontext = gtk.gtkgl.widget_get_gl_context(self)
-        #gldrawable = gtk.gtkgl.widget_get_gl_drawable(self)
-
-        #return gldrawable and glcontext and gldrawable.gl_begin(glcontext)
         return True
 
     def swapbuffers(self):
         GLX.glXSwapBuffers(self.xdisplay, self.xwindow_id)
-        #gldrawable = gtk.gtkgl.widget_get_gl_drawable(self)
-        #gldrawable.swap_buffers()
         return
 
     def deactivate(self):
-        #yolo (actually @makecurrent the previous context should be cached + rebound and buffers maybe should be swapped, but yolo)
         return
-        #TODO
-        #gldrawable = Gtk.gtkgl.widget_get_gl_drawable(self)
-        #gldrawable.gl_end()
 
     def winfo_width(self):
         return  self.get_allocated_width()

--- a/src/emc/usr_intf/gremlin/gremlin.py
+++ b/src/emc/usr_intf/gremlin/gremlin.py
@@ -46,7 +46,6 @@ from gi.repository import GLib
 import sys
 from OpenGL.GL import *
 from OpenGL.GLU import *
-from OpenGL.GLUT import *
 from OpenGL import GLX
 from OpenGL.raw.GLX._types import struct__XDisplay
 from OpenGL import GL

--- a/src/emc/usr_intf/gremlin/gremlin.py
+++ b/src/emc/usr_intf/gremlin/gremlin.py
@@ -115,12 +115,6 @@ class Gremlin(Gtk.DrawingArea,rs274.glcanon.GlCanonDraw,glnav.GlNavBase):
     
         self.xwindow_id = None
 
-        #self.set_has_alpha(True)
-        #'set_has_stencil_buffer',
-        glutInit()
-        glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH )
-
-
         self.add_attribute(GLX.GLX_RGBA, True)
         self.add_attribute(GLX.GLX_RED_SIZE, 1)
         self.add_attribute(GLX.GLX_GREEN_SIZE, 1)

--- a/src/emc/usr_intf/gremlin/gremlin.py
+++ b/src/emc/usr_intf/gremlin/gremlin.py
@@ -137,6 +137,7 @@ class Gremlin(Gtk.DrawingArea,rs274.glcanon.GlCanonDraw,glnav.GlNavBase):
 #        glconfig = gtk.gdkgl.Config(mode=display_mode)
 
 #        gtk.gtkgl.widget.DrawingArea.__init__(self, glconfig)
+        Gtk.DrawingArea.__init__(self)
         glnav.GlNavBase.__init__(self)
         def C(s):
             a = self.colors[s + "_alpha"]


### PR DESCRIPTION
This:
 * Removes the import and use of GLUT. GLUT is never used to create a UI window by Axis or Gremlin.
 * fixes the gremlin commandline program so it starts again
 * fixes exceptions printed on the terminal while running configs/sim/touchy/gladevcp/touchy.ini which may have also affected correct behavior
 * comments on why it's necessary to make direct GLX calls in gremlin, which is obstensibly a Gtk program
 * remove some commented out code

I don't know how these fixes intersect (if at all) with the current problems running axis & gremlin-based UIs on unstable or testing.