### PR TITLE
force PyOpenGL to use GLX

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -22,6 +22,12 @@ if test "xyes" = "x@RUN_IN_PLACE@"; then
     fi
 fi
 
+# Force pyopengl (python3-opengl) to use its GLX backend, even
+# if we're running on Wayland where it would normally use EGL.
+if [[ ! -v LINUXCNC_OPENGL_PLATFORM || "${LINUXCNC_OPENGL_PLATFORM}" == "glx" ]]; then
+    export PYOPENGL_PLATFORM="x11"
+fi
+
 ################################################################################
 # 0. Values that come from configure
 ################################################################################


### PR DESCRIPTION
On Bookworm and newer pyopengl detects if it's running on Wayland, and chooses EGL there.  This is problematic because the rest of LinuxCNC is still on GLX, and (as i understand it) one should not mix GLX and EGL within a single application.

See <https://github.com/LinuxCNC/linuxcnc/issues/2264> for some details.

The correct fix is probably to teach our code to either use GLX everywhere (for when running on X, and like it does after this commit) or EGL everywhere (for when running on Wayland).

This commit fixes Axis on Wayland on Bookworm for me.