### PR TITLE
message: Update HAL component docs to match behavior

### DIFF
--- a/src/hal/components/message.comp
+++ b/src/hal/components/message.comp
@@ -55,7 +55,7 @@ pin in bit trigger =FALSE "signal that triggers the message";
 pin in bit force =FALSE """A FALSE->TRUE transition forces the message to be
 displayed again if the trigger is active""";
  
-param rw bit edge =TRUE """Selects the desired edge: TRUE means falling, FALSE
+param rw bit edge =TRUE """Selects the desired edge: FALSE means falling, TRUE
 means rising""";
 
 modparam dummy messages """The messages to display. These should be listed,


### PR DESCRIPTION
The code is implemented as edge=1 meaning rising edge, docs said the opposite.
This commit changes the documentation only.

@sheetcam @andypugh Do either of you want to take a look?

Might make sense to merge this to 2.8 branch also.