### PR TITLE
xyzab_tdr sim config fix wrong sign in fwd kins

### DIFF
--- a/src/hal/components/xyzab_tdr_kins.comp
+++ b/src/hal/components/xyzab_tdr_kins.comp
@@ -181,7 +181,7 @@ int kinematicsForward(const double *j,
             pos->tran.x =   cb*px + sb*pz
                           + x_rot_point;
 
-            pos->tran.y =   sa*sb*px + ca*py - cb*sa*pz - sa*dz
+            pos->tran.y =   sa*sb*px + ca*py - cb*sa*pz + sa*dz
                           + y_rot_point;
 
             pos->tran.z = - ca*sb*px + sa*py + ca*cb*pz - ca*dz


### PR DESCRIPTION
Fixes wrong kinematics in the recently added 5-axis table-dual-rotary  simulation config 'xyzab-tdr' 