### PR TITLE
qtvcp: workaround for transparent preview on wayland

### DIFF
--- a/src/emc/usr_intf/qtvcp/qtvcp.py
+++ b/src/emc/usr_intf/qtvcp/qtvcp.py
@@ -8,6 +8,10 @@ import hal
 import signal
 import subprocess
 
+# workaround for transparent preview on Wayland
+# can be removed when opengl code is changed to run on both X and Wayland
+os.environ['QT_QPA_PLATFORM'] = 'xcb'
+
 from optparse import Option, OptionParser
 from PyQt5 import QtWidgets, QtCore, QtGui
 


### PR DESCRIPTION
Tested on bookworm amd64 and arm64.

No ill effects noticed on amd64 buster and bullseye.

Issue reported [here](https://github.com/LinuxCNC/linuxcnc/issues/1486)