### PR TITLE
tooldata: comment field with interp/python intfc

### DIFF
--- a/configs/common/linuxcnc_big.nml
+++ b/configs/common/linuxcnc_big.nml
@@ -12,7 +12,7 @@ B emcStatus             SHMEM   localhost       170000  0       0       2       
 
 # These are for the IO controller, EMCIO
 B toolCmd               SHMEM   localhost       2048    0       0       4       16 1004 TCP=5005 xdr
-B toolSts               SHMEM   localhost       131072  0       0       5       16 1005 TCP=5005 xdr
+B toolSts               SHMEM   localhost     155648    0       0       5       16 1005 TCP=5005 xdr
 
 # Processes
 # Name          Buffer          Type    Host            Ops     server? timeout master? cnum

--- a/configs/sim/axis/db_demo/db.py
+++ b/configs/sim/axis/db_demo/db.py
@@ -243,7 +243,8 @@ def save_tools_to_file(fname,comment=""):
            if l == "T" or     l == "P": continue # always include
            if l in D   and D[l] == "0": del D[l] # drop zero entries
         tools[tno] = dict_to_toolline(D,all_letters)
-    for i in sorted(tools,key=tools.get): f.write(tools[i]+"\n")
+    for i in sorted(tools,key=tools.get):
+        f.write(tools[i] + " ;" + tool_comment(i) + "\n")
 
     global history
     if comment: history.append(comment)
@@ -527,6 +528,10 @@ def check_params(tno,params):
     for l in params.upper():
         if l in alphabet and not l in tletters:
             umsg("unknown param letter:%s in %s"%(l,params))
+
+def tool_comment(tno):
+    from datetime import datetime as dt
+    return "Tool_%2d %s"%(tno,dt.today().strftime("%d%b%y:%H.%M.%S"))
 #-----------------------------------------------------------
 # Interface (callback) functions
 
@@ -541,6 +546,7 @@ def user_get_tool(tno):
         for l in tletters:
             if l in item: ans = ans + " " + item
     mutex.release()
+    ans = ans + " ;" + tool_comment(tno)
     return ans.strip()
 
 #   'p' interface command (ran or nonran toolchanger)

--- a/docs/src/config/python-interface.adoc
+++ b/docs/src/config/python-interface.adoc
@@ -397,6 +397,30 @@ else:
     print("No tool loaded.")
 ----
 
+*toolinfo(toolno)*:: '(returns dict of tooldata for toolno)' -
+  An initial stat.poll() is required to initialize.
+  toolno must be greater than zero and less than or equal to the highest tool number in use.
+  Dictionary items include all tooldata items:
+     'toolno', 'pocketno',
+     'diameter','frontangle','backangle','orientation',
+     'xoffset','yoffset', ...  'woffset',
+     'comment'
+
+[source,python]
+----
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import linuxcnc
+s = linuxcnc.stat()
+s.poll()
+toolno = 1
+print(s.toolinfo(toolno))
+----
+
+
+': 0, 'xoffset': 0.0, 'yoffset': 0.0, 'zoffset': 0.18, 'aoffset': 0.0, 'boffset': 0.0, 'coffset': 0.0, 'uoffset': 0.0, 'voffset': 0.0, 'woffset': 0.0, 'comment': 'Tool_18 28Jan23:18.53.25'}
+
+
 *velocity*:: '(returns float)' -
   This property is defined, but it does not have a useful interpretation.
 

--- a/src/emc/nml_intf/emctool.h
+++ b/src/emc/nml_intf/emctool.h
@@ -24,6 +24,7 @@
 */
 #define CANON_POCKETS_MAX 1001	// max size of carousel handled
 #define CANON_TOOL_ENTRY_LEN 256	// how long each file line can be
+#define CANON_TOOL_COMMENT_SIZE 40 // max comment string (include trailing null)
 
 struct CANON_TOOL_TABLE {
     int toolno;
@@ -33,6 +34,7 @@ struct CANON_TOOL_TABLE {
     double frontangle;
     double backangle;
     int orientation;
+    char comment[CANON_TOOL_COMMENT_SIZE];
 };
 
 #endif

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -2568,6 +2568,14 @@ int Interp::set_tool_parameters()
     default_tool_parameters();
     return 0;
   }
+// test to examine tool comment field for current tool:
+// #define TOOL_COMMENT_SHOW
+#ifdef  TOOL_COMMENT_SHOW //{
+    fprintf(stderr,"%s %s toolno=%d comment=%s\n",
+           __FILE__,__FUNCTION__,
+           _setup.tool_table[0].toolno,
+           _setup.tool_table[0].comment);
+#endif //}
   _setup.parameters[5400] = _setup.tool_table[0].toolno;
   _setup.parameters[5401] = _setup.tool_table[0].offset.tran.x;
   _setup.parameters[5402] = _setup.tool_table[0].offset.tran.y;

--- a/src/emc/sai/driver.cc
+++ b/src/emc/sai/driver.cc
@@ -338,7 +338,7 @@ int read_tool_file(  /* ARGUMENTS         */
     }
 
   // no toolTable[] param used
-  return tooldata_load(tool_file_name, 0);
+  return tooldata_load(tool_file_name);
 }
 
 /************************************************************************/

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -447,12 +447,6 @@ Task::Task() : use_iocontrol(0), random_toolchanger(0) {
 	if ((t = inifile.Find("TOOL_TABLE", "EMCIO")) != NULL)
 	    tooltable_filename = strdup(t);
     }
-    if (!use_iocontrol) {
-	for(int i = 0; i < CANON_POCKETS_MAX; i++) {
-	    ttcomments[i] = (char *)malloc(CANON_TOOL_ENTRY_LEN);
-	}
-    }
-
 };
 
 

--- a/src/emc/task/taskclass.hh
+++ b/src/emc/task/taskclass.hh
@@ -54,9 +54,6 @@ public:
     int random_toolchanger;
     const char *ini_filename;
     const char *tooltable_filename;
-private:
-
-    char *ttcomments[CANON_POCKETS_MAX];
 };
 
 extern Task *task_methods;

--- a/src/emc/tooldata/tooldata.hh
+++ b/src/emc/tooldata/tooldata.hh
@@ -64,22 +64,18 @@ int    tooldata_find_index_for_tool(int toolno);
 void   tooldata_format_toolline (int idx,
                                  bool ignore_zero_values,
                                  CANON_TOOL_TABLE tdata,
-                                 char * ttcomments[],
                                  char formatted_line[CANON_TOOL_ENTRY_LEN]
                                  );
 
 void   tooldata_add_init(int nonrandom_start_idx);
-int    tooldata_read_entry(const char *input_line,
-                           char *ttcomments[]);
+int    tooldata_read_entry(const char *input_line);
 
 void   tooldata_set_db(tooldb_t mode);
 
 //----------------------------------------------------------
-int tooldata_load(const char *filename,
-                  char *ttcomments[CANON_POCKETS_MAX]);
+int tooldata_load(const char *filename);
 
-int tooldata_save(const char *filename,
-                  char *ttcomments[CANON_POCKETS_MAX]);
+int tooldata_save(const char *filename);
 
 //----------------------------------------------------------
 //mmap specific

--- a/src/emc/tooldata/tooldata_common.cc
+++ b/src/emc/tooldata/tooldata_common.cc
@@ -48,6 +48,7 @@ struct CANON_TOOL_TABLE tooldata_entry_init()
     tdata.backangle   =  0;
     tdata.orientation =  0;
     ZERO_EMC_POSE(tdata.offset);
+    tdata.comment[0]  =  0;
 
     return tdata;
 } // tooldata_entry_init()
@@ -66,8 +67,7 @@ void tooldata_add_init(int nonrandom_start_idx)
     return;
 } // tooldata_add_init()
 
-int tooldata_read_entry(const char *input_line,
-                        char *ttcomments[])
+int tooldata_read_entry(const char *input_line)
 {
     char work_line[CANON_TOOL_ENTRY_LEN];
     const char *token;
@@ -208,11 +208,20 @@ int tooldata_read_entry(const char *input_line,
         tdata.frontangle  = frontangle;
         tdata.backangle   = backangle;
         tdata.orientation = orientation;
+        if (comment) {
+            strncpy(tdata.comment,comment,CANON_TOOL_COMMENT_SIZE-1);
+            tdata.comment[CANON_TOOL_COMMENT_SIZE-1] = 0;
+            if (strlen(comment) > (CANON_TOOL_COMMENT_SIZE-1) ) {
+                fprintf(stderr,"%s():comment for toolno %d truncated to %d chars:\n   <%s>\n"
+                       ,__FUNCTION__
+                       ,tdata.toolno
+                       ,CANON_TOOL_COMMENT_SIZE-1
+                       ,tdata.comment
+                       );
+            }
+        }
         if (tooldata_put(tdata,idx) == IDX_FAIL) {
             UNEXPECTED_MSG;
-        }
-        if (ttcomments && comment) {
-             strcpy(ttcomments[idx], comment);
         }
     } else {
          return -1;
@@ -223,7 +232,6 @@ int tooldata_read_entry(const char *input_line,
 void tooldata_format_toolline (int idx,
                                bool ignore_zero_values,
                                CANON_TOOL_TABLE tdata,
-                               char * ttcomments[],
                                char formatted_line[CANON_TOOL_ENTRY_LEN]
                                )
 {
@@ -261,15 +269,14 @@ void tooldata_format_toolline (int idx,
     I_ITEM(orientation,    "Q");
 #undef F_ITEM
 #undef I_ITEM
-    if (ttcomments) {  //ignore if nil pointer
-       snprintf(tmp,sizeof(tmp)," ;%s\n",ttcomments[idx]);
-       strncat(formatted_line,tmp,CANON_TOOL_ENTRY_LEN-1);
-    }
+    if (tdata.comment[0]) {
+        snprintf(tmp,sizeof(tmp)," ;%s\n",tdata.comment); \
+        strncat(formatted_line,tmp,CANON_TOOL_ENTRY_LEN-1); \
+    } 
     return;
 } // tooldata_format_toolline()
 
-int tooldata_load(const char *filename,
-                  char *ttcomments[])
+int tooldata_load(const char *filename)
 {
     FILE *fp;
     char input_line[CANON_TOOL_ENTRY_LEN];
@@ -289,10 +296,6 @@ int tooldata_load(const char *filename,
 
     // clear out tool table
     // (Set vars to indicate no tool in pocket):
-    int  idx;
-    for (idx = 0; idx < CANON_POCKETS_MAX; idx++) {
-        if(ttcomments) ttcomments[idx][0] = '\0';
-    }
     tooldata_reset();
 
     // open tool table file
@@ -319,7 +322,7 @@ int tooldata_load(const char *filename,
         strcpy(orig_line, input_line);
 
         // parse and store one line from tool table file
-        int entry_idx = tooldata_read_entry(input_line, ttcomments);
+        int entry_idx = tooldata_read_entry(input_line);
         if (entry_idx <0) {
             printf("File: %s Unrecognized line skipped:\n    %s",filename, orig_line);
             continue;
@@ -347,7 +350,7 @@ int tooldata_load(const char *filename,
     return 0;
 } // tooldata_load()
 
-static void write_tool_line(FILE* fp,int idx,char *ttcomments[])
+static void write_tool_line(FILE* fp,int idx)
 {
     CANON_TOOL_TABLE tdata;
     if (tooldata_get(&tdata,idx) != IDX_OK) {return;}
@@ -359,14 +362,13 @@ static void write_tool_line(FILE* fp,int idx,char *ttcomments[])
         char theline[CANON_TOOL_ENTRY_LEN] = {0};
         tooldata_format_toolline (idx,
                                   1, // ignore_zero_values
-                                  tdata,ttcomments,theline);
+                                  tdata,theline);
         fprintf(fp,"%s",theline);
     }
     return;
 } // write_tool_line()
 
-int tooldata_save(const char *filename,
-                  char *ttcomments[CANON_POCKETS_MAX])
+int tooldata_save(const char *filename)
 {
     int idx;
     FILE *fp;
@@ -389,11 +391,11 @@ int tooldata_save(const char *filename,
 
     if (db_mode == DB_ACTIVE) {
         int spindle_idx = 0;
-        write_tool_line(fp,spindle_idx,ttcomments);
+        write_tool_line(fp,spindle_idx);
     } else {
         start_idx = is_random_toolchanger ? 0 : 1;
         for (idx = start_idx; idx < CANON_POCKETS_MAX; idx++) {
-            write_tool_line(fp,idx,ttcomments);
+            write_tool_line(fp,idx);
         }
     }
     fclose(fp);

--- a/src/emc/tooldata/tooldata_db.cc
+++ b/src/emc/tooldata/tooldata_db.cc
@@ -221,9 +221,8 @@ int tooldata_db_getall() {
             //fprintf(stderr,"=====<ct=%3d>%s\n",ct,reply);
             break;
         }
-        char **ttcomments = NULL; //not used with db
 
-        int foundidx = tooldata_read_entry(reply,ttcomments);
+        int foundidx = tooldata_read_entry(reply);
         ct++;
         if (foundidx < 0) {
             fprintf(stderr,"!!!tooldata_db_getall %s\n",reply);
@@ -231,7 +230,7 @@ int tooldata_db_getall() {
         }
     }
     // update the single-entry tbl file (typ: db_spindle.tbl)
-    tooldata_save((char*)NULL,(char**)NULL);
+    tooldata_save((char*)NULL);
     initial_getall = 0;
     return 0;
 } // tooldata_db_getall()
@@ -305,7 +304,6 @@ int tooldata_db_notify(tool_notify_t ntype,
                        CANON_TOOL_TABLE tdata)
 {
     if (!db_live) return 0;   //silently ignore
-    char **ttcomments = NULL; //not used with db
     char msg[CANON_TOOL_ENTRY_LEN +20];
     char buffer[CANON_TOOL_ENTRY_LEN] = {0};
 
@@ -319,14 +317,14 @@ int tooldata_db_notify(tool_notify_t ntype,
     case SPINDLE_LOAD: // 'l' command
          tooldata_format_toolline(pocketno,
                                   1, // ignore_zero_values
-                                  notifydata, ttcomments, buffer);
+                                  notifydata, buffer);
          snprintf(msg,sizeof(msg),"l %s\n",buffer);
          if (db_debug) {fprintf(stderr,"SPINDLE_LOAD:%s\n",msg);}
          break;
     case SPINDLE_UNLOAD: // 'u' command
          tooldata_format_toolline(pocketno,
                                   1, // ignore_zero_values
-                                  notifydata, ttcomments, buffer);
+                                  notifydata, buffer);
          snprintf(msg,sizeof(msg),"u %s\n",buffer);
          if (db_debug) {fprintf(stderr,"SPINDLE_UNLOAD:%s\n",msg);}
          break;
@@ -336,7 +334,7 @@ int tooldata_db_notify(tool_notify_t ntype,
          notifydata.pocketno = pocketno;
          tooldata_format_toolline(pocketno,
                                   0, // do not ignore_zero_values
-                                  notifydata, ttcomments, buffer);
+                                  notifydata, buffer);
          snprintf(msg,sizeof(msg),"p %s\n",buffer);
          if (db_debug) {fprintf(stderr,"PUT:   %s\n",msg);}
          break;

--- a/src/emc/tooldata/tooldata_mmap.cc
+++ b/src/emc/tooldata/tooldata_mmap.cc
@@ -287,7 +287,8 @@ toolidx_t tooldata_get(CANON_TOOL_TABLE* pdata, int idx)
         exit(EXIT_FAILURE);
     }
     if (idx < 0 || idx >= CANON_POCKETS_MAX) {
-        UNEXPECTED_MSG;
+        // ui programs may query for nonexistent idx values
+        // and must handle this error
         return IDX_FAIL;
     }
 

--- a/src/emc/tooldata/tooldata_nml.cc
+++ b/src/emc/tooldata/tooldata_nml.cc
@@ -74,8 +74,8 @@ void tooldata_reset()
 toolidx_t tooldata_get(CANON_TOOL_TABLE* pdata,int idx)
 {
     if (idx < 0 || idx >= CANON_POCKETS_MAX) {
-        fprintf(stderr,"!!!%5d PROBLEM tooldata_get(): idx=%d, maxallowed=%d\n",
-                getpid(),idx,CANON_POCKETS_MAX-1);
+        // ui programs may query for nonexistent idx values
+        // and must handle this error
         return IDX_FAIL;
     }
 

--- a/tests/linuxcncrsh-tcp/tcp.nml
+++ b/tests/linuxcncrsh-tcp/tcp.nml
@@ -15,7 +15,8 @@ B emcError              SHMEM   localhost       8192    0       0       3       
 
 # These are for the IO controller, EMCIO
 B toolCmd               SHMEM   localhost       1024    0       0       4       16 1004 TCP=5005 xdr
-B toolSts               SHMEM   localhost       131072  0       0       5       16 1005 TCP=5005 xdr
+# toolSts size made big enough to accomodate --enable-toolnml option (see linuxcnc_big.nml)
+B toolSts               SHMEM   localhost     155648    0       0       5       16 1005 TCP=5005 xdr
 
 # Processes
 # Name          Buffer          Type    Host              Ops     server? timeout master? cnum


### PR DESCRIPTION
1) Comment field added to CANON_TOOL_TABLE structure:
     #define CANON_TOOL_COMMENT_SIZE 40
     char comment [CANON_TOOL_COMMENT_SIZE]

2) New function in python interface (emcmodule.cc)
     linuxcnc.status.toolinfo(toolno) returns dict of all
     tooldata fields. Example:
        linuxcnc.command.toolinfo(10)
        {'toolno': 10, 'pocketno': 112, 'diameter': 0.1,
         ...
        'woffset': 0.0, 'comment': 'Tool_10 28Jan23:16.35.06'}

3) Update api functions:
      tooldata_read_entry(),tooldata_load(),tooldata_save()
   to remove obsoleted ttcomments parameter:

4) Update configs/sim/axis/db_demo/db*.ini to include comment field
   in demonstrations

Notes:
 1) Interpreter and python programs can access a tool's
    comment field
 2) tooldata_common.cc:tooldata_read_entry() supports both
    [EMCIO]TOOL_TABLE and [EMCIO]DB_PROGRAM sources for tooldata
 3) Size of TOOL_MMAP_FILENAME is increased by
    CANON_TOOL_COMMENT_SIZE*CANON_POCKETS_MAX
 4) Very long input comments are truncated to
    CANON_TOOL_COMMENT_SIZE chars (including trailing 0)
 5) The new CANON_TOOL_COMMENT_SIZE is based on the max
    chars used in sim configs examples.
 6) A random toolchanger writes back to a [EMCIO]TOOL_TABLE file
    and truncates comments if necessary
 7) The python intfc stat.toolinfo() is available after an
    initial stat.poll() without requiring further polling
 8) Spindle tool data is available (as always, polling required)
    as: linuxcnc.stat().tool_table[0]
 9) The existing/unchanged linuxcnc.stat().tool_table[] items
    are indexed by the internal index that corresponds
    to a) the entry order for nonrandom toolchangers (default)
    or b) by the pocket number for random tool changers.  This
    legacy provision is likely seldom used and not as convenient
    as the new toolinfo() function.
10) Includes support for configs using --enable-toolnml
    with increased size of toolSts (doubtful future)