### PR TITLE
tweak glBitmap so it works on Buster, Bullseye, and Bookworm

### DIFF
--- a/lib/python/glnav.py
+++ b/lib/python/glnav.py
@@ -62,7 +62,7 @@ def use_pango_font(font, start, count, will_call_prepost=False):
         context.restore()
         w, h = int(w / Pango.SCALE), int(h / Pango.SCALE)
         glNewList(base+i, GL_COMPILE)
-        glBitmap(1, 1, 0, 0, 0, h-d, bytearray([0]*4))
+        glBitmap(1, 0, 0, 0, 0, h-d, bytearray([0]*4))
         #glDrawPixels(0, 0, 0, 0, 0, h-d, '');
         if not will_call_prepost:
             pango_font_pre()
@@ -73,7 +73,7 @@ def use_pango_font(font, start, count, will_call_prepost=False):
             except Exception as e:
                 print("glnav Exception ",e)
 
-        glBitmap(1, 1, 0, 0, w, -h+d, bytearray([0]*4))
+        glBitmap(1, 0, 0, 0, w, -h+d, bytearray([0]*4))
         if not will_call_prepost:
             pango_font_post()
         glEndList()


### PR DESCRIPTION
Sigh.

This fixes DRO corruption on Buster (X11) [pointed out](https://github.com/LinuxCNC/linuxcnc/commit/56ecf76e11c5ce9feb78d3cd830c135db83c09d7#commitcomment-99885313) by @snowgoer540, and it still works fine on Bullseye (Wayland) and Bookworm (Wayland).