### PR TITLE
Refresh hm2 configs

### DIFF
--- a/configs/by_interface/mesa/hm2-servo/5i23.ini
+++ b/configs/by_interface/mesa/hm2-servo/5i23.ini
@@ -85,7 +85,7 @@ CYCLE_TIME =            0.100
 TOOL_TABLE = tool.tbl
 
 [KINS]
-KINEMATICS =  trivkins
+KINEMATICS = trivkins
 JOINTS = 3
 
 [AXIS_X]

--- a/configs/by_interface/mesa/hm2-servo/7i93.ini
+++ b/configs/by_interface/mesa/hm2-servo/7i93.ini
@@ -1,0 +1,206 @@
+[EMC]
+# The version string for this INI file.
+VERSION = 1.1
+# Name of machine, for use with display, etc.
+MACHINE =               HM2-Servo
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+#DEBUG =                0x00000003
+#DEBUG =                0x00000007
+DEBUG = 0
+
+[DISPLAY]
+# Name of display program, e.g., tklinuxcnc
+DISPLAY =              axis
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.0500
+# Path to help file
+HELP_FILE =             tklinuxcnc.txt
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.5
+# Prefix to be used
+PROGRAM_PREFIX = ../../nc_files/
+# Introductory graphic
+INTRO_GRAPHIC =         linuxcnc.gif
+INTRO_TIME =            5
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+
+[RS274NGC]
+# File containing interpreter variables
+PARAMETER_FILE = hm2-servo.var
+
+[EMCMOT]
+EMCMOT =                motmod
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+# Servo task period, in nanoseconds
+SERVO_PERIOD =          1000000
+
+[TASK]
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.010
+
+[HAL]
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+HALFILE = hm2-servo-eth.hal
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =               save neta
+
+[HALUI]
+#No Content
+
+[TRAJ]
+# COORDINATES =         X Y Z R P W
+COORDINATES =           X Y Z
+HOME =                  0 0 0 0
+LINEAR_UNITS =          inch
+ANGULAR_UNITS =         degree
+DEFAULT_LINEAR_VELOCITY = 3.0
+MAX_LINEAR_VELOCITY = 4.0
+DEFAULT_LINEAR_ACCELERATION = 6.0
+MAX_LINEAR_ACCELERATION = 7.0
+
+[EMCIO]
+# Name of IO controller program, e.g., io
+EMCIO =                 io
+# cycle time, in seconds
+CYCLE_TIME =            0.100
+# tool table file
+TOOL_TABLE = tool.tbl
+
+[KINS]
+KINEMATICS = trivkins
+JOINTS = 3
+
+[AXIS_X]
+MIN_LIMIT = -3.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 1.0
+MAX_ACCELERATION = 4.0
+
+[JOINT_0]
+TYPE =                  LINEAR
+MAX_VELOCITY =          1.0
+MAX_ACCELERATION =      4.0
+BACKLASH =              0.000
+FERROR =                0.010
+MIN_FERROR =            0.002
+INPUT_SCALE =           81920
+OUTPUT_SCALE =          -1.000
+OUTPUT_OFFSET =         0.0
+MAX_OUTPUT =            1.0
+MIN_LIMIT =             -3.0
+MAX_LIMIT =             10.0
+HOME =                  0.000
+HOME_OFFSET =           -2.9
+HOME_SEARCH_VEL =       -0.50
+HOME_LATCH_VEL =        0.10
+# the X axis servo's encoder does not have an index channel, so we have to home without index
+HOME_USE_INDEX =        NO
+HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         1
+# PID tuning params
+DEADBAND =              0.000015
+P =                     100.0
+I =                     0.000
+D =                     0.000
+FF0 =                   0.000
+FF1 =                   1.000
+FF2 =			0.0
+BIAS =                  0.000
+
+[AXIS_Y]
+MIN_LIMIT = -3.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 1.0
+MAX_ACCELERATION = 4.0
+
+[JOINT_1]
+TYPE =                  LINEAR
+MAX_VELOCITY =          1.0
+MAX_ACCELERATION =      4.0
+BACKLASH =              0.000
+FERROR =                0.010
+MIN_FERROR =            0.002
+INPUT_SCALE =           -81920
+OUTPUT_SCALE =          1.000
+OUTPUT_OFFSET =         0.0
+MAX_OUTPUT =            1.0
+MIN_LIMIT =             -3.0
+MAX_LIMIT =             10.0
+HOME =                  0.000
+HOME_OFFSET =           -2.9
+HOME_SEARCH_VEL =       -0.50
+HOME_LATCH_VEL =        0.10
+# the Y axis servo's encoder has an index channel, so we use it to improve the home accuracy
+HOME_USE_INDEX =        YES
+HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         1
+# PID tuning params
+DEADBAND =              0.000015
+P =                     100.0
+I =                     0.000
+D =                     0.000
+FF0 =                   0.000
+FF1 =                   1.000
+FF2 =			0.0
+BIAS =                  0.000
+
+[AXIS_Z]
+MIN_LIMIT = -3.0
+MAX_LIMIT = 3.0
+MAX_VELOCITY = 1.0
+MAX_ACCELERATION = 4.0
+
+[JOINT_2]
+TYPE =                  LINEAR
+MAX_VELOCITY =          1.0
+MAX_ACCELERATION =      4.0
+BACKLASH =              0.000
+FERROR =                0.010
+MIN_FERROR =            0.002
+INPUT_SCALE =           81920
+OUTPUT_SCALE =          -1.000
+OUTPUT_OFFSET =         0.0
+MAX_OUTPUT =            1.0
+MIN_LIMIT =             -3.0
+MAX_LIMIT =             3.0
+HOME =                  0.0
+HOME_OFFSET =           -2.9
+HOME_SEARCH_VEL =       -0.50
+HOME_LATCH_VEL =        0.10
+# the Z axis servo's encoder does not have an index channel, so we have to home without index
+HOME_USE_INDEX =        NO
+HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         0
+# PID tuning params
+DEADBAND =              0.000015
+P =                     100.0
+I =                     0.000
+D =                     0.000
+FF0 =                   0.000
+FF1 =                   1.000
+FF2 =			0.0
+BIAS =                  0.000
+
+[HOSTMOT2]
+DRIVER=hm2_eth
+BOARD_IP=192.168.1.121
+BOARD=7i93
+CONFIG="num_encoders=3 num_pwmgens=3 num_stepgens=0"

--- a/configs/by_interface/mesa/hm2-servo/7i96s.ini
+++ b/configs/by_interface/mesa/hm2-servo/7i96s.ini
@@ -1,0 +1,206 @@
+[EMC]
+# The version string for this INI file.
+VERSION = 1.1
+# Name of machine, for use with display, etc.
+MACHINE =               HM2-Servo
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+#DEBUG =                0x00000003
+#DEBUG =                0x00000007
+DEBUG = 0
+
+[DISPLAY]
+# Name of display program, e.g., tklinuxcnc
+DISPLAY =              axis
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.0500
+# Path to help file
+HELP_FILE =             tklinuxcnc.txt
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.5
+# Prefix to be used
+PROGRAM_PREFIX = ../../nc_files/
+# Introductory graphic
+INTRO_GRAPHIC =         linuxcnc.gif
+INTRO_TIME =            5
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+
+[RS274NGC]
+# File containing interpreter variables
+PARAMETER_FILE = hm2-servo.var
+
+[EMCMOT]
+EMCMOT =                motmod
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+# Servo task period, in nanoseconds
+SERVO_PERIOD =          1000000
+
+[TASK]
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.010
+
+[HAL]
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+HALFILE = hm2-servo-eth.hal
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =               save neta
+
+[HALUI]
+#No Content
+
+[TRAJ]
+# COORDINATES =         X Y Z R P W
+COORDINATES =           X Y Z
+HOME =                  0 0 0 0
+LINEAR_UNITS =          inch
+ANGULAR_UNITS =         degree
+DEFAULT_LINEAR_VELOCITY = 3.0
+MAX_LINEAR_VELOCITY = 4.0
+DEFAULT_LINEAR_ACCELERATION = 6.0
+MAX_LINEAR_ACCELERATION = 7.0
+
+[EMCIO]
+# Name of IO controller program, e.g., io
+EMCIO =                 io
+# cycle time, in seconds
+CYCLE_TIME =            0.100
+# tool table file
+TOOL_TABLE = tool.tbl
+
+[KINS]
+KINEMATICS = trivkins
+JOINTS = 3
+
+[AXIS_X]
+MIN_LIMIT = -3.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 1.0
+MAX_ACCELERATION = 4.0
+
+[JOINT_0]
+TYPE =                  LINEAR
+MAX_VELOCITY =          1.0
+MAX_ACCELERATION =      4.0
+BACKLASH =              0.000
+FERROR =                0.010
+MIN_FERROR =            0.002
+INPUT_SCALE =           81920
+OUTPUT_SCALE =          -1.000
+OUTPUT_OFFSET =         0.0
+MAX_OUTPUT =            1.0
+MIN_LIMIT =             -3.0
+MAX_LIMIT =             10.0
+HOME =                  0.000
+HOME_OFFSET =           -2.9
+HOME_SEARCH_VEL =       -0.50
+HOME_LATCH_VEL =        0.10
+# the X axis servo's encoder does not have an index channel, so we have to home without index
+HOME_USE_INDEX =        NO
+HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         1
+# PID tuning params
+DEADBAND =              0.000015
+P =                     100.0
+I =                     0.000
+D =                     0.000
+FF0 =                   0.000
+FF1 =                   1.000
+FF2 =			0.0
+BIAS =                  0.000
+
+[AXIS_Y]
+MIN_LIMIT = -3.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 1.0
+MAX_ACCELERATION = 4.0
+
+[JOINT_1]
+TYPE =                  LINEAR
+MAX_VELOCITY =          1.0
+MAX_ACCELERATION =      4.0
+BACKLASH =              0.000
+FERROR =                0.010
+MIN_FERROR =            0.002
+INPUT_SCALE =           -81920
+OUTPUT_SCALE =          1.000
+OUTPUT_OFFSET =         0.0
+MAX_OUTPUT =            1.0
+MIN_LIMIT =             -3.0
+MAX_LIMIT =             10.0
+HOME =                  0.000
+HOME_OFFSET =           -2.9
+HOME_SEARCH_VEL =       -0.50
+HOME_LATCH_VEL =        0.10
+# the Y axis servo's encoder has an index channel, so we use it to improve the home accuracy
+HOME_USE_INDEX =        YES
+HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         1
+# PID tuning params
+DEADBAND =              0.000015
+P =                     100.0
+I =                     0.000
+D =                     0.000
+FF0 =                   0.000
+FF1 =                   1.000
+FF2 =			0.0
+BIAS =                  0.000
+
+[AXIS_Z]
+MIN_LIMIT = -3.0
+MAX_LIMIT = 3.0
+MAX_VELOCITY = 1.0
+MAX_ACCELERATION = 4.0
+
+[JOINT_2]
+TYPE =                  LINEAR
+MAX_VELOCITY =          1.0
+MAX_ACCELERATION =      4.0
+BACKLASH =              0.000
+FERROR =                0.010
+MIN_FERROR =            0.002
+INPUT_SCALE =           81920
+OUTPUT_SCALE =          -1.000
+OUTPUT_OFFSET =         0.0
+MAX_OUTPUT =            1.0
+MIN_LIMIT =             -3.0
+MAX_LIMIT =             3.0
+HOME =                  0.0
+HOME_OFFSET =           -2.9
+HOME_SEARCH_VEL =       -0.50
+HOME_LATCH_VEL =        0.10
+# the Z axis servo's encoder does not have an index channel, so we have to home without index
+HOME_USE_INDEX =        NO
+HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         0
+# PID tuning params
+DEADBAND =              0.000015
+P =                     100.0
+I =                     0.000
+D =                     0.000
+FF0 =                   0.000
+FF1 =                   1.000
+FF2 =			0.0
+BIAS =                  0.000
+
+[HOSTMOT2]
+DRIVER=hm2_eth
+BOARD_IP=192.168.1.121
+BOARD=7i96s
+CONFIG="num_encoders=3 num_pwmgens=3 num_stepgens=0"

--- a/configs/by_interface/mesa/hm2-servo/hm2-servo-eth.hal
+++ b/configs/by_interface/mesa/hm2-servo/hm2-servo-eth.hal
@@ -1,0 +1,230 @@
+# #######################################
+#
+# HAL file for HostMot2 with 3 servos
+#
+# Derived from Ted Hyde's original hm2-servo config
+#
+# Based up work and discussion with Seb & Peter & Jeff
+# GNU license references - insert here. www.linuxcnc.org
+#
+#
+# ########################################
+# Firmware files are in /lib/firmware/hm2/7i43/
+# Must symlink the hostmot2 firmware directory of sanbox to
+# /lib/firmware before running EMC2...
+# sudo ln -s $HOME/emc2-sandbox/src/hal/drivers/mesa-hostmot2/firmware /lib/firmware/hm2
+#
+# See also:
+# <http://www.linuxcnc.org/docs/devel/html/man/man9/hostmot2.9.html#config%20modparam>
+# and http://wiki.linuxcnc.org/cgi-bin/emcinfo.pl?HostMot2
+#
+# #####################################################################
+
+
+# ###################################
+# Core EMC/HAL Loads
+# ###################################
+
+# kinematics
+loadrt [KINS]KINEMATICS
+
+# motion controller, get name and thread periods from ini file
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[KINS]JOINTS
+
+# standard components
+loadrt pid num_chan=3 
+
+# hostmot2 driver
+# if you have any firmware trouble, enable the debug flags here and see what's going on in the syslog
+#loadrt hostmot2 debug_idrom=1 debug_module_descriptors=1 debug_pin_descriptors=1 debug_modules=1
+loadrt hostmot2
+
+# load low-level driver
+loadrt [HOSTMOT2](DRIVER) board_ip=[HOSTMOT2](BOARD_IP) config=[HOSTMOT2](CONFIG)
+
+setp hm2_[HOSTMOT2](BOARD).0.pwmgen.pwm_frequency 40000
+
+
+# ################################################
+# THREADS
+# ################################################
+
+addf hm2_[HOSTMOT2](BOARD).0.read          servo-thread
+
+addf motion-command-handler                servo-thread
+addf motion-controller                     servo-thread
+
+addf pid.0.do-pid-calcs                    servo-thread
+addf pid.1.do-pid-calcs                    servo-thread
+addf pid.2.do-pid-calcs                    servo-thread
+
+addf hm2_[HOSTMOT2](BOARD).0.write         servo-thread
+       
+
+# ######################################################
+# Axis-of-motion Specific Configs (not the GUI)
+# ######################################################
+
+
+# ################
+# X [0] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.00.enable bit
+sets emcmot.00.enable FALSE
+net emcmot.00.enable => pid.0.enable
+net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.pwmgen.00.enable
+net emcmot.00.enable <= joint.0.amp-enable-out 
+
+# encoder feedback
+setp hm2_[HOSTMOT2](BOARD).0.encoder.00.counter-mode 0
+setp hm2_[HOSTMOT2](BOARD).0.encoder.00.filter 1
+setp hm2_[HOSTMOT2](BOARD).0.encoder.00.index-invert 0
+setp hm2_[HOSTMOT2](BOARD).0.encoder.00.index-mask 0
+setp hm2_[HOSTMOT2](BOARD).0.encoder.00.index-mask-invert 0
+
+setp  hm2_[HOSTMOT2](BOARD).0.encoder.00.scale  [JOINT_0]INPUT_SCALE
+net motor.00.pos-fb hm2_[HOSTMOT2](BOARD).0.encoder.00.position => pid.0.feedback
+net motor.00.pos-fb => joint.0.motor-pos-fb #push copy back to Axis GUI
+
+# set PID loop gains from inifile
+setp pid.0.Pgain [JOINT_0]P
+setp pid.0.Igain [JOINT_0]I
+setp pid.0.Dgain [JOINT_0]D
+setp pid.0.bias [JOINT_0]BIAS
+setp pid.0.FF0 [JOINT_0]FF0
+setp pid.0.FF1 [JOINT_0]FF1
+setp pid.0.FF2 [JOINT_0]FF2
+setp pid.0.deadband [JOINT_0]DEADBAND
+setp pid.0.maxoutput [JOINT_0]MAX_OUTPUT
+
+# position command signals
+setp hm2_[HOSTMOT2](BOARD).0.pwmgen.00.output-type 1 #pwm on pin1, dir on pin2
+setp hm2_[HOSTMOT2](BOARD).0.pwmgen.00.scale  [JOINT_0]OUTPUT_SCALE
+
+net emcmot.00.pos-cmd joint.0.motor-pos-cmd => pid.0.command
+net motor.00.command  pid.0.output  =>  hm2_[HOSTMOT2](BOARD).0.pwmgen.00.value
+
+
+# ################
+# Y [1] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.01.enable bit
+sets emcmot.01.enable FALSE
+net emcmot.01.enable => pid.1.enable
+net emcmot.01.enable => hm2_[HOSTMOT2](BOARD).0.pwmgen.01.enable
+net emcmot.01.enable <= joint.1.amp-enable-out 
+
+# encoder feedback
+setp hm2_[HOSTMOT2](BOARD).0.encoder.01.counter-mode 0
+setp hm2_[HOSTMOT2](BOARD).0.encoder.01.filter 1
+setp hm2_[HOSTMOT2](BOARD).0.encoder.01.index-invert 0
+setp hm2_[HOSTMOT2](BOARD).0.encoder.01.index-mask 0
+setp hm2_[HOSTMOT2](BOARD).0.encoder.01.index-mask-invert 0
+
+setp  hm2_[HOSTMOT2](BOARD).0.encoder.01.scale  [JOINT_1]INPUT_SCALE
+net motor.01.pos-fb hm2_[HOSTMOT2](BOARD).0.encoder.01.position => pid.1.feedback
+net motor.01.pos-fb => joint.1.motor-pos-fb #push copy back to Axis GUI
+
+# set PID loop gains from inifile
+setp pid.1.Pgain [JOINT_1]P
+setp pid.1.Igain [JOINT_1]I
+setp pid.1.Dgain [JOINT_1]D
+setp pid.1.bias [JOINT_1]BIAS
+setp pid.1.FF0 [JOINT_1]FF0
+setp pid.1.FF1 [JOINT_1]FF1
+setp pid.1.FF2 [JOINT_1]FF2
+setp pid.1.deadband [JOINT_1]DEADBAND
+setp pid.1.maxoutput [JOINT_1]MAX_OUTPUT
+
+# position command signals
+setp hm2_[HOSTMOT2](BOARD).0.pwmgen.01.output-type 1 #pwm on pin1, dir on pin2
+setp hm2_[HOSTMOT2](BOARD).0.pwmgen.01.scale [JOINT_1]OUTPUT_SCALE
+
+net emcmot.01.pos-cmd joint.1.motor-pos-cmd => pid.1.command
+net motor.01.command  pid.1.output  =>  hm2_[HOSTMOT2](BOARD).0.pwmgen.01.value
+
+
+# ################
+# Z [2] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.02.enable bit
+sets emcmot.02.enable FALSE
+net emcmot.02.enable => pid.2.enable
+net emcmot.02.enable => hm2_[HOSTMOT2](BOARD).0.pwmgen.02.enable
+net emcmot.02.enable <= joint.2.amp-enable-out 
+
+# encoder feedback
+setp hm2_[HOSTMOT2](BOARD).0.encoder.02.counter-mode 0
+setp hm2_[HOSTMOT2](BOARD).0.encoder.02.filter 1
+setp hm2_[HOSTMOT2](BOARD).0.encoder.02.index-invert 0
+setp hm2_[HOSTMOT2](BOARD).0.encoder.02.index-mask 0
+setp hm2_[HOSTMOT2](BOARD).0.encoder.02.index-mask-invert 0
+
+setp  hm2_[HOSTMOT2](BOARD).0.encoder.02.scale  [JOINT_2]INPUT_SCALE
+net motor.02.pos-fb hm2_[HOSTMOT2](BOARD).0.encoder.02.position => pid.2.feedback
+net motor.02.pos-fb => joint.2.motor-pos-fb #push copy back to Axis GUI
+
+# set PID loop gains from inifile
+setp pid.2.Pgain [JOINT_2]P
+setp pid.2.Igain [JOINT_2]I
+setp pid.2.Dgain [JOINT_2]D
+setp pid.2.bias [JOINT_2]BIAS
+setp pid.2.FF0 [JOINT_2]FF0
+setp pid.2.FF1 [JOINT_2]FF1
+setp pid.2.FF2 [JOINT_2]FF2
+setp pid.2.deadband [JOINT_2]DEADBAND
+setp pid.2.maxoutput [JOINT_2]MAX_OUTPUT
+
+# position command signals
+setp hm2_[HOSTMOT2](BOARD).0.pwmgen.02.output-type 1 #pwm on pin1, dir on pin2
+setp hm2_[HOSTMOT2](BOARD).0.pwmgen.02.scale [JOINT_2]OUTPUT_SCALE
+
+net emcmot.02.pos-cmd joint.2.motor-pos-cmd => pid.2.command
+net motor.02.command  pid.2.output  =>  hm2_[HOSTMOT2](BOARD).0.pwmgen.02.value
+
+
+# ##################################################
+# Standard I/O Block - EStop, Etc
+# ##################################################
+
+# create a signal for the estop loopback
+net estop-loop iocontrol.0.user-enable-out => iocontrol.0.emc-enable-in
+
+# create signals for tool loading loopback
+net tool-prep-loop iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
+net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
+
+
+#
+# homing
+#
+
+#
+# In this example, each of the three axes have their own home switch.  All
+# home switches are connected to GPIO 25, though hostmot2 boards generally
+# have enough GPIO pins to put each axis' home switch on its own pin.
+#
+# Each switch is normally open, momentarily closed.  When the switch is open,
+# GPIO 25 floats high (because that is the hostmot2 way).  When the switch is
+# closed, it shorts GPIO 25 to ground.
+#
+# EMC expects the value on the .home-sw-in HAL pin to be active high, ie
+# True when the switch is closed and False when the switch is open.
+# We get this behavior by linking the GPIO .in_not pin instead of the .in
+# pin.
+#
+
+net home-switch <= hm2_[HOSTMOT2](BOARD).0.gpio.025.in_not
+net home-switch => joint.0.home-sw-in
+net home-switch => joint.1.home-sw-in
+net home-switch => joint.2.home-sw-in
+
+# only the Y servo has an index, X and Z home without using the index
+net y-index-enable hm2_[HOSTMOT2](BOARD).0.encoder.01.index-enable <=> joint.1.index-enable
+

--- a/configs/by_interface/mesa/hm2-stepper/3x20-small.ini
+++ b/configs/by_interface/mesa/hm2-stepper/3x20-small.ini
@@ -71,6 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
 
 [EMCIO]
 # Name of IO controller program, e.g., io

--- a/configs/by_interface/mesa/hm2-stepper/4i65.ini
+++ b/configs/by_interface/mesa/hm2-stepper/4i65.ini
@@ -71,7 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
-
+MAX_LINEAR_VELOCITY = 100
 [EMCIO]
 # Name of IO controller program, e.g., io
 EMCIO =                 io

--- a/configs/by_interface/mesa/hm2-stepper/4i68.ini
+++ b/configs/by_interface/mesa/hm2-stepper/4i68.ini
@@ -71,6 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
 
 [EMCIO]
 # Name of IO controller program, e.g., io

--- a/configs/by_interface/mesa/hm2-stepper/5i20.ini
+++ b/configs/by_interface/mesa/hm2-stepper/5i20.ini
@@ -71,6 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
 
 [EMCIO]
 # Name of IO controller program, e.g., io

--- a/configs/by_interface/mesa/hm2-stepper/5i22-big.ini
+++ b/configs/by_interface/mesa/hm2-stepper/5i22-big.ini
@@ -71,6 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
 
 [EMCIO]
 # Name of IO controller program, e.g., io

--- a/configs/by_interface/mesa/hm2-stepper/5i22-small.ini
+++ b/configs/by_interface/mesa/hm2-stepper/5i22-small.ini
@@ -71,6 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
 
 [EMCIO]
 # Name of IO controller program, e.g., io

--- a/configs/by_interface/mesa/hm2-stepper/5i23.ini
+++ b/configs/by_interface/mesa/hm2-stepper/5i23.ini
@@ -71,6 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
 
 [EMCIO]
 # Name of IO controller program, e.g., io

--- a/configs/by_interface/mesa/hm2-stepper/5i23.ini
+++ b/configs/by_interface/mesa/hm2-stepper/5i23.ini
@@ -81,7 +81,7 @@ CYCLE_TIME =            0.100
 TOOL_TABLE =            tool.tbl
 
 [KINS]
-KINEMATICS =  trivkins
+KINEMATICS = trivkins
 JOINTS = 3
 
 [AXIS_X]

--- a/configs/by_interface/mesa/hm2-stepper/7i43-big.ini
+++ b/configs/by_interface/mesa/hm2-stepper/7i43-big.ini
@@ -71,6 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
 
 [EMCIO]
 # Name of IO controller program, e.g., io

--- a/configs/by_interface/mesa/hm2-stepper/7i43-small.ini
+++ b/configs/by_interface/mesa/hm2-stepper/7i43-small.ini
@@ -71,6 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
 
 [EMCIO]
 # Name of IO controller program, e.g., io

--- a/configs/by_interface/mesa/hm2-stepper/7i90.ini
+++ b/configs/by_interface/mesa/hm2-stepper/7i90.ini
@@ -71,6 +71,7 @@ COORDINATES =           X Y Z
 #HOME =                  0 0 0
 LINEAR_UNITS =          inch
 ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
 
 [EMCIO]
 # Name of IO controller program, e.g., io

--- a/configs/by_interface/mesa/hm2-stepper/7i93.ini
+++ b/configs/by_interface/mesa/hm2-stepper/7i93.ini
@@ -1,0 +1,200 @@
+[EMC]
+# The version string for this INI file.
+VERSION = 1.1
+# Name of machine, for use with display, etc.
+MACHINE =               HM2-Stepper
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+#DEBUG =                0x00000003
+#DEBUG =                0x00000007
+DEBUG = 0
+
+[DISPLAY]
+# Name of display program, e.g., tklinuxcnc
+#DISPLAY =               tklinuxcnc
+DISPLAY =              axis
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.0500
+# Path to help file
+HELP_FILE =             tklinuxcnc.txt
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.5
+# Prefix to be used
+PROGRAM_PREFIX = ../../nc_files/
+# Introductory graphic
+INTRO_GRAPHIC =         linuxcnc.gif
+INTRO_TIME =            5
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+
+[RS274NGC]
+# File containing interpreter variables
+PARAMETER_FILE =        hm2-stepper.var
+
+[EMCMOT]
+EMCMOT =                motmod
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+# Servo task period, in nanoseconds
+SERVO_PERIOD =          1000000
+
+[TASK]
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.010
+
+[HAL]
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+HALFILE =		hm2-stepper-eth.hal
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =               save neta
+
+[HALUI]
+#No Content
+
+[TRAJ]
+COORDINATES =           X Y Z
+#HOME =                  0 0 0
+LINEAR_UNITS =          inch
+ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
+
+[EMCIO]
+# Name of IO controller program, e.g., io
+EMCIO =                 io
+# cycle time, in seconds
+CYCLE_TIME =            0.100
+# tool table file
+TOOL_TABLE =            tool.tbl
+
+[KINS]
+KINEMATICS = trivkins
+JOINTS = 3
+
+[AXIS_X]
+MIN_LIMIT = -10.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 10
+MAX_ACCELERATION = 20
+
+[JOINT_0]
+# 
+# Step timing is 40 us steplen + 40 us stepspace
+# That gives 80 us step period = 12.5 KHz step freq
+#
+# Bah, even software stepping can handle that, hm2 doesn't buy you much with
+# such slow steppers.
+#
+# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
+#
+# This gives a maxvel of 12.5/1 = 12.5 ips
+#
+TYPE =              LINEAR
+MAX_VELOCITY =       10
+MAX_ACCELERATION =   20
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    12
+STEPGEN_MAX_ACC =    24
+BACKLASH =           0.000
+# scale is 200 steps/rev * 5 revs/inch
+SCALE =           1000
+MIN_LIMIT =             -10.0
+MAX_LIMIT =             10.0
+FERROR =     0.050
+MIN_FERROR = 0.005
+#HOME =                  0.000
+#HOME_OFFSET =           0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         1
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              40000
+STEPSPACE  =              40000
+
+[AXIS_Y]
+MIN_LIMIT = -10.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 10
+MAX_ACCELERATION = 20
+
+[JOINT_1]
+TYPE =              LINEAR
+MAX_VELOCITY =       10
+MAX_ACCELERATION =   20
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    12
+STEPGEN_MAX_ACC =    24
+BACKLASH =           0.000
+SCALE = 1000
+MIN_LIMIT =             -10.0
+MAX_LIMIT =             10.0
+FERROR =     0.050
+MIN_FERROR = 0.005
+#HOME =                  0.000
+#HOME_OFFSET =           0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         1
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              40000
+STEPSPACE  =              40000
+
+[AXIS_Z]
+MIN_LIMIT = -10.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 10
+MAX_ACCELERATION = 20
+
+[JOINT_2]
+TYPE =              LINEAR
+MAX_VELOCITY =      10
+MAX_ACCELERATION =  20
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    12
+STEPGEN_MAX_ACC =    24
+BACKLASH =           0.000
+SCALE = 1000
+MIN_LIMIT =             -10.0
+MAX_LIMIT =             10.0
+FERROR =     0.050
+MIN_FERROR = 0.005
+#HOME =                  0.000
+#HOME_OFFSET =           0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         0
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              40000
+STEPSPACE  =              40000
+
+[HOSTMOT2]
+DRIVER=hm2_eth
+BOARD_IP=192.168.1.121
+BOARD=7i93
+CONFIG="num_encoders=0 num_pwmgens=0 num_stepgens=3"

--- a/configs/by_interface/mesa/hm2-stepper/7i96s.ini
+++ b/configs/by_interface/mesa/hm2-stepper/7i96s.ini
@@ -1,0 +1,200 @@
+[EMC]
+# The version string for this INI file.
+VERSION = 1.1
+# Name of machine, for use with display, etc.
+MACHINE =               HM2-Stepper
+# Debug level, 0 means no messages. See src/emc/nml_int/emcglb.h for others
+#DEBUG =                0x00000003
+#DEBUG =                0x00000007
+DEBUG = 0
+
+[DISPLAY]
+# Name of display program, e.g., tklinuxcnc
+#DISPLAY =               tklinuxcnc
+DISPLAY =              axis
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.0500
+# Path to help file
+HELP_FILE =             tklinuxcnc.txt
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET =       RELATIVE
+# Initial display setting for position, COMMANDED or ACTUAL
+POSITION_FEEDBACK =     ACTUAL
+# Highest value that will be allowed for feed override, 1.0 = 100%
+MAX_FEED_OVERRIDE =     1.5
+# Prefix to be used
+PROGRAM_PREFIX = ../../nc_files/
+# Introductory graphic
+INTRO_GRAPHIC =         linuxcnc.gif
+INTRO_TIME =            5
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Grayscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+
+[RS274NGC]
+# File containing interpreter variables
+PARAMETER_FILE =        hm2-stepper.var
+
+[EMCMOT]
+EMCMOT =                motmod
+# Timeout for comm to emcmot, in seconds
+COMM_TIMEOUT =          1.0
+# Servo task period, in nanoseconds
+SERVO_PERIOD =          1000000
+
+[TASK]
+# Name of task controller program, e.g., milltask
+TASK =                  milltask
+# Cycle time, in seconds, that task controller will sleep between polls
+CYCLE_TIME =            0.010
+
+[HAL]
+# The run script first uses halcmd to execute any HALFILE
+# files, and then to execute any individual HALCMD commands.
+# list of hal config files to run through halcmd
+# files are executed in the order in which they appear
+HALFILE =		hm2-stepper-eth.hal
+# list of halcmd commands to execute
+# commands are executed in the order in which they appear
+#HALCMD =               save neta
+
+[HALUI]
+#No Content
+
+[TRAJ]
+COORDINATES =           X Y Z
+#HOME =                  0 0 0
+LINEAR_UNITS =          inch
+ANGULAR_UNITS =         degree
+MAX_LINEAR_VELOCITY = 100
+
+[EMCIO]
+# Name of IO controller program, e.g., io
+EMCIO =                 io
+# cycle time, in seconds
+CYCLE_TIME =            0.100
+# tool table file
+TOOL_TABLE =            tool.tbl
+
+[KINS]
+KINEMATICS = trivkins
+JOINTS = 3
+
+[AXIS_X]
+MIN_LIMIT = -10.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 10
+MAX_ACCELERATION = 20
+
+[JOINT_0]
+# 
+# Step timing is 40 us steplen + 40 us stepspace
+# That gives 80 us step period = 12.5 KHz step freq
+#
+# Bah, even software stepping can handle that, hm2 doesn't buy you much with
+# such slow steppers.
+#
+# Scale is 200 steps/rev * 5 revs/inch = 1000 steps/inch
+#
+# This gives a maxvel of 12.5/1 = 12.5 ips
+#
+TYPE =              LINEAR
+MAX_VELOCITY =       10
+MAX_ACCELERATION =   20
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    12
+STEPGEN_MAX_ACC =    24
+BACKLASH =           0.000
+# scale is 200 steps/rev * 5 revs/inch
+SCALE =           1000
+MIN_LIMIT =             -10.0
+MAX_LIMIT =             10.0
+FERROR =     0.050
+MIN_FERROR = 0.005
+#HOME =                  0.000
+#HOME_OFFSET =           0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         1
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              40000
+STEPSPACE  =              40000
+
+[AXIS_Y]
+MIN_LIMIT = -10.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 10
+MAX_ACCELERATION = 20
+
+[JOINT_1]
+TYPE =              LINEAR
+MAX_VELOCITY =       10
+MAX_ACCELERATION =   20
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    12
+STEPGEN_MAX_ACC =    24
+BACKLASH =           0.000
+SCALE = 1000
+MIN_LIMIT =             -10.0
+MAX_LIMIT =             10.0
+FERROR =     0.050
+MIN_FERROR = 0.005
+#HOME =                  0.000
+#HOME_OFFSET =           0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         1
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              40000
+STEPSPACE  =              40000
+
+[AXIS_Z]
+MIN_LIMIT = -10.0
+MAX_LIMIT = 10.0
+MAX_VELOCITY = 10
+MAX_ACCELERATION = 20
+
+[JOINT_2]
+TYPE =              LINEAR
+MAX_VELOCITY =      10
+MAX_ACCELERATION =  20
+# Set Stepgen max 20% higher than the axis
+STEPGEN_MAX_VEL =    12
+STEPGEN_MAX_ACC =    24
+BACKLASH =           0.000
+SCALE = 1000
+MIN_LIMIT =             -10.0
+MAX_LIMIT =             10.0
+FERROR =     0.050
+MIN_FERROR = 0.005
+#HOME =                  0.000
+#HOME_OFFSET =           0.10
+#HOME_SEARCH_VEL =       0.10
+#HOME_LATCH_VEL =        -0.01
+#HOME_USE_INDEX =        YES
+#HOME_IGNORE_LIMITS =    YES
+HOME_SEQUENCE =         0
+# these are in nanoseconds
+DIRSETUP   =              200
+DIRHOLD    =              200
+STEPLEN    =              40000
+STEPSPACE  =              40000
+
+[HOSTMOT2]
+DRIVER=hm2_eth
+BOARD_IP=192.168.1.121
+BOARD=7i96s
+CONFIG="num_encoders=0 num_pwmgens=0 num_stepgens=3"

--- a/configs/by_interface/mesa/hm2-stepper/hm2-stepper-eth.hal
+++ b/configs/by_interface/mesa/hm2-stepper/hm2-stepper-eth.hal
@@ -1,0 +1,202 @@
+# #######################################
+#
+# HAL file for HostMot2 with 3 steppers
+#
+# Derived from Ted Hyde's original hm2-servo config
+#
+# Based up work and discussion with Seb & Peter & Jeff
+# GNU license references - insert here. www.linuxcnc.org
+#
+#
+# ########################################
+# Firmware files are in /lib/firmware/hm2/7i43/
+# Must symlink the hostmot2 firmware directory of sanbox to
+# /lib/firmware before running EMC2...
+# sudo ln -s $HOME/emc2-sandbox/src/hal/drivers/mesa-hostmot2/firmware /lib/firmware/hm2
+#
+# See also:
+# <http://www.linuxcnc.org/docs/devel/html/man/man9/hostmot2.9.html#config%20modparam>
+# and http://wiki.linuxcnc.org/cgi-bin/emcinfo.pl?HostMot2
+#
+# #####################################################################
+
+
+# ###################################
+# Core EMC/HAL Loads
+# ###################################
+
+# kinematics
+loadrt [KINS]KINEMATICS
+
+# motion controller, get name and thread periods from ini file
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[KINS]JOINTS
+
+# hostmot2 driver
+loadrt hostmot2
+
+# load low-level driver
+loadrt [HOSTMOT2](DRIVER) board_ip=[HOSTMOT2](BOARD_IP) config=[HOSTMOT2](CONFIG)
+
+# load estop latch component
+loadrt estop_latch
+
+# ################################################
+# THREADS
+# ################################################
+
+addf hm2_[HOSTMOT2](BOARD).0.read         servo-thread
+addf motion-command-handler               servo-thread
+addf motion-controller                    servo-thread
+# revel in the free time here from not having to run PID 
+addf hm2_[HOSTMOT2](BOARD).0.write        servo-thread
+addf estop-latch.0                        servo-thread
+       
+
+# ######################################################
+# Axis-of-motion Specific Configs (not the GUI)
+# ######################################################
+
+
+# ################
+# X [0] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.00.enable bit
+sets emcmot.00.enable FALSE
+
+net emcmot.00.enable <= joint.0.amp-enable-out 
+net emcmot.00.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.00.enable
+
+
+# position command and feedback
+net emcmot.00.pos-cmd <= joint.0.motor-pos-cmd
+net emcmot.00.pos-cmd => hm2_[HOSTMOT2](BOARD).0.stepgen.00.position-cmd
+
+net motor.00.pos-fb <= hm2_[HOSTMOT2](BOARD).0.stepgen.00.position-fb
+net motor.00.pos-fb => joint.0.motor-pos-fb
+
+
+# timing parameters
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.dirsetup        [JOINT_0]DIRSETUP
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.dirhold         [JOINT_0]DIRHOLD
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.steplen         [JOINT_0]STEPLEN
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.stepspace       [JOINT_0]STEPSPACE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.position-scale  [JOINT_0]SCALE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.maxvel          [JOINT_0]STEPGEN_MAX_VEL
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.maxaccel        [JOINT_0]STEPGEN_MAX_ACC
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.00.step_type       0
+
+
+# ################
+# Y [1] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.01.enable bit
+sets emcmot.01.enable FALSE
+
+net emcmot.01.enable <= joint.1.amp-enable-out 
+net emcmot.01.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.01.enable
+
+
+# position command and feedback
+net emcmot.01.pos-cmd <= joint.1.motor-pos-cmd
+net emcmot.01.pos-cmd => hm2_[HOSTMOT2](BOARD).0.stepgen.01.position-cmd
+
+net motor.01.pos-fb <= hm2_[HOSTMOT2](BOARD).0.stepgen.01.position-fb
+net motor.01.pos-fb => joint.1.motor-pos-fb
+
+
+# timing parameters
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.dirsetup        [JOINT_1]DIRSETUP
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.dirhold         [JOINT_1]DIRHOLD
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.steplen         [JOINT_1]STEPLEN
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.stepspace       [JOINT_1]STEPSPACE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.position-scale  [JOINT_1]SCALE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.maxvel          [JOINT_1]STEPGEN_MAX_VEL
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.maxaccel        [JOINT_1]STEPGEN_MAX_ACC
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.01.step_type       0
+
+
+# ################
+# Z [2] Axis
+# ################
+
+# axis enable chain
+newsig emcmot.02.enable bit
+sets emcmot.02.enable FALSE
+
+net emcmot.02.enable <= joint.2.amp-enable-out 
+net emcmot.02.enable => hm2_[HOSTMOT2](BOARD).0.stepgen.02.enable
+
+
+# position command and feedback
+net emcmot.02.pos-cmd <= joint.2.motor-pos-cmd
+net emcmot.02.pos-cmd => hm2_[HOSTMOT2](BOARD).0.stepgen.02.position-cmd
+
+net motor.02.pos-fb <= hm2_[HOSTMOT2](BOARD).0.stepgen.02.position-fb
+net motor.02.pos-fb => joint.2.motor-pos-fb
+
+
+# timing parameters
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.dirsetup        [JOINT_2]DIRSETUP
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.dirhold         [JOINT_2]DIRHOLD
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.steplen         [JOINT_2]STEPLEN
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.stepspace       [JOINT_2]STEPSPACE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.position-scale  [JOINT_2]SCALE
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.maxvel          [JOINT_2]STEPGEN_MAX_VEL
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.maxaccel        [JOINT_2]STEPGEN_MAX_ACC
+
+setp hm2_[HOSTMOT2](BOARD).0.stepgen.02.step_type       0
+
+
+
+
+# 
+# The Mesa AnyIO output pins can be in open-drain mode (drive low, float
+# high) or push/pull mode (drive low, drive high).
+#
+# When a logical output is 1 in open-drain mode, the FPGA lets the pin
+# float and it gets pulled high to +5V via a 10K resistor.
+#
+# When a logical output is 1 in push/pull mode, the FPGA pushes the pin
+# high but only to +3.3V.  This is problematic on some kinds of inputs.
+#
+
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.048.is_opendrain 1
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.049.is_opendrain 1
+
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.054.is_opendrain 1
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.055.is_opendrain 1
+
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.060.is_opendrain 1
+#setp hm2_[HOSTMOT2](BOARD).0.gpio.061.is_opendrain 1
+
+
+
+
+# ##################################################
+# Standard I/O Block - EStop, Etc
+# ##################################################
+
+# A basic estop loop that only includes the hostmot watchdog.
+net user-enable iocontrol.0.user-request-enable => estop-latch.0.reset
+net enable-latch estop-latch.0.ok-out => iocontrol.0.emc-enable-in
+net watchdog hm2_[HOSTMOT2](BOARD).0.watchdog.has_bit => estop-latch.0.fault-in
+
+# create signals for tool loading loopback
+net tool-prep-loop iocontrol.0.tool-prepare => iocontrol.0.tool-prepared
+net tool-change-loop iocontrol.0.tool-change => iocontrol.0.tool-changed
+


### PR DESCRIPTION
This makes the hm2-stepper configs run again on 2.9 (they were missing INI variables that are now required).  Also adds sample hm2 configs (stepper & servo) for a couple of Ethernet boards.