### PR TITLE
Update Error Message in Ini File

### DIFF
--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -109,7 +109,7 @@ static int Ini_init(pyIniFile *self, PyObject *a, PyObject *k) {
         self->i = new IniFile();
 
     if (!self->i->Open(inifile)) {
-        PyErr_Format( error, "inifile.open() failed");
+        PyErr_Format( error, "inifile.open(%s) failed", inifile);
         return -1;
     }
     return 0;


### PR DESCRIPTION
Using a python script loading the ini file with linuxcnc.ini(). Several hours of debugging to find out the wrong INI file was passing in. This would've saved a few hours.