### PR TITLE
axis: copy gcode to temporary file before opening (fixes #2418)

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1183,7 +1183,7 @@ def open_file_guts(f, filtered=False, addrecent=True):
         loaded_file = f
         program_filter = get_filter(f)
         if program_filter:
-            tempfile = os.path.join(tempdir, os.path.basename(f))
+            tempfile = os.path.join(tempdir, "filtered-" + os.path.basename(f))
             exitcode, stderr = filter_program(program_filter, f, tempfile)
             if exitcode:
                 root_window.tk.call("nf_dialog", (".error", "-ext", stderr),
@@ -1900,9 +1900,14 @@ def reload_file(refilter=True):
     o.set_highlight_line(None)
 
     if refilter or not get_filter(loaded_file):
-        open_file_guts(loaded_file, False, False)
-    else:
+        # we copy the file to a temporary file so that even if it subsequently
+        # changes on disk, LinuxCNC is parsing the file contents from the time
+        # the user opened the file
         tempfile = os.path.join(tempdir, os.path.basename(loaded_file))
+        shutil.copyfile(loaded_file, tempfile)
+        open_file_guts(tempfile, False, False)
+    else:
+        tempfile = os.path.join(tempdir, "filtered-" + os.path.basename(loaded_file))
         open_file_guts(tempfile, True, False)
     if line:
         o.set_highlight_line(line)


### PR DESCRIPTION
The issue here is that if you open a gcode file, and then change the file on disk, you'll think your changes are completely inert because they don't show up in the GUI, but actually LinuxCNC has its own separate file handle behind-the-scenes, and your machine can do scary and unpredictable things.

With this fix, the code being executed by LinuxCNC always matches what is displayed in the AXIS GUI even if you subsequently change the file.