### PR TITLE
Fix task motion race

### DIFF
--- a/src/emc/motion-logger/motion-logger.c
+++ b/src/emc/motion-logger/motion-logger.c
@@ -312,12 +312,11 @@ int main(int argc, char* argv[]) {
     init_comm_buffers();
 
     while (1) {
-        if (c->commandNum != c->tail) {
-            // "split read"
-            continue;
-        }
+        rtapi_mutex_get(&emcmotStruct->command_mutex);
+
         if (c->commandNum == emcmotStatus->commandNumEcho) {
             // nothing new
+            rtapi_mutex_give(&emcmotStruct->command_mutex);
             maybe_reopen_logfile();
             usleep(10 * 1000);
             continue;
@@ -706,6 +705,8 @@ int main(int argc, char* argv[]) {
         emcmotStatus->commandNumEcho = c->commandNum;
         emcmotStatus->commandStatus = EMCMOT_COMMAND_OK;
         emcmotStatus->tail = emcmotStatus->head;
+
+        rtapi_mutex_give(&emcmotStruct->command_mutex);
     }
 
     return 0;

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -692,10 +692,8 @@ static int init_comm_buffers(void)
     emcmotErrorInit(emcmotError);
 
     /* init command struct */
-    emcmotCommand->head = 0;
     emcmotCommand->command = 0;
     emcmotCommand->commandNum = 0;
-    emcmotCommand->tail = 0;
 
     /* init status struct */
     emcmotStatus->head = 0;

--- a/src/emc/motion/motion.h
+++ b/src/emc/motion/motion.h
@@ -214,7 +214,6 @@ extern "C" {
    memory, and all commands from higher level code come thru it.
 */
     typedef struct emcmot_command_t {
-	unsigned char head;	/* flag count for mutex detect */
 	cmd_code_t command;	/* command code (enum) */
 	int commandNum;		/* increment this for new command */
 	double motor_offset;    /* offset from joint to motor position */
@@ -265,7 +264,6 @@ extern "C" {
 	char    direction;      /* CANON_DIRECTION flag for spindle orient */
 	double  timeout;        /* of wait for spindle orient to complete */
 	unsigned char wait_for_spindle_at_speed; // EMCMOT_SPINDLE_ON now carries this, for next feed move
-	unsigned char tail;	/* flag count for mutex detect */
         int arcBlendOptDepth;
         int arcBlendEnable;
         int arcBlendFallbackEnable;

--- a/src/emc/motion/motion_struct.h
+++ b/src/emc/motion/motion_struct.h
@@ -12,9 +12,14 @@
 #ifndef MOTION_STRUCT_H
 #define MOTION_STRUCT_H
 
+#include <rtapi_mutex.h>
+
+
 /* big comm structure, for upper memory */
     typedef struct emcmot_struct_t {
+        rtapi_mutex_t command_mutex;  // Used to protect access to `command`.
         struct emcmot_command_t command;   /* struct used to pass commands/data from Task to Motion */
+
 	struct emcmot_status_t status;	/* Struct used to store RT status */
 	struct emcmot_config_t config;	/* Struct used to store RT config */
 	struct emcmot_internal_t internal;	/*! \todo FIXME - doesn't need to be in

--- a/src/emc/motion/motion_struct.h
+++ b/src/emc/motion/motion_struct.h
@@ -14,8 +14,7 @@
 
 /* big comm structure, for upper memory */
     typedef struct emcmot_struct_t {
-	struct emcmot_command_t command;	/* struct used to pass commands/data
-					   to the RT module from usr space */
+        struct emcmot_command_t command;   /* struct used to pass commands/data from Task to Motion */
 	struct emcmot_status_t status;	/* Struct used to store RT status */
 	struct emcmot_config_t config;	/* Struct used to store RT config */
 	struct emcmot_internal_t internal;	/*! \todo FIXME - doesn't need to be in

--- a/src/emc/motion/usrmotintf.cc
+++ b/src/emc/motion/usrmotintf.cc
@@ -76,15 +76,13 @@ int usrmotWriteEmcmotCommand(emcmot_command_t * c)
 {
     emcmot_status_t s;
     static int commandNum = 0;
-    static unsigned char headCount = 0;
     double end;
 
     if (!MOTION_ID_VALID(c->id)) {
         rcs_print("USRMOT: ERROR: invalid motion id: %d\n",c->id);
 	return EMCMOT_COMM_INVALID_MOTION_ID;
     }
-    c->head = ++headCount;
-    c->tail = c->head;
+
     c->commandNum = ++commandNum;
 
     /* check for mapped mem still around */
@@ -92,8 +90,12 @@ int usrmotWriteEmcmotCommand(emcmot_command_t * c)
         rcs_print("USRMOT: ERROR: can't connect to shared memory\n");
 	return EMCMOT_COMM_ERROR_CONNECT;
     }
+
     /* copy entire command structure to shared memory */
+    rtapi_mutex_get(&emcmotStruct->command_mutex);
     *emcmotCommand = *c;
+    rtapi_mutex_give(&emcmotStruct->command_mutex);
+
     /* poll for receipt of command */
     /* set timeout for comm failure, now + timeout */
     end = etime() + EMCMOT_COMM_TIMEOUT;


### PR DESCRIPTION
This fixes a race condition in communications between Task and Motion, identified by @devinor in #2386.

It introduces a mutex to synchronize the command buffer between Task and Motion.

Task (which is non-realtime) takes the mutex to lock the buffer while it's writing the new command to the shared memory buffer.

Motion (which is realtime) uses trylock so it won't block if Task has the command buffer locked.  Instead it waits until the next invocation of `motion-command-handler`, when it checks again to see if Task is done copying and has unlocked the mutex.  I believe this "try again later" behavior is the same as the intent of the old racy `head`/`tail` synchronization code (which probably worked fine on single-core machines, back at the dawn of time, but falls apart on "modern" 1990s-era hardware).