### PR TITLE
Fix elbpcom

### DIFF
--- a/docs/man/man1/elbpcom.1
+++ b/docs/man/man1/elbpcom.1
@@ -10,6 +10,7 @@ Common options:
 .BI [\-\-port= PORT ]
 .BI [\-\-timeout= TIMEOUT ]
 .BI [\-\-space= MEMSPACE ]
+.BI [\-\-size= TRANSFER_SIZE ]
 .RE
 
 Reading data:
@@ -54,7 +55,14 @@ If not specified, the default values are
 .BI \-\-port= 27181
 .BI \-\-timeout= .2
 .BI \-\-space= 0
+.BI \-\-size= 0
 .RE 
+
+If the
+.B --size
+argument
+.I TRANSFER_SIZE
+is 0, elbpcom will look up the preferred transfer size of the space in the space's info area.
 
 This example demonstrates reading the HOSTMOT2 identifying string from the
 IDROM in space 0:

--- a/docs/man/man1/elbpcom.1
+++ b/docs/man/man1/elbpcom.1
@@ -9,13 +9,13 @@ Common options:
 .BI [\-\-ip= IP ]
 .BI [\-\-port= PORT ]
 .BI [\-\-timeout= TIMEOUT ]
+.BI [\-\-space= MEMSPACE ]
 .RE
 
 Reading data:
 .RS
 .SY elbpcom
 .BI [ common\ options ]
-.BI \-\-space= SPACE
 .B [\-\-info]
 .BI \-\-address= ADDRESS
 .BI \-\-read= LENGTH
@@ -25,7 +25,6 @@ Writing data:
 .RS
 .SY elbpcom
 .BI [ common\ options ]
-.BI \-\-space= SPACE
 .BI \-\-address= ADDRESS
 .BI \-\-write= HEXDATA
 .RE
@@ -54,13 +53,14 @@ If not specified, the default values are
 .BI \-\-ip= 192.168.1.121
 .BI \-\-port= 27181
 .BI \-\-timeout= .2
+.BI \-\-space= 0
 .RE 
 
 This example demonstrates reading the HOSTMOT2 identifying string from the
 IDROM in space 0:
 .RS
 .nf
-$ elbpcom \-\-space 0 \-\-address 0x104 \-\-read 8
+$ elbpcom \-\-address 0x104 \-\-read 8
 > 82420401
 < 484f53544d4f5432
       HOSTMOT2

--- a/docs/man/man1/elbpcom.1
+++ b/docs/man/man1/elbpcom.1
@@ -30,6 +30,13 @@ Writing data:
 .BI \-\-write= HEXDATA
 .RE
 
+Read and decode memory space info area:
+.RS
+.SY elbpcom
+.BI [\-\-space= MEMSPACE ]
+.BI \-\-read-info
+.RE
+
 Sending arbitrary packets:
 .RS
 .SY elbpcom

--- a/src/hal/utils/elbpcom.py
+++ b/src/hal/utils/elbpcom.py
@@ -42,7 +42,7 @@ parser.add_option("-a", "--address", type="int", dest="address", default=None,
     help="Base address to read or write")
 parser.add_option("-I", "--increment", dest="increment", action="store_true",
     default=True,
-    help="auto-increment address")
+    help="auto-increment address (enabled by default, use --no-increment to disable)")
 parser.add_option("-n", "--no-increment", dest="increment",
     action="store_false",
     help="do not auto-increment address")

--- a/src/hal/utils/elbpcom.py
+++ b/src/hal/utils/elbpcom.py
@@ -46,6 +46,9 @@ parser.add_option("-I", "--increment", dest="increment", action="store_true",
 parser.add_option("-n", "--no-increment", dest="increment",
     action="store_false",
     help="do not auto-increment address")
+parser.add_option("--size", dest="size",
+    help="Transfer size in number of bytes (default: look up preferred transfer size in the space's info area)",
+    type="int", default=0)
 parser.add_option("-r", "--read", type="int", dest="read", default=None,
     help="Number of bytes to read")
 parser.add_option("-w", "--write", type="string", dest="write", default=None,
@@ -109,16 +112,18 @@ def optimal_size(space:int, info:bool, address:int, nbytes:int):
 
 if options.read:
     if options.address is None: raise SystemExit("--read must specify --address")
-    size = optimal_size(options.space, options.info, options.address, options.read if options.increment else 0)
-    command = make_read_request(options.space, options.info, size, options.increment, options.address, options.read)
+    if options.size == 0:
+        options.size = optimal_size(options.space, options.info, options.address, options.read if options.increment else 0)
+    command = make_read_request(options.space, options.info, options.size, options.increment, options.address, options.read)
     print(">", command.hex())
     transact(command)
 
 elif options.write:
     if options.address is None: raise SystemExit("--write must specify --address")
     write = bytes.fromhex(options.write)
-    size = optimal_size(options.space, options.info, options.address, len(write) if options.increment else 0)
-    command = make_write_request(options.space, options.info, size, options.increment, options.address, write)
+    if options.size == 0:
+        options.size = optimal_size(options.space, options.info, options.address, len(write) if options.increment else 0)
+    command = make_write_request(options.space, options.info, options.size, options.increment, options.address, write)
     print(">", command.hex())
     transact(command, response=False)
 

--- a/src/hal/utils/elbpcom.py
+++ b/src/hal/utils/elbpcom.py
@@ -26,12 +26,12 @@ import struct
 parser = optparse.OptionParser("%prog [options] [commands]",
     description="Communicate with Mesa ethernet cards using the LBP16 protocol")
 parser.add_option("-i", "--ip", dest="sip",
-    help="IP address of board",
+    help="IP address of board (default: 192.168.1.121)",
     metavar="X.Y.Z.W", default="192.168.1.121")
 parser.add_option("-p", "--port", dest="sport",
-    help="UDP port of board", type="int", default=27181)
+    help="UDP port of board (default: 27181)", type="int", default=27181)
 parser.add_option("-t", "--timeout", dest="timeout",
-    help="Response timeout in seconds", type="float", default=.2)
+    help="Response timeout in seconds (default: 0.2)", type="float", default=.2)
 parser.add_option("-s", "--space", dest="space", default=None,
     choices = ["0", "1", "2", "3", "4", "5", "6", "7"],
     help="Address space to read or write")

--- a/src/hal/utils/elbpcom.py
+++ b/src/hal/utils/elbpcom.py
@@ -32,9 +32,9 @@ parser.add_option("-p", "--port", dest="sport",
     help="UDP port of board (default: 27181)", type="int", default=27181)
 parser.add_option("-t", "--timeout", dest="timeout",
     help="Response timeout in seconds (default: 0.2)", type="float", default=.2)
-parser.add_option("-s", "--space", dest="space", default=None,
+parser.add_option("-s", "--space", dest="space", default=0,
     choices = ["0", "1", "2", "3", "4", "5", "6", "7"],
-    help="Address space to read or write")
+    help="Address space to read or write (default: 0, the hm2 register file)")
 parser.add_option("--info", dest="info", action="store_true",
     default=False,
     help="Select info area for read operation (default: memory space)")
@@ -109,7 +109,6 @@ def optimal_size(space, info, address, nbytes):
     raise ValueError("Access size incompatible with address or length (address=%d nbytes=%d memsizes=%d)" % (address, nbytes, memsizes))
 
 if options.read:
-    if options.space is None: raise SystemExit("--read must specify --space")
     if options.address is None: raise SystemExit("--read must specify --address")
     size = optimal_size(options.space, options.info, options.address, options.read if options.increment else 0)
     command = make_read_request(options.space, options.info, size, options.increment, options.address, options.read)
@@ -118,7 +117,6 @@ if options.read:
     transact(command)
 
 elif options.write:
-    if options.space is None: raise SystemExit("--write must specify --space")
     if options.address is None: raise SystemExit("--write must specify --address")
     write = options.write.decode("hex")
     size = optimal_size(options.space, options.info, options.address, len(write) if options.increment else 0)


### PR DESCRIPTION
elbpcom is a low-level tool for talking to Hostmot2 ethernet devices.  It doesn't get used much, and has been broken since the python2-to-python3 transition.  This PR makes it run under python3, and extends the functionality slightly.