### PR TITLE
Fix a race between Task and Motion

### DIFF
--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -417,6 +417,14 @@ void emcmotCommandHandler(void *arg, long servo_period)
     int abort = 0;
     char* emsg = "";
 
+    if (emcmotCommand->commandNum == emcmotStatus->commandNumEcho) {
+      // if (emcmotCommand->commandNum == emcmotstatus->commandNumEcho)
+      // means has no new command, not need to execute
+      // if (emcmotCommand->commandNum != emcmotstatus->commandNumEcho)
+      // means has new command, will check complete of the new command
+      return;
+    }
+
     /* check for split read */
     if (emcmotCommand->head != emcmotCommand->tail) {
 	emcmotDebug->split++;


### PR DESCRIPTION
This fixes <#2386>

Follow is a summary quoted from Seb Kuzminsky.

> Before this commit, communication of the emcmot_command_t from Task to
> Motion had a race condition.  The race could cause Motion to process a
> command buffer consisting of some old fields from the previous command
  and some new fields from the current command.  The race is demonstrated
  by the following sequence of events:
>
> 1. Motion starts `emcmotCommandHandler()`.  It gets to command.c line 421 and reads the (old) `head` and `tail`, sees that they are the same, and believes that the command buffer is in a consistent state (i.e., not in the process of being updated).
>
> 2. Task starts `usrmotWriteEmcmotCommand()`.  It gets to usrmotintf.cc line 96 and starts writing a new command to shared memory.  It writes `head` and `commandNum`, but nothing after that.
>
> 3. Motion continues, gets to command.c line 425, sees the new `commandNum`, and believes that it has a new command.  Motion starts processing the command buffer, even though most of the fields haven't been updated by Task yet.
>
> 4. Task finishes copying the command into the shared memory buffer, but it's too late; Motion has processed an inconsistent command.

This commit ensures data complete by comparing emcmotCommand->commandNum and emcmotStatus->commandNumEcho, without changing the original solution.