### PR TITLE
Allowing Default Spindle to be selected

### DIFF
--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -508,6 +508,7 @@ if __name__ == "__main__":
   Specifies a list of colon (:) separated directories for user defined functions.
   Directories are specified relative to the current directory for the INI file or as absolute paths.
   The list must contain no intervening whitespace.
+* `DEFAULT_SPINDLE = 0` - Specify Default spindle used by M3,M4,M5 (-1 for all spindles)
 +
 A search is made for each possible user defined function, typically (M100-M199). The search order is:
 +

--- a/docs/src/gcode/m-code.adoc
+++ b/docs/src/gcode/m-code.adoc
@@ -101,7 +101,8 @@ on what using % does not do.
 * 'M5 [$n]' - stop the selected spindle.
 
 Use $ to operate on specific spindles.
-If $ is omitted then the commands default to operating on spindle 0.
+If RS274NGC:DEFAULT_SPINDLE is set in the ini file, commands will use specified spindle
+If RS274NGC:DEFAULT_SPINDLE is not set and $ is omitted then the commands default to operating on spindle 0.
 Use $-1 to operate on all active spindles.
 
 This example will start spindles 0, 1, and 2 simultaneously at different

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -3467,11 +3467,11 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
      } else { // default spindle
        if (settings->default_spindle == -1) {
          enqueue_START_SPINDLE_CLOCKWISE(0);
-         settings->spindle_turning[0] = CANON_CLOCKWISE;
+         settings->spindle_turning[0] = CANON_COUNTERCLOCKWISE;
        }
        else {
          enqueue_START_SPINDLE_CLOCKWISE(settings->default_spindle);
-         settings->spindle_turning[settings->default_spindle] = CANON_CLOCKWISE;
+         settings->spindle_turning[settings->default_spindle] = CANON_COUNTERCLOCKWISE;
        }
      }
  } else if ((block->m_modes[7] == 5) && ONCE_M(7)){

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -3442,8 +3442,14 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
             settings->spindle_turning[(int)block->dollar_number] = CANON_CLOCKWISE;
         }
      } else { // the default spindle
-        enqueue_START_SPINDLE_CLOCKWISE(0);
-        settings->spindle_turning[0] = CANON_CLOCKWISE;
+        if (settings->default_spindle == -1) {
+          enqueue_START_SPINDLE_CLOCKWISE(0);
+          settings->spindle_turning[0] = CANON_CLOCKWISE;
+        }
+        else {
+          enqueue_START_SPINDLE_CLOCKWISE(settings->default_spindle);
+          settings->spindle_turning[settings->default_spindle] = CANON_CLOCKWISE;
+        }
      }
  } else if ((block->m_modes[7] == 4) && ONCE_M(7)) {
      if (block->dollar_flag){
@@ -3459,8 +3465,14 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
             settings->spindle_turning[(int)block->dollar_number] = CANON_COUNTERCLOCKWISE;
         }
      } else { // default spindle
-         enqueue_START_SPINDLE_COUNTERCLOCKWISE(0);
-         settings->spindle_turning[0] = CANON_COUNTERCLOCKWISE;
+       if (settings->default_spindle == -1) {
+         enqueue_START_SPINDLE_CLOCKWISE(0);
+         settings->spindle_turning[0] = CANON_CLOCKWISE;
+       }
+       else {
+         enqueue_START_SPINDLE_CLOCKWISE(settings->default_spindle);
+         settings->spindle_turning[settings->default_spindle] = CANON_CLOCKWISE;
+       }
      }
  } else if ((block->m_modes[7] == 5) && ONCE_M(7)){
     if (block->dollar_flag){
@@ -3476,8 +3488,15 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
             enqueue_STOP_SPINDLE_TURNING(block->dollar_number);
         }
     } else { // the default spindle
-        settings->spindle_turning[0] = CANON_STOPPED;
-        enqueue_STOP_SPINDLE_TURNING(0);
+      if(settings->default_spindle == -1){
+        for (int i = 0; i < settings->num_spindles; i++){
+          settings->spindle_turning[i] = CANON_STOPPED;
+          enqueue_STOP_SPINDLE_TURNING(i);
+        }
+      }else {
+        settings->spindle_turning[settings->default_spindle] = CANON_STOPPED;
+        enqueue_STOP_SPINDLE_TURNING(settings->default_spindle);
+      }
     }
   } else if ((block->m_modes[7] == 19) && ONCE_M(7)) {
       for (int i = 0; i < settings->num_spindles; i++)

--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -805,6 +805,7 @@ struct setup
     bool loop_on_main_m99;
 
   int disable_g92_persistence;
+  int default_spindle;
 
 #define FEATURE(x) (_setup.feature_set & FEATURE_ ## x)
 #define FEATURE_RETAIN_G43           0x00000001

--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -177,6 +177,7 @@ setup::setup() :
     disable_fanuc_style_sub(false),
     loop_on_main_m99(false),
     disable_g92_persistence(0),
+    default_spindle(-1),
     pythis(),
     on_abort_command(NULL),
     init_once(CANON_STOPPED)

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -1063,7 +1063,13 @@ int Interp::init()
 		       "DISABLE_G92_PERSISTENCE",
 		       "RS274NGC");
 
-	  // INI file m98/m99 subprogram default setting
+    // INI file g52/g92 offset persistence default setting
+    inifile.Find(&_setup.default_spindle,
+                 "DEFAULT_SPINDLE",
+                 "RS274NGC");
+
+
+        // INI file m98/m99 subprogram default setting
 	  inifile.Find(&_setup.disable_fanuc_style_sub,
 		       "DISABLE_FANUC_STYLE_SUB",
 		       "RS274NGC");
@@ -1074,6 +1080,7 @@ int Interp::init()
           inifile.Close();
       }
   }
+
 
   _setup.length_units = GET_EXTERNAL_LENGTH_UNIT_TYPE();
   USE_LENGTH_UNITS(_setup.length_units);


### PR DESCRIPTION
Adds a setting to INI files to allow changes to M3,M4,M5

Feedback would be appreciated on if this should also affect M19, M51, G33, G74, G76, G84, G85, G86, G93-G97

Motivation: Mill with multiple spindles, our machinists did not like M5 didn't stop all spindles. I see the conversation here was to make a default value, #713. But this allows default behavior to be be changed. To comply with that setting the default should be 0.