### PR TITLE
RS274: M5 default to all spindles.

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -3476,8 +3476,10 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
             enqueue_STOP_SPINDLE_TURNING(block->dollar_number);
         }
     } else { // the default spindle
-        settings->spindle_turning[0] = CANON_STOPPED;
-        enqueue_STOP_SPINDLE_TURNING(0);
+      for (int i = 0; i < settings->num_spindles; i++){
+        settings->spindle_turning[i] = CANON_STOPPED;
+        enqueue_STOP_SPINDLE_TURNING(i);
+      }
     }
   } else if ((block->m_modes[7] == 19) && ONCE_M(7)) {
       for (int i = 0; i < settings->num_spindles; i++)


### PR DESCRIPTION
Default M5 to stop all spindles. Replaces: #2437 