### PR TITLE
Add note about axis direction and cite original source of 5-axis-kinematics docs

### DIFF
--- a/docs/src/motion/5-axis-kinematics.adoc
+++ b/docs/src/motion/5-axis-kinematics.adoc
@@ -20,6 +20,8 @@ Coordinated multi-axis CNC machine tools controlled with LinuxCNC, require a spe
 
 The kinematics components are given as well as vismach simulation models to demonstrate their behaviour on a computer screen. Examples of HAL file data are also given.
 
+Note that with these kinematics, the rotational axes move in the opposite direction of what the convention is. See section ["rotational axes"](https://linuxcnc.org/docs/html/gcode/machining-center.html#_rotational_axes) for details.
+
 == 5-Axis Machine Tool Configurations
 
 In this section we deal with the typical 5-axis milling or router machines with five joints or degrees-of-freedom which are controlled in coordinated moves.
@@ -412,6 +414,7 @@ image::5-axis-figures/Figure-11.png["Spindle tilting/rotary configuration",align
 
 == REFERENCES
 
+. AXIS MACHINE TOOLS: Kinematics and Vismach Implementation in LinuxCNC, RJ du Preez, SA-CNC-CLUB, April 7, 2016.
 . A Postprocessor Based on the Kinematics Model for General Five-Axis machine
   Tools: C-H She, R-S Lee, J Manufacturing Processes, V2 N2, 2000.
 . NC Post-processor for 5-axis milling of table-rotating/tilting type: YH Jung,

--- a/src/emc/kinematics/5axiskins.c
+++ b/src/emc/kinematics/5axiskins.c
@@ -42,6 +42,9 @@
 *  9) Coordinates XYZBCW are required, AUV may be used
 *     if specified with the coordinates parameter and will
 *     be mapped one-to-one with the assigned joint.
+* 10) The direction of the tilt axis is the opposite of the 
+*     conventional axis direction. See 
+*     https://linuxcnc.org/docs/html/gcode/machining-center.html
 ********************************************************************/
 
 // non-required coordinates (A,U,V) can be set by using

--- a/src/emc/kinematics/maxkins.c
+++ b/src/emc/kinematics/maxkins.c
@@ -10,6 +10,13 @@
 * Copyright (c) 2007 Chris Radek
 ********************************************************************/
 
+/********************************************************************
+* Note: The direction of the B axis is the opposite of the 
+* conventional axis direction. See 
+* https://linuxcnc.org/docs/html/gcode/machining-center.html
+********************************************************************/
+
+
 #include "kinematics.h"		/* these decls */
 #include "posemath.h"
 #include "hal.h"

--- a/src/emc/kinematics/trtfuncs.c
+++ b/src/emc/kinematics/trtfuncs.c
@@ -24,6 +24,10 @@
 *  2) 5 axis mill (XYZBC)
 *     This mill has a tilting table (B axis) and horizontal rotary
 *     mounted to the table (C axis).
+*
+* Note: The directions of the rotational axes are the opposite of the 
+* conventional axis directions. See 
+* https://linuxcnc.org/docs/html/gcode/machining-center.html
 
 ********************************************************************/
 

--- a/src/emc/kinematics/xyzac-trt-kins.c
+++ b/src/emc/kinematics/xyzac-trt-kins.c
@@ -7,6 +7,8 @@
 *  2) specify 3 KS,KF,KI functions for switchkins_type=0,1,2
 *  3) the 0th switchkins_type is the startup default
 *  4) sparm is a module string parameter for configuration
+*  5) The directions of the rotational axes are the opposite of the 
+*     conventional axis directions.
 */
 
 #include "motion.h"

--- a/src/emc/kinematics/xyzbc-trt-kins.c
+++ b/src/emc/kinematics/xyzbc-trt-kins.c
@@ -7,6 +7,8 @@
 *  2) specify 3 KS,KF,KI functions for switchkins_type=0,1,2
 *  3) the 0th switchkins_type is the startup default
 *  4) sparm is a module string parameter for configuration
+*  5) The directions of the rotational axes are the opposite of the 
+*     conventional axis directions.
 */
 
 #include "motion.h"


### PR DESCRIPTION
in 5-axis-kinematics docs:
-Add note that with the described kinematics, rotational axes move in the opposite direction of conventional kinematics. (https://github.com/LinuxCNC/linuxcnc/issues/2435)

- Cite the original source of the text