### PR TITLE
Carousel.comp - added debounce for jog

### DIFF
--- a/src/hal/components/carousel.comp
+++ b/src/hal/components/carousel.comp
@@ -471,7 +471,12 @@ FUNCTION(_){
         old_index = (sense(0) && sense(1));
         break; // So that we don't see the tool1 pulse twice
     case 20: //jogging fwd/rev
-        if (current_position != target) return;
+        if (current_position != target){
+			deb = debounce;
+			return;
+        } else if (deb-- >0) {
+			return;
+		}
         if (align_dc != 0 && ! align_pin) return;
         motor_fwd = 0;
         motor_rev = 0;


### PR DESCRIPTION
Hello,

I have machine with ATC encoder without trigger signal. In the past carousel.comp did not work well for my machine. Andy helped me and made debounce for positioning. https://github.com/LinuxCNC/linuxcnc/commit/f6e8d08c35be9dfb04476db0f9ac3a3094125f34

Now I am making jog ATC. I solved the encoder reading problem for jog just like Andy solved for positioning.