### PR TITLE
mb2hal tests: accept any comp id

### DIFF
--- a/tests/mb2hal/mb2hal.1a/checkresult
+++ b/tests/mb2hal/mb2hal.1a/checkresult
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+TESTDIR=$(dirname $1)
+cd "${TESTDIR}"
+
+# HAL assigns each component a unique component ID at load-time.
+# The RTAI and uspace HAL implementations assign different component IDs,
+# so remove all mentions of specific component IDs from the result file,
+# so that a single `expected` file works for both.
+sed --in-place --regexp-extended --expression='s/^(.*unloading HAL module \[)[0-9]+(.*)$/\1(ignored comp id)\2/' result
+
+diff -u expected result

--- a/tests/mb2hal/mb2hal.1a/expected
+++ b/tests/mb2hal/mb2hal.1a/expected
@@ -126,6 +126,6 @@ mb2hal main OK: Link thread loop and logic 0 created OK
 mb2hal main OK: mb2hal is running
 mb2hal quit_signal DEBUG: signal [15] received
 mb2hal quit_cleanup DEBUG: started
-mb2hal quit_cleanup DEBUG: unloading HAL module [4] ret[0]
+mb2hal quit_cleanup DEBUG: unloading HAL module [(ignored comp id)] ret[0]
 mb2hal quit_cleanup DEBUG: done OK
 mb2hal main OK: going to exit!

--- a/tests/mb2hal/mb2hal.1b/checkresult
+++ b/tests/mb2hal/mb2hal.1b/checkresult
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+TESTDIR=$(dirname $1)
+cd "${TESTDIR}"
+
+# HAL assigns each component a unique component ID at load-time.
+# The RTAI and uspace HAL implementations assign different component IDs,
+# so remove all mentions of specific component IDs from the result file,
+# so that a single `expected` file works for both.
+sed --in-place --regexp-extended --expression='s/^( *)[0-9]+(.*mb2hal.Modbus_fnct_.*)$/\1(ignored comp id)\2/' result
+
+diff -u expected result

--- a/tests/mb2hal/mb2hal.1b/expected
+++ b/tests/mb2hal/mb2hal.1b/expected
@@ -1,39 +1,39 @@
 Component Pins:
 Owner   Type  Dir         Value  Name
-     4  bit   OUT         FALSE  mb2hal.Modbus_fnct_02.00
-     4  bit   OUT         FALSE  mb2hal.Modbus_fnct_02.01
-     4  bit   OUT         FALSE  mb2hal.Modbus_fnct_02.02
-     4  bit   OUT         FALSE  mb2hal.Modbus_fnct_02.03
+     (ignored comp id)  bit   OUT         FALSE  mb2hal.Modbus_fnct_02.00
+     (ignored comp id)  bit   OUT         FALSE  mb2hal.Modbus_fnct_02.01
+     (ignored comp id)  bit   OUT         FALSE  mb2hal.Modbus_fnct_02.02
+     (ignored comp id)  bit   OUT         FALSE  mb2hal.Modbus_fnct_02.03
 
 Component Pins:
 Owner   Type  Dir         Value  Name
-     4  float OUT             0  mb2hal.Modbus_fnct_03.00.float
-     4  s32   OUT             0  mb2hal.Modbus_fnct_03.00.int
-     4  float OUT             0  mb2hal.Modbus_fnct_03.01.float
-     4  s32   OUT             0  mb2hal.Modbus_fnct_03.01.int
-     4  float OUT             0  mb2hal.Modbus_fnct_03.02.float
-     4  s32   OUT             0  mb2hal.Modbus_fnct_03.02.int
-     4  float OUT             0  mb2hal.Modbus_fnct_03.03.float
-     4  s32   OUT             0  mb2hal.Modbus_fnct_03.03.int
+     (ignored comp id)  float OUT             0  mb2hal.Modbus_fnct_03.00.float
+     (ignored comp id)  s32   OUT             0  mb2hal.Modbus_fnct_03.00.int
+     (ignored comp id)  float OUT             0  mb2hal.Modbus_fnct_03.01.float
+     (ignored comp id)  s32   OUT             0  mb2hal.Modbus_fnct_03.01.int
+     (ignored comp id)  float OUT             0  mb2hal.Modbus_fnct_03.02.float
+     (ignored comp id)  s32   OUT             0  mb2hal.Modbus_fnct_03.02.int
+     (ignored comp id)  float OUT             0  mb2hal.Modbus_fnct_03.03.float
+     (ignored comp id)  s32   OUT             0  mb2hal.Modbus_fnct_03.03.int
 
 Component Pins:
 Owner   Type  Dir         Value  Name
-     4  float IN              0  mb2hal.Modbus_fnct_06.00
-     4  float IN              0  mb2hal.Modbus_fnct_06.01
-     4  float IN              0  mb2hal.Modbus_fnct_06.02
-     4  float IN              0  mb2hal.Modbus_fnct_06.03
+     (ignored comp id)  float IN              0  mb2hal.Modbus_fnct_06.00
+     (ignored comp id)  float IN              0  mb2hal.Modbus_fnct_06.01
+     (ignored comp id)  float IN              0  mb2hal.Modbus_fnct_06.02
+     (ignored comp id)  float IN              0  mb2hal.Modbus_fnct_06.03
 
 Component Pins:
 Owner   Type  Dir         Value  Name
-     4  bit   IN          FALSE  mb2hal.Modbus_fnct_15.00
-     4  bit   IN          FALSE  mb2hal.Modbus_fnct_15.01
-     4  bit   IN          FALSE  mb2hal.Modbus_fnct_15.02
-     4  bit   IN          FALSE  mb2hal.Modbus_fnct_15.03
+     (ignored comp id)  bit   IN          FALSE  mb2hal.Modbus_fnct_15.00
+     (ignored comp id)  bit   IN          FALSE  mb2hal.Modbus_fnct_15.01
+     (ignored comp id)  bit   IN          FALSE  mb2hal.Modbus_fnct_15.02
+     (ignored comp id)  bit   IN          FALSE  mb2hal.Modbus_fnct_15.03
 
 Component Pins:
 Owner   Type  Dir         Value  Name
-     4  float IN              0  mb2hal.Modbus_fnct_16.00
-     4  float IN              0  mb2hal.Modbus_fnct_16.01
-     4  float IN              0  mb2hal.Modbus_fnct_16.02
-     4  float IN              0  mb2hal.Modbus_fnct_16.03
+     (ignored comp id)  float IN              0  mb2hal.Modbus_fnct_16.00
+     (ignored comp id)  float IN              0  mb2hal.Modbus_fnct_16.01
+     (ignored comp id)  float IN              0  mb2hal.Modbus_fnct_16.02
+     (ignored comp id)  float IN              0  mb2hal.Modbus_fnct_16.03
 


### PR DESCRIPTION
uspace and RTAI assign different component ids at component load-time.

This test used to verify that the mb2hal component got a specific component id, which means it only worked on uspace, and always failed on RTAI.

This commit makes the tests ignore the component ids, but still verify everything they actually care about.