### PR TITLE
mb2hal: wait for threads to stop before deallocating the memory they'…

### DIFF
--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -91,7 +91,6 @@ int main(int argc, char **argv)
 
     /* Each link has it's own thread */
     pthread_attr_init(&thrd_attr);
-    pthread_attr_setdetachstate(&thrd_attr, PTHREAD_CREATE_DETACHED);
     for (counter = 0; counter < gbl.tot_mb_links; counter++) {
         ret = pthread_create(&gbl.mb_links[counter].thrd, &thrd_attr, link_loop_and_logic, (void *) &gbl.mb_links[counter].mb_link_num);
         if (ret != 0) {
@@ -103,6 +102,14 @@ int main(int argc, char **argv)
     OK(gbl.init_dbg, "%s is running", gbl.hal_mod_name);
     while (gbl.quit_flag == 0) {
         sleep(1);
+    }
+
+    for (counter = 0; counter < gbl.tot_mb_links; counter++) {
+        ret = pthread_join(gbl.mb_links[counter].thrd, NULL);
+        if (ret != 0) {
+            ERR(gbl.init_dbg, "Unable to join thread for link number %d: %s", counter, strerror(ret));
+        }
+        // OK(gbl.init_dbg, "Link thread %d joined OK OK", counter);
     }
 
 QUIT_CLEANUP:


### PR DESCRIPTION
…re using

This fixes a shutdown-time race condition in mb2hal between the main thread and the per-link threads.

The main thread connects to all the Modbus interfaces and allocates all HAL data structures, then starts a worker thread for each modbus link.

The main thread and the worker threads all watch a "time to shutdown" status variable, which is set by a shutdown signal handler.  When the "time to shutdown" variable gets set, the per-link threads all exit and the main thread closes down the modbus communications and deallocates the HAL memory.

But there was no synchronization between the shutdown of the main thread and the shutdown of the worker threads, so sometimes the worker threads were still accessing the stuff that the main thread was freeing, leading to segfaults.

This commit makes the main thread join the worker threads before deallocating anything.