### PR TITLE
mb2hal test: remove signal timing requirement

### DIFF
--- a/tests/mb2hal/mb2hal.1a/checkresult
+++ b/tests/mb2hal/mb2hal.1a/checkresult
@@ -10,4 +10,9 @@ cd "${TESTDIR}"
 # so that a single `expected` file works for both.
 sed --in-place --regexp-extended --expression='s/^(.*unloading HAL module \[)[0-9]+(.*)$/\1(ignored comp id)\2/' result
 
+# The SIGQUIT signal does not arrive at a well-defined time, so don't
+# check for that debug log message.  The rest of the shutdown messages
+# seem to have well-defined order.
+sed --in-place --regexp-extended --expression='/^mb2hal quit_signal DEBUG: signal \[15\] received$/d' result
+
 diff -u expected result

--- a/tests/mb2hal/mb2hal.1a/expected
+++ b/tests/mb2hal/mb2hal.1a/expected
@@ -124,7 +124,6 @@ mb2hal create_each_mb_tx_hal_pins DEBUG: mb_tx_num [4] pin_name [mb2hal.Modbus_f
 mb2hal main OK: HAL components created OK
 mb2hal main OK: Link thread loop and logic 0 created OK
 mb2hal main OK: mb2hal is running
-mb2hal quit_signal DEBUG: signal [15] received
 mb2hal quit_cleanup DEBUG: started
 mb2hal quit_cleanup DEBUG: unloading HAL module [(ignored comp id)] ret[0]
 mb2hal quit_cleanup DEBUG: done OK


### PR DESCRIPTION
The exact delivery time of the SIGQUIT signal can vary somewhat, and doesn't matter for this test, so don't expect it in a specific place in the log file.

The rest of the "quit" debug messages are well ordered, so we still check for most of the quit logging.