### PR TITLE
debian: Change QtVCP dependencies from recommended to required

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -93,13 +93,13 @@ PYTHON_GST=python3-gst-1.0,gstreamer1.0-plugins-base
 TCLTK_VERSION=8.6
 PYTHON_IMAGING=python3-pil
 PYTHON_IMAGING_TK=python3-pil.imagetk
-QTVCP_DEPENDS="python3-pyqt5,\n    python3-pyqt5.qsci,\n    python3-pyqt5.qtsvg,\n    python3-pyqt5.qtopengl,\n    python3-opencv,\n    python3-dbus,\n    python3-espeak,\n    python3-dbus.mainloop.pyqt5,\n    python3-pyqt5.qtwebkit,\n    espeak-ng,\n    pyqt5-dev-tools,\n    gstreamer1.0-tools,espeak,\n    sound-theme-freedesktop,\n    python3-poppler-qt5"
+QTVCP_DEPENDS="python3-pyqt5,\n    python3-pyqt5.qsci,\n    python3-pyqt5.qtsvg,\n    python3-pyqt5.qtopengl,\n    python3-opencv,\n    python3-dbus,\n    python3-espeak,\n    python3-dbus.mainloop.pyqt5,\n    python3-pyqt5.qtwebkit,\n    espeak-ng,\n    pyqt5-dev-tools,\n    gstreamer1.0-tools,\n    espeak,\n    sound-theme-freedesktop,\n    python3-poppler-qt5"
 YAPPS_RUNTIME="python3-yapps"
 DEBHELPER="debhelper (>= 12)"
 COMPAT="12"
 
 case $DISTRIB_NAME in
-    Ubuntu-21.*|Debian-11|Debian-11.*|Debian-testing|Debian-unstable)
+    Ubuntu-21.*|Debian-11|Debian-11.*|Debian-12|Debian-12.*|Debian-testing|Debian-unstable)
         LIBREADLINE_DEV=libeditreadline-dev
         COMPAT=""
         DEBHELPER="debhelper-compat (= 13)"

--- a/debian/control.main-pkg.in
+++ b/debian/control.main-pkg.in
@@ -28,6 +28,7 @@ Depends:
     bwidget (>= 1.7),
     tclreadline,
     tclx,
+    @QTVCP_DEPENDS@,
     procps, psmisc,
     udev
 Recommends:
@@ -35,8 +36,7 @@ Recommends:
     librsvg2-dev,
     @EXTRA_RECOMMENDS@,
     @PYTHON_IMAGING@,
-    @PYTHON_IMAGING_TK@,
-    @QTVCP_DEPENDS@
+    @PYTHON_IMAGING_TK@
 Suggests: mesaflash,
     onboard
 Description: motion controller for CNC machines and robots


### PR DESCRIPTION

Moving these dependencies to required as QtVCP screens such as  QtPlasmaC, QtDragon, QtAxis, etc are very popular and should work "out  of the box".  New users should not have to rely on a command line script to install the necessary dependencies.  There have been a few recent new installs recently where users were confused by the lack of working features caused by missing dependencies.