### PR TITLE
halscope: fix initialization of gain/scale for new channels

### DIFF
--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -1094,6 +1094,11 @@ void channel_changed(void)
     gtk_adjustment_set_lower(adj, chan->min_index);
     gtk_adjustment_set_upper(adj, chan->max_index);
     gtk_adjustment_set_value(adj, chan->scale_index);
+
+    // Call the `scale_changed()` callback once by hand to initialize
+    // the new channel's scale/gain.
+    scale_changed(adj, NULL);
+
     /* update the channel number and name display */
     snprintf(buf1, BUFLEN, "%2d", vert->selected);
     name = chan->name;


### PR DESCRIPTION
@havardAasen I'd appreciate your review on this PR.

This fixes a glitch introduced during the gtk2-to-gtk3 update.

To reproduce the glitch:

    1. Check out the parent of this commit.

    2. Build everything.

    3. Remove any `autosave.halscope` file from the `configs/sim/axis`
       directory.

    4. Start linuxcnc with the `sim/axis/axis` config.

    5. Start halscope.  Select the signal `Xpos` on channel 1 and `Xvel`
       on channel 2 (or whatever, this is just an example and not relevant
       to the problem).

       Note that the trigger arrow indicator does *not* show up in the
       trace window, and the "Trigger Level" slider does *not* have any
       effect (level stays at 0.0 even if you move it).  This is one
       symptom of the bug.

    6. Switch the Trigger Run Mode to "Normal".

    7. Make some motion in Axis to trigger the scope.

       Note that the scope triggers but the display *doesn't* show any
       traces (though the trace names show up now).  This is another
       symptom of the bug.

    8. Quit halscope (so it writes `autosave.hal`) and restart it.
       It loads the new `autosave.halscope` config file, and now
       everything works.  The Trigger Level slider is updated to whatever
       it was left at when you quit, and if you trigger it the traces
       show up as expected.

Before the gtk3 update (i.e. before #1156 was merged in commit 2ff6c6bde1ad21b7d0bb1206e46d04e9b446246f), halscope used to force the trigger level slider widget to run its "value changed" callback, but that function was deprecated by gtk3 and the call was simply removed, causing this bug.  This commit calls the callback directly there instead, so the callback can initialize the stuff it needs to.