### PR TITLE
Issue #2483. Simplistic fix to suit 90%+ of use cases.

### DIFF
--- a/src/emc/rs274ngc/interp_write.cc
+++ b/src/emc/rs274ngc/interp_write.cc
@@ -161,10 +161,12 @@ int Interp::write_m_codes(block_pointer block,   //!< pointer to a block of RS27
     (settings->mist) ? 7 : (settings->flood) ? -1 : 9;
   emz[5] =                      /* 5 flood       */
     (settings->flood) ? 8 : -1;
+  // This only considers spindle 0. This function //
+  //doesn't even know how many spindles there are //
   if (settings->feed_override) {
-    if (settings->speed_override) emz[6] =  48;
+    if (settings->speed_override[0]) emz[6] =  48;
     else emz[6] = 50;
-  } else if (settings->speed_override) {
+  } else if (settings->speed_override[0]) {
     emz[6] = 51;
   } else emz[6] = 49;
   
@@ -315,7 +317,7 @@ int Interp::write_state_tag(block_pointer block,
     state.flags[GM_FLAG_FLOOD] = (settings->flood);
 
     state.flags[GM_FLAG_FEED_OVERRIDE] = settings->feed_override;
-    state.flags[GM_FLAG_SPEED_OVERRIDE] = settings->speed_override;
+    state.flags[GM_FLAG_SPEED_OVERRIDE] = settings->speed_override[0];
 
     state.flags[GM_FLAG_ADAPTIVE_FEED] = (settings->adaptive_feed);
 


### PR DESCRIPTION
A possible fix to #2483 

This probably covers 90+% of installations, ie those with only one spindle. 
A better fix would require:
1) The settings struct to have a copy of the count of spindles, to iterate through them
2) The state-tags struct to have 8 spindle-on bits, 8 spindle-cw bits and 9 speed-override bits. 

Active M-codes could either attempt to report for each spindle, or just report that spindle override is active if it is active on _any_ spindle. 

Spindle-override has been reporting enabled even if disabled for years now, with no complaints. It is probably very unusual to use the M51 P0 command
