### PR TITLE
docs: update methods for translating

### DIFF
--- a/docs/src/code/contributing-to-linuxcnc.adoc
+++ b/docs/src/code/contributing-to-linuxcnc.adoc
@@ -248,6 +248,7 @@ revisions that are ahead of origin/master, so you can do things like
 `git format-patch` them to share with others without pushing to the
 central repository.
 
+[[sec:contributing-translations]]
 == Translations
 
 The LinuxCNC project uses `gettext` to translate the software into
@@ -257,15 +258,12 @@ any programming, and you don't need to install any special translation
 programs or other software.
 
 The easiest way to help with translations is using Weblate,
-an open-source web service.  Our translation project is here:
+an open-source web service. Our translation project is here:
+
 https://hosted.weblate.org/projects/linuxcnc/
 
 Documentation on how to use Weblate is here:
 https://docs.weblate.org/en/latest/user/basic.html
-
-If web services are not your thing, you can also work on translations
-using a variety of local gettext translator apps including gtranslator,
-poedit, and many more.
 
 == Other ways to contribute
 

--- a/docs/src/gui/gmoccapy.adoc
+++ b/docs/src/gui/gmoccapy.adoc
@@ -33,14 +33,9 @@ GMOCCAPY offers a separate settings page to configure most settings of the GUI w
 
 GMOCCAPY can be localized very easy, because the corresponding files are separated from the linuxcnc.po files,
 so there is no need to translate unneeded stuff.
-The files are placed in */src/po/gmoccapy*.
-You could just copy the gmoccapy.pot file to something like it.po and translate that file with gtranslator or poedit.
-After rebuilding, you'd get the GUI in your preference language.
-To facilitate the sharing of the translation,
-GMOCCAPY is available on the https://hosted.weblate.org/projects/linuxcnc/gmocappy/[Weblate web interface].
-GMOCCAPY is currently available in English, German, Spanish, Polish, Serbian and Hungarian.
-Feel free to help me to introduce more languages, be it locally or via the web.
-If you need help, don't hesitate to contact me on *nieson@web.de*.
+If you want to contribute a translation, please use the
+link:https://hosted.weblate.org/projects/linuxcnc/gmocappy/[web based
+translation editor Weblate]. For more information see the section <<sec:contributing-translations,Translations>>
 
 image:images/gmoccapy_5_axis_mid.png[align="left",link="images/gmoccapy_5_axis.png"]
 


### PR DESCRIPTION
Updating the translating method as Weblate is the only way for translating for master.

What do you think about this document: https://github.com/LinuxCNC/linuxcnc/blob/master/src/po/README?
Delete this in master and keep it in 2.9?

And what about the docs about translating in 2.9 - Weblate is only for master, so I propose to remove the references to Weblate in this branch?