### PR TITLE
Backport clang fixes from master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,41 @@ jobs:
     - run: git fetch --recurse-submodules=no https://github.com/linuxcnc/linuxcnc refs/tags/*:refs/tags/*
     - name: Build RIP & test
       run: |
-        ./scripts/travis-install-build-deps.sh
+        set -x
         sudo apt-get install -y eatmydata
-        curl -O https://snapshot.debian.org/archive/debian/20220716T154603Z/pool/main/p/po4a/po4a_0.67-2_all.deb
-        sudo apt install ./po4a_0.67-2_all.deb
+        eatmydata ./scripts/travis-install-build-deps.sh
+        eatmydata curl -O https://snapshot.debian.org/archive/debian/20220716T154603Z/pool/main/p/po4a/po4a_0.67-2_all.deb
+        sudo eatmydata apt install ./po4a_0.67-2_all.deb
         cd src
         eatmydata ./autogen.sh
         eatmydata ./configure --with-realtime=uspace --disable-check-runtime-deps
+        eatmydata make -O -j$((1+$(nproc))) default pycheck V=1
+        # Note that the package build covers html docs
+        eatmydata ../scripts/rip-environment runtests -p
+
+  rip-and-test-clang:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+    - run: git fetch --recurse-submodules=no https://github.com/linuxcnc/linuxcnc refs/tags/*:refs/tags/*
+    - name: Clang build RIP & test
+      run: |
+        set -x
+        sudo apt-get install -y eatmydata
+        eatmydata ./scripts/travis-install-build-deps.sh
+        sudo eatmydata apt-get install -y clang
+        eatmydata curl -O https://snapshot.debian.org/archive/debian/20220716T154603Z/pool/main/p/po4a/po4a_0.67-2_all.deb
+        sudo eatmydata apt install ./po4a_0.67-2_all.deb
+        cd src
+        eatmydata ./autogen.sh
+        CC=clang CXX=clang++ eatmydata ./configure --with-realtime=uspace --disable-check-runtime-deps
         eatmydata make -O -j$((1+$(nproc))) default pycheck V=1
         # Note that the package build covers html docs
         eatmydata ../scripts/rip-environment runtests -p

--- a/src/Makefile
+++ b/src/Makefile
@@ -252,7 +252,7 @@ INCLUDE += $(LIBTIRPC_CFLAGS)
 # Compilation options.	Perhaps some of these should come from Makefile.inc? (CXXFLAGS now does)
 INTEGER_OVERFLOW_FLAGS := -fwrapv
 OPT := -Os $(INTEGER_OVERFLOW_FLAGS)
-DEBUG := $(DEBUG) -g -Wall -Wno-stringop-truncation -D_FORTIFY_SOURCE=2
+DEBUG := $(DEBUG) -g -Wall -D_FORTIFY_SOURCE=2
 CFLAGS := $(INCLUDE) $(OPT) $(DEBUG) $(EXTRA_DEBUG) -DULAPI -std=gnu11 -Werror=implicit-function-declaration $(CFLAGS) $(CPPFLAGS)
 CXXFLAGS := $(INCLUDE) $(EXTRA_DEBUG) -DULAPI $(DEBUG) $(OPT) -Werror=overloaded-virtual $(CXXFLAGS) $(CPPFLAGS)
 CXXFLAGS += -std=gnu++17

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -30,7 +30,7 @@ if test "$srcdir" != "."; then
     AC_MSG_ERROR([Building outside of srcdir is not supported])
 fi
 
-AC_PROG_CXX
+AC_PROG_CXX([$RTSCC c++ clang++])
 AC_PROG_INSTALL
 
 m4_include([m4/ax_require_defined.m4])

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -408,6 +408,14 @@ elif ! test `$CC -dumpversion | cut -d '.' -f 1` -gt 2 ; then
   AC_MSG_ERROR([Compilers older than gcc 3.x are no longer supported])
 fi
 
+# Set flags for C and C++ if supported
+for commonflag in -Wno-stringop-truncation ; do
+  if echo "int main() { return 0;}" | $CC -Werror $commonflag -E - > /dev/null; then
+    CFLAGS="$CFLAGS $flag"
+    CXXFLAGS="$CXXFLAGS $flag"
+  fi
+done
+
 AC_MSG_CHECKING([for usability of linux/hidraw.h])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/ioctl.h>


### PR DESCRIPTION
This backports #2214 from master to 2.9, except for the commit that fixes a problem in the `reset` component, which is not in 2.9 for some reason.