### PR TITLE
Build conflict on libjpeg8-dev, libtiff4-dev not working with gtk 3 / gdk-pixbuf.

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -45,6 +45,7 @@ Build-Depends:
     yapps2
 Build-Depends-Indep:
     @DOC_DEPENDS@,
+Build-Conflict: libjpeg8-dev, libtiff4-dev
 Standards-Version: 4.6.1
 Homepage: https://linuxcnc.org/
 Vcs-Browser: https://github.com/LinuxCNC/linuxcnc


### PR DESCRIPTION
If these alternative dependencies are installed, pkg-config is uable to get a working gtk build setup.