### PR TITLE
Corrected internal Axis widget name of Coolant label

### DIFF
--- a/configs/sim/axis/axis.ini
+++ b/configs/sim/axis/axis.ini
@@ -118,6 +118,7 @@ HALFILE = sim_spindle_encoder.hal
 HALFILE = axis_manualtoolchange.hal
 HALFILE = simulated_home.hal
 HALFILE = check_xyz_constraints.hal
+HALFILE = cooling.hal
 
 # list of halcmd commands to execute
 # commands are executed in the order in which they appear

--- a/configs/sim/axis/axis_mm.ini
+++ b/configs/sim/axis/axis_mm.ini
@@ -109,6 +109,7 @@ HALFILE = core_sim.hal
 HALFILE = sim_spindle_encoder.hal
 HALFILE = axis_manualtoolchange.hal
 HALFILE = simulated_home.hal
+HALFILE = cooling.hal
 
 # list of halcmd commands to execute
 # commands are executed in the order in which they appear

--- a/configs/sim/axis/cooling.hal
+++ b/configs/sim/axis/cooling.hal
@@ -1,0 +1,7 @@
+# Fake the existance of coolant options
+loadrt and2 count=3
+addf and2.0 servo-thread
+addf and2.1 servo-thread
+net flood iocontrol.0.coolant-flood => and2.0.in0
+net mist iocontrol.0.coolant-mist => and2.0.in1
+net lube iocontrol.0.lube => and2.1.in0

--- a/configs/sim/axis/historical_lathe.ini
+++ b/configs/sim/axis/historical_lathe.ini
@@ -45,6 +45,7 @@ HALFILE = core_sim.hal
 HALFILE = axis_manualtoolchange.hal
 HALFILE = simulated_home.hal
 HALFILE = lathe.hal
+HALFILE = cooling.hal
 POSTGUI_HALFILE = lathe_postgui.hal
 
 [TRAJ]

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1359,7 +1359,7 @@ widget_list=[
 
        ("ajogspeed", Entry, pane_top + ".ajogspeed"),
 
-       ("lubel", Label, tabs_manual + ".coolant"),
+       ("coolant", Label, tabs_manual + ".coolant"),
        ("flood", Checkbutton, tabs_manual + ".flood"),
        ("mist", Checkbutton, tabs_manual + ".mist"),
 
@@ -4198,7 +4198,7 @@ if not has_limit_switch:
 
 forget(widgets.mist, "iocontrol.0.coolant-mist")
 forget(widgets.flood, "iocontrol.0.coolant-flood")
-forget(widgets.lubel, "iocontrol.0.coolant-flood", "iocontrol.0.coolant-mist")
+forget(widgets.coolant, "iocontrol.0.coolant-flood", "iocontrol.0.coolant-mist")
 
 rcfile = "~/.axisrc"
 user_command_file = inifile.find("DISPLAY", "USER_COMMAND_FILE") or ""


### PR DESCRIPTION
The label 'Coolant:' was misnamed lubel.  It is not related to lubing,
but to cooling, so rename to 'coolantl' instead.  Adjusted
Axis simulation configs to also simulate coolant to get the label
to show up during simulation.