### PR TITLE
Fix typos in configs/ subdirectory

### DIFF
--- a/configs/sim/axis/laser/python/remap.py
+++ b/configs/sim/axis/laser/python/remap.py
@@ -33,7 +33,7 @@ def rasterData(self, **words):
 
 def rasterStart(self, **words):
     global rasterProgrammer
-    #matchine must be in position before run issued
+    #machine must be in position before run issued
     #make motion complete queue prior to run program command
     yield INTERP_EXECUTE_FINISH
     if rasterProgrammer:

--- a/configs/sim/axis/plasma/README
+++ b/configs/sim/axis/plasma/README
@@ -1,6 +1,6 @@
 plasmac2 is a customised AXIS GUI for operating a plasma cutting table using the plasmac component.
 
-Included is an appliction to enable migrating a working QtPlasmaC configuration to plasmac2.
+Included is an application to enable migrating a working QtPlasmaC configuration to plasmac2.
 To begin a migration, call the application from a terminal using one of the following commands depending on the LinuxCNC installation type:
 
 Package installation:

--- a/configs/sim/axis/plasma/plasmac2/lib/custom/user_periodic.py
+++ b/configs/sim/axis/plasma/plasmac2/lib/custom/user_periodic.py
@@ -1,5 +1,5 @@
 # CUSTOM PERIODIC CODE, RUNS ONCE EVERY CYCLE
 
-# example to print vaue of custom hal pin if not zero
+# example to print value of custom hal pin if not zero
 #if comp['my-halpin']:
 #    print(comp['my-halpin'])

--- a/configs/sim/axis/plasma/plasmac2/migrate.py
+++ b/configs/sim/axis/plasma/plasmac2/migrate.py
@@ -151,7 +151,7 @@ class Migrate(Tk):
         title = _('Directory Name')
         msg1 = _('The new directory name will be')
         msg2 = _('If you change it to the same name as the QtPlasmaC config')
-        msg3 = _('then the QtPlasmaC config directory wil be renamed to:')
+        msg3 = _('then the QtPlasmaC config directory will be renamed to:')
         msg4 = _('Accept it or change it then accept')
         reply = Dialog(self, title, f'{msg1}: {newBase}\n\n{msg2}\n{msg3}\n{base}_qtplasmac\n\n{msg4}\n', buttons=2, entry=newBase).show()
         if reply == base:

--- a/configs/sim/axis/plasma/plasmac2/plasmac2.py
+++ b/configs/sim/axis/plasma/plasmac2/plasmac2.py
@@ -4030,7 +4030,7 @@ if os.path.isdir(os.path.join(p2Path, 'lib')):
 
     # not used:
     # use a non existant file name so Axis doesn't open a default file
-    # only usefull if we move the file open code in Axis so it is called after the user command file is called
+    # only useful if we move the file open code in Axis so it is called after the user command file is called
     #args = ['do_not_open_a_file']
 
     PREF = plasmacPreferences()

--- a/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyyz.ini
+++ b/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyyz.ini
@@ -128,12 +128,12 @@ HALFILE = gantrysim.hal
 HALFILE = simulated-xyyz-home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyzy.ini
+++ b/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyzy.ini
@@ -129,12 +129,12 @@ HALFILE = gantrysim.hal
 HALFILE = simulated-gantry-home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyzya.ini
+++ b/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyzya.ini
@@ -134,12 +134,12 @@ HALFILE = simulated-gantry-home.hal
 POSTGUI_HALCMD = net joint_4_pos joint.4.motor-pos-cmd => joint.4.motor-pos-fb
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_tool_probe/qtdragon_auto_tool_probe.ini
+++ b/configs/sim/qtdragon/qtdragon_tool_probe/qtdragon_auto_tool_probe.ini
@@ -138,12 +138,12 @@ HALUI = halui
 HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 # added to simulate probing
@@ -170,7 +170,7 @@ Z = 8
 X = 300
 Y = 300
 Z = -50
-# how migh to lift when moving to the tool setter
+# how high to lift when moving to the tool setter
 Z_MAX_CLEAR = 9.999
 # tool setter diameter for diameter probing
 DIAMETER = 25

--- a/configs/sim/qtdragon/qtdragon_xyz/qtdragon_inch.ini
+++ b/configs/sim/qtdragon/qtdragon_xyz/qtdragon_inch.ini
@@ -64,7 +64,7 @@ MDI_HISTORY_FILE = mdi_history.dat
 LOG_FILE = qtdragon.log
 
 # optional user dialogs (3), controlled by HAL pins
-# persistant
+# persistent
 MESSAGE_BOLDTEXT = Critical and Persistent
 MESSAGE_TEXT = This is a persistent dialog test
 MESSAGE_DETAILS = There seems to be something wrong\n You must fix it to clear message
@@ -80,7 +80,7 @@ MESSAGE_TYPE = yesnodialog
 MESSAGE_PINNAME = yndialogtest
 MESSAGE_ICON = QUESTION
 
-# aknowledge
+# acknowledge
 MESSAGE_BOLDTEXT = This is an information message
 MESSAGE_TEXT = This is low priority
 MESSAGE_DETAILS = press ok to clear
@@ -158,12 +158,12 @@ HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_xyz/qtdragon_metric.ini
+++ b/configs/sim/qtdragon/qtdragon_xyz/qtdragon_metric.ini
@@ -155,12 +155,12 @@ HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_xyz/qtdragon_xyza.ini
+++ b/configs/sim/qtdragon/qtdragon_xyz/qtdragon_xyza.ini
@@ -133,12 +133,12 @@ HALFILE = gantrysim.hal
 HALFILE = simulated-gantry-home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_postgui.hal
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_postgui.hal
@@ -4,7 +4,7 @@
 loadrt logic names=logic-and personality=0x102
 addf logic-and servo-thread
 
-# load a summing compnent for adding spindle lift and Z compensation
+# load a summing component for adding spindle lift and Z compensation
 loadrt scaled_s32_sums
 addf scaled-s32-sums.0 servo-thread
 

--- a/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyz.ini
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyz.ini
@@ -126,12 +126,12 @@ HALUI = halui
 HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_hd_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 # uncomment to simulate probing

--- a/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyza.ini
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyza.ini
@@ -133,12 +133,12 @@ HALFILE = gantrysim.hal
 HALFILE = simulated-gantry-home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_hd_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 # uncomment to simulate probing

--- a/configs/sim/qtdragon_hd/qtdragon_hd_z_compensation/qtdragon_hd_postgui.hal
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_z_compensation/qtdragon_hd_postgui.hal
@@ -4,7 +4,7 @@
 loadrt logic names=logic-and personality=0x102
 addf logic-and servo-thread
 
-# load a summing compnent for adding spindle lift and Z compensation
+# load a summing component for adding spindle lift and Z compensation
 loadrt scaled_s32_sums
 addf scaled-s32-sums.0 servo-thread
 

--- a/configs/sim/qtdragon_hd/qtdragon_hd_z_compensation/qtdragon_hd_z_compensation.ini
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_z_compensation/qtdragon_hd_z_compensation.ini
@@ -126,12 +126,12 @@ HALUI = halui
 HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_hd_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 # uncomment to simulate probing

--- a/configs/sim/qtvcp_screens/qtdragon/qtdragon_inch.ini
+++ b/configs/sim/qtvcp_screens/qtdragon/qtdragon_inch.ini
@@ -37,8 +37,8 @@ LOG_FILE = qtdragon.log
 TOOL_EDITOR = tooledit
 CONFIRM_EXIT = True
 
-MESSAGE_BOLDTEXT = Critical and Persistant
-MESSAGE_TEXT = This is a persistant dialog test
+MESSAGE_BOLDTEXT = Critical and Persistent
+MESSAGE_TEXT = This is a persistent dialog test
 MESSAGE_DETAILS = There seems to be something wrong\n You must fix it to clear message
 MESSAGE_TYPE = nonedialog
 MESSAGE_PINNAME = nonedialogtest

--- a/configs/sim/woodpecker/1280x1024_5axis/woodpecker_handler.py
+++ b/configs/sim/woodpecker/1280x1024_5axis/woodpecker_handler.py
@@ -1187,7 +1187,7 @@ class HandlerClass:
         if state:
             self.w.lineEdit_eoffset_count.text()
 
-    # show ngcgui info tab (in the stackedWidget) if ngcgui utilites
+    # show ngcgui info tab (in the stackedWidget) if ngcgui utilities
     # tab is selected
     def tab_utilities_changed(self, num):
         if num == 2:

--- a/configs/sim/woodpecker/woodpecker_/images/QTvcp Widgets_files/asciidoc.css
+++ b/configs/sim/woodpecker/woodpecker_/images/QTvcp Widgets_files/asciidoc.css
@@ -427,7 +427,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.svg,*.ts,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es,./src/hal/classicladder -L ans,ba,bu,bulle,componentes,currenty,doubleclick,dout,dum,extint,faktor,fo,fpr,halp,ihs,inout,inport,parm,parms,ro,ser,te,tey,ue,ure,wille,wont,wonte`