### PR TITLE
Fix typos in configs/ subdirectory

### DIFF
--- a/configs/attic/dallur-thc/dallur-advanced.hal
+++ b/configs/attic/dallur-thc/dallur-advanced.hal
@@ -11,7 +11,7 @@
 # Load Driver for Two Parallel Ports, one for Breakout Board, other for Plasma Torch Height Control
 loadrt hal_parport cfg="0xa400 0xac00"
 
-# Connect both Paralell Ports to Threads for Read / Write
+# Connect both Parallel Ports to Threads for Read / Write
 addf parport.0.read base-thread 1
 addf parport.0.write base-thread -1
 addf parport.1.read base-thread 1
@@ -28,10 +28,10 @@ addf classicladder.0.refresh        servo-thread 1
 # later we will need to add the clp file mentioned below
 # to the ini file so that we do not need to hardcode it here.
 loadusr -w classicladder --nogui dallur-advanced.clp
-# load the GUI aswell
+# load the GUI as well
 loadusr classicladder
 
-#Reverse Direction for A(Auxilary) Axis so both motors drive in same direction
+#Reverse Direction for A(Auxiliary) Axis so both motors drive in same direction
 setp parport.0.pin-09-out-invert 1
 
 # begin to connect physical pins to signals
@@ -42,7 +42,7 @@ net Xdir parport.0.pin-06-out
 #Axis for Gantry, primary stepper motor (same side as ctrl box), marked Axis Y in breakout
 net Ystep parport.0.pin-03-out
 net Ydir parport.0.pin-07-out
-#Axis for Gantry, secondary stepper motor (other side of ctrl box), marked Axis A(Auxilary) in breakout
+#Axis for Gantry, secondary stepper motor (other side of ctrl box), marked Axis A(Auxiliary) in breakout
 net Ystep parport.0.pin-05-out
 net Ydir parport.0.pin-09-out
 #Axis for Height Control, single stepper motor marked Axis Z in breakout
@@ -62,7 +62,7 @@ net estop-in iocontrol.0.user-request-enable  classicladder.0.in-02
 # This bit is an external estop button connected to parport pin 10 
 net ext-estop parport.0.pin-10-in
 net ext-estop classicladder.0.in-01
-# This bit signal is comand to estop from CL to EMC
+# This bit signal is command to estop from CL to EMC
 net emc-enable-in iocontrol.0.emc-enable-in classicladder.0.out-00 
 
 
@@ -114,7 +114,7 @@ net stepcp parport.1.pin-17-out
 
 ###########Torch Height Control ########
 
-# Load the neccessary functions
+# Load the necessary functions
 loadrt mux2 count=7
 loadrt or2 count=4
 loadrt not count=4
@@ -146,7 +146,7 @@ net senseZUp not.2.out
 # Make a sensor for the Z Float Switch
 # Invert because THC has active low
 # The Z float switch is a proxmity sensor from torch to work piece
-# PNP or NPN Capacative or Inductive switches are recomended, Capacative for non metals but Inductive for metals
+# PNP or NPN Capacative or Inductive switches are recommended, Capacative for non metals but Inductive for metals
 net senseZFloatSwitchInverted <= parport.1.pin-13-in
 
 # invert the senseZFloatSwitch so TRUE = At distance (active high)

--- a/configs/sim/craftsman/craftsmancnc
+++ b/configs/sim/craftsman/craftsmancnc
@@ -1266,7 +1266,7 @@ class craftsman(object):
 		else: 
 			self.set_ops_leds(1, 3, False)
 		
-		##Overide limits LED			
+		##Override limits LED			
 		#if self.machine_overide_limits:		
 		if self.status.joint[0]['override_limits'] != 0:
 			self.set_ops_leds(5,  5,   True)

--- a/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyyz.ini
+++ b/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyyz.ini
@@ -128,12 +128,12 @@ HALFILE = gantrysim.hal
 HALFILE = simulated-xyyz-home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyzy.ini
+++ b/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyzy.ini
@@ -129,12 +129,12 @@ HALFILE = gantrysim.hal
 HALFILE = simulated-gantry-home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyzya.ini
+++ b/configs/sim/qtdragon/qtdragon_multi_joint/qtdragon_xyzya.ini
@@ -134,12 +134,12 @@ HALFILE = simulated-gantry-home.hal
 POSTGUI_HALCMD = net joint_4_pos joint.4.motor-pos-cmd => joint.4.motor-pos-fb
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_tool_probe/qtdragon_auto_tool_probe.ini
+++ b/configs/sim/qtdragon/qtdragon_tool_probe/qtdragon_auto_tool_probe.ini
@@ -138,12 +138,12 @@ HALUI = halui
 HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 # added to simulate probing
@@ -170,11 +170,11 @@ Z = 8
 X = 300
 Y = 300
 Z = -50
-# how migh to lift when moving to the tool setter
+# how high to lift when moving to the tool setter
 Z_MAX_CLEAR = 9.999
 # tool setter diameter for diameter probing
 DIAMETER = 25
-# maximuim machine units to lower while probing
+# maximum machine units to lower while probing
 MAXPROBE =  -40
 
 [AXIS_X]

--- a/configs/sim/qtdragon/qtdragon_xyz/qtdragon_inch.ini
+++ b/configs/sim/qtdragon/qtdragon_xyz/qtdragon_inch.ini
@@ -64,7 +64,7 @@ MDI_HISTORY_FILE = mdi_history.dat
 LOG_FILE = qtdragon.log
 
 # optional user dialogs (3), controlled by HAL pins
-# persistant
+# persistent
 MESSAGE_BOLDTEXT = Critical and Persistent
 MESSAGE_TEXT = This is a persistent dialog test
 MESSAGE_DETAILS = There seems to be something wrong\n You must fix it to clear message
@@ -80,7 +80,7 @@ MESSAGE_TYPE = yesnodialog
 MESSAGE_PINNAME = yndialogtest
 MESSAGE_ICON = QUESTION
 
-# aknowledge
+# acknowledge
 MESSAGE_BOLDTEXT = This is an information message
 MESSAGE_TEXT = This is low priority
 MESSAGE_DETAILS = press ok to clear
@@ -158,12 +158,12 @@ HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_xyz/qtdragon_metric.ini
+++ b/configs/sim/qtdragon/qtdragon_xyz/qtdragon_metric.ini
@@ -155,12 +155,12 @@ HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon/qtdragon_xyz/qtdragon_xyza.ini
+++ b/configs/sim/qtdragon/qtdragon_xyz/qtdragon_xyza.ini
@@ -133,12 +133,12 @@ HALFILE = gantrysim.hal
 HALFILE = simulated-gantry-home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 

--- a/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_postgui.hal
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_postgui.hal
@@ -4,7 +4,7 @@
 loadrt logic names=logic-and personality=0x102
 addf logic-and servo-thread
 
-# load a summing compnent for adding spindle lift and Z compensation
+# load a summing component for adding spindle lift and Z compensation
 loadrt scaled_s32_sums
 addf scaled-s32-sums.0 servo-thread
 

--- a/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyz.ini
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyz.ini
@@ -126,12 +126,12 @@ HALUI = halui
 HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_hd_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 # uncomment to simulate probing

--- a/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyza.ini
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_xyz/qtdragon_hd_xyza.ini
@@ -133,12 +133,12 @@ HALFILE = gantrysim.hal
 HALFILE = simulated-gantry-home.hal
 
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_hd_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 # uncomment to simulate probing

--- a/configs/sim/qtdragon_hd/qtdragon_hd_z_compensation/qtdragon_hd_postgui.hal
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_z_compensation/qtdragon_hd_postgui.hal
@@ -4,7 +4,7 @@
 loadrt logic names=logic-and personality=0x102
 addf logic-and servo-thread
 
-# load a summing compnent for adding spindle lift and Z compensation
+# load a summing component for adding spindle lift and Z compensation
 loadrt scaled_s32_sums
 addf scaled-s32-sums.0 servo-thread
 

--- a/configs/sim/qtdragon_hd/qtdragon_hd_z_compensation/qtdragon_hd_z_compensation.ini
+++ b/configs/sim/qtdragon_hd/qtdragon_hd_z_compensation/qtdragon_hd_z_compensation.ini
@@ -126,12 +126,12 @@ HALUI = halui
 HALFILE = core_sim.hal
 HALFILE = simulated_home.hal
 # this file is loaded after qtdragon has made it's HAl pins
-# you can add mutiple entries
+# you can add multiple entries
 POSTGUI_HALFILE = qtdragon_hd_postgui.hal
 
 # this command is run after qtdragon has made it's HAl pins
 # any HAL conmmand can be used
-# you can add mutiple entries
+# you can add multiple entries
 # uncomment this one to print all HAL pins that start with qt
 #POSTGUI_HALCMD = show pin qt
 # uncomment to simulate probing

--- a/configs/sim/woodpecker/1280x1024_5axis/woodpecker_handler.py
+++ b/configs/sim/woodpecker/1280x1024_5axis/woodpecker_handler.py
@@ -1187,7 +1187,7 @@ class HandlerClass:
         if state:
             self.w.lineEdit_eoffset_count.text()
 
-    # show ngcgui info tab (in the stackedWidget) if ngcgui utilites
+    # show ngcgui info tab (in the stackedWidget) if ngcgui utilities
     # tab is selected
     def tab_utilities_changed(self, num):
         if num == 2:

--- a/configs/sim/woodpecker/woodpecker_/images/QTvcp Widgets_files/asciidoc.css
+++ b/configs/sim/woodpecker/woodpecker_/images/QTvcp Widgets_files/asciidoc.css
@@ -427,7 +427,7 @@ thead, p.table.header {
 p.table {
   margin-top: 0;
 }
-/* Because the table frame attribute is overriden by CSS in most browsers. */
+/* Because the table frame attribute is overridden by CSS in most browsers. */
 div.tableblock > table[frame="void"] {
   border-style: none;
 }


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.svg,*.ts,./.git/logs,./share,./docs/man/es,./configs/attic,./configs/sim/axis/orphans,*_fr.*,*_es.*,README_es,./src/hal/classicladder -L ans,aready,ba,bu,bulle,componentes,currenty,doubleclick,dout,dum,extint,faktor,fo,fpr,halp,ihs,inout,inport,parm,parms,ro,ser,te,tey,trough,ue,ure,wille,wont,wonte`

Edit: this PR is made against the 2.9 branch and supercedes #2545