### PR TITLE
Fix typos in lib/ subdirectory

### DIFF
--- a/lib/python/gladevcp/offsetwidget.py
+++ b/lib/python/gladevcp/offsetwidget.py
@@ -141,7 +141,7 @@ class HAL_Offset(Gtk.Label):
         return g5x,tool,g92,rot
 
     # This does the units conversion
-    # it just mutiplies the two arrays 
+    # it just multiplies the two arrays 
     def convert_units(self,v):
         c = self.conversion
         return list(map(lambda x,y: x*y, v, c))

--- a/lib/python/qtvcp/lib/qt_vismach/scara.py
+++ b/lib/python/qtvcp/lib/qt_vismach/scara.py
@@ -22,7 +22,7 @@ import math
 # no component made here - reads the pins directly
 comp = None
 
-# set mesurement system
+# set measurement system
 METRIC = 1
 IMPERIAL = 25.4
 MODEL_SCALING = METRIC

--- a/lib/python/qtvcp/lib/ripper/gcode_ripper.py
+++ b/lib/python/qtvcp/lib/ripper/gcode_ripper.py
@@ -82,7 +82,7 @@
                    (It now uses the first Z position in the g-code for the z-safe for probe moves before a z position is specified.)
 
     Version 0.21 - Added option to disable the g-code path display (might speed things up for large g-code files
-                 - Fixed handling of G43 commands with G0 moves mixed in on the same line (whos writes g-code like that anyway...)
+                 - Fixed handling of G43 commands with G0 moves mixed in on the same line (who writes g-code like that anyway...)
                  - Bounding box now displays when in auto-probe mode 
 
     Version 0.22 - Added support for DDCS probing to file
@@ -3435,7 +3435,7 @@ class Application(Frame):
         self.MAXZ=maxz
         self.MINZ=minz
 
-        # Reset Staus Bar and Entry Fields
+        # Reset Status Bar and Entry Fields
 
         self.entry_set(self.Entry_GscaleXY,   self.Entry_GscaleXY_Check() ,1)
         self.entry_set(self.Entry_GscaleZ,    self.Entry_GscaleZ_Check()  ,1)
@@ -5482,7 +5482,7 @@ class G_Code_Rip:
         g_code.append("0")
         g_code.append("ENDSEC")
         
-        #This block section is not necessary but apperantly it's good form to include one anyway.
+        #This block section is not necessary but apparently it's good form to include one anyway.
         #The following is an empty block section.
         g_code.append("0")
         g_code.append("SECTION")
@@ -6129,9 +6129,9 @@ class G_Code_Rip:
         ###  While there are still brackets "[...]" keep processing   ###
         #################################################################
         while s != -1:
-            ##############################################################
-            ### Find the first occurence of "]" after the current "["  ###
-            ##############################################################
+            ###############################################################
+            ### Find the first occurrence of "]" after the current "["  ###
+            ###############################################################
             e=-1
             for cnt in range(len(line)-1,s,-1):
                 if line[cnt] == ']':

--- a/lib/python/qtvcp/lib/writer/ext/table.py
+++ b/lib/python/qtvcp/lib/writer/ext/table.py
@@ -96,7 +96,7 @@ class Table(QtWidgets.QDialog):
 
             fmt.setCellSpacing(space)
 
-            # Inser the new table
+            # Insert the new table
             cursor.insertTable(rows,cols,fmt)
 
             self.close()

--- a/lib/python/qtvcp/plugins/container_plugin.py
+++ b/lib/python/qtvcp/plugins/container_plugin.py
@@ -82,7 +82,7 @@ class JointEnableWidgetPlugin(QPyDesignerCustomWidgetPlugin):
         return QtGui.QIcon(QtGui.QPixmap(ICON.get_path('jointenablewidget')))
 
     def toolTip(self):
-        return "Linuxcnc Joint Availablility enable/disable widget"
+        return "Linuxcnc Joint Availability enable/disable widget"
 
     def whatsThis(self):
         return ""

--- a/lib/python/qtvcp/qt_action.py
+++ b/lib/python/qtvcp/qt_action.py
@@ -853,7 +853,7 @@ class _Lcnc_Action(object):
     # Action Helper functions
     ######################################
 
-    # adjust the jog rate by one aproximate division of the
+    # adjust the jog rate by one approximate division of the
     # min/max range on an exponential scale.
     # cut off at the upper and lower jog rates as per the INI
     def _step_jograte(self, jograte, minrate, maxrate, inc, divs):

--- a/lib/python/qtvcp/widgets/camview_widget.py
+++ b/lib/python/qtvcp/widgets/camview_widget.py
@@ -35,7 +35,7 @@ if __name__ != '__main__':  # This avoids segfault when testing directly in pyth
     INFO = Info()
 LOG = logger.getLogger(__name__)
 
-# Surpress cryptic messages when chacking for useable ports
+# Suppress cryptic messages when checking for useable ports
 os.environ["OPENCV_LOG_LEVEL"]="FATAL"
 
 # If the library is missing don't crash the GUI

--- a/lib/python/qtvcp/widgets/dialog_widget.py
+++ b/lib/python/qtvcp/widgets/dialog_widget.py
@@ -167,7 +167,7 @@ class GeometryMixin(_HalWidgetBase):
                     self._geometry_string = self.get_current_geometry()
 
             else:
-                # assuming geometry is actual size/positon
+                # assuming geometry is actual size/position
                 temp = self._geometry_string.split(' ')
                 self.setGeometry(int(temp[0]), int(temp[1]), int(temp[2]), int(temp[3]))
         except Exception as e:

--- a/lib/python/qtvcp/widgets/hal_label.py
+++ b/lib/python/qtvcp/widgets/hal_label.py
@@ -61,7 +61,7 @@ class HALLabel(ScaledLabel, _HalWidgetBase):
             else:
                 self.hal_pin.value_changed.connect(lambda data: self._changeText(data))
 
-    # display formated text
+    # display formatted text
     def _setText(self, data):
         try:
             tmpl = lambda s: str(self._textTemplate) % s
@@ -77,7 +77,7 @@ class HALLabel(ScaledLabel, _HalWidgetBase):
             self._setText(self._multi_label_list[data])
 
     # one can connect signals to this widget to
-    # feed an input that gets formated by this widget.
+    # feed an input that gets formatted by this widget.
     @pyqtSlot(float)
     @pyqtSlot(int)
     @pyqtSlot(bool)

--- a/lib/python/qtvcp/widgets/hal_selectionbox.py
+++ b/lib/python/qtvcp/widgets/hal_selectionbox.py
@@ -195,7 +195,7 @@ class HALSelectionBox(TreeComboBox, _HalWidgetBase):
       types = [HAL_BIT,HAL_FLOAT,HAL_S32,HAL_U32], \
       driven = [True, False]):
         ''' Sets the pin type: HAL_BIT,HAL_FLOAT,HAL_S32,HAL_U32
-            and what tyoe of signals (driven by a pin, not or both).
+            and what type of signals (driven by a pin, not or both).
             True being driven and False being un-driven signals 
             combobox.setSignalTypes([combobox.HAL_BIT], direction = [True,False])'''
         self.SIGTYPE = types

--- a/lib/python/qtvcp/widgets/probe_routines.py
+++ b/lib/python/qtvcp/widgets/probe_routines.py
@@ -347,7 +347,7 @@ class ProbeRoutines():
         if rtn != 1:
             return 'failed: {}'.format(rtn)
 
-        # move to finded  point X
+        # move to found point X
         s = "G1 F%s X%f" % (self.data_rapid_vel, xpres)
         rtn = self.CALL_MDI_WAIT(s, self.timeout) 
         if rtn != 1:
@@ -441,7 +441,7 @@ class ProbeRoutines():
         ymres=float(a[1])-0.5*self.data_probe_diam
         self.length_y()
 
-        # find, show and move to finded  point
+        # find, show and move to found point
         ycres=0.5*(ypres+ymres)
         self.status_yc = ycres
         diam=self.data_probe_diam + (ymres-ypres-self.data_ts_diam)
@@ -454,7 +454,7 @@ class ProbeRoutines():
         tmpz=STATUS.stat.position[2] - self.data_z_clearance
         self.status_z=tmpz
         self.add_history('Tool diameter',"XcYcZD",0,xcres,0,0,0,ycres,0,0,tmpz,diam,0)
-        # move to finded  point
+        # move to found point
         s = "G1 Y%f" % ycres
         rtn = self.CALL_MDI_WAIT(s, self.timeout) 
         if rtn != 1:


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.svg,*.ts,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es,./src/hal/classicladder -L ans,ba,breal,bu,bulle,componentes,currenty,doubleclick,dout,dum,extint,faktor,fo,fpr,halp,ihs,inout,inport,mot,parm,parms,propertys,ro,seh,ser,smoe,te,tey,trough,ue,ure,wille,wont,wonte`'

Follow-up to #2548