### PR TITLE
src/configure.ac: suggest libeditreadline, which is GPL-2 compatible

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1555,7 +1555,8 @@ GPL-2 only) and Readline version 6 and greater (GPL-3 or later).])
             AC_MSG_ERROR(
 [To configure LinuxCNC in this way, you must
 invoke configure with "--enable-non-distributable=yes".  Note that on
-Debian-based systems, you may be able to use libreadline-gplv2-dev instead.])
+Debian-based systems, you may be able to use libeditreadline-dev or
+libreadline-gplv2-dev instead of libreadline-dev.])
         fi
 ])
 


### PR DESCRIPTION
The configure script checks if libreadline is too new to be distributable under GPL-2, and if so suggests some options to the user.  This updates the error message to also suggest libeditreadline as an alternative, which is what we currently use on newer Debian distros.