### PR TITLE
Fix typos in src/ subdirectory

### DIFF
--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -842,7 +842,7 @@ int Interp::init_named_parameters()
   init_readonly_param("_line", NP_LINE, PA_USE_LOOKUP);
 
   // any of G1 G2 G3 G5.2 G73 G80 G82 G83 G86 G87 G88 G89
-  // value is number after 'G' mutiplied by 10 (10,20,30,52..)
+  // value is number after 'G' multiplied by 10 (10,20,30,52..)
 
   init_readonly_param("_motion_mode", NP_MOTION_MODE, PA_USE_LOOKUP);
 

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -1764,7 +1764,7 @@ STATIC int tpRunOptimization(TP_STRUCT * const tp) {
                 tp_debug_print("Found 2nd non-tangent segment, stopping optimization\n");
                 return TP_ERR_OK;
             } else  {
-                tp_debug_print("Found first non-tangent segment, contining\n");
+                tp_debug_print("Found first non-tangent segment, continuing\n");
                 hit_non_tangent = true;
                 continue;
             }

--- a/src/emc/usr_intf/gscreen/gscreen.py
+++ b/src/emc/usr_intf/gscreen/gscreen.py
@@ -919,7 +919,7 @@ class Gscreen:
         function signature would be written in python.
 
         :param method: a python method
-        :return: A string similar describing the pythong method signature.
+        :return: A string similar describing the python method signature.
         eg: "my_method(first_argArg, second_arg=42, third_arg='something')"
         """
 

--- a/src/emc/usr_intf/pncconf/dialogs.glade
+++ b/src/emc/usr_intf/pncconf/dialogs.glade
@@ -311,7 +311,7 @@ Field power should be connected to detect all pins.
         <col id="1" translatable="yes">hm2_4i43</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Parellel Port- 7i90</col>
+        <col id="0" translatable="yes">Parallel Port- 7i90</col>
         <col id="1" translatable="yes">hm2_7i90</col>
       </row>
     </data>
@@ -337,7 +337,7 @@ Field power should be connected to detect all pins.
         <col id="1" translatable="yes">hm2_4i43</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Parellel Port- 7i90</col>
+        <col id="0" translatable="yes">Parallel Port- 7i90</col>
         <col id="1" translatable="yes">hm2_7i90</col>
       </row>
     </data>

--- a/src/emc/usr_intf/pncconf/pncconf-help/help-axismotor.txt
+++ b/src/emc/usr_intf/pncconf/pncconf-help/help-axismotor.txt
@@ -108,7 +108,7 @@ Open loop servo test Button:
     the axis a known distance and noting the encoder count. The encoder
     should function with out the amp enabled depending how it is powered.
     The limit switches are not functional during this test.
-    The fast-dac / slow-dac options are preselect options so it is convienant
+    The fast-dac / slow-dac options are preselect options so it is convenient
     to switch between slow speed and fast speed. Set them to what you like - 
     remember there is no ramping.
     Bias - used to add / subtract a constant value to the dac. It can only be 

--- a/src/emc/usr_intf/pncconf/pncconf.py
+++ b/src/emc/usr_intf/pncconf/pncconf.py
@@ -3039,7 +3039,7 @@ Clicking 'existing custom program' will avoid this warning. "),False):
                         self.widgets[ptype].set_sensitive(0)
                         self.widgets[p].set_model(self.d._notusedsignaltree)
                         self.widgets[p].set_active(0)
-                        return 'ERROR: more then maximium channels'
+                        return 'ERROR: more then maximum channels'
 
                     #print("**** INFO: SMART SERIAL ENCODER:",firmptype," compnum = ",compnum," channel = ",channelnum)
                     #print("sserial channel:%d"% numofsserialchannels)

--- a/src/hal/components/moveoff.comp
+++ b/src/hal/components/moveoff.comp
@@ -17,7 +17,7 @@ Typically, the move-enable pin is connected to external controls and the apply-o
 Applied offsets are \\fBautomatically returned\\fR to zero (respecting limits) when either of the enabling inputs is deactivated.
 The zero value tolerance is specified by the epsilon input pin value.
 
-Waypoints are recorded when the moveoff componenent is enabled.
+Waypoints are recorded when the moveoff component is enabled.
 Waypoints are managed with the waypoint-sample-secs and waypoint-threshold pins.
 When the backtrack-enable pin is TRUE, the auto-return path follows the recorded waypoints.
 When the memory available for waypoints is exhausted, offsets are frozen and the waypoint-limit pin is asserted.

--- a/src/hal/components/mux16.comp
+++ b/src/hal/components/mux16.comp
@@ -10,7 +10,7 @@ This stops unwanted jumps in output between transitions of input.
 but make in00 unavailable.
 """;
 pin in float debounce_time"""\
-sets debouce time in seconds.  eg. .10 = a tenth of a second
+sets debounce time in seconds.  eg. .10 = a tenth of a second
 input must be stable this long before outputs changes. This
 helps to ignore 'noisy' switches.
 """;

--- a/src/hal/components/panelui.c
+++ b/src/hal/components/panelui.c
@@ -109,7 +109,7 @@ int nochange = 0x40;
 int rowshift;
 int ncols = 8;
 int nrows = 8;
-int rollover = 2; //maximuim number of simultaneous keys presses recognised
+int rollover = 2; //maximum number of simultaneous keys presses recognised
 int s = 0; //key press state argument to pass to python
 int r; //row argument passed to python
 int c; //column argument passed to python

--- a/src/hal/components/panelui.c
+++ b/src/hal/components/panelui.c
@@ -109,7 +109,7 @@ int nochange = 0x40;
 int rowshift;
 int ncols = 8;
 int nrows = 8;
-int rollover = 2; //maximuim number of simultaneous keys presses recongnised
+int rollover = 2; //maximuim number of simultaneous keys presses recognised
 int s = 0; //key press state argument to pass to python
 int r; //row argument passed to python
 int c; //column argument passed to python

--- a/src/hal/components/xyzab_tdr_kins.comp
+++ b/src/hal/components/xyzab_tdr_kins.comp
@@ -166,7 +166,7 @@ int kinematicsForward(const double *j,
     // define forward kinematic models using case structure for
     // for switchable kinematics
     switch (switchkins_type) {
-        case 0: // ====================== IDENTITIY kinematics FORWARD ===================
+        case 0: // ====================== IDENTITY kinematics FORWARD ====================
             pos->tran.x = j[0];
             pos->tran.y = j[1];
             pos->tran.z = j[2];
@@ -227,7 +227,7 @@ int kinematicsInverse(const EmcPose * pos,
     double       qz = 0;
 
     switch (switchkins_type) {
-        case 0:// ====================== IDENTITIY kinematics INVERSE ===================
+        case 0:// ====================== IDENTITY kinematics INVERSE =====================
             j[0] = pos->tran.x;
             j[1] = pos->tran.y;
             j[2] = pos->tran.z;

--- a/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
+++ b/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
@@ -731,7 +731,7 @@ int parse_data_frame(hm2_modbus_inst_t *inst){
     }
     rtapi_print_msg(RTAPI_MSG_INFO, "\n");
     if ((bytes[1] & 0x7F ) != ch->func) {
-        rtapi_print_msg(RTAPI_MSG_ERR, "call/response function number missmatch\n");
+        rtapi_print_msg(RTAPI_MSG_ERR, "call/response function number mismatch\n");
         return -1;
     }
 

--- a/src/hal/drivers/mesa-hostmot2/outm.c
+++ b/src/hal/drivers/mesa-hostmot2/outm.c
@@ -20,7 +20,7 @@
 //
 // Register map:
 //
-// OutM: Simple output module to allow renumbering pins and simplyfying hal setup
+// OutM: Simple output module to allow renumbering pins and simplifying hal setup
 // both have debounce filtering with an option of long or
 // short time on a per input basis. Up to 4 MPG encoder counters are provided
 //

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -547,7 +547,7 @@ int hm2_pktuart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames, rt
 }
 
 /* The function hm2_pktuart_read performs reads/writes outside of the normal
- * thread cycles. This is espacially a problem with the Ethernet and p-port
+ * thread cycles. This is especially a problem with the Ethernet and p-port
  * connected cards where the reads and writes should be packeted.
  * This function has been left in place for backwards compatibility, but it
  * is recommended to use the hm2_pktuart_queue_* functions instead */
@@ -649,7 +649,7 @@ int hm2_pktuart_read(char *name, unsigned char data[], rtapi_u8 *num_frames, rta
           }
 
            // a packet is completely received, but its byte count is zero
-           // is very unprobable, however we intercept this error too
+           // is very improbable, however we intercept this error too
           if (countb==0) {
               HM2_ERR_NO_LL("%s: packet %d has %d bytes.\n", name, countp+1, countb);
               return -HM2_PKTUART_RxPacketSizeZero; 

--- a/src/hal/drivers/mesa-hostmot2/pktuart_errno.h
+++ b/src/hal/drivers/mesa-hostmot2/pktuart_errno.h
@@ -34,7 +34,7 @@
 #define HM2_PKTUART_RxPacketStartbitError (1114)    // Bit 14         False Start bit error in this packet
 
 // the next two error conditions
-// are very unprobable, but we consider them nevertheless
+// are very improbable, but we consider them nevertheless
 #define HM2_PKTUART_RxPacketSizeZero      (1120)    // the length of the received packet is 0
 #define HM2_PKTUART_RxArraySizeError      (1140)    // sizeof(data array)= num_frames*max_frame_length is too small for all the data in the buffer
 

--- a/src/hal/user_comps/vismach/hbmgui.py
+++ b/src/hal/user_comps/vismach/hbmgui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-#    Visulization model of a Horizontal Boring Mill with quill
+#    Visualization model of a Horizontal Boring Mill with quill
 #
 #    Copyright 2007 John Kasunich
 #    Derived from a work by John Kasunich, Jeff Epler, and Chris Radek

--- a/src/hal/user_comps/vismach/maho600gui.py
+++ b/src/hal/user_comps/vismach/maho600gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-#    Visulization model of U of Akron's Maho 600C with 2-axis NC table
+#    Visualization model of U of Akron's Maho 600C with 2-axis NC table
 #
 #    Copyright 2007 John Kasunich
 #    Derived from a work by John Kasunich, Jeff Epler, and Chris Radek

--- a/src/hal/user_comps/vismach/max5gui.py
+++ b/src/hal/user_comps/vismach/max5gui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-#    Visulization model of Chris's MAX-NC mill, as modified to 5-axis
+#    Visualization model of Chris's MAX-NC mill, as modified to 5-axis
 #
 #    Copyright 2007 John Kasunich
 #    Derived from a work by John Kasunich, Jeff Epler, and Chris Radek

--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -190,7 +190,7 @@ void userinit(int argc, char **argv)
 				if(baud == 0)
 				{
 					fprintf(stderr,
-						"Invalid argument: buad must be a number. Given '%s'\n",
+						"Invalid argument: baud must be a number. Given '%s'\n",
 						optarg);
 					exit(1);
 				}

--- a/src/rtapi/rtapi_mutex.h
+++ b/src/rtapi/rtapi_mutex.h
@@ -52,7 +52,7 @@ typedef unsigned long rtapi_mutex_t;
     returns 0 and the mutex is no longer available, since the
     caller now has it.  If the mutex is not available, it returns
     a non-zero value to indicate that someone else has the mutex.
-    The programer is responsible for "doing the right thing" when
+    The programmer is responsible for "doing the right thing" when
     it returns non-zero.  "Doing the right thing" almost certainly
     means doing something that will yield the CPU, so that whatever
     other process has the mutex gets a chance to release it.


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.svg,*.ts,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es,./src/hal/classicladder -L ans,ba,breal,bu,bulle,busses,componentes,currenty,doubleclick,dout,dum,extint,faktor,fo,fpr,halp,ihs,inout,inport,mot,parm,parms,propertys,ro,seh,ser,smoe,te,tey,trough,ue,ure,wille,wont,wonte`

Follow-up to #2548  
Supercedes #2553 
