### PR TITLE
Fix typos in docs/ and misc. leftovers

### DIFF
--- a/configs/by_interface/parport/plasma-thc-sim/simulator.hal
+++ b/configs/by_interface/parport/plasma-thc-sim/simulator.hal
@@ -63,6 +63,6 @@ setp wcomp.3.max -10
 setp wcomp.3.min -15
 setp wcomp.4.max 15
 setp wcomp.4.min 10
-# ArcOK comarator, uses ignition timeout
+# ArcOK comparator, uses ignition timeout
 setp wcomp.5.max 4
 setp wcomp.5.min -1

--- a/configs/sim/axis/cooling.hal
+++ b/configs/sim/axis/cooling.hal
@@ -1,4 +1,4 @@
-# Fake the existance of coolant options
+# Fake the existence of coolant options
 loadrt and2 count=3
 addf and2.0 servo-thread
 addf and2.1 servo-thread

--- a/docs/man/man1/iov2.1
+++ b/docs/man/man1/iov2.1
@@ -116,7 +116,7 @@ NB: after signaling an emc\-abort, iov2 will block until emc\-abort\-ack is rais
 Usage: UI informational. Valid during emc\-abort True. 
 .TP
 \fBiocontrol.0.start\-change
-(BIT,OUT) Asserted at the very beginning of an M6 operation, before any spindle\-off, quill\-up, or move\-to\-toolchange\-position oeprations are executed.
+(BIT,OUT) Asserted at the very beginning of an M6 operation, before any spindle\-off, quill\-up, or move\-to\-toolchange\-position operations are executed.
 .TP
 \fBiocontrol.0.start\-change\-ack
 (BIT,IN) Acknowledgment line for start\-change.

--- a/docs/man/man1/mb2hal.1
+++ b/docs/man/man1/mb2hal.1
@@ -40,7 +40,7 @@ loadusr -Wn mymodule mb2hal config=config_file.ini
 .br
 .SH DESCRIPTION
 MB2HAL is a generic non-realtime HAL component to communicate with one or more
-Modbus devices. It supoorts Modbus RTU and Modbus TCP.
+Modbus devices. It supports Modbus RTU and Modbus TCP.
 
 .PP
 See 

--- a/docs/man/man1/mitsub_vfd.1
+++ b/docs/man/man1/mitsub_vfd.1
@@ -56,7 +56,7 @@ You must power cycle the inverter for some of these, e.g. 79.
 
 \fBPARAMETER 121\fR COM tries - 10
 .br
-(if maximuim 10 COM errors then inverter faults- can change.)
+(if maximum 10 COM errors then inverter faults- can change.)
 
 \fBPARAMETER 122\fR COM check time interval 9999
 .br

--- a/docs/man/man9/hm2_eth.9
+++ b/docs/man/man9/hm2_eth.9
@@ -152,7 +152,7 @@ Setting it too high can cause realtime delay errors.
 hm2_eth uses an iptables chain called "hm2\-eth\-rules\-output.
 That technology is common to control network access to (INPUT chain), through (FORWARD chain) or from (OUTPUT chain) your computer.
 Someone who has configured a firewall on Linux has encountered iptables and is familiar with that technology.
-This chain contains addtional rules to control network interface while HAL is running.
+This chain contains additional rules to control network interface while HAL is running.
 The chain is created if it does not exist, and a jump to it is inserted at the beginning of the OUTPUT chain if it is not there already.
 If you have an existing iptables setup, you can insert a direct jump from OUTPUT to hm2\-eth\-rules\-output in an order appropriate to your local network.
 

--- a/docs/man/man9/matrix_kb.9
+++ b/docs/man/man9/matrix_kb.9
@@ -16,7 +16,7 @@ and a set of input columns will be scanned.
 
 The \fBnames\fR parameter is optional,
 but if used then the HAL pins and functions will use the specified names rather than the default ones.
-This can be useful for readbility and 2-pass HAL parsing.
+This can be useful for readability and 2-pass HAL parsing.
 
 There must be no spaces in the parameter lists.
 

--- a/docs/man/man9/mux_generic.9
+++ b/docs/man/man9/mux_generic.9
@@ -20,7 +20,7 @@ This stops unwanted jumps in output between transitions of input but makes in00 
 
 .TP
 .B mux\-gen.\fINN\fB.debounce\-us\fR unsigned in \fR
-sets debouce time in microseconds, e.g. 100000 = a tenth of a second.
+sets debounce time in microseconds, e.g. 100000 = a tenth of a second.
 The selection inputs must be stable this long before the output changes.
 This helps to ignore 'noisy' switches.
 

--- a/docs/src/drivers/mitsub-vfd.adoc
+++ b/docs/src/drivers/mitsub-vfd.adoc
@@ -180,7 +180,7 @@ One must power cycle the VFD for some of these to register eg PR 79
    '-no parity'
 
  * 'PR 121' set to 1-10
-   '-if 10 (maximuim) COM errors then VFD faults.'
+   '-if 10 (maximum) COM errors then VFD faults.'
 
  * 'PR 122' tested with 9999
    '-if communication is lost VFD will not error.'

--- a/docs/src/hal/intro.adoc
+++ b/docs/src/hal/intro.adoc
@@ -62,7 +62,7 @@ Taken together, HAL allows
   * listen to what the machine wants to tell about the state it is in. 
 . Vertical Abstractions: The human system integrator of such machine uses HAL
   * to describe what the machine is looking like and how what cable controls which motor that drives which axis.
-  * The description of the machine, the programmer's interfaces and the user's interface somehow "meet" in that abtract layer.
+  * The description of the machine, the programmer's interfaces and the user's interface somehow "meet" in that abstract layer.
 . Horizontal Abstractions:
   * Not all machines have all kinds of features
   * Mills, Lathes and Robots share many
@@ -89,7 +89,7 @@ It is a bit tricky though and the community is still organizing its thoughts on 
 HAL lies at the core of LinuxCNC and is used and/or extended by all the parts of LinuxCNC, which includes the GUIs.
 The G-code (or alternative language) interpreter knows how to interpret the G-code and translates it into machine operations by triggering signals in HAL.
 The user may query HAL in various ways to gain information about its state, which then also represents the state of the machine.
-Whilst writing during the develpment of version 2.9, the GUIs still make bit of an exception to that rule and may know something that HAL does not (need to) know.
+Whilst writing during the development of version 2.9, the GUIs still make bit of an exception to that rule and may know something that HAL does not (need to) know.
 
 
 == Communication
@@ -134,7 +134,7 @@ HAL components prepare such input and output pins and are thus automatically tri
 .HAL Components
 The many "expert" software parts of LinuxCNC are typically implemented as _components_ of HAL, conceptually also referred to as _modules_.
 These computer-implemented experts perpetually read from HAL about a state that the machine should strive to achieve and compare that desired state with the state the machine is in at the current moment.
-When there is a difference beween what should be and what the current state is then some action is performed to reduce that difference,
+When there is a difference between what should be and what the current state is then some action is performed to reduce that difference,
 while perpetually writing updates of the current states back to the HAL data space.
 
 There are components specializing on how to talk to stepper motors, and other components know how to control servos.

--- a/lib/python/qtvcp/core.py
+++ b/lib/python/qtvcp/core.py
@@ -17,7 +17,7 @@ from . import logger
 log = logger.getLogger(__name__)
 # log.setLevel(logger.INFO) # One of DEBUG, INFO, WARNING, ERROR, CRITICAL, VERBOSE
 
-# The order of these classes is importanr, otherwise - cirular imports.
+# The order of these classes is importanr, otherwise - circular imports.
 # the some of the later classes reference the earlier classes
 
 ################################################################

--- a/nc_files/macros/lathe/facing.ngc
+++ b/nc_files/macros/lathe/facing.ngc
@@ -10,7 +10,7 @@
 ; #4 feed/rpm
 ; #5 Face Z length
 ; #6 face angle
-; #7 tool numbber
+; #7 tool number
 ; #8 max RPM
 ;Facing
 

--- a/nc_files/remap-subroutines/qt_auto_probe_tool.ngc
+++ b/nc_files/remap-subroutines/qt_auto_probe_tool.ngc
@@ -8,7 +8,7 @@ o<qt_auto_probe_tool> sub
 ; or preview will break, so test for '#<_task>' which is 1 for 
 ; the milltask interpreter and 0 in the UI's
 O100 if [#<_task> EQ 0]
-        (debug, Task ist Null)
+        (debug, Task is Null)
 O100     return [999]
 O100 endif
 

--- a/src/emc/usr_intf/pncconf/pncconf-help/help-axismotor.txt
+++ b/src/emc/usr_intf/pncconf/pncconf-help/help-axismotor.txt
@@ -49,12 +49,12 @@ Analog Scale:
     The 5i25 spindle/analog outputs use these three settings to scale and range
     the output voltage.
     Min Limit is the minimum output eg -10 or 0 volts.
-    Max Limit is the Maximuim output eg 10 volts.
-    Scale sets the user units based on the maximuim output of 10 volts.
+    Max Limit is the Maximum output eg 10 volts.
+    Scale sets the user units based on the maximum output of 10 volts.
     If you wish the units to be voltage then set the scale to 10
     If you wish the units to be RPM (of say a VDF spindle) set the scale to the
-    maximuim RPM of the spindle with a 10 volt signal.
-    For an axis setting the scale at maximuim axis velocity (machine units per 
+    maximum RPM of the spindle with a 10 volt signal.
+    For an axis setting the scale at maximum axis velocity (machine units per 
     second) would make sense.
 
     eg. scale to voltage, range of +- 10
@@ -130,7 +130,7 @@ Spindle-at-speed settings:
     There is the option of percent or RPM range.
     If you leave percent at 100 then set the RPM difference that is acceptable.
     Other wise set the RPM difference to 0 and set the percent that is acceptable.
-    The default is a difference of +-200 RPM. Maximuim is 500 RPM.
+    The default is a difference of +-200 RPM. Maximum is 500 RPM.
 
 Spindle display filter gain:
     If a spindle speed display was chosen, this sets the filter

--- a/src/hal/components/limit_axis.comp
+++ b/src/hal/components/limit_axis.comp
@@ -35,7 +35,7 @@ function _;
 pin out bit error-no-range "error pin indicating that no range matches the fb";
 pin out float min-output "Minimum limit output";
 pin out float max-output "Maximum limit output";
-pin in float fb "Feedback pin, the value of this pin determiens which range is active";
+pin in float fb "Feedback pin, the value of this pin determines which range is active";
 pin out unsigned current-range "Indicates which range is currently active";
 pin in float min-limit-## [10:personality] "The array of minimum limits to select from";
 pin in float max-limit-## [10:personality] "The array of macimum limits";

--- a/src/hal/user_comps/mitsub_vfd.py
+++ b/src/hal/user_comps/mitsub_vfd.py
@@ -30,7 +30,7 @@
 # PR 118 communication speed 96           (can be optionally set 48,96,192) if component is also set
 # PR 119 stop bit/data length - 1         8 bits, two stop (don't change)
 # PR 120 parity - 0                       no parity (don't change)
-# PR 121 COM tries - 10                   if 10 (maximuim) COM errors then inverter faults (can change)
+# PR 121 COM tries - 10                   if 10 (maximum) COM errors then inverter faults (can change)
 # PR 122 COM check time interval 9999     (never check) if communication is lost inverter will not know (can change)
 # PR 123 wait time - 9999 -               no wait time is added to the serial data frame (don't change)
 # PR 124 CR selection - 0                 don't change
@@ -377,7 +377,7 @@ if __name__ == "__main__":
         print(' PR 118 communication speed 96           baud rate, can be optionally set 48,96,192 if component is also set')
         print(''' PR 119 stop bit/data length - 1         8 bits, two stop (don't change)''')
         print(''' PR 120 parity - 0                       no parity (don't change)''')
-        print(' PR 121 COM tries - 10                   if 10 (maximuim) COM errors then inverter faults (can change)')
+        print(' PR 121 COM tries - 10                   if 10 (maximum) COM errors then inverter faults (can change)')
         print(' PR 122 COM check time interval 9999     (never check) if communication is lost inverter will not know (can change)')
         print(''' PR 123 wait time - 9999 -               no wait time is added to the serial data frame (don't change)''')
         print(''' PR 124 CR selection - 0                 don't change''')

--- a/tcl/ngcgui.tcl
+++ b/tcl/ngcgui.tcl
@@ -2659,7 +2659,7 @@ proc ::ngcgui::dcheck {hdl} {
   foreach n [array names ::ngc $hdl,arg,entrywidget,*] {
     set i1 [string last , $n]
     set num02 [string range $n [expr 1 + $i1] end]
-    # under some contitions, this entrywidget may be done:
+    # under some conditions, this entrywidget may be done:
     if ![winfo exists $::ngc($hdl,arg,entrywidget,$num02)] continue
     if {   [info exists ::ngc($hdl,arg,dvalue,$num02)] \
         && "$::ngc($hdl,arg,dvalue,$num02)" \

--- a/tests/mb2hal/mb2hal.1a/readme
+++ b/tests/mb2hal/mb2hal.1a/readme
@@ -1,1 +1,1 @@
-This test runs mb2hal im compatibilty mode (means version = 1.0, not explicitly set) compares the INI DEBUG output of MB2HAL.
+This test runs mb2hal im compatibility mode (means version = 1.0, not explicitly set) compares the INI DEBUG output of MB2HAL.

--- a/tests/mb2hal/mb2hal.1b/readme
+++ b/tests/mb2hal/mb2hal.1b/readme
@@ -1,1 +1,1 @@
-This test runs mb2hal im compatibilty mode (means version = 1.0, not explicitly set) and compares the created pins (including types).
+This test runs mb2hal im compatibility mode (means version = 1.0, not explicitly set) and compares the created pins (including types).

--- a/tests/mqtt/display.py
+++ b/tests/mqtt/display.py
@@ -45,7 +45,7 @@ while (time.time() - start_time) < timeout and \
       hal.get_value(name) == lastpublish:
     time.sleep(0.1)
 if hal.get_value(name) == lastpublish:
-    raise RuntimeError(f"error: no MQTT publishing happend within {timeout} seconds")
+    raise RuntimeError(f"error: no MQTT publishing happened within {timeout} seconds")
 
 print("info: Turning machine off")
 c.state(linuxcnc.STATE_OFF)


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.svg,*.ts,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es,./src/hal/classicladder -L ans,ba,breal,bu,bulle,busses,componentes,currenty,doubleclick,dout,dum,extint,faktor,fo,fpr,halp,ihs,inout,inport,mot,parm,parms,propertys,ro,seh,ser,smoe,te,tey,trough,ue,ure,wille,wont,wonte`

Follow-up to #2548

----

I made this a catch-all PR and added leftover typos. Hopefully that is OK to do. Also please review closely, I wasn't sure if the man pages were generated and therefore not the target for a fix. 