### PR TITLE
Gmoccapy - new HAL pin disable_automatic_G43

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -3537,11 +3537,14 @@ class gmoccapy(object):
             self.on_hal_status_interp_idle(None)
             return
 
+        # automatic run command "G43"
         if "G43" in self.active_gcodes and self.stat.task_mode != linuxcnc.MODE_AUTO:
-            self.command.mode(linuxcnc.MODE_MDI)
-            self.command.wait_complete()
-            self.command.mdi("G43")
-            self.command.wait_complete()
+            if not hal.get_value("gmoccapy.disable_automatic_G43"):
+                self.command.mode(linuxcnc.MODE_MDI)
+                self.command.wait_complete()
+                self.command.mdi("G43")
+                self.command.wait_complete()
+                LOG.debug("automatic run command G43 was executed ")
 
     def _set_enable_tooltips(self, value):
         LOG.debug("_set_enable_tooltips = {0}".format(value))
@@ -5685,6 +5688,10 @@ class gmoccapy(object):
         pin = self.halcomp.newpin('toolchange-change', hal.HAL_BIT, hal.HAL_IN)
         hal_glib.GPin(pin).connect('value_changed', self.on_tool_change)
         self.halcomp.newpin('toolchange-confirm', hal.HAL_BIT, hal.HAL_IN)
+
+        # make a pin to disable automatic run command "G43" after toolchange
+        # automatic run command "G43" can cause run condition
+        self.halcomp.newpin("disable_automatic_G43", hal.HAL_BIT, hal.HAL_IN)
 
         # make a pin to confirm a warning dialog
         self.halcomp.newpin('warning-confirm', hal.HAL_BIT, hal.HAL_IN)


### PR DESCRIPTION
Hello,

It is said that a bad programmer, when he cannot solve a problem, creates a parameter that the user must set. The bad programmer also declares it as an advantage that the user can set many things himself.

I didn't want to use this solution because it is not automatic.

One of the causes of this bug:
https://github.com/LinuxCNC/linuxcnc/issues/2453
That will run this command:
https://github.com/LinuxCNC/linuxcnc/blob/56883b969838b721c0b0ebe12b9c14abf91d640e/src/emc/usr_intf/gmoccapy/gmoccapy.py#L3540-L3544
after tool change.

The bug https://github.com/LinuxCNC/linuxcnc/issues/2453 could be solved by having command.wait_complete() wait for mdi-commands by HALUI to complete. It would be fantastic because it would be automatic. The user would not have to worry about anything. Unfortunately, I was unable to create such a fix.

However, yesterday I realized that there may be more situations where it is necessary to prevent race conditions. For example, if I write my own python module. Therefore, I am deliberately not calling this Pull Request FIX 2453. 

This Pull Request can be used for FIX 2453, but I would like bug 2453 to be solved more elegantly in the future and the automatic command G43 to be turned off automatically.

If this Pull Request is approved, it would be necessary to modify the manual:
1) http://linuxcnc.org/docs/2.9/html/gui/gmoccapy.html#_tool_related_pins
disable_automatic_G43(bit IN) - disable automatic run command "G43" after toolchange
Automatic run command "G43" can cause run condition. So writing a program makes you responsible to disable automatic run command "G43" so that a race condition does not occur.

2) http://linuxcnc.org/docs/2.9/html/gui/gmoccapy.html#_known_problems
12.3 Warning "Must be in MDI mode....." after tool change
Gmoccapy will run the after tool change MDI command G43. This function is very useful, unfortunately it can cause a problem in certain cases when a race condition occurs and this message is raised:
![Must be in MDI mode](https://github.com/LinuxCNC/linuxcnc/assets/96618597/d11ddc3a-74de-4063-a9ea-86b52e48238c)
Be careful, this bug is random. Just because it didn't show up right away doesn't mean it won't show up later. This can be caused by using:
1. HALUI - MDI commnads:
For example in INI file is:
```
[HALUI]
MDI_COMMAND = M61 Q1
MDI_COMMAND = M61 Q2
```
(If you are in MDI mode the bug will not appear.)
2. Your own program
For example:
```
self.command.mode(linuxcnc.MODE_MDI)
self.command.wait_complete()
self.command.mdi("M61 Q1")
self.command.wait_complete()
self.command.mode(MODE_MANUAL)
self.command.wait_complete()
```
Sometimes the automatic run command "G43" will win and then self.command.mode(MODE_MANUAL) will run. In this case, nothing happens.
Sometimes self.command.mode(MODE_MANUAL) wins and then an error occurs when trying to run G43.


I would like ask for requested a review from [gmoccapy](https://github.com/gmoccapy)