### PR TITLE
Make life easier for translators by synchronizing pin list between chapters.

### DIFF
--- a/docs/src/config/core-components.adoc
+++ b/docs/src/config/core-components.adoc
@@ -322,19 +322,19 @@ iocontrol's HAL pins are turned on and off in non-realtime context.  If you have
 
 === Pins (((iocontrol (HAL pins))))
 
-* 'iocontrol.0.coolant-flood' - (bit, out) TRUE when flood coolant is requested.
-* 'iocontrol.0.coolant-mist' - (bit, out) TRUE when mist coolant is requested.
-* 'iocontrol.0.emc-enable-in' - (bit, in) Should be driven FALSE when an external E-Stop condition exists.
-* 'iocontrol.0.lube' - (bit, out) TRUE when lube is commanded.
-* 'iocontrol.0.lube_level' - (bit, in) Should be driven TRUE when lube level is high enough.
-* 'iocontrol.0.tool-change' - (bit, out) TRUE when a tool change is requested.
-* 'iocontrol.0.tool-changed' - (bit, in) Should be driven TRUE when a tool change is completed.
-* 'iocontrol.0.tool-number' - (s32, out) The current tool number.
-* 'iocontrol.0.tool-prep-number' - (s32, out) The number of the next tool, from the RS274NGC T-word.
-* 'iocontrol.0.tool-prepare' - (bit, out) TRUE when a tool prepare is requested.
-* 'iocontrol.0.tool-prepared' - (bit, in) Should be driven TRUE when a tool prepare is completed.
-* 'iocontrol.0.user-enable-out' - (bit, out) FALSE when an internal E-Stop condition exists.
-* 'iocontrol.0.user-request-enable' - (bit, out) TRUE when the user has requested that E-Stop be cleared.
+* 'iocontrol.0.coolant-flood' (bit, out) TRUE when flood coolant is requested.
+* 'iocontrol.0.coolant-mist' (bit, out) TRUE when mist coolant is requested.
+* 'iocontrol.0.emc-enable-in' (bit, in) Should be driven FALSE when an external E-Stop condition exists.
+* 'iocontrol.0.lube' (bit, out) TRUE when lube is commanded.
+* 'iocontrol.0.lube_level' (bit, in) Should be driven TRUE when lube level is high enough.
+* 'iocontrol.0.tool-change' (bit, out) TRUE when a tool change is requested.
+* 'iocontrol.0.tool-changed' (bit, in) Should be driven TRUE when a tool change is completed.
+* 'iocontrol.0.tool-number' (s32, out) The current tool number.
+* 'iocontrol.0.tool-prep-number' (s32, out) The number of the next tool, from the RS274NGC T-word.
+* 'iocontrol.0.tool-prepare' (bit, out) TRUE when a tool prepare is requested.
+* 'iocontrol.0.tool-prepared' (bit, in) Should be driven TRUE when a tool prepare is completed.
+* 'iocontrol.0.user-enable-out' (bit, out) FALSE when an internal E-Stop condition exists.
+* 'iocontrol.0.user-request-enable' (bit, out) TRUE when the user has requested that E-Stop be cleared.
 
 == INI settings
 

--- a/docs/src/config/iov2.adoc
+++ b/docs/src/config/iov2.adoc
@@ -71,80 +71,67 @@ DEBUG :: To get a (quite detailed) trace, set either the RCS debugging flag
 
 == Pins
 
-* iocontrol.0.coolant-flood (Bit, Out) TRUE when flood coolant is requested
-
-* iocontrol.0.coolant-mist (Bit, Out) TRUE when mist coolant is requested
-
-* iocontrol.0.emc-enable-in (Bit, In) Should be driven FALSE when an external
+* 'iocontrol.0.coolant-flood' (bit, out) TRUE when flood coolant is requested.
+* 'iocontrol.0.coolant-mist' (bit, out) TRUE when mist coolant is requested.
+* 'iocontrol.0.emc-enable-in' (bit, in) Should be driven FALSE when an external
   estop condition exists.
-
-* iocontrol.0.lube (Bit, Out) TRUE when lube is requested. This pin gets driven
+* 'iocontrol.0.lube' (bit, out) TRUE when lube is requested. This pin gets driven
   TRUE when the controller comes out of E-stop, and when the "Lube On" command
   gets sent to the controller. It gets driven FALSE when the controller goes
   into E-stop, and when the "Lube Off" command gets sent to the controller.
-
-* iocontrol.0.lube_level (Bit, In) Should be driven FALSE when lubrication tank
+* 'iocontrol.0.lube_level' (bit, in) Should be driven FALSE when lubrication tank
   is empty.
-
-* iocontrol.0.tool-change (Bit, Out) TRUE when a tool change is requested
-
-* iocontrol.0.tool-changed (Bit, In) Should be driven TRUE when a tool change is
+* 'iocontrol.0.tool-change' (bit, out) TRUE when a tool change is requested
+* 'iocontrol.0.tool-changed' (bit, in) Should be driven TRUE when a tool change is
   completed.
-
-* iocontrol.0.tool-number (s32, Out) Current tool number
-
-* iocontrol.0.tool-prep-number (s32, Out) The number of the next tool, from the
+* 'iocontrol.0.tool-number' (s32, out) Current tool number
+* 'iocontrol.0.tool-prep-number' (s32, out) The number of the next tool, from the
   RS274NGC T-word
-
-* iocontrol.0.tool-prep-pocket (s32, Out) This is the pocket number (location in
+* 'iocontrol.0.tool-prep-pocket' (s32, out) This is the pocket number (location in
   the tool storage mechanism) of the tool requested by the most recent T-word.
-
-* iocontrol.0.tool-prepare (Bit, Out) TRUE when a Tn tool prepare is requested
-
-* iocontrol.0.tool-prepared (Bit, In) Should be driven TRUE when a tool prepare 
+* 'iocontrol.0.tool-prepare' (bit, out) TRUE when a Tn tool prepare is requested
+* 'iocontrol.0.tool-prepared' (bit, in) Should be driven TRUE when a tool prepare 
   is completed.
-
-* iocontrol.0.user-enable-out (Bit, Out) FALSE when an internal estop condition
+* 'iocontrol.0.user-enable-out' (bit, out) FALSE when an internal estop condition
   exists
-
-* iocontrol.0.user-request-enable (Bit, Out) TRUE when the user has requested 
+* 'iocontrol.0.user-request-enable' (bit, out) TRUE when the user has requested 
   that estop be cleared
 
 Additional pins added by I/O Control V2
 
-* emc-abort: (Bit, Out) signals emc-originated abort to toolchanger.
+* emc-abort: (bit, out) signals emc-originated abort to toolchanger.
 
-* emc-abort-ack: (Bit, In) Acknowledge line from toolchanger for previous signal,
+* emc-abort-ack: (bit, in) Acknowledge line from toolchanger for previous signal,
   or jumpered to abort-tool-change if not used in toolchanger. NB: after
   signaling an emc-abort, iov2 will block until emc-abort-ack is raised.
 
-* emc-reason: (S32, Out) convey cause for EMC-originated abort to toolchanger.
+* emc-reason: (S32, out) convey cause for EMC-originated abort to toolchanger.
   Usage: UI informational. Valid during emc-abort TRUE.
 
-* start-change: (Bit, Out) asserted at the very beginning of an M6 operation,
+* start-change: (bit, out) asserted at the very beginning of an M6 operation,
   before any spindle-off, quill-up, or move-to-toolchange-position operations
   are executed.
 
-* start-change-ack: (Bit, In) acknowledgment line for start-change. 
+* start-change-ack: (bit, in) acknowledgment line for start-change. 
 
-* toolchanger-fault: (Bit, In) toolchanger signals fault. This line is
+* toolchanger-fault: (bit, in) toolchanger signals fault. This line is
   contionuously monitored. A fault toggles a flag in iocontrol which is
   reflected in the toolchanger-faulted pin.
 
-* toolchanger-fault-ack: (Bit, Out) handshake line for above signal. will be set
+* toolchanger-fault-ack: (bit, out) handshake line for above signal. will be set
   by iov2 after above fault line TRUE is recognized and deasserted when
   toolchanger-fault drops. Toolchanger is free to interpret the ack; reading the
   -ack lines assures fault has been received and acted upon.
 
-* toolchanger-reason: (S32, In) convey reason code for toolchanger-originated
+* toolchanger-reason: (S32, in) convey reason code for toolchanger-originated
   fault to iov2. Usage: signal whether to continue or abort the program, plus UI
   informational if negative. Read during toolchanger-fault TRUE. Non-zero values
   will cause an Axis operator operator message or error message, see below. 
 
-* toolchanger-faulted: (Bit, Out) signals toolchanger-notify line has toggled and
+* toolchanger-faulted: (bit, out) signals toolchanger-notify line has toggled and
   toolchanger-reason-code was in the fault range. Next M6 will abort.
 
-* toolchanger-clear-fault: (Bit, In) resets TC fault condition. Deasserts
+* toolchanger-clear-fault: (bit, in) resets TC fault condition. Deasserts
   toolchanger-faulted if toolchanger-notify is line FALSE. Usage: UI - e.g.
   clear fault condition button.
 


### PR DESCRIPTION
The pin description for iocontrol in iov2.adoc and core-components.adoc were similar but not quite identical.  This caused translators to handle these strings twice.  Gave the pin list in the two locations the same format/structure, to reduce the number of stings for translators to handle.