### PR TITLE
Get rid of stdout lines from GUI drawing interpreter.

### DIFF
--- a/src/emc/canterp/canterp.cc
+++ b/src/emc/canterp/canterp.cc
@@ -102,6 +102,7 @@ public:
     void print_state_tag(StateTag const &tag);
     void set_loglevel(int level);
     void set_loop_on_main_m99(bool state);
+    FILE* get_stdout() { return NULL; };
     FILE *f;
     char filename[PATH_MAX];
 };

--- a/src/emc/rs274ngc/interp_base.hh
+++ b/src/emc/rs274ngc/interp_base.hh
@@ -19,6 +19,7 @@
 #ifndef INTERP_BASE_HH
 #define INTERP_BASE_HH
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <boost/noncopyable.hpp>
 #include <emcpos.h>
@@ -66,6 +67,7 @@ public:
     virtual void print_state_tag(StateTag const &tag) = 0;
     virtual void set_loglevel(int level) = 0;
     virtual void set_loop_on_main_m99(bool state) = 0;
+    FILE* get_stdout() { return stdout; };
 };
 
 InterpBase *interp_from_shlib(const char *shlib);

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -1505,7 +1505,7 @@ int Interp::convert_comment(char *comment, bool enqueue)       //!< string with 
   char MSG_STR[] = "msg,";
 
   //!!!KL add two -- debug => same as msg
-  //!!!KL         -- print => goes to stderr
+  //!!!KL         -- print => goes to stdout
   char DEBUG_STR[] = "debug,";
   char PRINT_STR[] = "print,";
   char LOG_STR[] = "log,";
@@ -1544,10 +1544,13 @@ int Interp::convert_comment(char *comment, bool enqueue)       //!< string with 
   }
   else if (startswith(lc, PRINT_STR))
   {
-      convert_param_comment(comment+start+strlen(PRINT_STR), expanded,
-                            EX_SIZE);
-      fprintf(stdout, "%s\n", expanded);
-      fflush(stdout);
+      FILE *fd = get_stdout();
+      if (fd) {
+          convert_param_comment(comment+start+strlen(PRINT_STR), expanded,
+                                EX_SIZE);
+          fprintf(fd, "%s\n", expanded);
+          fflush(fd);
+      }
       return INTERP_OK;
   }
   else if (startswith(lc, LOG_STR))


### PR DESCRIPTION
Every time the GUI parse the G code program to draw the expected moves, any (print, message) line will output its message to stdout.  This is very confusing when debugging a program.  This patch rewrite the handling of (print, ...) to avoid this output.

Fixes #2559.