### PR TITLE
More tiny bits that I found while revisiting weblate (smoe:docs29_mac_103)

### DIFF
--- a/docs/man/man1/halshow.1
+++ b/docs/man/man1/halshow.1
@@ -67,7 +67,7 @@ LinuxCNC 2.9:
 None known at this time. 
 .PP
 .SH AUTHOR
-Raymond E Henry
+Raymond E. Henry
 .SH REPORTING BUGS
 Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
 .SH COPYRIGHT

--- a/docs/src/code/adding-configs.adoc
+++ b/docs/src/code/adding-configs.adoc
@@ -2,26 +2,20 @@
 
 = Adding Configuration Selection Items
 
-Example Configurations can be added to the Configuration Selector
-by two methods:
+Example Configurations can be added to the Configuration Selector by two methods:
 
-* Auxiliary applications -- Applications installed independently
-  with a deb package can place configuration subdirectories in
-  a specified system directory.  The directory name is specified
-  using the shell linuxcnc_var script:
+* Auxiliary applications -- Applications installed independently with a deb package can place configuration subdirectories in a specified system directory.
+  The directory name is specified using the shell linuxcnc_var script:
 +
 ----
 $ linuxcnc_var LINUXCNC_AUX_EXAMPLES
 /usr/share/linuxcnc/aux_examples
 ----
 
-* Runtime settings -- the configuration selector can also offer
-  configuration subdirectories specified at runtime using an
-  exported environamental variable (LINUXCNC_AUX_CONFIGS).  This
-  variable should be a path list of one or more configuration
-  directories separated by a (:).  Typically, this variable
-  would be set in a shell starting linuxcnc or in a user's
-  ~/.profile startup script.  Example:
+* Runtime settings -- the configuration selector can also offer configuration subdirectories specified at runtime using an exported environamental variable (LINUXCNC_AUX_CONFIGS).
+  This variable should be a path list of one or more configuration directories separated by a (:).
+  Typically, this variable would be set in a shell starting `linuxcnc` or in a user's `~/.profile` startup script.
+  Example:
 +
 ----
 export LINUXCNC_AUX_CONFIGS=~/myconfigs:/opt/otherconfigs

--- a/docs/src/common/linux-faq.adoc
+++ b/docs/src/common/linux-faq.adoc
@@ -139,8 +139,8 @@ Open the file with File > Open > Edit
 === Root Access
 
 In Ubuntu you can become root by typing in "sudo -i" in a terminal
-window then typing in your password. Be careful, because you can really 
-foul things up as root if you don't know what you're doing. 
+window then typing in your password. Be careful, because you can really
+foul things up as root if you don't know what you're doing.
 
 == Terminal Commands
 
@@ -183,7 +183,7 @@ cd linuxcnc/configs
 
 === Listing files in a directory
 
-To view a list of all the files and subdirectories in the terminal window type: 
+To view a list of all the files and subdirectories in the terminal window type:
 
 ----
 dir
@@ -213,7 +213,7 @@ Open a new terminal window and type:
 pwd
 ----
 
-And pwd might return the following result: 
+And pwd might return the following result:
 
 ----
 /home/joe

--- a/docs/src/config/ini-homing.adoc
+++ b/docs/src/config/ini-homing.adoc
@@ -41,7 +41,7 @@ Homing relies on some fundamental machine assumptions.
 * Soft(ware) limits are inside the limit switch area.
 * (Final) Homed Position is inside the soft limit area
 * (If using switch based homing) the homing switch(es) either utilize the limit switches (shared home / limit switch),
-  or when using a separate home switch, are inside the limit switch area. 
+  or when using a separate home switch, are inside the limit switch area.
 * If using a separate homing switch, it is possible to start homing on the wrong side of the home switch,
   which combined with HOME_IGNORE_LIMITS option will lead to a hard crash.
   You can avoid this by making the home switch toggle its state when the trip dog is on a particular side until it returns passed the trip point again.
@@ -59,7 +59,7 @@ This example shows minimum and maximum limit switches with a separate home switc
 .Demonstrative Separate Switch Layout
 image::images/HomeAxisTravel_V2.png["Example Homing Switch layout",align="center"]
 
-* A is the negative soft limit 
+* A is the negative soft limit
 * B is the G53 machine coordinate Origin
 * C is the home switch trip point
 * D is the positive soft limit

--- a/docs/src/config/iov2.adoc
+++ b/docs/src/config/iov2.adoc
@@ -14,8 +14,7 @@
 
 I/O control handles I/O tasks like coolant, toolchange, E-stop and lube. The signals are turned on and off with G-code or in the case of E-stop in HAL.
 
-I/O Control V2 adds more toolchanger support for communication with the
-toolchanger.
+I/O Control V2 adds more toolchanger support for communication with the toolchanger.
 
 * LinuxCNC originated abort and toolchanger fault: iocontrol reliably abort a
   change operation in progress (tool-change asserted). A toolchanger may at any
@@ -42,7 +41,7 @@ toolchanger.
   Handshaking is optional and can be jumpered in HAL if not needed.
 
 * Backwards compatibility: A toolchanger ignoring the iocontrol emc-abort line
-  and sticking to old handling will "continue to work" (subject to race condition) 
+  and sticking to old handling will "continue to work" (subject to race condition)
 
 If you have strict timing requirements or simply need more I/O, consider using
 the realtime I/O provided by link:../man/man9/motion.9.html[motion] instead.
@@ -52,50 +51,39 @@ the realtime I/O provided by link:../man/man9/motion.9.html[motion] instead.
 INI file options:
 
 .[EMCIO] section
-PROTOCOL_VERSION = 2 :: Defaults to 2. Setting to 1 will emulate old iocontrol behaviour. 
+PROTOCOL_VERSION = 2 :: Defaults to 2. Setting to 1 will emulate old iocontrol behaviour.
 
-EMCIO = iov2 -support-start-change :: You need to explicitly enable the start-change protocol by adding the 
+EMCIO = iov2 -support-start-change :: You need to explicitly enable the start-change protocol by adding the
   -support-start-change option; otherwise the start-change pin remains
   low and   start-change-ack is ignored. The reason for this is better
   backwards compatibility.
 
 .[TASK] section
-IO_ERROR :: Printf-style template for operator error display (negative
-  toolchanger fault codes) . No quoting needed. Example: `IO_ERROR = Toolchanger
-  fault %d`. Default: toolchanger error %d.
+IO_ERROR :: Printf-style template for operator error display (negative toolchanger fault codes).
+  No quoting needed. Example: `IO_ERROR = Toolchanger fault %d`. Default: toolchanger error %d.
 
 .[EMC] section +
-DEBUG :: To get a (quite detailed) trace, set either the RCS debugging flag
-  (0x00000200) to turn on RCS debugging messages all over LinuxCNC or use the
-  new iocontrol debugging bit (0x00001000) only for iov2 messages. 
+DEBUG :: To get a (quite detailed) trace,
+  set either the RCS debugging flag (0x00000200) to turn on RCS debugging messages all over LinuxCNC or use the new iocontrol debugging bit (0x00001000) only for iov2 messages.
 
 == Pins
 
 * 'iocontrol.0.coolant-flood' (bit, out) TRUE when flood coolant is requested.
 * 'iocontrol.0.coolant-mist' (bit, out) TRUE when mist coolant is requested.
-* 'iocontrol.0.emc-enable-in' (bit, in) Should be driven FALSE when an external
-  estop condition exists.
-* 'iocontrol.0.lube' (bit, out) TRUE when lube is requested. This pin gets driven
-  TRUE when the controller comes out of E-stop, and when the "Lube On" command
-  gets sent to the controller. It gets driven FALSE when the controller goes
-  into E-stop, and when the "Lube Off" command gets sent to the controller.
-* 'iocontrol.0.lube_level' (bit, in) Should be driven FALSE when lubrication tank
-  is empty.
+* 'iocontrol.0.emc-enable-in' (bit, in) Should be driven FALSE when an external E-stop condition exists.
+* 'iocontrol.0.lube' (bit, out) TRUE when lube is requested.
+  This pin gets driven TRUE when the controller comes out of E-stop, and when the "Lube On" command gets sent to the controller.
+  It gets driven FALSE when the controller goes into E-stop, and when the "Lube Off" command gets sent to the controller.
+* 'iocontrol.0.lube_level' (bit, in) Should be driven FALSE when lubrication tank is empty.
 * 'iocontrol.0.tool-change' (bit, out) TRUE when a tool change is requested
-* 'iocontrol.0.tool-changed' (bit, in) Should be driven TRUE when a tool change is
-  completed.
+* 'iocontrol.0.tool-changed' (bit, in) Should be driven TRUE when a tool change is completed.
 * 'iocontrol.0.tool-number' (s32, out) Current tool number
-* 'iocontrol.0.tool-prep-number' (s32, out) The number of the next tool, from the
-  RS274NGC T-word
-* 'iocontrol.0.tool-prep-pocket' (s32, out) This is the pocket number (location in
-  the tool storage mechanism) of the tool requested by the most recent T-word.
-* 'iocontrol.0.tool-prepare' (bit, out) TRUE when a Tn tool prepare is requested
-* 'iocontrol.0.tool-prepared' (bit, in) Should be driven TRUE when a tool prepare 
-  is completed.
-* 'iocontrol.0.user-enable-out' (bit, out) FALSE when an internal estop condition
-  exists
-* 'iocontrol.0.user-request-enable' (bit, out) TRUE when the user has requested 
-  that estop be cleared
+* 'iocontrol.0.tool-prep-number' (s32, out) The number of the next tool, from the RS274NGC T-word
+* 'iocontrol.0.tool-prep-pocket' (s32, out) This is the pocket number (location in the tool storage mechanism) of the tool requested by the most recent T-word.
+* 'iocontrol.0.tool-prepare' (bit, out) TRUE when a T__n__ tool prepare is requested.
+* 'iocontrol.0.tool-prepared' (bit, in) Should be driven TRUE when a tool prepare is completed.
+* 'iocontrol.0.user-enable-out' (bit, out) FALSE when an internal E-stop condition exists
+* 'iocontrol.0.user-request-enable' (bit, out) TRUE when the user has requested that E-stop be cleared
 
 Additional pins added by I/O Control V2
 
@@ -112,7 +100,7 @@ Additional pins added by I/O Control V2
   before any spindle-off, quill-up, or move-to-toolchange-position operations
   are executed.
 
-* start-change-ack: (bit, in) acknowledgment line for start-change. 
+* start-change-ack: (bit, in) acknowledgment line for start-change.
 
 * toolchanger-fault: (bit, in) toolchanger signals fault. This line is
   contionuously monitored. A fault toggles a flag in iocontrol which is
@@ -126,20 +114,20 @@ Additional pins added by I/O Control V2
 * toolchanger-reason: (S32, in) convey reason code for toolchanger-originated
   fault to iov2. Usage: signal whether to continue or abort the program, plus UI
   informational if negative. Read during toolchanger-fault TRUE. Non-zero values
-  will cause an Axis operator operator message or error message, see below. 
+  will cause an Axis operator operator message or error message, see below.
 
 * toolchanger-faulted: (bit, out) signals toolchanger-notify line has toggled and
   toolchanger-reason-code was in the fault range. Next M6 will abort.
 
-* toolchanger-clear-fault: (bit, in) resets TC fault condition. Deasserts
-  toolchanger-faulted if toolchanger-notify is line FALSE. Usage: UI - e.g.
-  clear fault condition button.
+* toolchanger-clear-fault: (bit, in) resets TC fault condition.
+  Deasserts toolchanger-faulted if toolchanger-notify is line FALSE.
+  Usage: UI - e.g., clear fault condition button.
 
 == Parameters
 
 * iocontrol.0.tool-prep-index (s32, RO) IO's internal array index of the prepped
   tool requested by the most recent T-word. 0 if no tool is prepped. On random
-  toolchanger machines this is tool's pocket number (ie, the same as the
+  toolchanger machines this is tool's pocket number (i.e., the same as the
   tool-prep-pocket pin), on non-random toolchanger machines this is a small
   integer corresponding to the tool's location in the internal representation of
   the tool table. This parameter returns to 0 after a successful tool change M6.
@@ -153,7 +141,7 @@ done. If you do not need the abort handshake feature, jumper them as follows:
 
 [source,{hal}]
 ----
- net emc-abort-ack iocontrol.0.emc-abort iocontrol.0.emc-abort-ack 
+net emc-abort-ack iocontrol.0.emc-abort iocontrol.0.emc-abort-ack
 ----
 
 The emc-reason pin is considered valid during emc-abort being TRUE.
@@ -169,7 +157,7 @@ The reason codes are as follows for LinuxCNC internally generated aborts
 *	EMC_ABORT_TASK_STATE_ESTOP = 6,
 *	EMC_ABORT_TASK_STATE_NOT_ON = 7,
 *	EMC_ABORT_TASK_ABORT = 8,
-*	EMC_ABORT_USER = 100 
+*	EMC_ABORT_USER = 100
 
 iov2 adds one more code, namely EMC_ABORT_BY_TOOLCHANGER_FAULT = 101 which is
 signaled when an M6 aborts due to the toolchanger-faulted pin being TRUE.
@@ -188,9 +176,9 @@ The value of the toolchanger-reason pin is used as follows:
   Parameter #5601 contains the value of the toolchanger-reason pin.
 ** toolchanger-reason = 0 : the program is aborted
 ** toolchanger-reason < 0 : the program is aborted and an operator error
-   message is displayed by using the IO_ERROR template. 
+   message is displayed by using the IO_ERROR template.
 
-The usage of the toolchanger-fault-ack pin is optional. It will become TRUE when
-toolchanger-fault is raised and the toolchanger-reason pin has been read by iov2. 
+The usage of the toolchanger-fault-ack pin is optional.
+It will become TRUE when toolchanger-fault is raised and the toolchanger-reason pin has been read by iov2.
 
 // vim: set syntax=asciidoc:

--- a/docs/src/drivers/mb2hal.adoc
+++ b/docs/src/drivers/mb2hal.adoc
@@ -29,7 +29,7 @@ Consider using MB2HAL if:
 * You have more than one device to connect. MB2HAL is very efficiently managing multiple devices, transactions and links.
   Currently I am monitoring two axis drivers using a Rs232 port, a VFD driver using another Rs232 port, and a remote I/O using TCP/IP.
 * You want a protocol to connect your Arduino to HAL.
-  Look the included sample configuration file, sketch and library for Arduino Modbus. 
+  Look the included sample configuration file, sketch and library for Arduino Modbus.
 
 == Usage
 

--- a/docs/src/examples/gs2-example.adoc
+++ b/docs/src/examples/gs2-example.adoc
@@ -23,19 +23,19 @@ In the custom.hal file we place the following to connect LinuxCNC to the GS2 and
 .GS2 Example
 [source,{hal}]
 ----
-# load the non-realtime component for the Automation Direct GS2 VFDs 
+# load the non-realtime component for the Automation Direct GS2 VFDs
 loadusr -Wn spindle-vfd gs2_vfd -r 9600 -p none -s 2 -n spindle-vfd
 
-# connect the spindle direction pin to the GS2 
+# connect the spindle direction pin to the GS2
 net gs2-fwd spindle-vfd.spindle-fwd <= spindle.N.forward
 
-# connect the spindle on pin to the GS2 
+# connect the spindle on pin to the GS2
 net gs2-run spindle-vfd.spindle-on <= spindle.N.on
 
-# connect the GS2 at speed to the motion at speed 
+# connect the GS2 at speed to the motion at speed
 net gs2-at-speed spindle.N.at-speed <= spindle-vfd.at-speed
 
-# connect the spindle RPM to the GS2 
+# connect the spindle RPM to the GS2
 net gs2-RPM spindle-vfd.speed-command <= spindle.N.speed-out
 ----
 

--- a/docs/src/gcode/g-code.adoc
+++ b/docs/src/gcode/g-code.adoc
@@ -1833,19 +1833,15 @@ image::images/g76-threads_en.svg["G76 Threading",align="center"]
 
 * 'Drive Line' - A line through the initial X position parallel to the Z.
 * 'P-' - The 'thread pitch' in distance per revolution.
-* 'Z-' - The final position of threads. At the end of the cycle the tool
-  will be at this Z position.
+* 'Z-' - The final position of threads. At the end of the cycle the tool will be at this Z position.
 
 [NOTE]
-When G7 'Lathe Diameter Mode' is in force the values for 'I', 'J' and 'K'
-are diameter measurements. When G8 'Lathe Radius Mode' is in force the
-values for 'I', 'J' and 'K' are radius measurements.
+When G7 'Lathe Diameter Mode' is in force the values for 'I', 'J' and 'K' are diameter measurements.
+When G8 'Lathe Radius Mode' is in force the values for 'I', 'J' and 'K' are radius measurements.
 
 * 'I-' - The 'thread peak' offset from the 'drive line'.
-  Negative 'I' values are external threads, and positive 'I' values are
-  internal threads.
-  Generally the material has been turned to this size before the 'G76'
-  cycle.
+  Negative 'I' values are external threads, and positive 'I' values are internal threads.
+  Generally the material has been turned to this size before the 'G76' cycle.
 * 'J-' - A positive value specifying the 'initial cut depth'.
   The first threading cut will be 'J' beyond the 'thread peak' position.
 * 'K-' - A positive value specifying the 'full thread depth'.
@@ -1853,41 +1849,29 @@ values for 'I', 'J' and 'K' are radius measurements.
 
 Optional settings
 
-* '$-' - The spindle number to which the motion will be synchronised
-  (default 0).
-  For example if $1 is programmed then the motion will begin on the
-  reset of spindle.1.index-enable and proceed in synchrony with the
-  value of spindle.1.revs
-* 'R-' - The 'depth degression'. 'R1.0' selects constant depth on
-  successive threading passes. 'R2.0' selects constant area.
+* '$-' - The spindle number to which the motion will be synchronised (default 0).
+  For example if $1 is programmed then the motion will begin on the reset of `spindle.1.index-enable` and proceed in synchrony with the value of `spindle.1.revs`.
+* 'R-' - The 'depth degression'. 'R1.0' selects constant depth on successive threading passes. 'R2.0' selects constant area.
   Values between 1.0 and 2.0 select decreasing depth but increasing area.
   Values above 2.0 select decreasing area.
-  Beware that unnecessarily high degression values will cause a large
-  number of passes to be used. (degression = a descent by stages or
-  steps.)
+  Beware that unnecessarily high degression values will cause a large number of passes to be used.
+  (degression = a descent by stages or steps.)
 
 [WARNING]
-Unnecessarily high degression values will produce an unnecessarily high
-number of passes. (degressing = dive in stages)
+Unnecessarily high degression values will produce an unnecessarily high number of passes. (degressing = dive in stages)
 
-* 'Q-' - The 'compound slide angle' is the angle (in degrees) describing
-  to what extent successive passes should be offset along the drive line.
-  This is used to cause one side of the tool to remove more material than
-  the other. A positive 'Q' value causes the leading edge of the tool to
-  cut more heavily.
-  Typical values are 29, 29.5 or 30.
+* 'Q-' - The 'compound slide angle' is the angle (in degrees) describing to what extent successive passes should be offset along the drive line.
+  This is used to cause one side of the tool to remove more material than the other.
+  A positive 'Q' value causes the leading edge of the tool to cut more heavily.  Typical values are 29, 29.5 or 30.
 * 'H-' - The number of 'spring passes'.
   Spring passes are additional passes at full thread depth.
   If no additional passes are desired, program 'H0'.
 
-Thread entries and exits can be programmed tapered with the 'E'
-and 'L' values.
+Thread entries and exits can be programmed tapered with the 'E' and 'L' values.
 
 * 'E-' - Specifies the distance along the drive line used for the taper.
-  The angle of the taper will be so the last pass tapers to the thread
-  crest over the distance specified with E.
-  'E0.2' will give a taper for the first/last 0.2 length units along the
-  thread.
+  The angle of the taper will be so the last pass tapers to the thread crest over the distance specified with E.
+  'E0.2' will give a taper for the first/last 0.2 length units along the thread.
   For a 45 degree taper program E the same as K.
 * 'L-' - Specifies which ends of the thread get the taper.
   Program 'L0' for no taper (the default), 'L1' for entry taper, 'L2'

--- a/docs/src/gcode/o-code.adoc
+++ b/docs/src/gcode/o-code.adoc
@@ -129,7 +129,8 @@ they are defined. They may be called from other functions, and may call
 themselves recursively if it makes sense to do so. The maximum
 subroutine nesting level is 10.
 
-Subroutines can change the value of parameters above #30 and those changes will be visible to the calling code. Subroutines may also change the value of <<gcode:named-parameters,global named parameters>> (i.e. parameters whose names begin with the underscore character "`_`");
+Subroutines can change the value of parameters above #30 and those changes will be visible to the calling code.
+Subroutines may also change the value of <<gcode:named-parameters,global named parameters>> (i.e. parameters whose names begin with the underscore character "`_`").
 
 [[ocode:fanuc-style-programs]]
 === Fanuc-Style Numbered Programs(((Subroutines,M98,M99)))

--- a/docs/src/gcode/tool-compensation.adoc
+++ b/docs/src/gcode/tool-compensation.adoc
@@ -151,7 +151,7 @@ The HAL input pin, `iocontrol.0.tool-prepared`, must be set by external HAL logi
 A G-code *M6* command asserts the HAL output pin `iocontrol.0.tool-change`.
 The related HAL input pin, `iocontrol.0.tool-prepared`, must be set by external HAL logic to indicate completion of the tool change leading to a subsequent reset of the tool-change pin.
 
-Tooldata is accessed by an ordered index (idx) that depends on the type of toolchanger specified by `[EMCIO]RANDOM_TOOLCHANGER=type`.
+Tooldata is accessed by an ordered index (idx) that depends on the type of toolchanger specified by `[EMCIO]RANDOM_TOOLCHANGER=`__type__.
 
 . For `RANDOM_TOOLCHANGER = 0`, (0 is default and specifies a non-random toolchanger) idx is a number indicating the sequence in which tooldata was loaded.
 . For `RANDOM_TOOLCHANGER = 1`, idx is the *current* pocket number for the tool number specified by the G-code select tool command *T__n__*.
@@ -211,7 +211,7 @@ Manual toolchanges can be aided by a HAL configuration that employs the non-real
 HALFILE = axis_manualtoolchange.hal
 ----
 
-.Fixed Location Tool Changers 
+.Fixed Location Tool Changers
 Fixed location tool changers always return the tools to a fixed position in the tool changer.
 This would also include designs like lathe turrets.
 When LinuxCNC is configured for a fixed location tool changer the 'P' number is not used internally (but read, preserved and rewritten) by LinuxCNC,
@@ -222,7 +222,7 @@ When using `[EMCIO]RANDOM_TOOLCHANGER = 0` (the default),
 the 'P' pocket number is a parameter of the tooldata that is retrieved from the tooldata source (`[EMCIO]TOOL_TABLE` or `[EMCIO]DB_PROGRAM`).
 In many applications it is fixed but it may be changed by edits to the `[EMCIO]TOOL_TABLE` or programmatically when the `[EMCIO]DB_PROGRAM` is used.
 LinuxCNC pushes updates to the data source (`[EMCIO]TOOL_TABLE` or `[EMCIO]DB_PROGRAM`) for G-codes G10L1, G10L10, G10L11, M61.
-LinuxCNC can pull tooldata updates from the data source by UI (user-interface) commands (Python example: `linuxcnc.command().load_tool_table()`) or by the G-code: G10L0.
+LinuxCNC can pull tooldata updates from the data source by UI (user-interface) commands (Python example: `linuxcnc.command().load_tool_table()`) or by the G-code: `G10L0`.
 
 .Random Location Tool Changers
 Random location tool changers (`[EMCIO]RANDOM_TOOLCHANGER = 1`) swap the tool in the spindle with the one in the changer.
@@ -237,7 +237,7 @@ A tool compensation is programmed using G43 H_n_, where _n_ is the index number 
 It is intended that all entries in the tool table are positive.
 The value of H is checked, it must be a non-negative integer when read. The interpreter behaves as follows:
 
-1. If G43 H_n_ is programmed, a call to the function USE_TOOL_LENGTH_OFFSET(length) is made (where length is the length difference, read from the tool table, of the indexed tool _n_),
+1. If G43 H_n_ is programmed, a call to the function `USE_TOOL_LENGTH_OFFSET(`__length__`)` is made (where _length_ is the length difference, read from the tool table, of the indexed tool _n_),
    tool_length_offset is repositioned in the machine settings model and the value of current_z in the model is adjusted.
    Note that _n_ does not have to be the same as the slot number of the tool currently in the spindle.
 

--- a/docs/src/getting-started/getting-linuxcnc.adoc
+++ b/docs/src/getting-started/getting-linuxcnc.adoc
@@ -164,15 +164,12 @@ NOTE: This has put you into a desktop as root. It is not best practice to work a
 [[linuxcnc:install-problems]]
 == Install Problems(((LinuxCNC:Installation Problems)))(((Installation:Problems)))
 
-Most problems booting the installation image are due to uefi hardware. Fortunately, Debian Bookworm has significantly better support for uefi systems than earlier versions of Linux.
+Most problems booting the installation image are due to uefi hardware.
+Fortunately, Debian Bookworm has significantly better support for uefi systems than earlier versions of Linux.
 
 Sometimes you can tell the BIOS to boot legacy (non-uefi) hardware.
 
-In rare cases you might have to reset the BIOS to default settings if
-during the Live CD install it cannot recognize the hard drive
-during the boot up.
-    
-
+In rare cases you might have to reset the BIOS to default settings if during the Live CD install it cannot recognize the hard drive during the boot up.
 
 [[sec:_bookworm_tweaks]]
 == Bookworm Tweaks(((LinuxCNC:Bookworm Tweaks)))(((Installation:Bookworm Tweaks)))
@@ -404,13 +401,12 @@ dpkg -i linux-image(tab)
 [[sec:_alternate_install_methods]]
 == Alternate Install Methods(((LinuxCNC:Alternate Install Methods)))(((Installation:Alternate Methods)))
 
-The easiest, preferred way to install LinuxCNC is to use the Live/Install
-Image or Debian Bookworm as described above.  Both methods are as simple and reliable as we can make it, and are suitable for novice users and experienced users alike. Both methods  will typically replace any existing operating system on your hard drive.
+The easiest, preferred way to install LinuxCNC is to use the Live/Install Image or Debian Bookworm as described above.
+Both methods are as simple and reliable as we can make it, and are suitable for novice users and experienced users alike.
+Both methods  will typically replace any existing operating system on your hard drive.
 
-Experienced users who are familiar with Debian system
-administration (finding install images, manipulating apt sources, changing kernel flavors, etc), new installs are supported on following platforms:
-("amd64" means "64-bit", and is not specific to AMD processors, it will
-run on any 64-bit x86 system)
+Experienced users who are familiar with Debian system administration (finding install images, manipulating apt sources, changing kernel flavors, etc), new installs are supported on following platforms:
+("amd64" means "64-bit", and is not specific to AMD processors, it will run on any 64-bit x86 system)
 Note that in Debian Bookworm, the preempt_rt kernel is a dependency of linuxcnc-uspace so it is automatically installed with linuxcnc so the Stock kernel is not listed.
 
 If you wish to use RTAI or Xenomai, please follow the instructions in the Linuxcnc V2.8 documentation.

--- a/docs/src/getting-started/getting-linuxcnc.adoc
+++ b/docs/src/getting-started/getting-linuxcnc.adoc
@@ -417,14 +417,14 @@ If you wish to use RTAI or Xenomai, please follow the instructions in the Linuxc
 
 [options="header"]
 |===
-| Distribution   | Architecture  | Kernel     | Package name    | Typical use
-| Debian Bookworm| amd64 & arm64 | preempt-rt | linuxcnc-uspace | machine control & simulation
-| Debian Buster  | amd64 & arm64 | preempt-rt | linuxcnc-uspace | machine control & simulation
-| Debian Buster  | amd64         | RTAI       | linuxcnc        | machine control (known issues)
-| Debian Jessie  | amd64 & i386  | Stock      | linuxcnc-uspace | simulation only
-| Debian Wheezy  | i386          | RTAI       | linuxcnc        | machine control & simulation
-| Debian Wheezy  | amd64 & i386  | Preempt-RT | linuxcnc-uspace | machine control & simulation
-| Debian Wheezy  | amd64 & i386  | Stock      | linuxcnc-uspace | simulation only
+| Distribution    | Architecture  | Kernel     | Package name    | Typical use
+| Debian Bookworm | amd64 & arm64 | preempt-rt | linuxcnc-uspace | machine control & simulation
+| Debian Buster   | amd64 & arm64 | preempt-rt | linuxcnc-uspace | machine control & simulation
+| Debian Buster   | amd64         | RTAI       | linuxcnc        | machine control (known issues)
+| Debian Jessie   | amd64 & i386  | Stock      | linuxcnc-uspace | simulation only
+| Debian Wheezy   | i386          | RTAI       | linuxcnc        | machine control & simulation
+| Debian Wheezy   | amd64 & i386  | Preempt-RT | linuxcnc-uspace | machine control & simulation
+| Debian Wheezy   | amd64 & i386  | Stock      | linuxcnc-uspace | simulation only
 |===
 
 NOTE: LinuxCNC v2.8 and above is not supported on Ubuntu Lucid or older.

--- a/docs/src/gui/gladevcp.adoc
+++ b/docs/src/gui/gladevcp.adoc
@@ -1327,7 +1327,7 @@ The `HAL_Offset` widget is used to display the offset of a single axis.
 
 display_units_mm::
   Display in metric units.
-joint_n_umber::
+joint_number::
   Used to select which axis (technically which joint) is displayed. +
   On a trivialkins machine (mill, lathe, router) axis vs. joint number are:
 +

--- a/docs/src/gui/gladevcp.adoc
+++ b/docs/src/gui/gladevcp.adoc
@@ -522,10 +522,10 @@ that is, has been created by the +hal_glib.GPin(halcomp.newpin(<name>,<type>,<di
 
 Event-driven programming means that the UI tells your code when "something happens" - through a callback, like when a button was pressed.
 The output HAL widgets (those which display a HAL pin's value) like LED, Bar, VBar, Meter, etc.,
-support the 'hal-pin-changed' signal, which may cause a callback into your Python code when - well, a HAL pin changes its value.
+support the `hal-pin-changed` signal, which may cause a callback into your Python code when - well, a HAL pin changes its value.
 This means there's no more need for permanent polling of HAL pin changes in your code, the widgets do that in the background and let you know.
 
-Here is an example how to set a +hal-pin-changed+ signal for a HAL_LED in the Glade UI editor:
+Here is an example how to set a `hal-pin-changed` signal for a HAL_LED in the Glade UI editor:
 
 image::images/hal-pin-change-66.png[]
 

--- a/docs/src/gui/gladevcp.adoc
+++ b/docs/src/gui/gladevcp.adoc
@@ -64,8 +64,7 @@ GladeVCP panel windows may be run in three different setups:
 - as a standalone toplevel window, which can be iconifyed/deiconified independent of the main window.
 
 .Installed LinuxCNC
-If you're using an installed version of LinuxCNC the examples shown below are in the <<cha:starting-linuxcnc,configuration picker>> in the 'Sample
-Configurations > apps > GladeVCP' branch.
+If you're using an installed version of LinuxCNC the examples shown below are in the <<cha:starting-linuxcnc,configuration picker>> in the 'Sample Configurations > apps > GladeVCP' branch.
 
 .Git Checkout
 The following instructions only apply if you're using a git checkout.
@@ -232,16 +231,12 @@ You're now ready to give it a try (while LinuxCNC, e.g. AXIS is running) it with
 gladevcp myui.ui
 ----
 
-GladeVCP creates a HAL component named like the basename of the UI
-file - 'myui' in this case - unless overridden by the `-c <component name>` option.
+GladeVCP creates a HAL component named like the basename of the UI file - 'myui' in this case - unless overridden by the `-c <component name>` option.
 If running AXIS, just try 'Show HAL configuration' and inspect its pins.
 
-You might wonder why widgets contained a 'HAL_Hbox' or 'HAL_Table' appear
-greyed out (inactive). HAL containers have an associated HAL pin which
-is off by default, which causes all contained widgets to render
-inactive. A common use case would be to associate these container HAL
-pins with `halui.machine.is-on` or one of the `halui.mode` signals,
-to assure some widgets appear active only in a certain state.
+You might wonder why widgets contained a 'HAL_Hbox' or 'HAL_Table' appear greyed out (inactive).
+HAL containers have an associated HAL pin which is off by default, which causes all contained widgets to render inactive.
+A common use case would be to associate these container HAL pins with `halui.machine.is-on` or one of the `halui.mode` signals, to assure some widgets appear active only in a certain state.
 
 To just activate a container, execute the HAL command `setp gladevcp.<container-name> 1`.
 
@@ -297,22 +292,17 @@ halcmd loadusr -Wn example gladevcp -c example -x {XID} -u ./hitcounter.py ./man
 ----
 
 [NOTE]
-The file specifiers like ./hitcounter.py, ./manual-example.ui, etc. indicate that the files
-are located in the same directory as the INI file.  You might have to copy them to you
-directory (alternatively, specify a correct absolute or relative path to the file(s))
+The file specifiers like ./hitcounter.py, ./manual-example.ui, etc. indicate that the files are located in the same directory as the INI file.
+You might have to copy them to you directory (alternatively, specify a correct absolute or relative path to the file(s)).
 
 [NOTE]
-The +[RS274NGC]SUBROUTINE_PATH=+ option is only set so the example
-panel will find the Oword subroutine (oword.ngc) for the MDI Command widget. It
-might not be needed in your setup. The relative path specifier ../../nc_files/gladevcp_lib
-is constructed to work with directories copied by the configuration picker and when
-using a run-in-place setup.
+The +[RS274NGC]SUBROUTINE_PATH=+ option is only set so the example panel will find the Oword subroutine (oword.ngc) for the MDI Command widget.
+It might not be needed in your setup. The relative path specifier ../../nc_files/gladevcp_lib is constructed to work with directories copied by the configuration picker and when using a run-in-place setup.
 
 [[gladevcp:embedding-tab]]
 === Embedding as a Tab
 
-To do so, edit your INI file and add to the DISPLAY and HAL sections of INI
-file as follows:
+To do so, edit your INI file and add to the DISPLAY and HAL sections of INI file as follows:
 
 [source,{ini}]
 ----
@@ -365,7 +355,7 @@ You might have to copy them to you directory (alternatively, specify a correct a
 Note the following differences to the AXIS tab setup:
 
 - The HAL command file is slightly modified since 'Touchy' does not use the 'halui' components so its signals are not available and some shortcuts have been taken.
-- There is no 'POSTGUI_HALFILE=' INI option, but passing the HAL command file on the 'EMBED_TAB_COMMAND=' line is ok
+- There is no 'POSTGUI_HALFILE=' INI option, but passing the HAL command file on the 'EMBED_TAB_COMMAND=' line is ok.
 - The 'halcmd loaduser -Wn ...' incantation is not needed.
 
 == GladeVCP command line options
@@ -426,19 +416,15 @@ The normal LinuxCNC startup process does the following:
 The introduction of GladeVCP brought the following issue:
 
 - GladeVCP panels need to be embedded in a master GUI window setup.
-- GladeVCP panels need to be embedded in a master GUI window setup,
-  e.g., AXIS, or Touchy, Gscreen, or GMOCCAPY (embedded window or as an embedded tab).
+- GladeVCP panels need to be embedded in a master GUI window setup, e.g., AXIS, or Touchy, Gscreen, or GMOCCAPY (embedded window or as an embedded tab).
 - This requires the master GUI to run before the GladeVCP window can be hooked into the master GUI.
 - However, GladeVCP is also a HAL component, and creates HAL pins of its own.
-- As a consequence, all HAL plumbing involving GladeVCP HAL pins as source
-  or destination must be run *after* the GUI has been set up.
+- As a consequence, all HAL plumbing involving GladeVCP HAL pins as source or destination must be run *after* the GUI has been set up.
 
-This is the purpose of the `POSTGUI_HALFILE`.
-This INI option is inspected by the GUIs.
+This is the purpose of the `POSTGUI_HALFILE`. This INI option is inspected by the GUIs.
 If a GUI detects this option, it runs the corresponding HAL file after any embedded GladeVCP panel is set up.
 However, it does not check whether a GladeVCP panel is actually used, in which case the HAL cmd file is just run normally.
-So if you do NOT start GladeVCP through `GLADEVCP` or `EMBED_TAB` etc.,
-but later in a separate shell window or some other mechanism, a HAL command file in `POSTGUI_HALFILE` will be executed too early.
+So if you do NOT start GladeVCP through `GLADEVCP` or `EMBED_TAB` etc, but later in a separate shell window or some other mechanism, a HAL command file in `POSTGUI_HALFILE` will be executed too early.
 Assuming GladeVCP pins are referenced herein, this will fail with an error message indicating that the GladeVCP HAL component is not available.
 
 So, in case you run GladeVCP from a separate shell window (i.e., not started by the GUI in an embedded fashion):
@@ -519,8 +505,9 @@ The are several HAL-specific methods of HAL Widgets, but the only relevant metho
 
 === Setting pin and widget values
 
-As a general rule, if you need to set a HAL output widget's value from Python code, do so by calling the underlying Gtk 'setter'
-(e.g.  +set_active()+, +set_value()+) - do not try to set the associated pin's value by +halcomp[pinname] = value+ directly because the widget will not take notice of the change!
+As a general rule, if you need to set a HAL output widget's value from Python code,
+do so by calling the underlying Gtk 'setter' (e.g.,  +set_active()+, +set_value()+).
+Do not try to set the associated pin's value by +halcomp[pinname] = value+ directly because the widget will not take notice of the change!
 
 It might be tempting to 'set HAL widget input pins' programmatically.
 Note this defeats the purpose of an input pin in the first place - it should be linked to, and react to signals generated by other HAL components.
@@ -534,8 +521,8 @@ that is, has been created by the +hal_glib.GPin(halcomp.newpin(<name>,<type>,<di
 === The hal-pin-changed signal
 
 Event-driven programming means that the UI tells your code when "something happens" - through a callback, like when a button was pressed.
-The output HAL widgets (those which display a HAL pin's value) like LED, Bar, VBar, Meter etc, support the 'hal-pin-changed' signal,
-which may cause a callback into your Python code when - well, a HAL pin changes its value.
+The output HAL widgets (those which display a HAL pin's value) like LED, Bar, VBar, Meter, etc.,
+support the 'hal-pin-changed' signal, which may cause a callback into your Python code when - well, a HAL pin changes its value.
 This means there's no more need for permanent polling of HAL pin changes in your code, the widgets do that in the background and let you know.
 
 Here is an example how to set a +hal-pin-changed+ signal for a HAL_LED in the Glade UI editor:
@@ -890,9 +877,8 @@ There are also Python methods to modify the widget:
 [widget name].set_adjustment(gtk-adjustment)
 ----
 
-You can assign a existing adjustment to the control, that way it is easy to replace
-existing sliders without many code changes. Be aware, that after changing the adjustment
-you may need to set a new increment, as it will be reset to its default (100 steps from MIN to MAX):
+You can assign a existing adjustment to the control, that way it is easy to replace existing sliders without many code changes.
+Be aware, that after changing the adjustment you may need to set a new increment, as it will be reset to its default (100 steps from MIN to MAX):
 
 * `[widget name].get_value()` +
   Will return the counts value as float
@@ -912,8 +898,7 @@ image::images/SpeedControl.png[align="center"]
 `hal_label` is a simple widget based on GtkLabel which represents a HAL pin value in a user-defined format.
 
 label_pin_type::
-  The pin's HAL type  (0:s32, 1:float, 2:u32), see also the tooltip on 'General→HAL pin type'
-  (note this is different from PyVCP which has three label widgets, one for each type).
+  The pin's HAL type  (0:s32, 1:float, 2:u32), see also the tooltip on 'General→HAL pin type' (note this is different from PyVCP which has three label widgets, one for each type).
 text_template::
   Determines the text displayed - a Python format string to convert the pin value to text.
   Defaults to +%s+ (values are converted by the str() function) but may contain any legit as an argument to Pythons format() method. +
@@ -1036,8 +1021,7 @@ HAL input pins:
 
 scale::
   Value scale. +
-  Sets the maximum absolute value of input. Same as setting
-  the <widgetname>.scale pin. +
+  Sets the maximum absolute value of input. Same as setting the <widgetname>.scale pin. +
   A float, range from -2^24 to +2^24.
 green_limit::
   Green zone lower limit
@@ -1046,8 +1030,7 @@ yellow_limit::
 red_limit::
   Red zone lower limit
 text_template::
-  Text template to display the current value of the
-  +<widgetname>+ pin. +
+  Text template to display the current value of the +<widgetname>+ pin. +
   Python formatting may be used for dict +{"value":value}+.
 
 .Example HAL_ProgressBar
@@ -1056,8 +1039,7 @@ image::images/progressbar2.png[align="center"]
 [[gladevcp:hal_combobox]]
 === ComboBox
 
-`HAL_ComboBox` is derived from gtk.ComboBox. It enables choice of a
-value from a dropdown list.
+`HAL_ComboBox` is derived from gtk.ComboBox. It enables choice of a value from a dropdown list.
 
 ==== Pins
 
@@ -1111,13 +1093,11 @@ show limits::
   Used to select/deselect the limits text on bar.
 zero::
   Zero point of range. +
-  If it is inside of min/max range then the bar will grow from that value
-  and not from the left (or right) side of the widget. +
+  If it is inside of min/max range then the bar will grow from that value and not from the left (or right) side of the widget. +
   Useful to represent values that may be both positive or negative.
 force_width, force_height::
   Forced width or height of widget. +
-  If not set then size will be deduced from packing or from fixed widget
-  size and bar will fill whole area.
+  If not set then size will be deduced from packing or from fixed widget size and bar will fill whole area.
 text_template::
   Like in Label, sets text format for min/max/current values. +
   Can be used to turn off value display.
@@ -1171,8 +1151,7 @@ min, max::
   It is not an error condition if the current value is outside this range.
 force_size::
   Forced diameter of widget. +
-  If not set then size will be deduced from packing or from fixed widget
-  size, and meter will fill all available space with respect to aspect ratio.
+  If not set then size will be deduced from packing or from fixed widget size, and meter will fill all available space with respect to aspect ratio.
 text_template::
   Like in Label, sets text format for current value. +
   Can be used to turn off value display.
@@ -1418,14 +1397,11 @@ homed_color::
   Gdk.RGBA(red=0.000000, green=0.501961, blue=0.000000, alpha=1.000000)
 Hints::
   - If you want the display to be right justified, set the Horizontal Alignment to `End`.
-  - The background of the widget is actually see through, so if you place it over an image,
-    the DRO numbers will show on top of it with no background.
-    There is a special technique to do this.
-    See the animated function diagrams below.
+  - The background of the widget is actually see through, so if you place it over an image, the DRO numbers will show on top of it with no background.
+    There is a special technique to do this.  See the animated function diagrams below.
   - The DRO widget is a modified gtk label widget.
     As such, much of what can be done to a gtk label can be done to the DRO widget.
-  - The font properties may also be set from a css stylesheet which has the highest priority
-    and will override values set by GObject properties.
+  - The font properties may also be set from a css stylesheet which has the highest priority and will override values set by GObject properties.
 
 ==== Direct program control
 
@@ -1459,7 +1435,7 @@ def str_to_rgba(color):
 
 Using a CSS stylesheet to set font properties::
 
-Colors may be specified in one of several formats, these would all specify the same color, red, *#ff0000, *rgb(255,0,0), or rgba(255,0,0,255)
+Colors may be specified in one of several formats, these would all specify the same color, red, *#ff0000, *rgb(255,0,0), or rgba(255,0,0,255).
 
 Colors may be referenced either collectively:
 
@@ -1628,8 +1604,7 @@ The widget will emit the following signals:
      The widget object that sends the signal.
   ** `system` = string +
      The actual coordinate system.
-     Will be one of G54 G55 G56 G57 G58 G59 G59.1 G59.2 G59.3 or Rel if non has been selected at all,
-     what will only happen in Glade with no LinuxCNC running.
+     Will be one of G54 G55 G56 G57 G58 G59 G59.1 G59.2 G59.3 or Rel if non has been selected at all, what will only happen in Glade with no LinuxCNC running.
 
 There are some information you can get through commands, which may be of interest for you:
 
@@ -1986,7 +1961,7 @@ image::images/hal_sourceview.png[align="center"]
 === MDI history
 
 This is for displaying and entering MDI codes. +
-It will be automatically grayed out when MDI is not available, eg during E-stop and program running.
+It will be automatically grayed out when MDI is not available, e.g., during E-stop and program running.
 
 ==== Properties
 
@@ -2103,10 +2078,9 @@ You can use a semicolon to separate multiple commands;
 print('Set Machine Off');CMD.state(linuxcnc.STATE_OFF)
 ----
 
-More information on INFO and ACTION can be found here: 
-<<cha:gladevcp-libraries,GladeVCP Libraries modules>>
+More information on INFO and ACTION can be found here: <<cha:gladevcp-libraries,GladeVCP Libraries modules>>.
 
-More information on GStat can be found here: <<cha:gstat,GStat>>
+More information on GStat can be found here: <<cha:gstat,GStat>>.
 
 === VCP ToggleAction widgets
 
@@ -2177,8 +2151,7 @@ image::images/oword.png[align="center"]
 === Preparing for an MDI Action, and cleaning up afterwards
 
 The LinuxCNC G-code interpreter has a single global set of variables, like feed, spindle speed, relative/absolute mode and others.
-If you use G-code commands or O-word subs, some of these variables might get changed by the command or subroutine - for example,
-a probing subroutine will very likely set the feed value quite low.
+If you use G-code commands or O-word subs, some of these variables might get changed by the command or subroutine - for example, a probing subroutine will very likely set the feed value quite low.
 With no further precautions, your previous feed setting will be overwritten by the probing subroutine's value.
 
 To deal with this surprising and undesirable side effect of a given O-word subroutine or G-code statement executed with an LinuxCNC ToggleAction_MDI,
@@ -2214,8 +2187,7 @@ They will make saving state before a subroutine call, and restoring state on ret
 Many actions depend on LinuxCNC status - is it in manual, MDI or auto mode?
 Is a program running, paused or idle?
 You cannot start an MDI command while a G-code program is running, so this needs to be taken care of.
-Many LinuxCNC actions take care of this themselves,
-and related buttons and menu entries are deactivated when the operation is currently impossible.
+Many LinuxCNC actions take care of this themselves, and related buttons and menu entries are deactivated when the operation is currently impossible.
 
 When using Python event handlers - which are at a lower level than Actions - one needs to take care of dealing with status dependencies oneself.
 For this purpose, there's the LinuxCNC Stat widget: to associate LinuxCNC status changes with event handlers.
@@ -2279,7 +2251,7 @@ ACTION = Action()
 INFO = Info()
 ----
 
-using the library functions:
+Using the library functions:
 
 [source,python]
 ----
@@ -2377,8 +2349,8 @@ The idea here is: Handlers are linked to class methods.
 The underlying class(es) are instantiated and inspected during GladeVCP startup and linked to the widget tree as signal handlers.
 So the task now is to write:
 
-- one or more several class definition(s) with one or several methods, in one module or split over several modules,
-- a function 'get_handlers' in each module which will return a list of class instances to GladeVCP - their method names will be linked to signal handlers
+- One or more several class definition(s) with one or several methods, in one module or split over several modules,
+- a function 'get_handlers' in each module which will return a list of class instances to GladeVCP - their method names will be linked to signal handlers.
 
 Here is a minimum user-defined handler example module:
 
@@ -2580,7 +2552,7 @@ To save the widget and/or variable state on exit, proceed as follows:
 
 - Select some interior widget (type is not important, for instance a table).
 - In the 'Signals' tab, select 'GtkObject'. It should show a 'destroy' signal in the first column.
-- Add the handler name, e.g. 'on_destroy' to the second column.
+- Add the handler name, e.g. 'on_destroy', to the second column.
 - Add a Python handler like below:
 
 [source,python]
@@ -2848,7 +2820,7 @@ See the getting-started/running-linuxcnc section for 'Adding Configuration Selec
 
 For testing, a runtime specification of auxiliary applications may be specified using the exported environmental variable: GLADEVCP_EXTRAS.
 This variable should be a path list of one or more configuration directories separated by a (:).
-Typically, this variable would be set in a shell starting linuxcnc or in a user's ~/.profile startup script.
+Typically, this variable would be set in a shell starting `linuxcnc` or in a user's `~/.profile startup` script.
 Example:
 
 ----

--- a/docs/src/gui/gladevcp.adoc
+++ b/docs/src/gui/gladevcp.adoc
@@ -1352,13 +1352,13 @@ It has the following properties:
 
 display_units_mm::
   Used to toggle the display units between metric and imperial.
-  Default is False
+  Default is False.
 actual::
   Select actual (feedback) position or commanded position.
-  Default is True
+  Default is True.
 diameter::
   Display diameter for a lathe.
-  Default is False
+  Default is False.
 mm_text_template::
   You can use Python formatting to display the position with different precision.
   Default is "%10.3f".
@@ -1367,7 +1367,7 @@ imperial_text_template::
   Default is "%9.4f".
 joint_number::
   Used to select which axis (technically which joint) is displayed.
-  Default is 0 +
+  Default is 0. +
   On a trivialkins machine (mill, lathe, router) axis vs. joint number are:
 +
   0:X  1:Y  2:Z  3:A  4:B  5:C  6:U  7:V  8:W +
@@ -1376,17 +1376,17 @@ reference_type::
   * 0 = `absolute` <<sec:machine-coordinate-system,(machine origin)>>.
   * 1 = `relative` (to current user coordinate origin - G5x).
   * 2 = `distance-to-go` (relative to current user coordinate origin).
-  Default is 0
+  Default is 0.
 font_family::
   Specify the font family e.g. mono. Defaults to sans.
   If the font does not exist then the current system font will be used.
-  Default is sans
+  Default is sans.
 font_size::
   Specify the size of the font between 8 and 96.
-  Default is 26
+  Default is 26.
 font_weight::
   Specify the weight of the font. Select from lighter, normal, bold, or bolder.
-  Default is bold
+  Default is bold.
 unhomed_color::
   The text color when unhomed specified as a Gdk.RGBA color.
   Default is red,
@@ -1527,8 +1527,7 @@ toggle_readout::
   Default is TRUE.
 cycle_time::
   The time the DRO waits between two polls. +
-  this setting should only be changed if you use more than 5 DRO at the same time,
-  i.e., on a 6 axis config, to avoid, that the DRO slows down the main application too much. +
+  This setting should only be changed if you use more than 5 DRO at the same time, i.e. on a 6 axis config, to avoid that the DRO slows down the main application too much. +
   The value must be an integer in the range of 100 to 1000. FIXME unit=ms ? +
   Default is 150.
 
@@ -1604,7 +1603,7 @@ The widget will emit the following signals:
      The widget object that sends the signal.
   ** `system` = string +
      The actual coordinate system.
-     Will be one of G54 G55 G56 G57 G58 G59 G59.1 G59.2 G59.3 or Rel if non has been selected at all, what will only happen in Glade with no LinuxCNC running.
+     Will be one of G54 G55 G56 G57 G58 G59 G59.1 G59.2 G59.3 or Rel if none has been selected at all, what will only happen in Glade with no LinuxCNC running.
 
 There are some information you can get through commands, which may be of interest for you:
 
@@ -1670,7 +1669,7 @@ There are Python methods to control the widget:
 * `[widget name].show_buttonbox(state)` +
   If False the bottom button box will be hidden. +
   This is helpful in custom screens, with special buttons layouts to not alter the layout of the GUI.
-  Good example for that is gmoccapy. +
+  Good example for that is GMOCCAPY. +
   `state` = boolean (True or False). +
   Default is True.
 * `[widget name].show_filelabel(state)` +
@@ -1717,7 +1716,7 @@ The widget will emit the following signals:
   It will return a string containing a file path if a file has been selected, or `None` if a directory has been selected.
 * `sensitive` +
   This signal is emitted when the buttons change their state from sensitive to not sensitive or vice versa. +
-  This signal is useful to maintain surrounding GUI synchronized with the button of the widget. See gmoccapy as example. +
+  This signal is useful to maintain surrounding GUI synchronized with the button of the widget. See GMOCCAPY as example. +
   It will return the **buttonname** and the new **state**: +
   ** `buttonname` is one of `btn_home`, `btn_dir_up`, `btn_sel_prev`,
      `btn_sel_next`, `btn_jump_to` or `btn_select`.
@@ -1973,7 +1972,7 @@ font_size_entry::
   Will modify the default font size of the entry to the selected value. +
 use_double_click::
   Boolean, True enables the mouse double click feature and a double click on an entry will submit that command. +
-  It is not recommended to use this feature on real machines, as a double click on a wrong entry may cause dangerous situations
+  It is not recommended to use this feature on real machines, as a double click on a wrong entry may cause dangerous situations.
 
 ==== Direct program control
 
@@ -1987,10 +1986,8 @@ Using goobject to set the above listed properties:
 
 === Animated function diagrams: HAL widgets in a bitmap
 
-For some applications it might be desirable to have a background image -
-like a functional diagram - and position widgets at appropriate places in that image.
-A good combination is setting a bitmap background image, like from a .png file, making the GladeVCP window fixed-size,
-and use the Glade Fixed widget to position widgets on this image.
+For some applications it might be desirable to have a background image - like a functional diagram - and position widgets at appropriate places in that image.
+A good combination is setting a bitmap background image, like from a .png file, making the GladeVCP window fixed-size, and use the Glade Fixed widget to position widgets on this image.
 The code for the below example can be found in `configs/apps/gladevcp/animated-backdrop`:
 
 .HAL widgets in a bitmap Example
@@ -2372,7 +2369,7 @@ For GladeVCP panel which respond to HAL inputs it may be important that the hand
 For example a panel inside the Touchy interface might well need to perform an action when the switch connected to touchy.cycle-start is operated (in the same way that the native tabs respond differently to the same button). +
 To make this possible, a signal is sent from the GUI (at the time of writing, only Touchy) to the embedded tab.
 The signal is of type "Gladevcp" and the two messages sent are "Visible" and "Hidden".
-(Note that the signals  have a fixed length of 20 characters so only the first characters should be used in any comparison, hence the [:7] below.)
+(Note that the signals have a fixed length of 20 characters so only the first characters should be used in any comparison, hence the [:7] below.)
 A sample handler for these signals is:
 
 [source,python]
@@ -2668,15 +2665,15 @@ class HandlerClass:
         self.meter.queue_draw() # force a widget redraw
 
     def __init__(self, halcomp,builder,useropts):
-  self.builder = builder
+        self.builder = builder
 
         # HAL pin with change callback.
         # When the pin's value changes the callback is executed.
         self.max_value = hal_glib.GPin(halcomp.newpin('max-value',  hal.HAL_FLOAT, hal.HAL_IN))
         self.max_value.connect('value-changed', self._on_max_value_change)
 
-  inifile = linuxcnc.ini(os.getenv("INI_FILE_NAME"))
-  mmin = float(inifile.find("METER", "MIN") or 0.0)
+        inifile = linuxcnc.ini(os.getenv("INI_FILE_NAME"))
+        mmin = float(inifile.find("METER", "MIN") or 0.0)
         self.meter = self.builder.get_object('meter')
         self.meter.min = mmin
 

--- a/docs/src/gui/gmoccapy.adoc
+++ b/docs/src/gui/gmoccapy.adoc
@@ -522,7 +522,7 @@ You can specify where to save the log file:
 [DISPLAY]
 LOG_FILE = gmoccapy.log
 ----
-If `LOG_FILE` is not set, logging happens to `$HOME/<base_log_name>.log`
+If `LOG_FILE` is not set, logging happens to `$HOME/<base_log_name>.log`.
 
 
 == HAL Pins
@@ -958,8 +958,7 @@ Tool Measurement in GMOCCAPY is done a little bit different to many other GUIs.
 You should follow these steps:
 
 . Touch off your workpiece in X and Y.
-. Measure the height of your block from the base where your tool switch is
-  located, to the upper face of the block (including chuck etc.).
+. Measure the height of your block from the base where your tool switch is located, to the upper face of the block (including chuck etc.).
 . Push the button block height and enter the measured value.
 . Go to auto mode and start your program.
 
@@ -1138,10 +1137,9 @@ You have three options:
 .Keyboard
 
 The checkboxes allow the user to select if he wants the on board keyboard to be shown immediately,
-when entering the MDI Mode, when entering the offset page, the tooledit widget or when open a program
-in the EDIT mode. The keyboard button on the bottom button list will not be affected by these settings,
-so you are able to show or hide the keyboard by pressing the button. The default behavior will be set by
-the checkboxes.
+when entering the MDI Mode, when entering the offset page, the tooledit widget or when open a program in the EDIT mode.
+The keyboard button on the bottom button list will not be affected by these settings, so you are able to show or hide the keyboard by pressing the button.
+The default behavior will be set by the checkboxes.
 
 Default are :
 

--- a/docs/src/gui/qtdragon.adoc
+++ b/docs/src/gui/qtdragon.adoc
@@ -51,7 +51,7 @@ For an exhaustive list of options, see the <<sub:ini:sec:display,display section
 
 [NOTE]
 You can only have one of each section (e.g., [HAL]) in the INI file.
-If you see in these docs multiple section options, place them all under the one appropriate section name.  
+If you see in these docs multiple section options, place them all under the one appropriate section name.
 
 === Display
 
@@ -719,7 +719,7 @@ In order to set Z0 to the top of the workpiece, it has to know
 
  . how far above the table the probe trigger point is (tool setter height) and
  . how far above the table the top of the workpiece is.
- 
+
 This operation has to be done every time the tool is changed as the tool length is not saved.
 
 For touching off with a touch probe, whether you use the touchplate operation with thickness set to 0 or use a probing routine,
@@ -732,20 +732,20 @@ It is only for the tool setter.
 image::images/qtvcp_versaProbe.png["QtDragon Probe",scale="25%"]
 
 Versa probe is used to semi-automatically probe work pieces to find edges, centers and angles. +
-It can also be sued to auto probe tool length at tool changes with added remap code. 
+It can also be sued to auto probe tool length at tool changes with added remap code.
 
 You must carefully set the 'Probing Parameters':
 
-* 'DIAMETER':: This is the diameter of the probe tip. The accuracy of probe measurements is directly affected by the accuracy of the probe tip diameter. 
-* 'TRAVEL':: The distance that the probe will travel during the initial search. If the search distance is too short, you will receive a message like "G38 finished without making contact". For safety reasons, it is recommended to set this parameter to 3-4 mm more than probe stylus diameter. 
-* 'LATCH RTN':: The distance the probe is retracted after making initial contact with the workpiece. This should be a short distance because the second approach will be at a slow speed, but large enough for the probe to break contact and bring it to the search ready state. If the Latch Rtn distance too large, you will end up spending a lot of time waiting for the search to complete. Recommendation: 1-2 mm 
-* 'SEARCH':: This is the feed rate at which the probe searches for the target workpiece in machine units per minute. The search speed should be slow enough to give an acceptable initial accuracy, but fast enough to not waste time waiting for movement. Recommendation: 200-500 mm/min. 
-* 'PROBE':: Once initial contact has been made and the probe is retracted, it will wait for 0.5 seconds before performing the search again at a lower speed, the probe velocity. This lower speed ensures the machine can stop movement as quickly as possible on contact with the workpiece. 
-* 'RAPID':: Axis movements not associated with searching are done at the speed defined by RAPID in machine units per minute. 
-* 'SIDE/EDGE LENGTH':: This is the distance the probe will move at the rapid rate to the position where it will begin a search. If measuring a corner, it will move EDGE LENGTH units away from the corner, then move away from the workpiece by XY CLEARANCE, lower by Z CLEARANCE and begin the initial search. If measuring an inner circle, then EDGE LENGTH should be set to the approximate radius of the circle. Note: NOT the diameter. 
-* 'PROBE HT':: The height of the tool sensor from the machine table surface. This value is used to calculate the Z zero height for the current work coordinate system when using the probe with a tool setter sensor. 
-* 'BLOCK HT':: The height of the top of the workpiece from the machine table surface. This value is used to calculate the Z zero height for the current work coordinate system when using the probe with a tool setter sensor. 
-* 'XY CLEARANCE':: The distance that the probe will move away from an edge or corner before performing a search. It should be large enough to ensure that the probe will not contact the workpiece or any other fixtures before moving down. It should be small enough to avoid excessive waiting for movement while searching. 
+* 'DIAMETER':: This is the diameter of the probe tip. The accuracy of probe measurements is directly affected by the accuracy of the probe tip diameter.
+* 'TRAVEL':: The distance that the probe will travel during the initial search. If the search distance is too short, you will receive a message like "G38 finished without making contact". For safety reasons, it is recommended to set this parameter to 3-4 mm more than probe stylus diameter.
+* 'LATCH RTN':: The distance the probe is retracted after making initial contact with the workpiece. This should be a short distance because the second approach will be at a slow speed, but large enough for the probe to break contact and bring it to the search ready state. If the Latch Rtn distance too large, you will end up spending a lot of time waiting for the search to complete. Recommendation: 1-2 mm
+* 'SEARCH':: This is the feed rate at which the probe searches for the target workpiece in machine units per minute. The search speed should be slow enough to give an acceptable initial accuracy, but fast enough to not waste time waiting for movement. Recommendation: 200-500 mm/min.
+* 'PROBE':: Once initial contact has been made and the probe is retracted, it will wait for 0.5 seconds before performing the search again at a lower speed, the probe velocity. This lower speed ensures the machine can stop movement as quickly as possible on contact with the workpiece.
+* 'RAPID':: Axis movements not associated with searching are done at the speed defined by RAPID in machine units per minute.
+* 'SIDE/EDGE LENGTH':: This is the distance the probe will move at the rapid rate to the position where it will begin a search. If measuring a corner, it will move EDGE LENGTH units away from the corner, then move away from the workpiece by XY CLEARANCE, lower by Z CLEARANCE and begin the initial search. If measuring an inner circle, then EDGE LENGTH should be set to the approximate radius of the circle. Note: NOT the diameter.
+* 'PROBE HT':: The height of the tool sensor from the machine table surface. This value is used to calculate the Z zero height for the current work coordinate system when using the probe with a tool setter sensor.
+* 'BLOCK HT':: The height of the top of the workpiece from the machine table surface. This value is used to calculate the Z zero height for the current work coordinate system when using the probe with a tool setter sensor.
+* 'XY CLEARANCE':: The distance that the probe will move away from an edge or corner before performing a search. It should be large enough to ensure that the probe will not contact the workpiece or any other fixtures before moving down. It should be small enough to avoid excessive waiting for movement while searching.
 * 'Z CLEARANCE':: The distance that the probe will move down before performing a search. If measuring an inside hole, the probe could be manually jogged to the starting Z height and then set Z CLEARANCE to 0.
 
 There are three toggle buttons:
@@ -985,8 +985,7 @@ REMAP=M6  modalgroup=6 prolog=change_prolog ngc=qt_auto_probe_tool epilog=change
 ----
 
 The abort command file should be in the configuration folder and look something like this sample. +
-According to the setting above, it would need to be saved as 'on_abort.ngc' within 
-LinuxCNC's [RS274NGC] SUBROUTINE_PATHS and [DISPLAY] PROGRAM_PREFIX search paths.
+According to the setting above, it would need to be saved as 'on_abort.ngc' within LinuxCNC's [RS274NGC] SUBROUTINE_PATHS and [DISPLAY] PROGRAM_PREFIX search paths.
 
 ----
 o<on_abort> sub
@@ -1123,7 +1122,7 @@ Tabs allow the user to select the most appropriate info/control on the top three
 If the on screen keyboard is showing and the user wishes to hide it but keep the current tab, they can do that by pressing the current show tab.
 In QtDragon, there is a splitter handle between the G-code text display and the G-code graphical display.
 One can use this to split the size between the two areas. This can be set differently in each tab and in each mode.
- 
+
 === Main tab
 
 This tab displays the graphical representation of the current program.
@@ -1198,7 +1197,7 @@ There are three sub tabs:
 * 'PDF' - any loaded PDF setup pages are displayed here
 * 'PROPERTIES' - when a program is loaded its gcode properties are displayed here.
 
-There are navigation buttons for HTML page; 
+There are navigation buttons for HTML page:
 
 * The up arrow returns you to the default HTML page
 * The left arrow moves backward one HTML page

--- a/docs/src/gui/qtdragon.adoc
+++ b/docs/src/gui/qtdragon.adoc
@@ -1142,7 +1142,7 @@ Up to tens buttons can be defined in the INI.
 
 You can use this tab to load or transfer programs.
 Editing of G-code programs can be selected from this tab.
-With `qtdragon_hd`, this is where you can load the 'G-code Ripper'
+With `qtdragon_hd`, this is where you can load the 'G-code Ripper'.
 
 === Offsets Tab
 

--- a/docs/src/gui/qtdragon.adoc
+++ b/docs/src/gui/qtdragon.adoc
@@ -50,7 +50,7 @@ If your configuration is not currently set up to use QtDragon, you can change it
 For an exhaustive list of options, see the <<sub:ini:sec:display,display section>> of the INI file documentation.
 
 [NOTE]
-You can only have one of each section ( ie [HAL] ) in the INI file.
+You can only have one of each section (e.g., [HAL]) in the INI file.
 If you see in these docs multiple section options, place them all under the one appropriate section name.  
 
 === Display

--- a/docs/src/gui/qtvcp-code-snippets.adoc
+++ b/docs/src/gui/qtvcp-code-snippets.adoc
@@ -974,7 +974,7 @@ In that case there are no sub-widgets in it, so comparing to the `widget.parent(
 
 == Read Command Line Load Time Options
 
-Some panels need information at load time for setup/options. Qtvcp covers this requirement with '-o' options. +
+Some panels need information at load time for setup/options. QtVCP covers this requirement with '-o' options. +
 The '-o' argument is good for a few, relatively short options, that can be added to the loading command line. +
 For more involved information, reading an INI or preference file is probably a better idea. +
 

--- a/docs/src/gui/qtvcp-vcp-panels.adoc
+++ b/docs/src/gui/qtvcp-vcp-panels.adoc
@@ -51,7 +51,7 @@ In addition, it is also a useful template to use for your custom panel because i
 * Saving data to the qtdragon.prefs file
 * Custom button to reset the VFD
 
-Modify this panel to suit your own requirements. Most common features are used. 
+Modify this panel to suit your own requirements. Most common features are used.
 The advantage of using panels is that it separates your custom display code from the qtdragon core code so upgrading the system will not break your customization.
 
 ==== Additional Requirements
@@ -89,7 +89,7 @@ Customizing the panel: +
 * Copy the files located in /user/share/qtvcp/qtdragon/panels/belts to:
 ~/linuxcnc/configs/<my_configuration_folder>/qtvcp/panels/belts (you can use the copy dialog panel to do this)
 
-* Edit belts.ui with designer. 
+* Edit belts.ui with designer.
 * Edit belts_handler.py with a text editor
 * Connect the relevant pins in a postgui.hal file
 * Make sure your postgui file is loaded by your .ini file.
@@ -204,7 +204,7 @@ Mouse controls:
 * left mouse single click - increase cross hair rotation one increment
 * right mouse single click - decrease cross hair rotation one increment
 * middle mouse single click - cycle through rotation increments
-* left mouse hold and scroll - scroll camera zoom 
+* left mouse hold and scroll - scroll camera zoom
 * right mouse hold and scroll - scroll cross hair rotation angle
 * mouse scroll only - scroll circle diameter
 * left mouse double click - reset zoom
@@ -221,7 +221,7 @@ MDI_COMMAND=G0 X0 Y0,Go To\nOrigin
 Where the first command is referring to the button "SET origin" and the second to the button "GOTO Origin". +
 Note the comma and text after is optional - it will override the default button text. +
 These buttons are QtVCP action buttons and follow those rules.
- 
+
 [[sub:qtvcp:panels:sim-panel]]
 === `sim_panel`
 
@@ -280,7 +280,7 @@ image::images/qtvismach.png["QtVCP vismach_mill_xyz - 3-Axis Mill 3D View Panel"
 3D OpenGL view of a _3-Axis router style, gantry bed milling machine_. +
 This particular panel shows how to define and connect the model parts in the handler file, rather then importing the
 pre-built model from qtvcp's vismach library.
- 
+
 [source,{hal}]
 ----
 loadusr qtvcp vismach_router_atc
@@ -441,7 +441,7 @@ except:
 When using python command option in Action Button widgets of an embedded panel:
 
 *`INSTANCE`*::
-  refers to the panel window 
+  refers to the panel window.
   E.g., `INSTANCE.my_panel_handler_function_call(True)`
 
 *'MAIN_INSTANCE'*::

--- a/docs/src/gui/qtvcp-vismach.adoc
+++ b/docs/src/gui/qtvcp-vismach.adoc
@@ -6,14 +6,12 @@
 
 *Vismach* is a set of *Python functions that can be used to create and animate models of machines*.
 
-This chapter is about the Qt embedded version of <<cha:vismach,Vismach>>,
-also see: https://sa-cnc.com/linuxcnc-vismach/ .
+This chapter is about the Qt embedded version of <<cha:vismach,Vismach>>, also see: https://sa-cnc.com/linuxcnc-vismach/ .
 
 [[sec:qtvcp:vismach:intro]]
 == Introduction
 
-Vismach displays the model in a *3D viewport*
-and the *model parts are animated as the values of associated HAL pins change*.
+Vismach displays the model in a *3D viewport* and the *model parts are animated as the values of associated HAL pins change*.
 
 .QtVismach 3D Viewport
 image::images/qtvismach.png["QtVismach 3D Viewport",align="center"]
@@ -105,8 +103,7 @@ then it finally groups with the base.
 [[sec:qtvcp:vismach:start]]
 == Start the script
 
-It is useful for testing to include the `#!/usr/bin/env python3` shebang line
-to _allow the file to be executed directly from the command line.
+It is useful for testing to include the `#!/usr/bin/env python3` shebang line to _allow the file to be executed directly from the command line.
 
 The first thing to do is to _import the required libraries_.
 
@@ -124,11 +121,9 @@ from qtvcp.lib.qt_vismach.qt_vismach import *
 [[sec:qtvcp:vismach:hal]]
 == HAL pins.
 
-Originally the vismach library required creating a component and
-connecting HAL pins to control the simulation.
+Originally the vismach library required creating a component and connecting HAL pins to control the simulation.
 
-`qt_vismach` can read the HAL system pins directly or if you wish,
-to use separate HAL pins that you must define in a HAL component:
+`qt_vismach` can read the HAL system pins directly or if you wish, to use separate HAL pins that you must define in a HAL component:
 
 [source,python]
 ----
@@ -160,11 +155,10 @@ part = AsciiOBJ(data="v 0.123 0.234 0.345 1.0 ...")
 ----
 
 - STL model parts are added to the Vismach space in the _same locations as they were created in the STL or OBJ space_,
-  ie ideally with a rotational point at their origin.
+  i.e. ideally with a rotational point at their origin.
 
 [NOTE]
-It is much easier to move while building if the origin of the model is at 
-a rotational pivot point.
+It is much easier to move while building if the origin of the model is at a rotational pivot point.
 
 [[sub:qtvcp:vismach:primitives]]
 === Build from Geometric Primitives
@@ -207,12 +201,10 @@ part4 = Collection([part1, part2])
 == Moving Model Parts
 
 Parts may need to be moved in the Vismach space to assemble the model.
-The origin does not move - Translate() and Rotate() move the Collection 
-as you add parts, relative to a stationary origin.
+The origin does not move - Translate() and Rotate() move the Collection as you add parts, relative to a stationary origin.
 
 //FIXME unclear
-They may also need to be moved to create the animation as the animation
-rotation axis is created at the origin (but moves with the Part).
+They may also need to be moved to create the animation as the animation rotation axis is created at the origin (but moves with the Part).
 
 [[sub:qtvcp:vismach:translate]]
 === Translating Model parts
@@ -223,8 +215,7 @@ rotation axis is created at the origin (but moves with the Part).
 === Rotating Model Parts
 
 *`part1 = Rotate([part1], theta, x, y, z)`*::
-  Rotate the part by angle theta [degrees] about an axis between the origin and
-  x, y, z.
+  Rotate the part by angle theta [degrees] about an axis between the origin and x, y, z.
 
 [[sec:qtvcp:vismach:animate]]
 == Animating Parts
@@ -393,7 +384,7 @@ myhud.show("Mill_XYZ")`
 ----
 
 *`myhud = HalHud()`*::
-  A more advanced version of the Hud that allows HAL pins to be displayed. eg.
+  A more advanced version of the Hud that allows HAL pins to be displayed:
 [source,python]
 ----
 myhud = HalHud()

--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -627,16 +627,16 @@ If you press and hold the button a pop up menu will show allowing one to:
 * Set the axis arbitrarily
 * Reset the axis to the last number recorded
 
-You must have selected an entry dialog that corresponds to the dialog_code_string, 
-usually this is selected from the screenOptions widget. 
+You must have selected an entry dialog that corresponds to the dialog_code_string,
+usually this is selected from the screenOptions widget.
 
 You can select the property `halpin_option', it will then set a HAL pin true when the axis is selected.
 The property 'joint_number' should be set to the appropriate joint number.
 The property 'axis_letter' should be set to the appropriate axis letter.
 
-The property 'dialog_code_string' can be changed to 'ENTRY' or 'CALCULATOR' 
+The property 'dialog_code_string' can be changed to 'ENTRY' or 'CALCULATOR'
 to call a typing only entry dialog or a touch/typing calculator type entry dialog.
- 
+
 It is based on PyQt's _QToolButton_.
 
 [[sub:qtvcp:widgets:camview]]

--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -2898,8 +2898,9 @@ QtVCP's version of NGC subroutine selector (Shown as used in QtDragon).
 
 ==== INI settings
 
-Linuxcnc needs to know where to look to run the subroutines. +
+LinuxCNC needs to know where to look to run the subroutines. +
 If the subroutine calls other subroutines or custom M codes, those paths must be added too.
+
 [source,{ini}]
 ----
 [RS274NGC]

--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -2924,17 +2924,17 @@ NGCGUI_SUBFILE = qpocket.ngc
 
 ==== Buttons
 
-* 'NEW TAB' -adds a new blank tab to ngcgui
-* 'SELECT PREAMBLE' -select a file that add preamble G-code
-* 'SELECT SUBFILE' -select a ngcgui subroutine file
-* 'SELECT POST' -select a file that add post G-code
-* 'REREAD FILE' -reload the subroutine file
-* 'CREATE FEATURE' -add feature to the list
+* 'NEW TAB' - add new blank tab to NGCGUI
+* 'SELECT PREAMBLE' - select a file that add preamble G-code
+* 'SELECT SUBFILE' - select a NGCGUI subroutine file
+* 'SELECT POST' - select a file that add post G-code
+* 'REREAD FILE' - reload the subroutine file
+* 'CREATE FEATURE' - add feature to the list
 * 'RESTART FEATURE' - remove all features from the list
-* 'FINALIZE GCODE' -create the full G-code and send it to LinuxCNC/a file
+* 'FINALIZE GCODE' - create the full G-code and send it to LinuxCNC/a file
 
 ==== Adding Custom Subroutines
-You can create your own subroutines for use with ngcgui.
+You can create your own subroutines for use with NGCGUI.
 They must follow these rules:
 
 * For creating a subroutine for use with NGCGUI, the filename and the subroutine name must be the same.
@@ -2943,7 +2943,7 @@ They must follow these rules:
 * The subroutine must be surrounded by the sub and endsub tags.
 * The variables used must be numbered variables and must not skip number.
 * Comments and presets may be included.
-* if an image file of the same name is in the folder, it will be shown.
+* If an image file of the same name is in the folder, it will be shown.
 
 [source,{css}]
 ----

--- a/docs/src/gui/vismach.adoc
+++ b/docs/src/gui/vismach.adoc
@@ -213,7 +213,7 @@ head = HalTranslate([head],c,"Z",0,0,0.1)
 
 # base
 base = AsciiSTL(filename="./base.stl")
-base = Color([0.5,0.5,0.5,1],[base]) 
+base = Color([0.5,0.5,0.5,1],[base])
 # mount head on it
 base = Collection([head, base])
 ----

--- a/docs/src/hal/basic-hal.adoc
+++ b/docs/src/hal/basic-hal.adoc
@@ -113,7 +113,7 @@ Flags may be one or more of the following:
 
 -n:: name a component when it is a valid option for that component.
 
-.Syntax and Examples of `loadusr` 
+.Syntax and Examples of `loadusr`
 [source,{hal}]
 ----
 loadusr <component> <options>
@@ -139,7 +139,7 @@ net signal-name pin-name <optional arrow> <optional second pin-name>
 net home-x joint.0.home-sw-in <= parport.0.pin-11-in
 ----
 
-In the above example `home-x` is the signal name, `joint.0.home-sw-in` is a 'Direction IN' pin, `<=` is the optional direction arrow, and `parport.0.pin-11-in` is a 'Direction OUT' pin. 
+In the above example `home-x` is the signal name, `joint.0.home-sw-in` is a 'Direction IN' pin, `<=` is the optional direction arrow, and `parport.0.pin-11-in` is a 'Direction OUT' pin.
 This may seem confusing but the in and out labels for a parallel port pin indicates the physical way the pin works not how it is handled in HAL.
 
 A pin can be connected to a signal if it obeys the following rules:

--- a/docs/src/hal/basic-hal.adoc
+++ b/docs/src/hal/basic-hal.adoc
@@ -523,7 +523,7 @@ The weight ('weight') of bit 0 is 1, that of bit 2 is 4, so the sum is 5.
 .Component pins of `weighted_sum`
 [width="90%",options="header"]
 |===
-|Owner |Type |Dir  |Value |Name
+|Owner |Type |Dir  |Value  |Name
 |10    |bit  |In   |TRUE  m|wsum.0.bit.0.in
 |10    |s32  |I/O  |1     m|wsum.0.bit.0.weight
 |10    |bit  |In   |FALSE m|wsum.0.bit.1.in

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -31,16 +31,16 @@ To search in the man pages, use the UNIX tool `apropos`.
 ==== Machine Control
 [{tab_options}]
 |===
-| link:../man/man1/axis.1.html[axis]               |AXIS LinuxCNC (The Enhanced Machine Controller) GUI       ||
-| link:../man/man1/axis-remote.1.html[axis-remote] |AXIS Remote Interface                                     ||
-| link:../man/man1/gmoccapy.1.html[gmoccapy]       |Touchy LinuxCNC Graphical User Interface                  ||
-| link:../man/man1/gscreen.1.html[gscreen]         |Touchy LinuxCNC Graphical User Interface                  ||
-| link:../man/man1/halui.1.html[halui]             |Observe HAL pins and command LinuxCNC through NML         ||
-| link:../man/man1/mdro.1.html[mdro]               |manual only Digital Read Out (DRO)                        ||
+| link:../man/man1/axis.1.html[axis]               |AXIS LinuxCNC (The Enhanced Machine Controller) GUI              ||
+| link:../man/man1/axis-remote.1.html[axis-remote] |AXIS Remote Interface                                            ||
+| link:../man/man1/gmoccapy.1.html[gmoccapy]       |Touchy LinuxCNC Graphical User Interface                         ||
+| link:../man/man1/gscreen.1.html[gscreen]         |Touchy LinuxCNC Graphical User Interface                         ||
+| link:../man/man1/halui.1.html[halui]             |Observe HAL pins and command LinuxCNC through NML                ||
+| link:../man/man1/mdro.1.html[mdro]               |manual only Digital Read Out (DRO)                               ||
 | link:../man/man1/ngcgui.1.html[ngcgui]           |Framework for conversational G-code generation on the controller ||
-| link:../man/man1/panelui.1.html[panelui]         |Short description                                         ||
-| link:../man/man1/pyngcgui.1.html[pyngcgui]       |Python implementation of NGCGUI                           ||
-| link:../man/man1/touchy.1.html[touchy]           |AXIS - TOUCHY LinuxCNC Graphical User Interface           ||
+| link:../man/man1/panelui.1.html[panelui]         |Short description                                                ||
+| link:../man/man1/pyngcgui.1.html[pyngcgui]       |Python implementation of NGCGUI                                  ||
+| link:../man/man1/touchy.1.html[touchy]           |AXIS - TOUCHY LinuxCNC Graphical User Interface                  ||
 |===
 
 ==== Virtual Control Panels (VCP)
@@ -79,7 +79,7 @@ To search in the man pages, use the UNIX tool `apropos`.
 | link:../man/man1/io.1.html[io]               |iocontrol - interacts with HAL or G-code in non-realtime                   ||
 | link:../man/man1/iocontrol.1.html[iocontrol] |Interacts with HAL or G-code in non-realtime                               ||
 | link:../man/man1/iov2.1.html[iov2]           |Interacts with HAL or G-code in non-realtime                               ||
-| link:../man/man1/mdi.1.html[mdi]             |Send G-code commands from the terminal to the running LinuxCNC instance ||
+| link:../man/man1/mdi.1.html[mdi]             |Send G-code commands from the terminal to the running LinuxCNC instance    ||
 | link:../man/man1/milltask.1.html[milltask]   |Non-realtime task controller for LinuxCNC                                  ||
 |===
 
@@ -87,24 +87,24 @@ To search in the man pages, use the UNIX tool `apropos`.
 ==== VFD & Communication Interfaces (non-realtime)
 [{tab_options}]
 |===
-| link:../man/man1/elbpcom.1.html[elbpcom] |Communicate with Mesa ethernet cards ||
-| link:../man/man1/gs2_vfd.1.html[gs2_vfd] |HAL non-realtime component for Automation Direct GS2 VFDs ||
-| link:../man/man1/hy_gt_vfd.1.html[hy_gt_vfd] |HAL non-realtime component for Huanyang GT-series VFDs ||
-| link:../man/man1/hy_vfd.1.html[hy_vfd] |HAL non-realtime component for Huanyang VFDs ||
+| link:../man/man1/elbpcom.1.html[elbpcom] |Communicate with Mesa ethernet cards                                                                                                   || 
+| link:../man/man1/gs2_vfd.1.html[gs2_vfd] |HAL non-realtime component for Automation Direct GS2 VFDs                                                                              ||
+| link:../man/man1/hy_gt_vfd.1.html[hy_gt_vfd] |HAL non-realtime component for Huanyang GT-series VFDs                                                                             ||
+| link:../man/man1/hy_vfd.1.html[hy_vfd] |HAL non-realtime component for Huanyang VFDs                                                                                             ||
 | link:../man/man1/mb2hal.1.html[mb2hal] | MB2HAL is a generic non-realtime HAL component to communicate with one or more Modbus devices. Modbus RTU and Modbus TCP are supported. ||
-| link:../man/man1/mitsub_vfd.1.html[mitsub_vfd] |HAL non-realtime component for Mitsubishi A500 F500 E500 A500 D700 E700 F700-series VFDs (others may work) ||
-| link:../man/man1/monitor-xhc-hb04.1.html[monitor-xhc-hb04] |Monitors the XHC-HB04 pendant and warns of disconnection ||
-| link:../man/man1/pi500_vfd.1.html[pi500_vfd] |Powtran PI500 modbus driver ||
-| link:../man/man1/pmx485.1.html[pmx485] |Modbus communications with a Powermax Plasma Cutter ||
-| link:../man/man1/pmx485-test.1.html[pmx485-test] |Modbus communications testing with a Powermax Plasma Cutter ||
-| link:../man/man1/shuttle.1.html[shuttle] |control HAL pins with the ShuttleXpress, ShuttlePRO, and ShuttlePRO2 device made by Contour Design ||
-| link:../man/man1/svd-ps_vfd.1.html[svd-ps_vfd] |HAL non-realtime component for SVD-P(S) VFDs ||
-| link:../man/man1/vfdb_vfd.1.html[vfdb_vfd] |HAL non-realtime component for Delta VFD-B Variable Frequency Drives ||
-| link:../man/man1/vfs11_vfd.1.html[vfs11_vfd] |HAL non-realtime component for Toshiba-Schneider VF-S11 Variable Frequency Drives ||
-| link:../man/man1/wj200_vfd.1.html[wj200_vfd] |Hitachi wj200 modbus driver ||
-| link:../man/man1/xhc-hb04.1.html[xhc-hb04] |Non-realtime HAL component for the xhc-hb04 pendant ||
-| link:../man/man1/xhc-hb04-accels.1.html[xhc-hb04-accels] |Obsolete script for jogging wheel ||
-| link:../man/man1/xhc-whb04b-6.1.html[xhc-whb04b-6] |Non-realtime jog dial HAL component for the wireless XHC WHB04B-6 USB device ||
+| link:../man/man1/mitsub_vfd.1.html[mitsub_vfd] |HAL non-realtime component for Mitsubishi A500 F500 E500 A500 D700 E700 F700-series VFDs (others may work)                       ||
+| link:../man/man1/monitor-xhc-hb04.1.html[monitor-xhc-hb04] |Monitors the XHC-HB04 pendant and warns of disconnection                                                             ||
+| link:../man/man1/pi500_vfd.1.html[pi500_vfd] |Powtran PI500 modbus driver                                                                                                        ||
+| link:../man/man1/pmx485.1.html[pmx485] |Modbus communications with a Powermax Plasma Cutter                                                                                      ||
+| link:../man/man1/pmx485-test.1.html[pmx485-test] |Modbus communications testing with a Powermax Plasma Cutter                                                                    ||
+| link:../man/man1/shuttle.1.html[shuttle] |control HAL pins with the ShuttleXpress, ShuttlePRO, and ShuttlePRO2 device made by Contour Design                                     ||
+| link:../man/man1/svd-ps_vfd.1.html[svd-ps_vfd] |HAL non-realtime component for SVD-P(S) VFDs                                                                                     ||
+| link:../man/man1/vfdb_vfd.1.html[vfdb_vfd] |HAL non-realtime component for Delta VFD-B Variable Frequency Drives                                                                 ||
+| link:../man/man1/vfs11_vfd.1.html[vfs11_vfd] |HAL non-realtime component for Toshiba-Schneider VF-S11 Variable Frequency Drives                                                  ||
+| link:../man/man1/wj200_vfd.1.html[wj200_vfd] |Hitachi wj200 modbus driver                                                                                                        ||
+| link:../man/man1/xhc-hb04.1.html[xhc-hb04] |Non-realtime HAL component for the xhc-hb04 pendant                                                                                  ||
+| link:../man/man1/xhc-hb04-accels.1.html[xhc-hb04-accels] |Obsolete script for jogging wheel                                                                                      ||
+| link:../man/man1/xhc-whb04b-6.1.html[xhc-whb04b-6] |Non-realtime jog dial HAL component for the wireless XHC WHB04B-6 USB device                                                 ||
 |===
 
 === Mesa and other I/O Cards (Realtime)

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -8,10 +8,10 @@
 
 // < explanation of the difference between a realtime and a non-realtime component >
 
-Most of the commands in the following list have their own dedicated man pages. 
-Some will have expanded descriptions, some will have limited descriptions. 
+Most of the commands in the following list have their own dedicated man pages.
+Some will have expanded descriptions, some will have limited descriptions.
 From this list you know what components exist, and you can use `man` _name_ on your UNIX command line to get additional information.
-To view the information in the man page, in a terminal window type: 
+To view the information in the man page, in a terminal window type:
 
 ----
 man axis
@@ -87,7 +87,7 @@ To search in the man pages, use the UNIX tool `apropos`.
 ==== VFD & Communication Interfaces (non-realtime)
 [{tab_options}]
 |===
-| link:../man/man1/elbpcom.1.html[elbpcom] |Communicate with Mesa ethernet cards                                                                                                   || 
+| link:../man/man1/elbpcom.1.html[elbpcom] |Communicate with Mesa ethernet cards                                                                                                   ||
 | link:../man/man1/gs2_vfd.1.html[gs2_vfd] |HAL non-realtime component for Automation Direct GS2 VFDs                                                                              ||
 | link:../man/man1/hy_gt_vfd.1.html[hy_gt_vfd] |HAL non-realtime component for Huanyang GT-series VFDs                                                                             ||
 | link:../man/man1/hy_vfd.1.html[hy_vfd] |HAL non-realtime component for Huanyang VFDs                                                                                             ||
@@ -211,9 +211,9 @@ Smart-serial remote parameters can now be set in the HAL file in the normal way.
 | link:../man/man9/knob2float.9.html[knob2float] |Converts counts (probably from an encoder) to a float value. ||
 | link:../man/man9/lowpass.9.html[lowpass]   |Low-pass filter | |
 | link:../man/man9/limit1.9.html[limit1]     |Limits the output signal to fall between min and max. footnote:[When the input is a position, this means that the 'position' is limited.] ||
-| link:../man/man9/limit2.9.html[limit2]     |Limits the output signal to fall between min and max.  Limit its slew rate to less than maxv per second. 
+| link:../man/man9/limit2.9.html[limit2]     |Limits the output signal to fall between min and max.  Limit its slew rate to less than maxv per second.
 footnote:[When the input is a position, this means that 'position' and 'velocity' are limited.] ||
-| link:../man/man9/limit3.9.html[limit3]     |Limit the output signal to fall between min and max. 
+| link:../man/man9/limit3.9.html[limit3]     |Limit the output signal to fall between min and max.
 Limit its slew rate to less than maxv per second. Limit its second derivative to less than MaxA per second squared footnote:[When
 the input is a position, this means that the 'position', 'velocity', and 'acceleration' are limited.]. ||
 | link:../man/man9/lincurve.9.html[lincurve] |One-dimensional lookup table ||

--- a/docs/src/hal/halshow.adoc
+++ b/docs/src/hal/halshow.adoc
@@ -223,7 +223,7 @@ image::images/halshow-settings.png["Halshow Settings",align="center"]
 
 Let's use this editor to add a differential module to a HAL and connect it to axis position so that we could see the rate of change in position, i.e., acceleration.
 We first need to load a HAL component named ddt, add it to the servo thread, then connect it to the position pin of a joint.
-Once that is done we can find the output of the differentiator in halscope. So let's go. 
+Once that is done we can find the output of the differentiator in halscope. So let's go.
 
 [source,{hal}]
 ----

--- a/docs/src/hal/intro.adoc
+++ b/docs/src/hal/intro.adoc
@@ -22,7 +22,7 @@ However, HAL can do more than just configure hardware drivers.
 
 == HAL Overview(((HAL)))
 
-The Hardware Abstraction Layer (or with a reference to the link:https://en.wikipedia.org/wiki/2001:_A_Space_Odyssey_(film)[2001 Space Odyssey movie] just "HAL") is a software to 
+The Hardware Abstraction Layer (or with a reference to the link:https://en.wikipedia.org/wiki/2001:_A_Space_Odyssey_(film)[2001 Space Odyssey movie] just "HAL") is a software to
 
 * provide the infrastructure for the communication with and between the many software and hardware components of the system.
 * optionally process and/or override that information as it flows from component to component.
@@ -35,7 +35,7 @@ Such a synchronisation of motor positions with real-world positions is reminisce
 
 Any machine controller needs to know:
 
-* about its internal state and how this maps to the environment (machine coordinates, state of switches/regulators), 
+* about its internal state and how this maps to the environment (machine coordinates, state of switches/regulators),
 * how actuators are expected to change that state,
 * how allow for updates of the internal state by sensors (encoders, probes).
 
@@ -50,7 +50,7 @@ The HAL layer consists of parts (referred to as "components") that
     . read out the position presented by an encoder.
   - with a lower frequency every millisecond (ms), e.g. to
     . adjust the planning for the next moves to complete a G-code instruction.
-  - as non-realtime "user-space" components that run a "main loop" just like any other software, and may be interrupted or delayed when the rest of the system is busy or overloaded. 
+  - as non-realtime "user-space" components that run a "main loop" just like any other software, and may be interrupted or delayed when the rest of the system is busy or overloaded.
 
 
 Taken together, HAL allows
@@ -59,7 +59,7 @@ Taken together, HAL allows
   but may rely on a programming interface with well-specified effect on the machine.
   That interface may be used to
   * tell the machine what to do
-  * listen to what the machine wants to tell about the state it is in. 
+  * listen to what the machine wants to tell about the state it is in.
 . Vertical Abstractions: The human system integrator of such machine uses HAL
   * to describe what the machine is looking like and how what cable controls which motor that drives which axis.
   * The description of the machine, the programmer's interfaces and the user's interface somehow "meet" in that abstract layer.
@@ -78,11 +78,11 @@ But multiple interfaces have been provided that allow HAL to be manipulated
 
 but none of these interfaces are 'HAL itself'.
 
-HAL itself is not a program, it consists of one or more lists of loaded programs (the components) that are periodically executed (in strict sequence), and an area of shared-memory that these components use to interchange data. 
+HAL itself is not a program, it consists of one or more lists of loaded programs (the components) that are periodically executed (in strict sequence), and an area of shared-memory that these components use to interchange data.
 The main HAL script runs only once at machine startup, setting up the realtime threads and the shared-memory locations, loading the components and setting up the data links between them (the "signals" and "pins")
 
 In principle multiple machines could share a common HAL to allow them to inter-operate, however the current implementation of LinuxCNC is limited to a single interpreter and a single Task module.
-Currently this is almost always a G-code interpreter and "milltask" (which was found to also work well for lathes and adequately for robots) but these modules are selectable at load-time. 
+Currently this is almost always a G-code interpreter and "milltask" (which was found to also work well for lathes and adequately for robots) but these modules are selectable at load-time.
 With an increasing interest in the control of multiple cooperating machines, to overcome this limitation is likely one of the prime steps for the future development of LinuxCNC to address.
 It is a bit tricky though and the community is still organizing its thoughts on this.
 
@@ -111,8 +111,8 @@ The communication with the hardware of the machine itself is performed by respec
 
 The HAL layer is a shared space in which all the many parts that constitute LinuxCNC are exchanging information.
 That space features pins that are identified by a name, though a LinuxCNC engineer may prefer the association with a pin of an electronic circuit.
-These pins can carry numerical and logical values, boolean, float and signed and unsigned integers. There is also a (relatively new) pin type named hal_port intended for byte streams, and a framework for exchanging more complex data called hal_stream (which uses a private shared memory area, rather than a HAL pin). 
-These latter two types are used relatively infrequently. 
+These pins can carry numerical and logical values, boolean, float and signed and unsigned integers. There is also a (relatively new) pin type named hal_port intended for byte streams, and a framework for exchanging more complex data called hal_stream (which uses a private shared memory area, rather than a HAL pin).
+These latter two types are used relatively infrequently.
 
 With HAL you can send a signal to that named pin.
 Every part of HAL can read that pin that holds that value of the signal.
@@ -144,7 +144,7 @@ Still, two machines may be looking very different since built for very different
 
 .From Where the Incentive to Move Originates
 On the lowest (closest to hardware) level, e.g. for stepper motors, the description of a state of that motor is very intuitive:
-It is the number of steps in a particular direction. 
+It is the number of steps in a particular direction.
 A difference between the desired position and the actual position translates into a movement.
 Speeds, acceleration and other parameters may be internally limited in the component itself, or may optionally be limited by upstream components.
 (For example, in most cases the moment-by-moment axis position values sent to the step-generator components have already been limited and shaped to suit the configured machine limits or the current feed rate.)
@@ -157,7 +157,7 @@ When traditional programmers think of variables, addresses or I/O ports, HAL ref
 And those pins are connected or assigned values to via signals.
 Much like an electrical engineer would connect wires between pins of components of a mill, a HAL engineer establishes the data flow between pins of module instances.
 
-The LinuxCNC GUIS (AXIS, GMOCCAPY, Touchy, etc.) will represent the states of some pins (such as limit switches) but other graphical tools also exist for troubleshooting and configuration: Halshow, Halmeter, Halscope and Halreport. 
+The LinuxCNC GUIS (AXIS, GMOCCAPY, Touchy, etc.) will represent the states of some pins (such as limit switches) but other graphical tools also exist for troubleshooting and configuration: Halshow, Halmeter, Halscope and Halreport.
 
 The remainder of this introduction presents
 
@@ -310,7 +310,7 @@ You may be wondering what relationship there is between the HAL_pins, physical_p
 
 Signal:: (((HAL Signal)))
   In a physical machine, the terminals of real hardware components are interconnected by wires.
-  The HAL equivalent of a wire is a 'signal' or 'HAL signal'. 
+  The HAL equivalent of a wire is a 'signal' or 'HAL signal'.
   HAL signals connect HAL pins together as required by the machine builder.
   HAL signals can be disconnected and reconnected at will (even while the machine is running).
 

--- a/docs/src/hal/intro.adoc
+++ b/docs/src/hal/intro.adoc
@@ -342,7 +342,7 @@ Function:: (((HAL:Function)))
 
 Thread:: (((HAL:Thread)))
   A 'thread' is a list of functions that runs at specific intervals as part of a realtime task.
-  When a thread is kirst created, it has a specific time interval (period), but no functions.
+  When a thread is first created, it has a specific time interval (period), but no functions.
   Functions can be added to the thread, and will be executed in order every time the thread runs.
 
 As an example, suppose we have a parport component named hal_parport.
@@ -375,7 +375,7 @@ A perfect example is a single rung ladder, with a NC contact in series with a co
 The contact and coil belong to the same relay.
 
 If this were a conventional relay, as soon as the coil is energized, the contacts begin to open and de-energize it.
-That means the contacts close again, etc, etc.
+That means the contacts close again, etc., etc.
 The relay becomes a buzzer.
 
 With a PLC, if the coil is OFF and the contact is closed when the PLC begins to evaluate the rung, then when it finishes that pass, the coil is ON.

--- a/docs/src/hal/rtcomps.adoc
+++ b/docs/src/hal/rtcomps.adoc
@@ -31,8 +31,7 @@ image::images/stepgen-block-diag.png[align="center"]
 halcmd: loadrt stepgen step_type=<type-array> [ctrl_type=<ctrl_array>]
 ----
 
-<type-array>:: is a series of comma separated decimal integers.
-  Each number causes a single step pulse generator to be loaded, the value of the number determines the stepping type.
+<type-array>:: is a series of comma separated decimal integers. Each number causes a single step pulse generator to be loaded, the value of the number determines the stepping type.
 <ctrl_array>:: is a comma separated series of 'p' or 'v' characters, to specify position or velocity mode.
 ctrl_type:: is optional, if omitted, all of the step generators will be position mode.
 
@@ -78,8 +77,7 @@ On the step type and control type selected.
 [[sec:stepgen-parameters]]
 === Parameters(((HAL stepgen parameters)))
 
-* (float) `stepgen.`__<chan>__`.position-scale` - Steps per position unit.
-  This parameter is used for both output and feedback.
+* (float) `stepgen.`__<chan>__`.position-scale` - Steps per position unit. This parameter is used for both output and feedback.
 * (float) `stepgen.`__<chan>__`.maxvel` - Maximum velocity, in position units per second. If 0.0, has no effect.
 * (float) `stepgen.`__<chan>__`.maxaccel` - Maximum accel/decel rate, in positions units per second squared.
   If 0.0, has no effect.
@@ -97,8 +95,7 @@ When set to values that are appropriate for the motor, even a large instantaneou
 The algorithm works by measuring both position error and velocity error, and calculating an acceleration that attempts to reduce both to zero at the same time.
 For more details, including the contents of the 'control equation' box, consult the code.
 
-In velocity mode, maxvel is a simple limit that is applied to the commanded velocity,
-and maxaccel is used to ramp the actual frequency if the commanded velocity changes abruptly.
+In velocity mode, maxvel is a simple limit that is applied to the commanded velocity, and maxaccel is used to ramp the actual frequency if the commanded velocity changes abruptly.
 As in position mode, proper values for these parameters ensure that the motor can follow the generated pulse train.
 
 [[sub:stepgen-step-types]]
@@ -153,17 +150,15 @@ image::images/stepgen-type11-14.png["Step Types: Five-Phase",align="center"]
 [[sub:stepgen-functions]]
 === Functions(((Hal stepgen Functions)))
 
-The component exports three functions. Each function acts on all of
-the step pulse generators - running different generators in different
-threads is not supported.
+The component exports three functions.
+Each function acts on all of the step pulse generators - running different generators in different threads is not supported.
 
 * (funct) `stepgen.make-pulses` - High speed function to generate and count pulses (no floating point).
 * (funct) `stepgen.update-freq` - Low speed function does position to velocity conversion, scaling and limiting.
 * (funct) `stepgen.capture-position` - Low speed function for feedback, updates latches and scales position.
 
 The high speed function 'stepgen.make-pulses' should be run in a very fast thread, from 10 to 50&#8239;µs depending on the capabilities of the computer.
-That thread's period determines the maximum step frequency,
-since 'steplen', 'stepspace', 'dirsetup', 'dirhold', and 'dirdelay' are all rounded up to a integer multiple of the thread periond in nanoseconds.
+That thread's period determines the maximum step frequency, since 'steplen', 'stepspace', 'dirsetup', 'dirhold', and 'dirdelay' are all rounded up to a integer multiple of the thread periond in nanoseconds.
 The other two functions can be called at a much lower rate.
 
 [[sec:pwmgen]]
@@ -214,8 +209,7 @@ The PWM generator supports three different 'output types'.
 * 'Output type 1' - PWM/PDM and direction pins.
   Positive and negative inputs will be output as positive and negative PWM.
   The direction pin is false for positive commands, and true for negative commands.
-  If your control needs positive PWM for both CW and CCW use the link:../man/man9/abs.9.html[abs] component to convert your PWM signal to positive value,
-  when a negative input is input.
+  If your control needs positive PWM for both CW and CCW use the link:../man/man9/abs.9.html[abs] component to convert your PWM signal to positive value, when a negative input is input.
 * 'Output type 2' - UP and DOWN pins.
   For positive commands, the PWM signal appears on the up output, and the down output remains false.
   For negative commands, the PWM signal appears on the down output, and the up output remains false.
@@ -301,14 +295,10 @@ halcmd: unloadrt encoder
 * `encoder._<chan>_.counter-mode` (bit, I/O) (default: FALSE) - Enables counter mode.
   When true, the counter counts each rising edge of the phase-A input, ignoring the value on phase-B.
   This is useful for counting the output of a single channel (non-quadrature) sensor. When false, it counts in quadrature mode.
-* `encoder._<chan>_.missing-teeth` (s32, In) (default: 0) - Enables the use
-  of missing-tooth index. This allows a single IO pin to provide both
-  position and index information. If the encoder wheel has 58 teeth with
-  two missing, spaced as if there were 60(common for automotive crank
-  sensors) then the position-scale should be set to 60 and
-  missing-teeth to 2. To use this mode counter-mode should be set
-  true. This mode will work for lathe threading but not for rigid
-  tapping.
+* `encoder._<chan>_.missing-teeth` (s32, In) (default: 0) - Enables the use of missing-tooth index.
+  This allows a single IO pin to provide both position and index information.
+  If the encoder wheel has 58 teeth with two missing, spaced as if there were 60(common for automotive crank sensors) then the position-scale should be set to 60 and missing-teeth to 2.
+  To use this mode counter-mode should be set true. This mode will work for lathe threading but not for rigid tapping.
 * `encoder._<chan>_.counts` (s32, Out) - Position in encoder counts.
 * `encoder._<chan>_.counts-latched` (s32, Out) - Not used at this time.
 * `encoder._<chan>_.index-enable` (bit, I/O) - When True, `counts` and
@@ -320,10 +310,8 @@ halcmd: unloadrt encoder
 * `encoder._<chan>_.latch-falling` (bit, In) (default: TRUE) - Not used at this time.
 * `encoder._<chan>_.latch-input` (bit, In) (default: TRUE) - Not used at this time.
 * `encoder._<chan>_.latch-rising` (bit, In) - Not used at this time.
-* `encoder._<chan>_.min-speed-estimate` (float, in) - Determine the minimum true velocity magnitude,
-  at which velocity will be estimated as nonzero and position-interpolated will be interpolated.
-  The units of `min-speed-estimate` are the same as the units of `velocity`.
-  Scale factor, in counts per length unit.
+* `encoder._<chan>_.min-speed-estimate` (float, in) - Determine the minimum true velocity magnitude, at which velocity will be estimated as nonzero and position-interpolated will be interpolated.
+  The units of `min-speed-estimate` are the same as the units of `velocity`. Scale factor, in counts per length unit.
   Setting this parameter too low will cause it to take a long time for velocity to go to 0 after encoder pulses have stopped arriving.
 * `encoder._<chan>_.phase-A` (bit, In) - Phase A of the quadrature encoder signal.
 * `encoder._<chan>_.phase-B` (bit, In) - Phase B of the quadrature encoder signal.

--- a/docs/src/hal/tutorial.adoc
+++ b/docs/src/hal/tutorial.adoc
@@ -29,7 +29,7 @@ $ man -M docs/man halcmd
 
 === Notation
 
-For this tutorial, commands for the operating system are typically shown without the prompt provided by the UNIX shell, i.e typically a dollar sign ($) or a hash/double cross (#). 
+For this tutorial, commands for the operating system are typically shown without the prompt provided by the UNIX shell, i.e typically a dollar sign ($) or a hash/double cross (#).
 When communicating directly with the HAL through `halcmd` or `halrun`, the prompts are shown in the examples.
 The terminal window is in 'Applications/Accessories' from the main Ubuntu menu bar.
 

--- a/docs/src/ladder/classic-ladder.adoc
+++ b/docs/src/ladder/classic-ladder.adoc
@@ -643,7 +643,7 @@ loadusr -w classicladder --modmaster myprogram.clp
 ----
 
 The `-w` makes HAL wait until you close ClassicLadder before closing realtime session.
-ClassicLadder also loads a TCP modbus slave if you add '--modserver' on command line.
+ClassicLadder also loads a TCP modbus slave if you add `--modserver` on command line.
 
 .Modbus Functions
 * '1' - read coils

--- a/docs/src/user/user-intro.adoc
+++ b/docs/src/user/user-intro.adoc
@@ -138,8 +138,9 @@ image::images/tklinuxcnc_fr.png["TkLinuxCNC graphical interface",align="center"]
 
 Xemc:: an X-Window program
 
-QtDragon:: <<cha:qtdragon-gui,QtDragon>>, a touch screen GUI based on QtVCP using the PyQt5 library. It comes in two versions 
-'QtDragon' and 'QtDragon_hd'. They are very similar in features but QtDragon_hd is made for larger monitors.
+QtDragon:: <<cha:qtdragon-gui,QtDragon>>, a touch screen GUI based on QtVCP using the PyQt5 library.
+It comes in two versions 'QtDragon' and 'QtDragon_hd'.
+They are very similar in features but QtDragon_hd is made for larger monitors.
 
 [[fig:QtDragon-graphical-interface]]
 .QtDragon, a touch screen GUI based on QtVCP
@@ -175,7 +176,7 @@ GladeVCP:: <<cha:glade-vcp,'GladeVCP'>>, a Glade-based virtual control panel tha
 .GladeVCP Example Embedded Into AXIS GUI
 image::../gui/images/axis-gladevcp.png["GladeVCP embedded into AXIS",align="center"]
 
-QtVCP:: <<cha:qtvcp,'QtVCP'>>, a PyQT5-based virtual control panel that can be added to most GUIs or run as a standalone panel.
+QtVCP:: <<cha:qtvcp,'QtVCP'>>, a PyQt5-based virtual control panel that can be added to most GUIs or run as a standalone panel.
   QtVCP has the advantage over PyVCP in that it is not limited to the display or control of HAL virtual signals,
   but can include other external interfaces outside LinuxCNC such as window or network events by extending with python code.
   QtVCP is also more flexible in how it may be configured to appear on the GUI with many special widgets:


### PR DESCRIPTION
Nothing special, I think. Most was on the removal of terminal blanks.
Concerning my "semantic line breaks" I need to back paddle a bit.
Weblate gets presented regular top-level paragraphs and the itemizations that start with "*"s just fine, i.e. all on a single line.

This "all in one line"-presentation fails when there are indentations, as they are found in man pages or the "::"-descriptions.

So, I was introducing far more semantic line breaks than I should have for which I want to apologize.
