### PR TITLE
private_data.py with 7c81 data added

### DIFF
--- a/src/emc/usr_intf/pncconf/private_data.py
+++ b/src/emc/usr_intf/pncconf/private_data.py
@@ -692,6 +692,112 @@ class Private_Data:
       [S.STEPA,2],[S.STEPB,2],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.STEPA,3],[S.STEPB,3],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0]
      ],
 
+    # 7c81 ####################
+    ['7c81-Internal Data', '7c81', '5ABOBX1', '7c81', 'hm2_rpspi',
+         1,3, 0,0, 3,1, 0,0, 10,2, 1,2, [],0,0,0,0,0,0,0, 1, 57, 100, 200, [1,2,7],
+        # TAB 1
+        [S.PWMP,0],[S.GPIOI,0],[S.STEPA,0],[S.GPIOI,0],[S.STEPB,0],[S.GPIOI,0],[S.STEPA,1],[S.GPIOI,0],[S.STEPB,1],[S.STEPA,2],
+        [S.STEPB,2],[S.STEPA,3],[S.STEPB,3],[S.GPIOI,0],[S.ENCA,0],[S.ENCB,0],[S.ENCI,0],[S.TXDATA0,0],[S.TXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 2
+        [S.PWMP,1],[S.GPIOI,0],[S.STEPA,4],[S.GPIOI,0],[S.STEPB,4],[S.GPIOI,0],[S.STEPA,5],[S.GPIOI,0],[S.STEPB,5],[S.STEPA,6],
+        [S.STEPB,6],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.TXEN0,0],[S.TXEN1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 7
+        [S.PWMP,2],[S.GPIOI,0],[S.STEPA,7],[S.GPIOI,0],[S.STEPB,7],[S.GPIOI,0],[S.STEPA,8],[S.GPIOI,0],[S.STEPB,8],[S.STEPA,9],
+        [S.STEPB,9],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.RXDATA0,0],[S.RXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],],
+
+    ['7c81-Internal Data', '7c81', '5ABOBX2', '7c81', 'hm2_rpspi',
+         2,3, 0,0, 2,1, 0,0, 8,2, 1,2, [],0,0,0,0,0,0,0, 1, 57, 100, 200, [1,2,7],
+        # TAB 1
+        [S.PWMP,0],[S.GPIOI,0],[S.STEPA,0],[S.GPIOI,0],[S.STEPB,0],[S.GPIOI,0],[S.STEPA,1],[S.GPIOI,0],[S.STEPB,1],[S.STEPA,2],
+        [S.STEPB,2],[S.STEPA,3],[S.STEPB,3],[S.GPIOI,0],[S.ENCA,0],[S.ENCB,0],[S.ENCI,0],[S.TXDATA0,0],[S.TXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 2
+        [S.PWMP,1],[S.GPIOI,0],[S.STEPA,4],[S.GPIOI,0],[S.STEPB,4],[S.GPIOI,0],[S.STEPA,5],[S.GPIOI,0],[S.STEPB,5],[S.STEPA,6],
+        [S.STEPB,6],[S.STEPA,7],[S.STEPB,7],[S.GPIOI,0],[S.ENCA,1],[S.ENCB,1],[S.ENCI,1],[S.TXEN0,0],[S.TXEN1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 7
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.RXDATA0,0],[S.RXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],],
+
+    ['7c81-Internal Data', '7c81', '5ABOBX3', '7c81', 'hm2_rpspi',
+         3,3, 0,0, 3,1, 0,0, 12,2, 0,0,[],0,0,0,0,0,0,0, 1, 57, 100, 200,[1,2,7],
+        # TAB 1
+        [S.PWMP,0],[S.GPIOI,0],[S.STEPA,0],[S.GPIOI,0],[S.STEPB,0],[S.GPIOI,0],[S.STEPA,1],[S.GPIOI,0],[S.STEPB,1],[S.STEPA,2],
+        [S.STEPB,2],[S.STEPA,3],[S.STEPB,3],[S.GPIOI,0],[S.ENCA,0],[S.ENCB,0],[S.ENCI,0],[S.GPIOI,0],[S.GPIOI,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 2
+        [S.PWMP,1],[S.GPIOI,0],[S.STEPA,4],[S.GPIOI,0],[S.STEPB,4],[S.GPIOI,0],[S.STEPA,5],[S.GPIOI,0],[S.STEPB,5],[S.STEPA,6],
+        [S.STEPB,6],[S.STEPA,7],[S.STEPB,7],[S.GPIOI,0],[S.ENCA,1],[S.ENCB,1],[S.ENCI,1],[S.GPIOI,0],[S.GPIOI,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 7
+        [S.PWMP,2],[S.GPIOI,0],[S.STEPA,8],[S.GPIOI,0],[S.STEPB,8],[S.GPIOI,0],[S.STEPA,9],[S.GPIOI,0],[S.STEPB,9],[S.STEPA,10],
+        [S.STEPB,10],[S.STEPA,11],[S.STEPB,11],[S.GPIOI,0],[S.ENCA,2],[S.ENCB,2],[S.ENCI,2],[S.GPIOI,0],[S.GPIOI,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],],
+
+    ['7c81-Internal Data', '7c81', '7I76X2', '7c81', 'hm2_rpspi',
+         2,3, 0,0, 0,0, 0,0, 10,2, 1,4,[],0,0,0,0,0,0,0, 1, 57, 100, 200,[1,2,7],
+        # TAB 1
+        [S.STEPB,0],[S.STEPA,0],[S.STEPB,1],[S.STEPA,1],[S.STEPB,2],[S.STEPA,2],[S.STEPB,3],[S.STEPA,3],[S.STEPB,4],[S.STEPA,4],
+        [S.TXDATA0,0],[S.RXDATA0,0],[S.TXDATA1,0],[S.RXDATA1,0],[S.ENCI,0],[S.ENCB,0],[S.ENCA,0],[S.GPIOI,0],[S.GPIOI,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 2
+        [S.STEPB,5],[S.STEPA,5],[S.STEPB,6],[S.STEPA,6],[S.STEPB,7],[S.STEPA,7],[S.STEPB,8],[S.STEPA,8],[S.STEPB,9],[S.STEPA,9],
+        [S.TXDATA2,0],[S.RXDATA2,0],[S.TXDATA3,0],[S.RXDATA3,0],[S.ENCI,1],[S.ENCB,1],[S.ENCA,1],[S.GPIOI,0],[S.GPIOI,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 7
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],],
+
+    ['7c81-Internal Data', '7c81', 'C11GX2', '7c81', 'hm2_rpspi',
+         2,3, 0,0, 2,1, 0,0, 10,2, 1,2,[],0,0,0,0,0,0,0, 1, 57, 100, 200,[1,2,7],
+        # TAB 1
+        [S.GPIOI,0],[S.PWMP,0],[S.STEPA,0],[S.GPIOI,0],[S.STEPB,0],[S.GPIOI,0],[S.STEPA,1],[S.STEPA,4],[S.STEPB,1],[S.STEPA,2],
+        [S.STEPB,2],[S.STEPA,3],[S.STEPB,3],[S.ENCA,0],[S.ENCB,0],[S.ENCI,0],[S.GPIOI,0],[S.TXDATA0,0],[S.TXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 2
+        [S.GPIOI,0],[S.PWMP,1],[S.STEPA,5],[S.GPIOI,0],[S.STEPB,5],[S.GPIOI,0],[S.STEPA,6],[S.STEPA,9],[S.STEPB,6],[S.STEPA,7],
+        [S.STEPB,7],[S.STEPA,8],[S.STEPB,8],[S.ENCA,1],[S.ENCB,1],[S.ENCI,1],[S.GPIOI,0],[S.TXEN0,0],[S.TXEN1,0], 
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 7
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.RXDATA0,0],[S.RXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],],
+
+    ['7c81-Internal Data', '7c81', 'G540X2', '7c81', 'hm2_rpspi',
+         2,3, 0,0, 2,1, 0,0, 10,2, 1,2,[],0,0,0,0,0,0,0, 1, 57, 100, 200,[1,2,7],
+        # TAB 1
+        [S.GPIOI,0],[S.PWMP,0],[S.STEPA,0],[S.GPIOI,0],[S.STEPB,0],[S.STEPA,4],[S.STEPA,1],[S.GPIOI,0],[S.STEPB,1],[S.STEPA,2],
+        [S.STEPB,2],[S.STEPA,3],[S.STEPB,3],[S.ENCA,0],[S.ENCB,0],[S.ENCI,0],[S.GPIOI,0],[S.TXDATA0,0],[S.TXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 2
+        [S.GPIOI,0],[S.PWMP,1],[S.STEPA,5],[S.GPIOI,0],[S.STEPB,5],[S.STEPA,9],[S.STEPA,6],[S.GPIOI,0],[S.STEPB,6],[S.STEPA,7],
+        [S.STEPB,7],[S.STEPA,8],[S.STEPB,8],[S.ENCA,1],[S.ENCB,1],[S.ENCI,1],[S.GPIOI,0],[S.TXEN0,0],[S.TXEN1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 7
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.RXDATA0,0],[S.RXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],],
+
+    ['7c81-Internal Data', '7c81', 'MX3660X2', '7c81', 'hm2_rpspi',
+         2,3, 0,0, 2,1, 0,0, 8,2, 1,2,[],0,0,0,0,0,0,0, 1, 57, 100, 200,[1,2,7],
+        # TAB 1
+        [S.GPIOI,0],[S.PWMP,0],[S.STEPA,0],[S.GPIOI,0],[S.STEPB,0],[S.STEPA,3],[S.STEPA,1],[S.GPIOI,0],[S.STEPB,1],[S.STEPA,2],
+        [S.STEPB,2],[S.GPIOI,0],[S.GPIOI,0],[S.ENCA,0],[S.ENCB,0],[S.ENCI,0],[S.GPIOI,0],[S.TXDATA0,0],[S.TXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 2
+        [S.GPIOI,0],[S.PWMP,1],[S.STEPA,4],[S.GPIOI,0],[S.STEPB,4],[S.STEPA,7],[S.STEPA,5],[S.GPIOI,0],[S.STEPB,5],[S.STEPA,6],
+        [S.STEPB,6],[S.GPIOI,0],[S.GPIOI,0],[S.ENCA,1],[S.ENCB,1],[S.ENCI,1],[S.GPIOI,0],[S.TXEN0,0],[S.TXEN1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],
+        # TAB 7
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],
+        [S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.GPIOI,0],[S.RXDATA0,0],[S.RXDATA1,0],
+        [S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],[S.NUSED,0],],
+
     # 7i76e ####################
     ['7i76e-Internal Data', '7i76e', '7i76e', '7i76', 'hm2_eth',
         1,3, 0,0, 0,3, 0,0, 5,2, 1,2, [],0,0,0,0,0,0,0, 1, 34, 33, 200, [1, 2, 3],
@@ -1185,6 +1291,7 @@ class Private_Data:
         '5i23':{'DRIVER':'hm2_pci','PINS_PER_CONNECTOR':24,'TOTAL_CONNECTORS':3},
         '5i24':{'DRIVER':'hm2_pci','PINS_PER_CONNECTOR':24,'TOTAL_CONNECTORS':3},
         '5i25':{'DRIVER':'hm2_pci','PINS_PER_CONNECTOR':17,'TOTAL_CONNECTORS':2,'TAB_NUMS':[2,3],'TAB_NAMES':['P2','P3']},
+        '7c81':{'DRIVER':'hm2_rpspi','PINS_PER_CONNECTOR':19,'TOTAL_CONNECTORS':3,'TAB_NUMS':[1,2,7],'TAB_NAMES':['P1','P2','P7']},
         '7i43':{'DRIVER':'hm2_7i43','PINS_PER_CONNECTOR':24,'TOTAL_CONNECTORS':2},
         '7i68':{'DRIVER':'hm2_pci','PINS_PER_CONNECTOR':24,'TOTAL_CONNECTORS':6},
         '7i76e':{'DRIVER':'hm2_eth','PINS_PER_CONNECTOR':17,'TOTAL_CONNECTORS':3,'TAB_NUMS':[1,2,3],'TAB_NAMES':['TB2/TB3','P1','P2']},


### PR DESCRIPTION
Please test and then merge the updated private_data.py file for pncconf into the 2.9 release. This request replaces my previous one in which I inadvertently based-lined the Master branch. This is base-lined against the 2.9 branch.

Best,

Gene