### PR TITLE
halcomp: insert shebang line rather than overwriting first line

### DIFF
--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -1222,7 +1222,7 @@ def main():
             elif f.endswith(".py") and mode == INSTALL:
                 lines = open(f).readlines()
                 if lines[0].startswith("#!"): del lines[0]
-                lines[0] = "#!%s\n" % sys.executable
+                lines.insert(0, "#!%s\n" % sys.executable)
                 outfile = os.path.join(BINDIR, basename)
                 try: os.unlink(outfile)
                 except os.error: pass


### PR DESCRIPTION
This showed up on the [forum](https://forum.linuxcnc.org/38-general-linuxcnc-questions/49465-python-component-path?start=10#276196)

It possibly belongs in 2.8 as well, I currently don't have any easily available machines with python2.
