### PR TITLE
Fix linking against libraries in Makefile.modinc

### DIFF
--- a/src/Makefile.modinc.in
+++ b/src/Makefile.modinc.in
@@ -122,7 +122,7 @@ $(foreach mod,$(patsubst %.o,%,$(obj-m)),\
 	$(Q)ld -d -r -o $*.tmp $^
 	$(Q)objcopy -j .rtapi_export -O binary $*.tmp $*.sym
 	$(Q)(echo '{ global : '; tr -s '\0' < $*.sym | xargs -r0 printf '%s;\n' | grep .; echo 'local : * ; };') > $*.ver
-	$(Q)$(CC) -shared -Bsymbolic $(LDFLAGS) -Wl,--version-script,$*.ver -o $@ $^ -lm
+	$(Q)$(CC) -shared -Bsymbolic $(LDFLAGS) -Wl,--version-script,$*.ver -o $@ $^ -lm $(EXTRA_LDFLAGS)
 	$(Q)chmod -x $@
 endif
 


### PR DESCRIPTION
When linking a shared object/executable, libraries have to be added  after the object files and not before. Otherwise, symbols used in the object files are not resolved.

See https://forum.linuxcnc.org/9-installing-linuxcnc/41983-linuxcnc-ethercat-undefined-symbol-ecrt-slave-config-sdo?start=0