### PR TITLE
Replace broken documentation links to emccalib.tcl and introduce emccalib(1) man page.

### DIFF
--- a/debian/linuxcnc.install.in
+++ b/debian/linuxcnc.install.in
@@ -147,6 +147,7 @@ usr/share/man/man1/axis.1
 usr/share/man/man1/axis-remote.1
 usr/share/man/man1/debuglevel.1
 usr/share/man/man1/elbpcom.1
+usr/share/man/man1/emccalib.tcl.1
 usr/share/man/man1/gladevcp.1
 usr/share/man/man1/gladevcp_demo.1
 usr/share/man/man1/gmoccapy.1

--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -1876,8 +1876,7 @@ Enter any of these _case sensitive_ commands to load the respective program or a
   link:../man/man1/linuxcnctop.1.html[`status`] utility.
 *`CALIBRATION`*::
   Starts LinuxCNC
-  link:../getting-started/updating-linuxcnc.html#_calibration_emccalib_tcl[calibration]
-  utility.
+  link:../man/man1/emccalib.tcl.1.html[calibration] utility.
 *`CLASSICLADDER`*::
   Starts the link:../ladder/classic-ladder.html[ClassicLadder GUI] if the _ClassicLadder realtime HAL component_ was loaded by the machine's config files.
 *`PREFERENCE`*::

--- a/docs/src/man/man1/emccalib.tcl.1.adoc
+++ b/docs/src/man/man1/emccalib.tcl.1.adoc
@@ -1,0 +1,52 @@
+= emccalib.tcl (1)
+
+== NAME
+
+emccalib.tcl - Adjust ini tuning variables on the fly with save option
+
+== SYNOPSIS
+
+*emccalib.tcl* [_options_]
+
+
+== DESCRIPTION
+
+The Calibration assistant.  This tool Reads the HAL file and for every
+'setp' that uses a variable from the INI file that is in an [AXIS_L],
+[JOINT_N], [SPINDLE_S], or [TUNE] section it creates an entry that can
+be edited and tested.
+
+== USAGE
+
+The calibration/tuning tool supports the following stanzas:
+
+  [JOINT_N], [AXIS_L], [SPINDLE_S], [TUNE]
+
+where _N_ is a joint number (0 .. ([KINS]JOINTS-1) ),
+_L_ is an axis coordinate letter (X,Y,Z,A,B,C,U,V,W),
+and _S_ is a spindle number (0 .. 9).
+
+[NOTE]
+
+The number of allowed spindles is 8 but legacy configurations
+may include a stanza [SPINDLE_9] unrelated to an actual spindle number.
+
+[NOTE]
+
+The [TUNE] stanza may be used for specifying tunable items
+not relevant to the other supported stanzas.
+
+== EXIT STATUS
+
+Return exit code 1 if the ini file is incompatible with the current
+version of emccalib.
+
+== SEE ALSO
+
+*linuxcnc*(1)
+
+== COPYRIGHT
+
+This is free software; see the source for copying conditions.  There
+is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.

--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -1303,7 +1303,7 @@ Some standard LinuxCNC utilities are provided as an aid in the diagnosis of issu
 - link:../hal/halshow.html#cha:halshow[Halshow]
 - link:../hal/tutorial.html#sec:tutorial-halscope[Halscope]
 - link:../hal/tutorial.html#sec:tutorial-halmeter[Halmeter]
-- link:../getting-started/updating-linuxcnc.html#_calibration_emccalib_tcl[Calibration]
+- link:../man/man1/emccalib.tcl.1.html[Calibration]
 - link:../man/man1/linuxcnctop.1.html[Status]
 
 In addition the following two QtPlasmaC specific utilities are provided:


### PR DESCRIPTION
The only documentation section about emccalib.tcl was removed in 339a94933bacfcc28c256cb0e2dce82c0d4fd85f, but some references to it were left behind.  Introduce new manual page for emccalib(1) and use this in references instead of the broken one.