### PR TITLE
strncpy -> rtapi_strlcpy for string termination

### DIFF
--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -26,6 +26,7 @@
 #include "libintl.h"
 #include <boost/python/object_fwd.hpp>
 #include <cmath>
+#include <rtapi_string.h>	// rtapi_strlcpy()
 #include "interp_parameter_def.hh"
 #include "interp_fwd.hh"
 #include "interp_base.hh"
@@ -859,7 +860,7 @@ macros totally crash-proof. If the function call stack is deeper than
     do {                                                   \
         setError (fmt, ## __VA_ARGS__);                    \
         _setup.stack_index = 0;                            \
-        (strncpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
+        (rtapi_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
         _setup.stack[_setup.stack_index][STACK_ENTRY_LEN-1] = 0; \
         _setup.stack_index++; \
         _setup.stack[_setup.stack_index][0] = 0;           \
@@ -870,7 +871,7 @@ macros totally crash-proof. If the function call stack is deeper than
     do {                                                   \
         setError (fmt, ## __VA_ARGS__);                    \
         _setup.stack_index = 0;                            \
-        (strncpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
+        (rtapi_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
         _setup.stack[_setup.stack_index][STACK_ENTRY_LEN-1] = 0; \
         _setup.stack_index++; \
         _setup.stack[_setup.stack_index][0] = 0;           \
@@ -881,7 +882,7 @@ macros totally crash-proof. If the function call stack is deeper than
 #define ERN(error_code)                                    \
     do {                                                   \
         _setup.stack_index = 0;                            \
-        (strncpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
+        (rtapi_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
         _setup.stack[_setup.stack_index][STACK_ENTRY_LEN-1] = 0; \
         _setup.stack_index++; \
         _setup.stack[_setup.stack_index][0] = 0;           \
@@ -893,7 +894,7 @@ macros totally crash-proof. If the function call stack is deeper than
 #define ERP(error_code)                                        \
     do {                                                       \
         if (_setup.stack_index < STACK_LEN - 1) {                         \
-            (strncpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
+            (rtapi_strlcpy(_setup.stack[_setup.stack_index], __PRETTY_FUNCTION__, STACK_ENTRY_LEN)); \
             _setup.stack[_setup.stack_index][STACK_ENTRY_LEN-1] = 0;    \
             _setup.stack_index++;                                       \
             _setup.stack[_setup.stack_index][0] = 0;           \

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -34,7 +34,7 @@
 #include "rs274ngc_interp.hh"
 #include "python_plugin.hh"
 #include "interp_python.hh"
-#include <rtapi_string.h>
+#include <rtapi_string.h>	// rtapi_strlcpy()
 
 namespace bp = boost::python;
 
@@ -60,7 +60,7 @@ int Interp::findFile( // ARGUMENTS
     snprintf(targetPath, PATH_MAX, "%s/%s", direct, target);
     file = fopen(targetPath, "r");
     if (file) {
-        strncpy(foundFileDirect, direct, PATH_MAX);
+        rtapi_strlcpy(foundFileDirect, direct, PATH_MAX);
         fclose(file);
         return INTERP_OK;
     }
@@ -71,8 +71,8 @@ int Interp::findFile( // ARGUMENTS
 
     while ((aFile = readdir(aDir))) {
         if (aFile->d_type == DT_DIR &&
-	    (0 != strcmp(aFile->d_name, "..")) &&
-	    (0 != strcmp(aFile->d_name, "."))) {
+	    (0 != strncmp(aFile->d_name, "..", 3)) &&
+	    (0 != strncmp(aFile->d_name, ".", 2))) {
 
             char path[PATH_MAX+1];
             snprintf(path, PATH_MAX, "%s/%s", direct, aFile->d_name);

--- a/src/emc/rs274ngc/interp_read.cc
+++ b/src/emc/rs274ngc/interp_read.cc
@@ -29,7 +29,7 @@
 #include "rs274ngc_interp.hh"
 #include "rtapi_math.h"
 #include <cmath>
-#include <rtapi_string.h>
+#include <rtapi_string.h>	// rtapi_strlcpy()
 
 using namespace interp_param_global;
 
@@ -1597,7 +1597,7 @@ int Interp::read_o(    /* ARGUMENTS                                     */
 	  // context
           if (strlen(_setup.sub_context[_setup.call_level].subName) >= sizeof(oNameBuf))
               ERS(NCE_UNABLE_TO_OPEN_FILE, _setup.sub_context[_setup.call_level].subName);
-	  strncpy(oNameBuf, _setup.sub_context[_setup.call_level].subName,
+	  rtapi_strlcpy(oNameBuf, _setup.sub_context[_setup.call_level].subName,
                   sizeof(oNameBuf));
       } else
 	  // any other m-code should have been handled by read_m()
@@ -3154,7 +3154,7 @@ int Interp::read_text(
          index--) { // remove space at end of raw_line, especially CR & LF
       raw_line[index] = 0;
     }
-    strncpy(line, raw_line, LINELEN);
+    rtapi_strlcpy(line, raw_line, LINELEN);
     CHP(close_and_downcase(line));
     if ((line[0] == '%') && (line[1] == 0) && (_setup.percent_flag)) {
         FINISH();
@@ -3162,8 +3162,8 @@ int Interp::read_text(
     }
   } else {
     CHKS((strlen(command) >= LINELEN), NCE_COMMAND_TOO_LONG);
-    strncpy(raw_line, command, LINELEN);
-    strncpy(line, command, LINELEN);
+    rtapi_strlcpy(raw_line, command, LINELEN);
+    rtapi_strlcpy(line, command, LINELEN);
     CHP(close_and_downcase(line));
   }
 

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -89,7 +89,7 @@ include an option for suppressing superfluous commands.
 #include <set>
 #include <stdexcept>
 #include <new>
-#include <rtapi_string.h>
+#include <rtapi_string.h>	// rtapi_strlcpy()
 
 #include "rtapi.h"
 #include "inifile.hh"		// INIFILE

--- a/src/emc/task/emctask.cc
+++ b/src/emc/task/emctask.cc
@@ -14,7 +14,7 @@
 ********************************************************************/
 
 #include <stdlib.h>
-#include <string.h>		// strncpy()
+#include <rtapi_string.h>	// rtapi_strlcpy()
 #include <sys/stat.h>		// struct stat
 #include <unistd.h>		// stat()
 #include <limits.h>		// PATH_MAX
@@ -34,7 +34,6 @@
 #include "python_plugin.hh"
 #include "taskclass.hh"
 #include "motion.h"
-#include <rtapi_string.h>
 
 #define USER_DEFINED_FUNCTION_MAX_DIRS 5
 #define MAX_M_DIRS (USER_DEFINED_FUNCTION_MAX_DIRS+1)
@@ -130,7 +129,7 @@ int emcTaskInit()
         strncpy(mdir[0], inistring, sizeof(mdir[0]));
     } else {
         // default dir if no PROGRAM_PREFIX
-        strncpy(mdir[0], "nc_files", sizeof(mdir[0]));
+        rtapi_strlcpy(mdir[0], "nc_files", sizeof(mdir[0]));
     }
     dmax = 1; //one directory mdir[0],  USER_M_PATH specifies additional dirs
 

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -59,7 +59,7 @@
 #include <libintl.h>
 #include <locale.h>
 #include "usrmotintf.h"
-#include <rtapi_string.h>
+#include <rtapi_string.h>	// rtapi_strlcpy()
 #include "tooldata.hh"
 
 #if 0
@@ -3171,16 +3171,16 @@ static int iniLoad(const char *filename)
     if (emc_debug & EMC_DEBUG_VERSIONS) {
 	if (NULL != (inistring = inifile.Find("VERSION", "EMC"))) {
 	    if(sscanf(inistring, "$Revision: %s", version) != 1) {
-		strncpy(version, "unknown", LINELEN-1);
+		rtapi_strlcpy(version, "unknown", LINELEN-1);
 	    }
 	} else {
-	    strncpy(version, "unknown", LINELEN-1);
+	    rtapi_strlcpy(version, "unknown", LINELEN-1);
 	}
 
 	if (NULL != (inistring = inifile.Find("MACHINE", "EMC"))) {
-	    strncpy(machine, inistring, LINELEN-1);
+	    rtapi_strlcpy(machine, inistring, LINELEN-1);
 	} else {
-	    strncpy(machine, "unknown", LINELEN-1);
+	    rtapi_strlcpy(machine, "unknown", LINELEN-1);
 	}
 	rcs_print("task: machine: '%s'  version '%s'\n", machine, version);
     }

--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -43,7 +43,7 @@
 #include "rcs_print.hh"
 #include "timer.hh"             // etime()
 #include "shcom.hh"             // NML Messaging functions
-#include <rtapi_string.h>
+#include <rtapi_string.h>	// rtapi_strlcpy()
 
 /*
   Using linuxcncrsh:
@@ -61,85 +61,85 @@
             to max sessions. Default is no limit (-1).
   With -- --path Sets the base path to program (G-Code) files, default is "../../nc_files/".
             Make sure to include the final slash (/).
-  With -- -ini <INI file>, uses specified INI file instead of default emc.ini. 
+  With -- -ini <INI file>, uses specified INI file instead of default emc.ini.
 
   There are six commands supported, Where the commands set and get contain LinuxCNC
-  specific sub-commands based on the commands supported by linuxcncrsh, but where the 
+  specific sub-commands based on the commands supported by linuxcncrsh, but where the
   usual prefix ( "emc_") is omitted. Commands and most parameters are not case sensitive.
   The exceptions are passwords, file paths and text strings.
-  
+
   The supported commands are as follows:
-  
+
   ==> HELLO <==
-  
+
   Hello <password> <client> <version>
   If a valid password was entered the server will respond with
-  
+
   HELLO ACK <Server Name> <Server Version>
-  
+
   Where server name and server version are looked up from the implementation.
-  if an invalid password or any other syntax error occurs then the server 
+  if an invalid password or any other syntax error occurs then the server
   responds with:
-  
+
   HELLO NAK
-  
+
   ==> Get <==
-  
+
   The get command includes one of the LinuxCNC sub-commands, described below and
-  zero or more additional parameters. 
-  
+  zero or more additional parameters.
+
   ==> Set <==
-  
+
   The set command inclides one of the LinuxCNC sub-commands, described below and
   one or more additional parameters.
-  
+
   ==> Quit <==
-  
+
   The quit command disconnects the associated socket connection.
-  
+
   ==> Shutdown <==
-  
+
   The shutdown command tells LinuxCNC to shutdown before quitting the connection. This
   command may only be issued if the Hello has been successfully negotiated and the
   connection has control of the CNC (see enable sub-command below). This command
   has no parameters.
-  
+
   ==> Help <==
-  
+
   The help command will return help information in text format over the telnet
   connection. If no parameters are specified, it will itemize the available commands.
   If a command is specified, it will provide usage information for the specified
   command. Help will respond regardless of whether a "Hello" has been
   successfully negotiated.
-  
-  
+
+
   LinuxCNC sub-commands:
-  
+
   echo on | off
   With get will return the current echo state, with set, sets the echo
   state. When echo is on, all commands will be echoed upon receipt. This
   state is local to each connection.
-  
+
   verbose on | off
   With get will return the current verbose state, with set, sets the
   verbose state. When in verbose mode is on, all set commands return
   positive acknowledgement in the form SET <COMMAND> ACK. In addition,
   text error messages will be issued when in verbose mode. This state
   is local to each connection.
-  
+
   enable <pwd> | off
   With get will return On or Off to indicate whether the current connection
   is enabled to perform control functions. With set and a valid password,
   the current connection is enabled for control functions. "OFF" may not
   be used as a password and disables control functions for this connection.
-  
+
   config [TBD]
-  
+
   comm_mode ascii | binary
   With get, will return the current communications mode. With set, will
-  set the communications mode to the specified mode. The binary protocol 
+  set the communications mode to the specified mode. The binary protocol
   is TBD.
-  
+
   comm_prot <version no>
   With get, returns the current protocol version used by the server,
   with set, sets the server to use the specified protocol version,
@@ -242,7 +242,7 @@
   load_tool_table <file>
   Loads the tool table specified by <file>
 
-  home 0 | 1 | 2 | ... 
+  home 0 | 1 | 2 | ...
   Homes the indicated joint.
 
   jog_stop joint_number|axis_letter
@@ -341,10 +341,10 @@
   1.000 is "mm", 0.1 is "cm", otherwise it's "custom".
   For angular joints, something close to 1.000 is deemed "deg",
   PI/180 is "rad", 100/90 is "grad", otherwise it's "custom".
- 
+
   program_units
   program_linear_units
-  Returns "inch", "mm", "cm", or "none", for the corresponding linear 
+  Returns "inch", "mm", "cm", or "none", for the corresponding linear
   units that are active in the program interpreter.
 
   program_angular_units
@@ -367,7 +367,7 @@
   display_linear_units
   display_angular_units
   Returns "inch", "mm", "cm", or "deg", "rad", "grad", or "custom",
-  for the linear or angular units that are active in the display. 
+  for the linear or angular units that are active in the display.
   This is effectively the value of linearUnitConversion or
   angularUnitConversion, resp.
 
@@ -375,7 +375,7 @@
   With no args, returns the unit conversion active. With arg, sets the
   units to be displayed. If it's "auto", the units to be displayed match
   the program units.
- 
+
   angular_unit_conversion {deg | rad | grad | auto}
   With no args, returns the unit conversion active. With arg, sets the
   units to be displayed. If it's "auto", the units to be displayed match
@@ -401,7 +401,7 @@
   kinematics_type
   returns the type of kinematics functions used identity=1, serial=2,
   parallel=3, custom=4
-  
+
   override_limits on | off
   If parameter is on, disables end of travel hardware limits to allow
   jogging off of a limit. If parameters is off, then hardware limits
@@ -409,11 +409,11 @@
 
   optional_stop  none | 0 | 1
   returns state of optional setop, sets it or deactivates it (used to stop/continue on M1)
-  
+
   <------------------------------------------------>
-  
+
   To Do:
-  
+
   1> Load / save connect and enable passwords to file.
   2> Implement commands to set / get passwords
   3> Get enable to tell peer connections which connection has control.
@@ -424,7 +424,7 @@
 
 typedef enum {
   cmdHello, cmdSet, cmdGet, cmdQuit, cmdShutdown, cmdHelp, cmdUnknown} commandTokenType;
-  
+
 typedef enum {
   scEcho, scVerbose, scEnable, scConfig, scCommMode, scCommProt, scIniFile,
   scPlat, scIni, scDebug, scSetWait, scWait, scSetTimeout, scUpdate, scError,
@@ -436,16 +436,16 @@ typedef enum {
   scPause, scResume, scStep, scAbort, scProgram, scProgramLine, scProgramStatus,
   scProgramCodes, scJointType, scJointUnits, scProgramUnits, scProgramLinearUnits,
   scProgramAngularUnits, scUserLinearUnits, scUserAngularUnits, scDisplayLinearUnits,
-  scDisplayAngularUnits, scLinearUnitConversion,  scAngularUnitConversion, scProbeClear, 
-  scProbeTripped, scProbeValue, scProbe, scTeleopEnable, scKinematicsType, scOverrideLimits, 
+  scDisplayAngularUnits, scLinearUnitConversion,  scAngularUnitConversion, scProbeClear,
+  scProbeTripped, scProbeValue, scProbe, scTeleopEnable, scKinematicsType, scOverrideLimits,
   scSpindleOverride, scOptionalStop, scUnknown
   } setCommandType;
-  
+
 typedef enum {
   rtNoError, rtHandledNoError, rtStandardError, rtCustomError, rtCustomHandledError
   } cmdResponseType;
-  
-typedef struct {  
+
+typedef struct {
   int cliSock;
   char hostName[80];
   char version[8];
@@ -483,10 +483,10 @@ const char *setCommands[] = {
   "REL_CMD_POS", "REL_ACT_POS", "JOINT_POS", "POS_OFFSET", "JOINT_LIMIT",
   "JOINT_FAULT", "JOINT_HOMED", "MDI", "TASK_PLAN_INIT", "OPEN", "RUN", "PAUSE",
   "RESUME", "STEP", "ABORT", "PROGRAM", "PROGRAM_LINE", "PROGRAM_STATUS", "PROGRAM_CODES",
-  "JOINT_TYPE", "JOINT_UNITS", "PROGRAM_UNITS", "PROGRAM_LINEAR_UNITS", "PROGRAM_ANGULAR_UNITS", 
-  "USER_LINEAR_UNITS", "USER_ANGULAR_UNITS", "DISPLAY_LINEAR_UNITS", "DISPLAY_ANGULAR_UNITS", 
-  "LINEAR_UNIT_CONVERSION", "ANGULAR_UNIT_CONVERSION", "PROBE_CLEAR", "PROBE_TRIPPED", 
-  "PROBE_VALUE", "PROBE", "TELEOP_ENABLE", "KINEMATICS_TYPE", "OVERRIDE_LIMITS", 
+  "JOINT_TYPE", "JOINT_UNITS", "PROGRAM_UNITS", "PROGRAM_LINEAR_UNITS", "PROGRAM_ANGULAR_UNITS",
+  "USER_LINEAR_UNITS", "USER_ANGULAR_UNITS", "DISPLAY_LINEAR_UNITS", "DISPLAY_ANGULAR_UNITS",
+  "LINEAR_UNIT_CONVERSION", "ANGULAR_UNIT_CONVERSION", "PROBE_CLEAR", "PROBE_TRIPPED",
+  "PROBE_VALUE", "PROBE", "TELEOP_ENABLE", "KINEMATICS_TYPE", "OVERRIDE_LIMITS",
   "SPINDLE_OVERRIDE", "OPTIONAL_STOP", ""};
 
 const char *commands[] = {"HELLO", "SET", "GET", "QUIT", "SHUTDOWN", "HELP", ""};
@@ -543,7 +543,7 @@ static int initSockets()
 {
   int optval = 1;
   int err;
-  
+
   server_sockfd = socket(AF_INET, SOCK_STREAM, 0);
   setsockopt(server_sockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
   server_address.sin_family = AF_INET;
@@ -561,7 +561,7 @@ static int initSockets()
       rcs_print_error("error listening on socket: %s\n", strerror(errno));
       return err;
   }
-  
+
   // ignore SIGCHLD
   {
     struct sigaction act;
@@ -589,7 +589,7 @@ static setCommandType lookupSetCommand(char *s)
 {
   setCommandType i = scEcho;
   int temp;
-  
+
   while (i < scUnknown) {
     if (strcmp(setCommands[i], s) == 0) return i;
 //    (int)i += 1;
@@ -610,11 +610,11 @@ static int commandHello(connectionRecType *context)
 
   pch = strtok(NULL, delims);
   if (pch == NULL || strlen(pch) >= sizeof(context->hostName)) return -1;
-  strncpy(context->hostName, pch, sizeof(context->hostName));
+  rtapi_strlcpy(context->hostName, pch, sizeof(context->hostName));
 
   pch = strtok(NULL, delims);
   if (pch == NULL|| strlen(pch) >= sizeof(context->version)) return -1;
-  strncpy(context->version, pch, sizeof(context->version));
+  rtapi_strlcpy(context->version, pch, sizeof(context->version));
 
   context->linked = true;
   printf("Connected to %s\n", context->hostName);
@@ -625,7 +625,7 @@ static int checkOnOff(char *s)
 {
   static const char *onStr = "ON";
   static const char *offStr = "OFF";
-  
+
   if (s == NULL) return -1;
   strupr(s);
   if (strcmp(s, onStr) == 0) return 0;
@@ -637,7 +637,7 @@ static int checkBinaryASCII(char *s)
 {
   static const char *binaryStr = "BINARY";
   static const char *ASCIIStr = "ASCII";
-  
+
   if (s == NULL) return -1;
   strupr(s);
   if (strcmp(s, ASCIIStr) == 0) return 0;
@@ -650,7 +650,7 @@ static int checkReceivedDoneNone(char *s)
   static const char *receivedStr = "RECEIVED";
   static const char *doneStr = "DONE";
   static const char *noneStr = "NONE";
-  
+
   if (s == NULL) return -1;
   strupr(s);
   if (strcmp(s, receivedStr) == 0) return 0;
@@ -663,7 +663,7 @@ static int checkNoneAuto(char *s)
 {
   static const char *noneStr = "NONE";
   static const char *autoStr = "AUTO";
-  
+
   if (s == NULL) return -1;
   strupr(s);
   if (strcmp(s, noneStr) == 0) return 0;
@@ -676,7 +676,7 @@ static int checkManualAutoMDI(char *s)
   static const char *manualStr = "MANUAL";
   static const char *autoStr = "AUTO";
   static const char *mDIStr = "MDI";
-  
+
   if (s == NULL) return -1;
   strupr(s);
   if (strcmp(s, manualStr) == 0) return 0;
@@ -693,7 +693,7 @@ static int checkSpindleStr(char *s)
   static const char *decreaseStr = "DECREASE";
   static const char *constantStr = "CONSTANT";
   static const char *offStr = "OFF";
-  
+
   if (s == NULL) return -1;
   strupr(s);
   if (strcmp(s, forwardStr) == 0) return 0;
@@ -712,7 +712,7 @@ static int checkConversionStr(char *s)
   static const char *cmStr = "CM";
   static const char *autoStr = "AUTO";
   static const char *customStr = "CUSTOM";
-  
+
   if (s == NULL) return -1;
   strupr(s);
   if (strcmp(s, inchStr) == 0) return 0;
@@ -730,7 +730,7 @@ static int checkAngularConversionStr(char *s)
   static const char *gradStr = "GRAD";
   static const char *autoStr = "AUTO";
   static const char *customStr = "CUSTOM";
-  
+
   if (s == NULL) return -1;
   strupr(s);
   if (strcmp(s, degStr) == 0) return 0;
@@ -743,7 +743,6 @@ static int checkAngularConversionStr(char *s)
 
 static cmdResponseType setEcho(char *s, connectionRecType *context)
 {
-   
    switch (checkOnOff(s)) {
      case -1: return rtStandardError;
      case 0: context->echo = true; break;
@@ -754,7 +753,6 @@ static cmdResponseType setEcho(char *s, connectionRecType *context)
 
 static cmdResponseType setVerbose(char *s, connectionRecType *context)
 {
-   
    switch (checkOnOff(s)) {
      case -1: return rtStandardError;
      case 0: context->verbose = true; break;
@@ -765,13 +763,13 @@ static cmdResponseType setVerbose(char *s, connectionRecType *context)
 
 static cmdResponseType setEnable(char *s, connectionRecType *context)
 {
-  
+
    if (s && (strcmp(s, enablePWD) == 0) ) {
      enabledConn = context->cliSock;
      context->enabled = true;
      return rtNoError;
      }
-   else 
+   else
      if (checkOnOff(s) == 1) {
        context->enabled = false;
        enabledConn = -1;
@@ -788,7 +786,7 @@ static cmdResponseType setConfig(char *s, connectionRecType *context)
 static cmdResponseType setCommMode(char *s, connectionRecType *context)
 {
   int ret;
-  
+
   ret = checkBinaryASCII(s);
   if (ret == -1) return rtStandardError;
   context->commMode = ret;
@@ -798,7 +796,7 @@ static cmdResponseType setCommMode(char *s, connectionRecType *context)
 static cmdResponseType setCommProt(char *s, connectionRecType *context)
 {
   char *pVersion;
-  
+
   pVersion = strtok(NULL, delims);
   if (pVersion == NULL) return rtStandardError;
   rtapi_strxcpy(context->version, pVersion);
@@ -809,7 +807,7 @@ static cmdResponseType setDebug(char *s, connectionRecType *context)
 {
   char *pLevel;
   int level;
-  
+
   pLevel = strtok(NULL, delims);
   if (pLevel == NULL) return rtStandardError;
   if (sscanf(pLevel, "%i", &level) == -1) return rtStandardError;
@@ -862,10 +860,10 @@ static cmdResponseType setWait(char *s, connectionRecType *context)
 {
   switch (checkReceivedDoneNone(s)) {
     case -1: return rtStandardError;
-    case 0: 
+    case 0:
       if (emcCommandWaitReceived() != 0) return rtStandardError;
       break;
-    case 1: 
+    case 1:
       if (emcCommandWaitDone() != 0) return rtStandardError;
       break;
     case 2: ;
@@ -877,7 +875,7 @@ static cmdResponseType setWait(char *s, connectionRecType *context)
 static cmdResponseType setTimeout(char *s, connectionRecType *context)
 {
   float Timeout;
-  
+
   if (s == NULL) return rtStandardError;
   if (sscanf(s, "%f", &Timeout) < 1) return rtStandardError;
   emcTimeout = Timeout;
@@ -986,7 +984,7 @@ static cmdResponseType setToolOffset(char *s, connectionRecType *context)
   int tool;
   float length, diameter;
   char *pch;
-  
+
   pch = strtok(NULL, delims);
   if (pch == NULL) return rtStandardError;
   if (sscanf(pch, "%d", &tool) <= 0) return rtStandardError;
@@ -996,7 +994,7 @@ static cmdResponseType setToolOffset(char *s, connectionRecType *context)
   pch = strtok(NULL, delims);
   if (pch == NULL) return rtStandardError;
   if (sscanf(pch, "%f", &diameter) <= 0) return rtStandardError;
-  
+
   if (sendToolSetOffset(tool, length, diameter) != 0) return rtStandardError;
   return rtNoError;
 }
@@ -1014,7 +1012,7 @@ static cmdResponseType setOverrideLimits(char *s, connectionRecType *context)
 static cmdResponseType setMDI(char *s, connectionRecType *context)
 {
   char *pch;
-  
+
   pch = strtok(NULL, "\n\r\0");
   if (sendMdiCmd(pch) !=0) return rtStandardError;
   return rtNoError;
@@ -1023,7 +1021,7 @@ static cmdResponseType setMDI(char *s, connectionRecType *context)
 static cmdResponseType setHome(char *s, connectionRecType *context)
 {
   int joint;
-  
+
   if (s == NULL) return rtStandardError;
   if (sscanf(s, "%d", &joint) <= 0) return rtStandardError;
   // joint == -1 means "Home All", any other negative is wrong
@@ -1052,7 +1050,7 @@ static cmdResponseType setJogStop(char *pch, connectionRecType *context)
   int ja,jnum,jjogmode;
   char aletter;
   //parms:  jnum|aletter
-  
+
   pch = strtok(NULL, delims);
   if (pch == NULL) return rtStandardError;
 
@@ -1097,7 +1095,7 @@ static cmdResponseType setJog(char *s, connectionRecType *context)
 
   pch = strtok(NULL, delims);
   if (pch == NULL) return rtStandardError;
-  if (sscanf(pch, "%f", &speed) <= 0) return rtStandardError; 
+  if (sscanf(pch, "%f", &speed) <= 0) return rtStandardError;
 
   if (sendJogCont(ja, jjogmode, speed) != 0) return rtStandardError;
   return rtNoError;
@@ -1106,7 +1104,7 @@ static cmdResponseType setJog(char *s, connectionRecType *context)
 static cmdResponseType setFeedOverride(char *s, connectionRecType *context)
 {
   int percent;
-  
+
   if (s == NULL) return rtStandardError;
   if (sscanf(s, "%d", &percent) <= 0) return rtStandardError;
   sendFeedOverride(((double) percent) / 100.0);
@@ -1120,7 +1118,7 @@ static cmdResponseType setJogIncr(char *s, connectionRecType *context)
   float speed, incr;
   char *pch;
   //parms:  jnum|aletter speed distance
-  
+
   pch = strtok(NULL, delims);
   if (pch == NULL) return rtStandardError;
 
@@ -1141,11 +1139,11 @@ static cmdResponseType setJogIncr(char *s, connectionRecType *context)
   pch = strtok(NULL, delims);
   if (pch == NULL) return rtStandardError;
 
-  if (sscanf(pch, "%f", &speed) <= 0) return rtStandardError; 
+  if (sscanf(pch, "%f", &speed) <= 0) return rtStandardError;
   pch = strtok(NULL, delims);
 
   if (pch == NULL) return rtStandardError;
-  if (sscanf(pch, "%f", &incr) <= 0) return rtStandardError; 
+  if (sscanf(pch, "%f", &incr) <= 0) return rtStandardError;
 
   if (sendJogIncr(ja, jjogmode, speed, incr) != 0) return rtStandardError;
   return rtNoError;
@@ -1177,7 +1175,7 @@ static cmdResponseType setOpen(char *s, connectionRecType *context)
 static cmdResponseType setRun(char *s, connectionRecType *context)
 {
   int lineNo;
-  
+
   if (s == NULL) // run from beginning
     if (sendProgramRun(0) != 0) return rtStandardError;
     else ;
@@ -1253,7 +1251,7 @@ static cmdResponseType setProbe(char *s, connectionRecType *context)
 {
   float x, y, z;
   char *pch;
-  
+
   pch = strtok(NULL, delims);
   if (pch == NULL) return rtStandardError;
 fprintf(stderr,"0_probe pch=%s\n",pch);
@@ -1268,7 +1266,7 @@ fprintf(stderr,"1_probe pch=%s\n",pch);
 fprintf(stderr,"2_probe pch=%s\n",pch);
   if (pch == NULL) return rtStandardError;
   if (sscanf(pch, "%f", &z) <= 0) return rtStandardError;
-  
+
   sendProbe(x, y, z);
   return rtNoError;
 }
@@ -1314,7 +1312,7 @@ int commandSet(connectionRecType *context)
   setCommandType cmd;
   char *pch;
   cmdResponseType ret = rtNoError;
-  
+
   pch = strtok(NULL, delims);
   if (pch == NULL) {
     return write(context->cliSock, setNakStr, strlen(setNakStr));
@@ -1385,14 +1383,14 @@ int commandSet(connectionRecType *context)
     case scPause: ret = setPause(pch, context); break;
     case scResume: ret = setResume(pch, context); break;
     case scAbort: ret = setAbort(pch, context); break;
-    case scStep: ret = setStep(pch, context); break;    
+    case scStep: ret = setStep(pch, context); break;
     case scProgram:ret = rtStandardError; break;
     case scProgramLine: ret = rtStandardError; break;
     case scProgramStatus: ret = rtStandardError; break;
     case scProgramCodes: ret = rtStandardError; break;
     case scJointType: ret = rtStandardError; break;
     case scJointUnits: ret = rtStandardError; break;
-    case scProgramUnits: 
+    case scProgramUnits:
     case scProgramLinearUnits: ret = rtStandardError; break;
     case scProgramAngularUnits: ret = rtStandardError; break;
     case scUserLinearUnits: ret = rtStandardError; break;
@@ -1413,14 +1411,14 @@ int commandSet(connectionRecType *context)
     case scUnknown: ret = rtStandardError;
     }
   switch (ret) {
-    case rtNoError:  
+    case rtNoError:
       if (context->verbose) {
         snprintf(context->outBuf, sizeof(context->outBuf), ackStr, pch);
         return write(context->cliSock, context->outBuf, strlen(context->outBuf));
         }
       break;
     case rtHandledNoError: // Custom ok response already handled, take no action
-      break; 
+      break;
     case rtStandardError:
       snprintf(context->outBuf, sizeof(context->outBuf), setCmdNakStr, pch);
       return write(context->cliSock, context->outBuf, strlen(context->outBuf));
@@ -1436,7 +1434,7 @@ int commandSet(connectionRecType *context)
 static cmdResponseType getEcho(char *s, connectionRecType *context)
 {
   static const char *pEchoStr = "ECHO %s";
-  
+
   if (context->echo) snprintf(context->outBuf, sizeof(context->outBuf), pEchoStr, "ON");
   else snprintf(context->outBuf, sizeof(context->outBuf), pEchoStr, "OFF");
   return rtNoError;
@@ -1445,7 +1443,7 @@ static cmdResponseType getEcho(char *s, connectionRecType *context)
 static cmdResponseType getVerbose(char *s, connectionRecType *context)
 {
   const char *pVerboseStr = "VERBOSE %s";
-  
+
   if (context->verbose) snprintf(context->outBuf, sizeof(context->outBuf), pVerboseStr, "ON");
   else snprintf(context->outBuf, sizeof(context->outBuf), pVerboseStr, "OFF");
   return rtNoError;
@@ -1454,8 +1452,8 @@ static cmdResponseType getVerbose(char *s, connectionRecType *context)
 static cmdResponseType getEnable(char *s, connectionRecType *context)
 {
   const char *pEnableStr = "ENABLE %s";
-  
-  if (context->cliSock == enabledConn) 
+
+  if (context->cliSock == enabledConn)
 //  if (context->enabled == true)
     snprintf(context->outBuf, sizeof(context->outBuf), pEnableStr, "ON");
   else snprintf(context->outBuf, sizeof(context->outBuf), pEnableStr, "OFF");
@@ -1473,7 +1471,7 @@ static cmdResponseType getConfig(char *s, connectionRecType *context)
 static cmdResponseType getCommMode(char *s, connectionRecType *context)
 {
   const char *pCommModeStr = "COMM_MODE %s";
-  
+
   switch (context->commMode) {
     case 0: snprintf(context->outBuf, sizeof(context->outBuf), pCommModeStr, "ASCII"); break;
     case 1: snprintf(context->outBuf, sizeof(context->outBuf), pCommModeStr, "BINARY"); break;
@@ -1484,7 +1482,7 @@ static cmdResponseType getCommMode(char *s, connectionRecType *context)
 static cmdResponseType getCommProt(char *s, connectionRecType *context)
 {
   const char *pCommProtStr = "COMM_PROT %s";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), pCommProtStr, context->version);
   return rtNoError;
 }
@@ -1492,7 +1490,7 @@ static cmdResponseType getCommProt(char *s, connectionRecType *context)
 static cmdResponseType getDebug(char *s, connectionRecType *context)
 {
   const char *pUpdateStr = "DEBUG %d";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), pUpdateStr, emcStatus->debug);
   return rtNoError;
 }
@@ -1500,7 +1498,7 @@ static cmdResponseType getDebug(char *s, connectionRecType *context)
 static cmdResponseType getSetWait(char *s, connectionRecType *context)
 {
   const char *pSetWaitStr = "SET_WAIT %s";
-  
+
   switch (emcWaitType) {
     case EMC_WAIT_RECEIVED: snprintf(context->outBuf, sizeof(context->outBuf), pSetWaitStr, "RECEIVED"); break;
     case EMC_WAIT_DONE: snprintf(context->outBuf, sizeof(context->outBuf), pSetWaitStr, "DONE"); break;
@@ -1512,15 +1510,15 @@ static cmdResponseType getSetWait(char *s, connectionRecType *context)
 static cmdResponseType getPlat(char *s, connectionRecType *context)
 {
   const char *pPlatStr = "PLAT %s";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), pPlatStr, "Linux");
-  return rtNoError;  
+  return rtNoError;
 }
 
 static cmdResponseType getEStop(char *s, connectionRecType *context)
 {
   const char *pEStopStr = "ESTOP %s";
-  
+
   if (emcStatus->task.state == EMC_TASK_STATE_ESTOP)
     snprintf(context->outBuf, sizeof(context->outBuf), pEStopStr, "ON");
   else snprintf(context->outBuf, sizeof(context->outBuf), pEStopStr, "OFF");
@@ -1530,7 +1528,7 @@ static cmdResponseType getEStop(char *s, connectionRecType *context)
 static cmdResponseType getTimeout(char *s, connectionRecType *context)
 {
   const char *pTimeoutStr = "SET_TIMEOUT %f";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), pTimeoutStr, emcTimeout);
   return rtNoError;
 }
@@ -1538,7 +1536,7 @@ static cmdResponseType getTimeout(char *s, connectionRecType *context)
 static cmdResponseType getTime(char *s, connectionRecType *context)
 {
   const char *pTimeStr = "TIME %f";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), pTimeStr, etime());
   return rtNoError;
 }
@@ -1546,7 +1544,7 @@ static cmdResponseType getTime(char *s, connectionRecType *context)
 static cmdResponseType getError(char *s, connectionRecType *context)
 {
   const char *pErrorStr = "ERROR %s";
-  
+
   if (updateError() != 0)
     snprintf(context->outBuf, sizeof(context->outBuf), pErrorStr, "emc_error: bad status from LinuxCNC");
   else
@@ -1562,7 +1560,7 @@ static cmdResponseType getError(char *s, connectionRecType *context)
 static cmdResponseType getOperatorDisplay(char *s, connectionRecType *context)
 {
   const char *pOperatorDisplayStr = "OPERATOR_DISPLAY %s";
-  
+
   if (updateError() != 0)
     snprintf(context->outBuf, sizeof(context->outBuf), pOperatorDisplayStr, "emc_operator_display: bad status from LinuxCNC");
   else
@@ -1572,13 +1570,13 @@ static cmdResponseType getOperatorDisplay(char *s, connectionRecType *context)
       snprintf(context->outBuf, sizeof(context->outBuf), pOperatorDisplayStr, operator_display_string);
       operator_display_string[0] = 0;
       }
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getOperatorText(char *s, connectionRecType *context)
 {
   const char *pOperatorTextStr = "OPERATOR_TEXT %s";
-  
+
   if (updateError() != 0)
     snprintf(context->outBuf, sizeof(context->outBuf), pOperatorTextStr, "emc_operator_text: bad status from LinuxCNC");
   else
@@ -1588,70 +1586,70 @@ static cmdResponseType getOperatorText(char *s, connectionRecType *context)
       snprintf(context->outBuf, sizeof(context->outBuf), pOperatorTextStr, operator_text_string);
       operator_text_string[0] = 0;
       }
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getMachine(char *s, connectionRecType *context)
 {
   const char *pMachineStr = "MACHINE %s";
-  
+
   if (emcStatus->task.state == EMC_TASK_STATE_ON)
     snprintf(context->outBuf, sizeof(context->outBuf), pMachineStr, "ON");
   else snprintf(context->outBuf, sizeof(context->outBuf), pMachineStr, "OFF");
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getMode(char *s, connectionRecType *context)
 {
   const char *pModeStr = "MODE %s";
-  
+
   switch (emcStatus->task.mode) {
     case EMC_TASK_MODE_MANUAL: snprintf(context->outBuf, sizeof(context->outBuf), pModeStr, "MANUAL"); break;
     case EMC_TASK_MODE_AUTO: snprintf(context->outBuf, sizeof(context->outBuf), pModeStr, "AUTO"); break;
     case EMC_TASK_MODE_MDI: snprintf(context->outBuf, sizeof(context->outBuf), pModeStr, "MDI"); break;
     default: snprintf(context->outBuf, sizeof(context->outBuf), pModeStr, "?");
     }
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getMist(char *s, connectionRecType *context)
 {
   const char *pMistStr = "MIST %s";
-  
+
   if (emcStatus->io.coolant.mist == 1)
     snprintf(context->outBuf, sizeof(context->outBuf), pMistStr, "ON");
   else snprintf(context->outBuf, sizeof(context->outBuf), pMistStr, "OFF");
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getFlood(char *s, connectionRecType *context)
 {
   const char *pFloodStr = "FLOOD %s";
-  
+
   if (emcStatus->io.coolant.flood == 1)
     snprintf(context->outBuf, sizeof(context->outBuf), pFloodStr, "ON");
   else snprintf(context->outBuf, sizeof(context->outBuf), pFloodStr, "OFF");
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getLube(char *s, connectionRecType *context)
 {
   const char *pLubeStr = "LUBE %s";
-  
+
   if (emcStatus->io.lube.on == 0)
     snprintf(context->outBuf, sizeof(context->outBuf), pLubeStr, "OFF");
   else snprintf(context->outBuf, sizeof(context->outBuf), pLubeStr, "ON");
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getLubeLevel(char *s, connectionRecType *context)
 {
   const char *pLubeLevelStr = "LUBE_LEVEL %s";
-  
+
   if (emcStatus->io.lube.level == 0)
     snprintf(context->outBuf, sizeof(context->outBuf), pLubeLevelStr, "LOW");
   else snprintf(context->outBuf, sizeof(context->outBuf), pLubeLevelStr, "OK");
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getSpindle(char *s, connectionRecType *context)
@@ -1677,7 +1675,7 @@ static cmdResponseType getSpindle(char *s, connectionRecType *context)
 			else snprintf(context->outBuf, sizeof(context->outBuf), pSpindleStr, n, "OFF");
 	  }
   }
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getBrake(char *s, connectionRecType *context)
@@ -1694,23 +1692,23 @@ static cmdResponseType getBrake(char *s, connectionRecType *context)
 		  else snprintf(context->outBuf, sizeof(context->outBuf),pBrakeStr, "OFF");
 	  }
   }
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getTool(char *s, connectionRecType *context)
 {
   const char *pToolStr = "TOOL %d";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), pToolStr, emcStatus->io.tool.toolInSpindle);
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getToolOffset(char *s, connectionRecType *context)
 {
   const char *pToolOffsetStr = "TOOL_OFFSET %f";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), pToolOffsetStr, emcStatus->task.toolOffset.tran.z);
-  return rtNoError; 
+  return rtNoError;
 }
 
 static cmdResponseType getAbsCmdPos(char *s, connectionRecType *context)
@@ -1718,7 +1716,7 @@ static cmdResponseType getAbsCmdPos(char *s, connectionRecType *context)
   const char *pAbsCmdPosStr = "ABS_CMD_POS";
   char buf[16];
   int axis;
-  
+
   if (s == NULL) axis = -1; // Return all axes
   else axis = atoi(s);
   rtapi_strxcpy(context->outBuf, pAbsCmdPosStr);
@@ -1758,7 +1756,7 @@ static cmdResponseType getAbsActPos(char *s, connectionRecType *context)
   const char *pAbsActPosStr = "ABS_ACT_POS";
   char buf[16];
   int axis;
-  
+
   if (s == NULL) axis = -1; // Return all axes
   else axis = atoi(s);
   rtapi_strxcpy(context->outBuf, pAbsActPosStr);
@@ -1798,7 +1796,7 @@ static cmdResponseType getRelCmdPos(char *s, connectionRecType *context)
   const char *pRelCmdPosStr = "REL_CMD_POS";
   char buf[16];
   int axis;
-  
+
   if (s == NULL) axis = -1; // Return all axes
   else axis = atoi(s);
   rtapi_strxcpy(context->outBuf, pRelCmdPosStr);
@@ -1838,7 +1836,7 @@ static cmdResponseType getRelActPos(char *s, connectionRecType *context)
   const char *pRelActPosStr = "REL_ACT_POS";
   char buf[16];
   int axis;
-  
+
   if (s == NULL) axis = -1; // Return all axes
   else axis = atoi(s);
   rtapi_strxcpy(context->outBuf, pRelActPosStr);
@@ -1878,7 +1876,7 @@ static cmdResponseType getJointPos(char *s, connectionRecType *context)
   const char *pJointPos = "JOINT_POS";
   int joint, i;
   char buf[16];
-  
+
   if (s == NULL) joint = -1; // Return all axes
   else joint = atoi(s);
   if (joint == -1) {
@@ -1890,7 +1888,7 @@ static cmdResponseType getJointPos(char *s, connectionRecType *context)
     }
   else
     snprintf(context->outBuf, sizeof(context->outBuf), "%s %d %f", pJointPos, joint, emcStatus->motion.joint[joint].input);
-  
+
   return rtNoError;
 }
 
@@ -1898,7 +1896,7 @@ static cmdResponseType getPosOffset(char *s, connectionRecType *context)
 {
   const char *pPosOffset = "POS_OFFSET";
   char buf[16];
-  
+
   if (s == NULL) {
     rtapi_strxcpy(context->outBuf, pPosOffset);
     snprintf(buf, sizeof(buf), " %f", convertLinearUnits(emcStatus->task.g5x_offset.tran.x + emcStatus->task.g92_offset.tran.x));
@@ -1920,11 +1918,11 @@ static cmdResponseType getPosOffset(char *s, connectionRecType *context)
         case 'X': snprintf(buf, sizeof(buf), " %f", convertLinearUnits(emcStatus->task.g5x_offset.tran.x + emcStatus->task.g92_offset.tran.x)); break;
         case 'Y': snprintf(buf, sizeof(buf), " %f", convertLinearUnits(emcStatus->task.g5x_offset.tran.y + emcStatus->task.g92_offset.tran.y)); break;
         case 'Z': snprintf(buf, sizeof(buf), " %f", convertLinearUnits(emcStatus->task.g5x_offset.tran.z + emcStatus->task.g92_offset.tran.z)); break;
-        case 'A': 
+        case 'A':
         case 'R': snprintf(buf, sizeof(buf), " %f", convertLinearUnits(emcStatus->task.g5x_offset.a + emcStatus->task.g92_offset.a)); break;
-        case 'B': 
+        case 'B':
         case 'P': snprintf(buf, sizeof(buf), " %f", convertLinearUnits(emcStatus->task.g5x_offset.b + emcStatus->task.g92_offset.b)); break;
-        case 'C': 
+        case 'C':
         case 'W': snprintf(buf, sizeof(buf), " %f", convertLinearUnits(emcStatus->task.g5x_offset.c + emcStatus->task.g92_offset.c));
       }
       snprintf(context->outBuf, sizeof(context->outBuf), "%s %c %s", pPosOffset, s[0], buf);
@@ -1937,7 +1935,7 @@ static cmdResponseType getJointLimit(char *s, connectionRecType *context)
   const char *pJointLimit = "JOINT_LIMIT";
   char buf[16];
   int joint, i;
-  
+
   if (s == NULL) {
     rtapi_strxcpy(context->outBuf, pJointLimit);
     for (i=0; i<6; i++) {
@@ -1981,7 +1979,7 @@ static cmdResponseType getJointFault(char *s, connectionRecType *context)
   const char *pJointFault = "JOINT_FAULT";
   char buf[16];
   int joint, i;
-  
+
   if (s == NULL) {
     rtapi_strxcpy(context->outBuf, pJointFault);
     for (i=0; i<6; i++) {
@@ -2003,7 +2001,7 @@ static cmdResponseType getJointFault(char *s, connectionRecType *context)
 static cmdResponseType getOverrideLimits(char *s, connectionRecType *context)
 {
   const char *pOverrideLimits = "OVERRIDE_LIMITS %d";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), pOverrideLimits, emcStatus->motion.joint[0].overrideLimits);
   return rtNoError;
 }
@@ -2013,7 +2011,7 @@ static cmdResponseType getJointHomed(char *s, connectionRecType *context)
   const char *pJointHomed = "JOINT_HOMED";
   char buf[16];
   int joint, i;
-  
+
   if (s == NULL) {
     rtapi_strxcpy(context->outBuf, pJointHomed);
     for (i=0; i<6; i++) {
@@ -2047,12 +2045,12 @@ static cmdResponseType getProgramLine(char *s, connectionRecType *context)
 {
   const char *pProgramLine = "PROGRAM_LINE %d";
   int lineNo;
-  
+
   if ((programStartLine< 0) || (emcStatus->task.readLine < programStartLine))
     lineNo = emcStatus->task.readLine;
   else
     if (emcStatus->task.currentLine > 0)
-      if ((emcStatus->task.motionLine > 0) && 
+      if ((emcStatus->task.motionLine > 0) &&
         (emcStatus->task.motionLine < emcStatus->task.currentLine))
 	  lineNo = emcStatus->task.motionLine;
       else lineNo = emcStatus->task.currentLine;
@@ -2064,7 +2062,7 @@ static cmdResponseType getProgramLine(char *s, connectionRecType *context)
 static cmdResponseType getProgramStatus(char *s, connectionRecType *context)
 {
   const char *pProgramStatus = "PROGRAM_STATUS %s";
-  
+
   switch (emcStatus->task.interpState) {
       case EMC_TASK_INTERP_READING:
       case EMC_TASK_INTERP_WAITING: snprintf(context->outBuf, sizeof(context->outBuf), pProgramStatus, "RUNNING"); break;
@@ -2079,7 +2077,7 @@ static cmdResponseType getProgramCodes(char *s, connectionRecType *context)
   const char *pProgramCodes = "PROGRAM_CODES ";
   char buf[256];
   int code, i;
-  
+
   buf[0] = 0;
   rtapi_strxcpy(context->outBuf, pProgramCodes);
   for (i=1; i<ACTIVE_G_CODES; i++) {
@@ -2101,7 +2099,7 @@ static cmdResponseType getJointType(char *s, connectionRecType *context)
   const char *pJointType = "JOINT_TYPE";
   char buf[16];
   int joint, i;
-  
+
   if (s == NULL) {
     rtapi_strxcpy(context->outBuf, pJointType);
     for (i=0; i<6; i++) {
@@ -2129,15 +2127,15 @@ static cmdResponseType getJointUnits(char *s, connectionRecType *context)
   const char *pJointUnits = "JOINT_UNITS";
   char buf[16];
   int joint, i;
-  
+
   if (s == NULL) {
     rtapi_strxcpy(context->outBuf, pJointUnits);
     for (i=0; i<6; i++) {
       switch (emcStatus->motion.joint[i].jointType) {
-        case EMC_LINEAR: 
+        case EMC_LINEAR:
 	  if (CLOSE(emcStatus->motion.joint[i].units, 1.0, LINEAR_CLOSENESS))
 	    rtapi_strxcat(context->outBuf, " MM");
-	  else 
+	  else
 	    if (CLOSE(emcStatus->motion.joint[i].units, INCH_PER_MM,
 	      LINEAR_CLOSENESS)) rtapi_strxcat(context->outBuf, " INCH");
 	    else
@@ -2163,10 +2161,10 @@ static cmdResponseType getJointUnits(char *s, connectionRecType *context)
   else {
       joint = atoi(s);
       switch (emcStatus->motion.joint[joint].jointType) {
-        case EMC_LINEAR: 
+        case EMC_LINEAR:
 	  if (CLOSE(emcStatus->motion.joint[joint].units, 1.0, LINEAR_CLOSENESS))
 	    rtapi_strxcpy(buf, "MM");
-	  else 
+	  else
 	    if (CLOSE(emcStatus->motion.joint[joint].units, INCH_PER_MM,
 	      LINEAR_CLOSENESS)) rtapi_strxcpy(buf, "INCH");
 	    else
@@ -2195,7 +2193,7 @@ static cmdResponseType getJointUnits(char *s, connectionRecType *context)
 static cmdResponseType getProgramLinearUnits(char *s, connectionRecType *context)
 {
   const char *programUnits = "PROGRAM_UNITS %s";
-  
+
   switch (emcStatus->task.programUnits) {
     case CANON_UNITS_INCHES: snprintf(context->outBuf, sizeof(context->outBuf), programUnits, "INCH"); break;
     case CANON_UNITS_MM: snprintf(context->outBuf, sizeof(context->outBuf), programUnits, "MM"); break;
@@ -2208,7 +2206,7 @@ static cmdResponseType getProgramLinearUnits(char *s, connectionRecType *context
 static cmdResponseType getProgramAngularUnits(char *s, connectionRecType *context)
 {
   const char *programAngularUnits = "PROGRAM_ANGULAR_UNITS %s";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), programAngularUnits, "DEG");
   return rtNoError;
 }
@@ -2216,7 +2214,7 @@ static cmdResponseType getProgramAngularUnits(char *s, connectionRecType *contex
 static cmdResponseType getUserLinearUnits(char *s, connectionRecType *context)
 {
   const char *userLinearUnits = "USER_LINEAR_UNITS %s";
-  
+
   if (CLOSE(emcStatus->motion.traj.linearUnits, 1.0, LINEAR_CLOSENESS))
     snprintf(context->outBuf, sizeof(context->outBuf), userLinearUnits, "MM");
   else
@@ -2233,7 +2231,7 @@ static cmdResponseType getUserLinearUnits(char *s, connectionRecType *context)
 static cmdResponseType getUserAngularUnits(char *s, connectionRecType *context)
 {
   const char *pUserAngularUnits = "USER_ANGULAR_UNITS %s";
-  
+
   if (CLOSE(emcStatus->motion.traj.angularUnits, 1.0, ANGULAR_CLOSENESS))
     snprintf(context->outBuf, sizeof(context->outBuf), pUserAngularUnits, "DEG");
   else
@@ -2250,12 +2248,12 @@ static cmdResponseType getUserAngularUnits(char *s, connectionRecType *context)
 static cmdResponseType getDisplayLinearUnits(char *s, connectionRecType *context)
 {
   const char *pDisplayLinearUnits = "DISPLAY_LINEAR_UNITS %s";
-  
+
   switch (linearUnitConversion) {
       case LINEAR_UNITS_INCH: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayLinearUnits, "INCH"); break;
       case LINEAR_UNITS_MM: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayLinearUnits, "MM"); break;
       case LINEAR_UNITS_CM: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayLinearUnits, "CM"); break;
-      case LINEAR_UNITS_AUTO: 
+      case LINEAR_UNITS_AUTO:
         switch (emcStatus->task.programUnits) {
 	    case CANON_UNITS_MM: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayLinearUnits, "MM"); break;
 	    case CANON_UNITS_INCHES: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayLinearUnits, "INCH"); break;
@@ -2271,12 +2269,12 @@ static cmdResponseType getDisplayLinearUnits(char *s, connectionRecType *context
 static cmdResponseType getDisplayAngularUnits(char *s, connectionRecType *context)
 {
   const char *pDisplayAngularUnits = "DISPLAY_ANGULAR_UNITS %s";
-  
+
   switch (angularUnitConversion) {
       case ANGULAR_UNITS_DEG: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayAngularUnits, "DEG"); break;
       case ANGULAR_UNITS_RAD: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayAngularUnits, "RAD"); break;
       case ANGULAR_UNITS_GRAD: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayAngularUnits, "GRAD"); break;
-      case ANGULAR_UNITS_AUTO: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayAngularUnits, "DEG"); break; 
+      case ANGULAR_UNITS_AUTO: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayAngularUnits, "DEG"); break;
       default: snprintf(context->outBuf, sizeof(context->outBuf), pDisplayAngularUnits, "CUSTOM");
     }
   return rtNoError;
@@ -2285,13 +2283,13 @@ static cmdResponseType getDisplayAngularUnits(char *s, connectionRecType *contex
 static cmdResponseType getLinearUnitConversion(char *s, connectionRecType *context)
 {
   const char *pLinearUnitConversion = "LINEAR_UNIT_CONVERSION %s";
-  
+
   switch (linearUnitConversion) {
       case LINEAR_UNITS_INCH: snprintf(context->outBuf, sizeof(context->outBuf), pLinearUnitConversion, "INCH"); break;
       case LINEAR_UNITS_MM: snprintf(context->outBuf, sizeof(context->outBuf), pLinearUnitConversion, "MM"); break;
       case LINEAR_UNITS_CM: snprintf(context->outBuf, sizeof(context->outBuf), pLinearUnitConversion, "CM"); break;
       case LINEAR_UNITS_AUTO: snprintf(context->outBuf, sizeof(context->outBuf), pLinearUnitConversion, "AUTO"); break;
-      default: snprintf(context->outBuf, sizeof(context->outBuf), pLinearUnitConversion, "CUSTOM"); 
+      default: snprintf(context->outBuf, sizeof(context->outBuf), pLinearUnitConversion, "CUSTOM");
     }
   return rtNoError;
 }
@@ -2299,7 +2297,7 @@ static cmdResponseType getLinearUnitConversion(char *s, connectionRecType *conte
 static cmdResponseType getAngularUnitConversion(char *s, connectionRecType *context)
 {
   const char *pAngularUnitConversion = "ANGULAR_UNIT_CONVERSION %s";
-  
+
   switch (angularUnitConversion) {
       case ANGULAR_UNITS_DEG: snprintf(context->outBuf, sizeof(context->outBuf), pAngularUnitConversion, "DEG"); break;
       case ANGULAR_UNITS_RAD: snprintf(context->outBuf, sizeof(context->outBuf), pAngularUnitConversion, "RAD"); break;
@@ -2313,25 +2311,25 @@ static cmdResponseType getAngularUnitConversion(char *s, connectionRecType *cont
 static cmdResponseType getProbeValue(char *s, connectionRecType *context)
 {
   const char *pProbeValue = "PROBE_VALUE %d";
-  
-  snprintf(context->outBuf, sizeof(context->outBuf), pProbeValue, emcStatus->motion.traj.probeval);  
+
+  snprintf(context->outBuf, sizeof(context->outBuf), pProbeValue, emcStatus->motion.traj.probeval);
   return rtNoError;
 }
 
 static cmdResponseType getProbeTripped(char *s, connectionRecType *context)
 {
   const char *pProbeTripped = "PROBE_TRIPPED %d";
-  
-  snprintf(context->outBuf, sizeof(context->outBuf), pProbeTripped, emcStatus->motion.traj.probe_tripped);  
+
+  snprintf(context->outBuf, sizeof(context->outBuf), pProbeTripped, emcStatus->motion.traj.probe_tripped);
   return rtNoError;
 }
 
 static cmdResponseType getTeleopEnable(char *s, connectionRecType *context)
 {
   const char *pTeleopEnable = "TELEOP_ENABLE %s";
-  
+
   if (emcStatus->motion.traj.mode == EMC_TRAJ_MODE_TELEOP)
-    snprintf(context->outBuf, sizeof(context->outBuf), pTeleopEnable, "YES");  
+    snprintf(context->outBuf, sizeof(context->outBuf), pTeleopEnable, "YES");
    else snprintf(context->outBuf, sizeof(context->outBuf), pTeleopEnable, "NO");
   return rtNoError;
 }
@@ -2339,8 +2337,8 @@ static cmdResponseType getTeleopEnable(char *s, connectionRecType *context)
 static cmdResponseType getKinematicsType(char *s, connectionRecType *context)
 {
   const char *pKinematicsType = "KINEMATICS_TYPE %d";
-  
-  snprintf(context->outBuf, sizeof(context->outBuf), pKinematicsType, emcStatus->motion.traj.kinematics_type);  
+
+  snprintf(context->outBuf, sizeof(context->outBuf), pKinematicsType, emcStatus->motion.traj.kinematics_type);
   return rtNoError;
 }
 
@@ -2348,7 +2346,7 @@ static cmdResponseType getFeedOverride(char *s, connectionRecType *context)
 {
   const char *pFeedOverride = "FEED_OVERRIDE %d";
   int percent;
-  
+
   percent = (int)floor(emcStatus->motion.traj.scale * 100.0 + 0.5);
   snprintf(context->outBuf, sizeof(context->outBuf), pFeedOverride, percent);
   return rtNoError;
@@ -2357,7 +2355,7 @@ static cmdResponseType getFeedOverride(char *s, connectionRecType *context)
 static cmdResponseType getIniFile(char *s, connectionRecType *context)
 {
   const char *pIniFile = "INIFILE %s";
-  
+
   snprintf(context->outBuf, sizeof(context->outBuf), pIniFile, emc_inifile);
   return rtNoError;
 }
@@ -2394,7 +2392,7 @@ int commandGet(connectionRecType *context)
   setCommandType cmd;
   char *pch;
   cmdResponseType ret = rtNoError;
-  
+
   pch = strtok(NULL, delims);
   if (pch == NULL) {
     return write(context->cliSock, setNakStr, strlen(setNakStr));
@@ -2463,7 +2461,7 @@ int commandGet(connectionRecType *context)
     case scProgramCodes: ret = getProgramCodes(pch, context); break;
     case scJointType: ret = getJointType(strtok(NULL, delims), context); break;
     case scJointUnits: ret = getJointUnits(strtok(NULL, delims), context); break;
-    case scProgramUnits: 
+    case scProgramUnits:
     case scProgramLinearUnits: ret = getProgramLinearUnits(pch, context); break;
     case scProgramAngularUnits: ret = getProgramAngularUnits(pch, context); break;
     case scUserLinearUnits: ret = getUserLinearUnits(pch, context); break;
@@ -2488,9 +2486,9 @@ int commandGet(connectionRecType *context)
       sockWrite(context);
       break;
     case rtHandledNoError: // Custom ok response already handled, take no action
-      break; 
+      break;
     case rtStandardError: // Standard error response
-      snprintf(context->outBuf, sizeof(context->outBuf), setCmdNakStr, pch); 
+      snprintf(context->outBuf, sizeof(context->outBuf), setCmdNakStr, pch);
       sockWrite(context);
       break;
     case rtCustomError: // Custom error response entered in buffer
@@ -2561,7 +2559,7 @@ static int helpGet(connectionRecType *context)
   rtapi_strxcat(context->outBuf, "    Comm_mode\n\r");
   rtapi_strxcat(context->outBuf, "    Comm_prot\n\r");
   rtapi_strxcat(context->outBuf, "    Debug\n\r");
-  rtapi_strxcat(context->outBuf, "    Display_angular_units\n\r"); 
+  rtapi_strxcat(context->outBuf, "    Display_angular_units\n\r");
   rtapi_strxcat(context->outBuf, "    Display_linear_units\n\r");
   rtapi_strxcat(context->outBuf, "    Echo\n\r");
   rtapi_strxcat(context->outBuf, "    Enable\n\r");
@@ -2592,7 +2590,7 @@ static int helpGet(connectionRecType *context)
   rtapi_strxcat(context->outBuf, "    Probe_tripped\n\r");
   rtapi_strxcat(context->outBuf, "    Probe_value\n\r");
   rtapi_strxcat(context->outBuf, "    Program\n\r");
-  rtapi_strxcat(context->outBuf, "    Program_angular_units\n\r"); 
+  rtapi_strxcat(context->outBuf, "    Program_angular_units\n\r");
   rtapi_strxcat(context->outBuf, "    Program_codes\n\r");
   rtapi_strxcat(context->outBuf, "    Program_line\n\r");
   rtapi_strxcat(context->outBuf, "    Program_linear_units\n\r");
@@ -2664,7 +2662,7 @@ static int helpSet(connectionRecType *context)
   rtapi_strxcat(context->outBuf, "    Tool_offset <Offset>\n\r");
   rtapi_strxcat(context->outBuf, "    Update <On | Off>\n\r");
   rtapi_strxcat(context->outBuf, "    Wait <Time>\n\r");
-  
+
   sockWrite(context);
   return 0;
 }
@@ -2699,7 +2697,7 @@ static int helpHelp(connectionRecType *context)
 int commandHelp(connectionRecType *context)
 {
   char *pch;
-  
+
   pch = strtok(NULL, delims);
   if (pch == NULL) return (helpGeneral(context));
   strupr(pch);
@@ -2718,7 +2716,7 @@ commandTokenType lookupToken(char *s)
 {
   commandTokenType i = cmdHello;
   int temp;
-  
+
   while (i < cmdUnknown) {
     if (strcmp(commands[i], s) == 0) return i;
 //    (int)i += 1;
@@ -2728,7 +2726,7 @@ commandTokenType lookupToken(char *s)
     }
   return i;
 }
-  
+
 // handle the linuxcncrsh command in context->inBuf
 int parseCommand(connectionRecType *context)
 {
@@ -2739,18 +2737,18 @@ int parseCommand(connectionRecType *context)
   static const char *shutdownNakStr = "SHUTDOWN NAK\r\n";
   static const char *helloAckStr = "HELLO ACK %s 1.1\r\n";
   static const char *setNakStr = "SET NAK\r\n";
-    
+
   pch = strtok(context->inBuf, delims);
   snprintf(s, sizeof(s), helloAckStr, serverName);
   if (pch != NULL) {
     strupr(pch);
     switch (lookupToken(pch)) {
-      case cmdHello: 
+      case cmdHello:
         if (commandHello(context) == -1)
           ret = write(context->cliSock, helloNakStr, strlen(helloNakStr));
         else ret = write(context->cliSock, s, strlen(s));
         break;
-      case cmdGet: 
+      case cmdGet:
         ret = commandGet(context);
         break;
       case cmdSet:
@@ -2758,7 +2756,7 @@ int parseCommand(connectionRecType *context)
 	  ret = write(context->cliSock, setNakStr, strlen(setNakStr));
         else ret = commandSet(context);
         break;
-      case cmdQuit: 
+      case cmdQuit:
         ret = commandQuit(context);
         break;
       case cmdShutdown:
@@ -2774,7 +2772,7 @@ int parseCommand(connectionRecType *context)
       }
     }
   return ret;
-}  
+}
 
 void *readClient(void *arg)
 {
@@ -2840,7 +2838,7 @@ finished:
 int sockMain()
 {
     int res;
-    
+
     while (1) {
       int client_sockfd;
 
@@ -2955,7 +2953,7 @@ int main(int argc, char *argv[])
     // get configuration information
     iniLoad(emc_inifile);
     if (initSockets()) {
-        rcs_print_error("error initializing sockets\n");  
+        rcs_print_error("error initializing sockets\n");
         exit(1);
     }
     // init NML

--- a/src/hal/user_comps/mb2hal/mb2hal_init.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_init.c
@@ -125,19 +125,19 @@ retCode parse_common_section()
 }
 
 #define NAME_ALLOC_SIZE 5
-retCode parse_pin_names(const char * names_string, mb_tx_t *this_mb_tx)
+static retCode parse_pin_names(const char * const names_string, mb_tx_t * const this_mb_tx)
 {
     char *fnct_name = "parse_pin_names";
     int name_count = 0;
     int name_buf_size = NAME_ALLOC_SIZE;
     char **name_ptrs = malloc(sizeof(char *) * name_buf_size);
-    char *names = malloc(strlen(names_string)  + 1);
+    /* FIXME This memory block is leaked */
+    char *names = strndup(names_string,999942);
     if(name_ptrs == NULL || names == NULL)
     {
         ERR(gbl.init_dbg, "Failed allocating memory");
         return retERR;
     }
-    strcpy(names, names_string);	// Keep the names in a buffer
     char * name = strtok(names, ",");
     while(name)
     {
@@ -700,7 +700,7 @@ retCode init_mb_links()
                     ERR(gbl.init_dbg, "serial_device name to long [%s]", this_mb_tx->cfg_serial_device);
                     return retERR;
                 }
-                strncpy(this_mb_link->lp_serial_device, this_mb_tx->cfg_serial_device, MB2HAL_MAX_DEVICE_LENGTH);
+                rtapi_strlcpy(this_mb_link->lp_serial_device, this_mb_tx->cfg_serial_device, MB2HAL_MAX_DEVICE_LENGTH);
                 this_mb_link->lp_serial_baud=this_mb_tx->cfg_serial_baud;
 
                 if (strcasecmp(this_mb_tx->cfg_serial_parity, "even") == 0) {
@@ -731,7 +731,7 @@ retCode init_mb_links()
                     ERR(gbl.init_dbg, "tcp_ip too long [%s]", this_mb_tx->cfg_tcp_ip);
                     return retERR;
                 }
-                strncpy(this_mb_link->lp_tcp_ip, this_mb_tx->cfg_tcp_ip, sizeof(this_mb_tx->cfg_tcp_ip));
+                rtapi_strlcpy(this_mb_link->lp_tcp_ip, this_mb_tx->cfg_tcp_ip, sizeof(this_mb_tx->cfg_tcp_ip));
                 this_mb_link->lp_tcp_port=this_mb_tx->cfg_tcp_port;
 
                 this_mb_link->modbus = modbus_new_tcp(this_mb_link->lp_tcp_ip, this_mb_link->lp_tcp_port);

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -38,12 +38,12 @@
  */
 
 #include "config.h"
-#include "rtapi.h"		/* RTAPI realtime OS API */
-#include "hal.h"		/* HAL public API decls */
-#include "../hal_priv.h"	/* private HAL decls */
+#include "rtapi.h"		// RTAPI realtime OS API
+#include "hal.h"		// HAL public API decls
+#include "../hal_priv.h"	// private HAL decls
 #include "halcmd_commands.h"
 #include <rtapi_mutex.h>
-#include <rtapi_string.h>
+#include <rtapi_string.h>	// rtapi_strlcpy
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -559,7 +559,7 @@ int do_newinst_cmd(char *comp_name, char *inst_name) {
         nanosleep(&ts, NULL);
         rtapi_mutex_get(&(hal_data->mutex));
     }
-    strncpy(hal_data->constructor_prefix, inst_name, HAL_NAME_LEN);
+    rtapi_strlcpy(hal_data->constructor_prefix, inst_name, HAL_NAME_LEN);
     hal_data->constructor_prefix[HAL_NAME_LEN]=0;
     hal_data->pending_constructor = comp->make;
     rtapi_mutex_give(&(hal_data->mutex));
@@ -1178,7 +1178,7 @@ int do_loadrt_cmd(char *mod_name, char *args[])
 	return -1;
     }
     /* copy string to shmem */
-    strcpy (cp1, arg_string);
+    strcpy(cp1, arg_string);
     /* get mutex before accessing shared data */
     rtapi_mutex_get(&(hal_data->mutex));
     /* search component list for the newly loaded component */

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -298,13 +298,14 @@
 #include <fnmatch.h>
 #include <getopt.h>
 
-#include "rtapi.h"		/* RTAPI realtime OS API */
+#include "rtapi.h"		// RTAPI realtime OS API
 #include <rtapi_mutex.h>
-#include "hal.h"		/* HAL public API decls */
-#include "../hal_priv.h"	/* private HAL decls */
-/* non-EMC related uses of halrmt may want to avoid libnml dependency */
+#include <rtapi_string.h>	// rtapi_strlcpy
+#include "hal.h"		// HAL public API decls
+#include "../hal_priv.h"	// private HAL decls
+/* non-EMC related uses of halrmt may want to avoid libnml dependency
 #ifndef NO_INI
-#include "inifile.h"		/* iniFind() from libnml */
+#include "inifile.h"		// iniFind() from libnml
 #endif
 #include <rtapi_string.h>
 
@@ -1486,7 +1487,7 @@ static int doLoadUsr(char *args[])
     prog_path[0] = '\0';
     if ( prog_path[0] == '\0' ) {
 	/* try the name by itself */
-	strncpy (prog_path, prog_name, MAX_CMD_LEN);
+	rtapi_strlcpy(prog_path, prog_name, MAX_CMD_LEN);
 	rtapi_print_msg(RTAPI_MSG_DBG, "Trying '%s'\n", prog_path);
 	if ( stat(prog_path, &stat_buf) != 0 ) {
 	    /* no luck, clear prog_path to indicate failure */

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -44,18 +44,19 @@
 #include <ctype.h>
 #include <string.h>
 
-#include "rtapi.h"		/* RTAPI realtime OS API */
+#include "rtapi.h"		// RTAPI realtime OS API
 #include <rtapi_mutex.h>
-#include "hal.h"		/* HAL public API decls */
-#include "../hal_priv.h"	/* private HAL decls */
+#include <rtapi_string.h>	// rtapi_strlcpy()
+#include "hal.h"		// HAL public API decls
+#include "../hal_priv.h"	// private HAL decls
 
 #include <gtk/gtk.h>
 
-#include "miscgtk.h"		/* generic GTK stuff */
-#include "scope_usr.h"		/* scope related declarations */
+#include "miscgtk.h"		// generic GTK stuff
+#include "scope_usr.h"		// scope related declarations
 #include <rtapi_string.h>
 
-#define BUFLEN 80		/* length for sprintf buffers */
+#define BUFLEN 80		// length for sprintf buffers
 
 /***********************************************************************
 *                  GLOBAL VARIABLES DECLARATIONS                       *
@@ -1047,7 +1048,7 @@ static void selection_changed(GtkTreeSelection *selection, char *name)
 
     if (gtk_tree_selection_get_selected(selection, &model, &iter)) {
         gtk_tree_model_get(model, &iter, LIST_ITEM, &tmp, -1);
-        strncpy(name, tmp, HAL_NAME_LEN);
+        rtapi_strlcpy(name, tmp, HAL_NAME_LEN);
         g_free(tmp);
     }
 }

--- a/src/libnml/buffer/shmem.cc
+++ b/src/libnml/buffer/shmem.cc
@@ -32,6 +32,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+#include <rtapi_string.h>	/* rtapi_strlcpy */
 #include "rcs_print.hh"		/* rcs_print_error() */
 #include "cms.hh"		/* class CMS */
 #include "shmem.hh"		/* class SHMEM */
@@ -315,11 +316,11 @@ int SHMEM::open()
 	if (!shm->created) {
 	    char *cptr = (char *) shm->addr;
 	    cptr[31] = 0;
-	    if (strncmp(cptr, BufferName, 31)) {
+	    if (rtapi_strlcpy(cptr, BufferName, 31)) {
 		rcs_print_error
 		    ("Shared memory buffers %s and %s may conflict. (key=%d(0x%X))\n",
 		    BufferName, cptr, key, key);
-		strncpy(cptr, BufferName, 32);
+		rtapi_strlcpy(cptr, BufferName, 32);
 	    }
 	}
 	if (master) {
@@ -331,7 +332,7 @@ int SHMEM::open()
 		memset(autokey_table_end, 0, size - 32 - autokey_table_size);
 	    }
 #endif
-	    strncpy((char *) shm->addr, BufferName, 32);
+	    rtapi_strlcpy((char *) shm->addr, BufferName, 32);
 	}
 /*! \todo Another #if 0 */
 #if 0				// PC Do we need to use autokey ?

--- a/src/libnml/cms/cms_cfg.cc
+++ b/src/libnml/cms/cms_cfg.cc
@@ -115,7 +115,7 @@ int load_nml_config_file(const char *file)
         loading_config_file = 0;
         return -1;
     }
-    strncpy(info->file_name, file, 80);
+    rtapi_strlcpy(info->file_name, file, 80);
     FILE *fp;
     fp = fopen(file, "r");
     if (fp == NULL) {
@@ -374,7 +374,7 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
 		strcpy(default_ptr, bufname);
 		default_ptr += strlen(bufname);
 		strcpy(default_ptr, buf2);
-		strncpy(search.proc_line, buf, LINELEN);
+		rtapi_strlcpy(search.proc_line, buf, LINELEN);
 	    }
 	    rtapi_strxcat(search.proc_line, " defaultbuf");
 	}
@@ -398,7 +398,7 @@ int cms_config(CMS ** cms, const char *bufname, const char *procname, const char
 		strcpy(default_ptr, bufname);
 		default_ptr += strlen(bufname);
 		strcpy(default_ptr, buf2);
-		strncpy(search.proc_line, buf, LINELEN);
+		rtapi_strlcpy(search.proc_line, buf, LINELEN);
 	    }
 	    rtapi_strxcat(search.proc_line, " defaultproc defaultbuf");
 	}

--- a/src/libnml/cms/cmsdiag.cc
+++ b/src/libnml/cms/cmsdiag.cc
@@ -18,7 +18,7 @@
 #include <unistd.h>		/* getpid() */
 #include "timer.hh"		// etime()
 #include <stdlib.h>		// memset()
-#include <string.h>		// strncpy()
+#include <rtapi_string.h> 	// strncpy() -> rtapi_strlcpy()
 #include <time.h>		// time_t, time()
 #include <math.h>		// floor()
 #include "linklist.hh"          // LinkedList
@@ -60,7 +60,7 @@ void CMS::setup_diag_proc_info()
     if (NULL == dpi) {
 	dpi = new CMS_DIAG_PROC_INFO();
     }
-    strncpy(dpi->name, ProcessName, 16);	// process name
+    rtapi_strlcpy(dpi->name, ProcessName, 16);	// process name
     int sysinfo_len = 0;
     memset(dpi->host_sysinfo, 0, 32);
     gethostname(dpi->host_sysinfo, 31);

--- a/src/libnml/cms/tcp_srv.cc
+++ b/src/libnml/cms/tcp_srv.cc
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-#include <string.h>		/* memset(), strerror() */
+#include <string.h>		// memset(), strerror()
 #include <stdlib.h>		// malloc(), free()
 #include <unistd.h>
 #include <sys/socket.h>
@@ -37,6 +37,8 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+#include <rtapi_string.h>	// rtapi_strlcpy
 
 #include <sys/types.h>
 #include <sys/wait.h>		// waitpid
@@ -964,7 +966,7 @@ void CMS_SERVER_REMOTE_TCP_PORT::switch_function(CLIENT_TCP_PORT *
 	    if (NULL != namereply) {
 		putbe32(temp_buffer, _client_tcp_port->serial_number);
 		putbe32(temp_buffer + 4, namereply->status);
-		strncpy(temp_buffer + 8, namereply->name, 31);
+		rtapi_strlcpy(temp_buffer + 8, namereply->name, 31);
 		if (sendn
 		    (_client_tcp_port->socket_fd, temp_buffer, 40, 0,
 			dtimeout) < 0) {

--- a/src/libnml/nml/nml.hh
+++ b/src/libnml/nml/nml.hh
@@ -171,8 +171,8 @@ class NML:public virtual CMS_USER {
 
     /* Constructors and destructors. */
       NML(NML_FORMAT_PTR f_ptr,
-	const char *, const char *, const char *, int set_to_server = 0, int set_to_master = 0);
-      NML(NML *, int set_to_server = 0, int set_to_master = 0);
+	const char *, const char *, const char *, const int set_to_server = 0, const int set_to_master = 0);
+      NML(NML *, const int set_to_server = 0, const int set_to_master = 0);
       NML(const char *buffer_line, const char *proc_line);
       virtual ~ NML();
     int reset();
@@ -180,17 +180,16 @@ class NML:public virtual CMS_USER {
     int queue_length;
     int print_queue_info();
     int set_error();
-    void print_info(const char *bufname = NULL, const char *procname = NULL,
-	    const char *cfg_file = NULL);
+    void print_info(const char * const bufname = NULL, const char * const procname = NULL, const char * const cfg_file = NULL);
   protected:
 
     int fast_mode;
     int *cms_status;
     long *cms_inbuffer_header_size;
-      NML(const char *, const char *, const char *, int set_to_server = 0, int set_to_master =
+      NML(const char *, const char *, const char *, const int set_to_server = 0, const int set_to_master =
 	0);
     void reconstruct(NML_FORMAT_PTR, const char *, const char *, const char *,
-	int set_to_server = 0, int set_to_master = 0);
+	const int set_to_server = 0, const int set_to_master = 0);
 
     int info_printed;
 
@@ -217,10 +216,9 @@ extern "C" {
 //    extern void nml_wipeout_lists();
     extern void set_default_nml_config_file(const char *);
     extern const char *get_default_nml_config_file();
-    extern NML *nmlWaitOpen(NML_FORMAT_PTR fPtr, char *buffer,
-	char *name, char *file, double sleepTime);
+    extern NML *nmlWaitOpen(NML_FORMAT_PTR fPtr, char *buffer, char *name, char *file, double sleepTime);
 
-    extern void nmlSetHostAlias(const char *hostName, const char *hostAlias);
+    extern void nmlSetHostAlias(const char * const hostName, const char * const hostAlias);
     extern void nmlClearHostAliases();
     extern void nmlAllowNormalConnection();
     extern void nmlForceRemoteConnection();

--- a/src/libnml/nml/nml_srv.cc
+++ b/src/libnml/nml/nml_srv.cc
@@ -16,29 +16,30 @@
 extern "C" {
 #endif
 
-#include <string.h>		/* memcpy() */
+#include <string.h>		// memcpy()
 
-#include <signal.h>		/* kill() */
+#include <signal.h>		// kill()
 #include <sys/types.h>
-#include <unistd.h>		/* getpid() */
-#include <sys/wait.h>		/* waitpid() */
-#include <stdlib.h>		/* atexit() */
+#include <unistd.h>		// getpid()
+#include <sys/wait.h>		// waitpid()
+#include <stdlib.h>		// atexit()
 
 #ifdef __cplusplus
 }
 #endif
+#include <rtapi_string.h>	// rtapi_strlcpy()
 #include "nml.hh"
 #include "nmlmsg.hh"
 #include "cms.hh"
 #include "nml_srv.hh"
-#include "rem_msg.hh"		/* struct REMOTE_READ_REQUEST, */
-#include "rcs_print.hh"		/* rcs_print_error() */
+#include "rem_msg.hh"		// struct REMOTE_READ_REQUEST
+#include "rcs_print.hh"		// rcs_print_error()
 #include "timer.hh"		// esleep()
 #include "rcs_exit.hh"		// rcs_exit
 #include "linklist.hh"
 #include "physmem.hh"
 #include "cmsdiag.hh"
-#include "cmd_msg.hh" // layering violation ahoy
+#include "cmd_msg.hh"		// layering violation ahoy
 NML_SERVER::NML_SERVER(NML * _nml, int _set_to_master):CMS_SERVER()
 {
     NML_SERVER_LOCAL_PORT *new_local_port = NULL;
@@ -321,8 +322,8 @@ set_diag_info(REMOTE_SET_DIAG_INFO_REQUEST * _req)
 	orig_info = new CMS_DIAG_PROC_INFO();
 	*orig_info = *dpi;
     }
-    strncpy(dpi->name, _req->process_name, 16);
-    strncpy(dpi->host_sysinfo, _req->host_sysinfo, 32);
+    rtapi_strlcpy(dpi->name, _req->process_name, 16);
+    rtapi_strlcpy(dpi->host_sysinfo, _req->host_sysinfo, 32);
     if (cms->total_connections > _req->c_num && _req->c_num >= 0) {
 	cms->connection_number = _req->c_num;
     }

--- a/src/libnml/rcs/rcs_print.cc
+++ b/src/libnml/rcs/rcs_print.cc
@@ -308,7 +308,7 @@ int rcs_vprint(const char *_fmt, va_list _args, int save_string)
 	}
 	last_error_buf_filled++;
 	last_error_buf_filled %= 4;
-	strncpy(last_error_bufs[last_error_buf_filled], temp_string, 99);
+	rtapi_strlcpy(last_error_bufs[last_error_buf_filled], temp_string, 99);
     }
     return (rcs_fputs(temp_string));
 }


### PR DESCRIPTION
Stuttgart LinuxCNC attempt to address compiler warnings.

Using rtapi_strlcpy to always have 0-terminated strings.