### PR TITLE
RTAI: Fix build against RTAI+GNU11

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -888,7 +888,7 @@ EXTRA_CFLAGS := $(filter-out -ffast-math,$(RTFLAGS)) -D__MODULE__ -I$(BASEPWD)/.
 	-I$(BASEPWD)/emc/nml_intf -I$(BASEPWD)/emc/kinematics -I$(BASEPWD)/emc/tp -I$(BASEPWD)/emc/motion \
 	-DSEQUENTIAL_SUPPORT -DHAL_SUPPORT -DDYNAMIC_PLCSIZE -DRT_SUPPORT -DOLD_TIMERS_MONOS_SUPPORT -DMODBUS_IO_MASTER \
 	-fno-fast-math $(call cc-option,-mieee-fp) -fno-unsafe-math-optimizations \
-	-Werror=frame-larger-than=2560 -Wno-declaration-after-statement \
+	-Wno-declaration-after-statement \
 	$(INTEGER_OVERFLOW_FLAGS)
 ifneq ($(KERNELRELEASE),)
 ifeq ($(RTARCH):$(RTAI):$(filter $(RTFLAGS),-msse),x86_64:3:)

--- a/src/rtapi/rtapi_math.h
+++ b/src/rtapi/rtapi_math.h
@@ -57,25 +57,6 @@ extern double floor(double);
 #define isinf(x) __builtin_isinf((x))
 #define isfinite(x) __builtin_isfinite((x))
 
-extern __inline double atan (double __y) {
-    return atan2(__y, 1.);
-}
-
-extern __inline double asin (double __x) {
-    return atan2(__x, sqrt (1.0 - __x * __x));
-}
-
-extern __inline double acos (double __x) {
-    return atan2(sqrt(1.0 - __x * __x), __x);
-}
-
-extern __inline double fmax(double __y, double __x) {
-    return __y > __x || __builtin_isnan(__x) ? __y : __x;
-}
-extern __inline double fmin(double __y, double __x) {
-    return __y < __x || __builtin_isnan(__x) ? __y : __x;
-}
-
 #ifdef __i386__
 #include "rtapi_math_i386.h"
 #endif


### PR DESCRIPTION
This may break RTAI builds that still use gnu89.

For some reason, if using GNU11, you don't need to define these anymore.