### PR TITLE
Improve treatment of o-codes in documentation

### DIFF
--- a/docs/src/gcode/o-code.adoc
+++ b/docs/src/gcode/o-code.adoc
@@ -15,11 +15,16 @@
 O-codes provide for flow control in NC programs. Each block has an
 associated number, which is the number used after O. Care must be taken
 to properly match the O-numbers. O codes use the letter 'O' not the
-number zero as the first character in the number like O100 or o100.
+number zero as the first character in the number like O100 or o100. o-codes are also sometimes called o-words and these terms are interchangeable. 
+
+[NOTE]
+Using the lower case 'o' makes it easier to distinguish from a 0
+that might have been mistyped. For example 'o100' is easier to
+see than 'O100' that it is not a '0'.
 
 == Numbering
 
-Numbered O codes must have a unique number for each subroutine,
+Numbered o-codes must have a unique number for each subroutine,
 
 .Numbering Example
 [source,{ngc}]
@@ -40,26 +45,22 @@ o100 endsub
 [[ocode:comments]]
 == Comments(((Comments)))
 
-Comments on the same line as the O word should not be used as the behavior can
+Comments on the same line as the o-word should not be used as the behavior can
 change in the future.
 
 The behavior is undefined if:
 
 * The same number is used for more than one block.
-* Other words are used on a line with an O- word.
-* Comments are used on a line with an O-word.
+* Other words are used on a line with an o-word.
+* Comments are used on a line with an o-word.
 
-[NOTE]
-Using the lower case 'o' makes it easier to distinguish from a 0
-that might have been mistyped. For example 'o100' is easier to
-see than 'O100' that it is not a '0'.
 
 [[ocode:subroutines]]
 == Subroutines(((Subroutines)))
 
-Subroutines starts at 'Onnn sub' and ends at 'Onnn endsub'. The lines between
-'Onnn sub' and 'Onnn endsub' are not executed until the subroutine is called
-with 'Onnn call'. Each subroutine must use a unique number.
+Subroutines starts at 'oNNN sub' and ends at 'oNNN endsub'. The lines between
+'oNNN sub' and 'oNNN endsub' are not executed until the subroutine is called
+with 'oNNN call'. Each subroutine must use a unique number.
 
 .Subroutine Example
 [source,{ngc}]
@@ -76,8 +77,8 @@ M2
 See <<gcode:g53,G53>>, <<gcode:g0,G0>> and <<mcode:m2-m30,M2>> sections for more information.
 
 .O- Return
-Inside a subroutine, 'O- return' can be executed. This immediately
-returns to the calling code, just as though 'O- endsub' was encountered.
+Inside a subroutine, 'o- return' can be executed. This immediately
+returns to the calling code, just as though 'o- endsub' was encountered.
 
 .O- Return Example
 [source,{ngc}]
@@ -96,7 +97,7 @@ o100 endsub
 See the <<gcode:binary-operators,Binary Operators>> and <<sec:overview-parameters,Parameters>> sections for more information.
 
 .O- Call
-'O- Call' takes up to 30 optional arguments, which are passed to the subroutine
+'o- Call' takes up to 30 optional arguments, which are passed to the subroutine
 as '#1', '#2' , ..., #N. Parameters from #N+1 to #30 have the same
 value as in the calling context.
 On return from the subroutine, the values of
@@ -178,7 +179,7 @@ The main program must be terminated with `M02` or `M30` (or `M99`; see
 below).
 
 .'O-' subprogram definition start
-Marks the start of a numbered subprogram definition.  The block `O100`
+Marks the start of a numbered subprogram definition.  The block `o100`
 is similar to `o100 sub`, except that it must be placed later in the
 file than the `M98 P100` calling block.
 
@@ -188,7 +189,7 @@ but may only terminate a numbered program (`o100` in this example),
 and may not terminate a subroutine beginning with the `o100 sub`
 syntax.
 
-The `M98` subprogram call differs from rs274ngc `O call` in the
+The `M98` subprogram call differs from rs274ngc `o call` in the
 following ways:
 
 * The numbered subprogram must follow the `M98` call in the program file.
@@ -214,32 +215,32 @@ at a tidy point when the operator is ready.
 .Numbered Subprogram Full Example
 [source,{ngc}]
 ----
-O1                             ; Main program 1
+o1                             ; Main program 1
   #1 = 0
   (PRINT,X MAIN BEGIN:  1=#1)
   M98 P100 L5                  ; Call subprogram 100
   (PRINT,X MAIN END:  1=#1)
 M30                            ; End main program
 
-O100                           ; Subprogram 100
+o100                           ; Subprogram 100
   #1 = [#1 + 1]
   M98 P200 L5                  ; Call subprogram 200
-  (PRINT,>> O100:  #1)
+  (PRINT,>> o100:  #1)
 M99                            ; Return from Subprogram 100
 
-O200                           ; Subprogram 200
+o200                           ; Subprogram 200
   #1 = [#1 + 0.01]
-  (PRINT,>>>> O200:  #1)
+  (PRINT,>>>> o200:  #1)
 M99                            ; Return from Subprogram 200
 ----
 
 In this example, parameter `#1` is initialized to `0`.  Subprogram
-`O100` is called five times in a loop.  Nested within each call to
-`O100`, subprogram `O200` is called five times in a loop, for 25 times
+`o100` is called five times in a loop.  Nested within each call to
+`o100`, subprogram `o200` is called five times in a loop, for 25 times
 total.
 
 Note that parameter `#1` is global.  At the end of the main program,
-after updates within `O100` and `O200`, its value will equal `5.25`.
+after updates within `o100` and `o200`, its value will equal `5.25`.
 
 [[ocode:looping]]
 == Looping(((Subroutines,Looping)))
@@ -283,7 +284,7 @@ o100 while [#1 LT 3]
 M2
 ----
 
-Inside a while loop, 'O- break' immediately exits the loop, and 'O-
+Inside a while loop, 'o- break' immediately exits the loop, and 'o-
 continue' immediately skips to the next evaluation of the 'while'
 condition. If it is still true, the loop begins again at the top. If
 it is false, it exits the loop.
@@ -336,15 +337,15 @@ Several conditions may be tested for by 'elseif' statements until the
 [source,{ngc}]
 ----
 (if parameter #2 is greater than 5 set F100)
-O102 if [#2 GT 5]
+o102 if [#2 GT 5]
   F100
 (else if parameter #2 less than 2 set F200)
-O102 elseif [#2 LT 2]
+o102 elseif [#2 LT 2]
   F20
 (parameter #2 is between 2 and 5)
-O102 else
+o102 else
   F200
-O102 endif
+o102 endif
 ----
 
 [[ocode:repeat]]
@@ -370,7 +371,7 @@ G90 (Absolute mode)
 [[ocode:indirection]]
 == Indirection(((Indirection)))
 
-The O-number may be given by a parameter and/or calculation.
+The o-number may be given by a parameter and/or calculation.
 
 .Indirection Example
 [source,{ngc}]

--- a/docs/src/gcode/overview.adoc
+++ b/docs/src/gcode/overview.adoc
@@ -1,8 +1,9 @@
 :lang: en
 :toc:
+:toclevels: 3
 
-[[cha:g-code-overview]]
-= G-code Overview
+[[cha:ngc-code-overview]]
+= NGC-code Overview
 
 :ini: {basebackend@docbook:'':ini}
 :hal: {basebackend@docbook:'':hal}
@@ -29,7 +30,7 @@ rate to the programmed end point', and 'X3' provides an argument
 value (the value of X should be 3 at the end of the move).
 Most LinuxCNC G-code commands start with either G or M (for
 General and Miscellaneous). The words for these commands are called 'G
-codes' and 'M-codes'.
+codes' and 'M-codes.' Also common are subroutine codes that begin with 'o-' which are called 'o-codes.'
 
 The LinuxCNC language has no indicator for the start of a program. The
 Interpreter, however, deals with files. A single program may be in a
@@ -55,10 +56,15 @@ A permissible line of input code consists of the following, in order,
 with the restriction that there is a maximum (currently 256) to the
 number of characters allowed on a line.
 
-* an optional block delete character, which is a slash '/'.
-* an optional line number.
-* any number of words, parameter settings, and comments.
-* an end of line marker (carriage return or line feed or both).
+. an optional block delete character, which is a slash '/'.
+. an optional line number.
+. Any number of: 
+[.indent]
+1. words,
+2. parameter settings, 
+3. subroutine codes, and 
+4. comments.
+. an end of line marker (carriage return or line feed or both).
 
 Any input not explicitly allowed is illegal and will cause the
 Interpreter to signal an error.
@@ -87,7 +93,7 @@ In AXIS, it is also possible to enable block delete with the following icon:
 .AXIS Block Delete Icon
 image:../gui/images/tool_blockdelete.png[]
 
-=== Line Number(((Line Number)))
+=== Optional Line Number(((Optional Line Number)))
 
 A line number is the letter N followed by an unsigned integer,
 optionally followed by a period and another unsigned integer. For
@@ -97,16 +103,16 @@ such usage. Line numbers may also be skipped, and that is normal
 practice. A line number is not required to be used, but must be in the
 proper place if used.
 
-=== Word(((Words)))
+NOTE: Line numbers are not recommended. See <<gcode:best-practices,Best Practices>>.
 
-A word is a letter other than N followed by a real value.
+=== Words, Parameters, Subroutines, Comments
+
+==== Words(((Words)))
+
+A word is a letter other than N or O ("o") followed by a real value.
 
 Words may begin with any of the letters shown in the following Table.
-The table includes N for completeness, even
-though, as defined above, line numbers are not words. Several letters
-(I, J, K, L, P, R) may have different meanings in different contexts.
-Letters which refer to axis names are not valid on a machine which does
-not have the corresponding axis.
+The table includes N and O for completeness, even though, as defined above, line numbers and program flow parameters are not words. Several letters (I, J, K, L, P, R) may have different meanings in different contexts. Letters which refer to axis names are not valid on a machine which does not have the corresponding axis.
 
 .Words and their meanings
 [width="75%",options="header",cols="^1,<5"]
@@ -125,7 +131,8 @@ not have the corresponding axis.
 <| Spindle-Motion Ratio for G33 synchronized movements.
 |L | generic parameter word for G10, M66 and others
 |M | Miscellaneous function (See table  <<cap:modal-groups,Modal Groups>>)
-|N | Line number
+|N | Line number (not recommended, see <<gcode:best-practices, Best Practices>>)
+|O | o-codes for program flow control (See <<cha:o-codes,o-Codes>>)
 .2+|P | Dwell time in canned cycles and with G4.
 <| Key used with G10.
 |Q | Feed increment in G73, G83 canned cycles
@@ -140,8 +147,27 @@ not have the corresponding axis.
 |Z | Z axis of machine
 |===
 
+
+==== Parameters(((Parameters)))
+
+Parameters are identified with a "#" symbol in front of them. See <<sec:overview-parameters, Parameters Section>> below. 
+
+==== Subroutine Codes(((Subroutine Codes)))
+
+Also called 'o-codes' these provide program flow control (such as if-else logic and callable subroutines) and are covered fully at the page on <<cha:o-codes,o-Codes>> and also below in <<sub:subroutine-parameters,Subroutine Codes and Parameters.>> 
+
+NOTE: o-codes are sometimes also called o-words. 
+
+==== Comments(((Comments)))
+
+Comments can be embedded in a line using parentheses () or for the remainder of a line using a semi-colon. There are also 'active' comments like MSG, DEBUG, etc. See the <<gcode:comments,section on comments>>.
+
+=== End of Line Marker(((End of Line Marker)))
+
+This is any combination of carriage return or line feed. 
+
 [[gcode:numbers]]
-=== Numbers(((Numbers)))
+== Numbers(((Numbers)))
 
 The following rules are used for (explicit) numbers. In these rules a
 digit is a single character between 0 and 9.
@@ -218,7 +244,7 @@ assignment statement.
 
 Persistence:: When LinuxCNC is shut down, volatile parameters lose their
 values. All parameters except numbered parameters in the current
-persistent range footnoteref:[persistent_range,The range of persistent
+persistent range footnote:[persistent_range,The range of persistent
 parameters may change as development progresses. This range is
 currently 5161- 5390. It is defined in the '_required_parameters array'
 in file the src/emc/rs274ngc/interp_array.cc .]  are volatile.
@@ -369,11 +395,15 @@ is written.
 |===
 
 [[sub:subroutine-parameters]]
-=== Subroutine Parameters(((Subroutine Parameters)))
+=== Subroutine Codes and Parameters(((Subroutine Codes and Parameters)))
 
-* '1-30' Subroutine local parameters of call arguments. These parameters are
-  local to the subroutine. Volatile. See also the chapter on
-  <<cha:o-codes,O-Codes>>.
+Subroutine codes, or o-codes (sometimes also called o-words), provide for  logic and flow control in NGC programs (as in if-else logic). They are called Subroutine codes because they can also form called subroutines (as in sub-endsub). 
+
+See the chapter on <<cha:o-codes,o-Codes>>.
+
+NOTE: If o-codes are used to form subroutines, then o-codes can also call those subroutines and pass up to 30 parameters, which are local to the subroutine and volatile. (Again, see <<cha:o-codes,o-Codes>> for fuller treatment and examples.)
+
+NOTE: While both lower and upper case o- are valid, best practice is using lower case "o-" because it disambiguates 0 (zero) and O (capital o).  
 
 [[gcode:named-parameters]]
 === Named Parameters(((Named Parameters)))
@@ -562,17 +592,17 @@ can be added easily without changes to the source code.
 * '#<_selected_tool>' - Return number of the selected tool post a T code. Default -1.
 * '#<_selected_pocket>' - Return the tooldata index of the selected pocket post a T code.
   Default -1 (no pocket selected).
-* '#<_value>' - Return value from the last O-word 'return' or 'endsub'. Default
+* '#<_value>' - Return value from the last O-code 'return' or 'endsub'. Default
   value 0 if no expression after 'return' or 'endsub'. Initialized
   to 0 on program start.
-* '#<_value_returned>' - 1.0 if the last O-word 'return' or 'endsub' returned a value, 0
-  otherwise. Cleared by the next O-word call.
+* '#<_value_returned>' - 1.0 if the last O-code 'return' or 'endsub' returned a value, 0
+  otherwise. Cleared by the next O-code call.
 * '#<_task>' - 1.0 if the executing interpreter instance is part of milltask, 0.0
   otherwise. Sometimes it is necessary to treat this case specially
   to retain proper preview, for instance when testing the success of
   a probe (G38.n) by inspecting #5070, which will always fail in the
   preview interpreter (e.g. Axis).
-* '#<_call_level>' - current nesting level of O-word procedures. For debugging.
+* '#<_call_level>' - current nesting level of O-code procedures. For debugging.
 * '#<_remap_level>' - current level of the remap stack. Each remap in a block adds one
   to the remap level. For debugging.
 
@@ -999,7 +1029,7 @@ comment will in effect disable the active comment. For example, '(foo)
 A comment introduced by a semicolon is by definition the last comment
 on that line, and will always be interpreted for active comment syntax.
 
-NOTE: Inline comments on O-words should not be used see the O-code
+NOTE: Inline comments on O-codes should not be used see the O-code
 <<ocode:comments,comments>> section for more information.
 
 [[gcode:messages]]
@@ -1134,7 +1164,7 @@ part programs. In Axis sections of the preview can be turned off using
 The order of execution of items on a line is defined not by the
 position of each item on the line, but by the following list:
 
-* O-word commands (optionally followed by a comment but no other words allowed
+* O-code commands (optionally followed by a comment but no other words allowed
   on the same line)
 * Comment (including message)
 * Set feed rate mode (G93, G94).


### PR DESCRIPTION
I recently learned the NGC coding language by reading the page currently titled G-code overview. I found it unnecessarily confusing because all the remapping code I was trying to decipher uses o-codes and the documentation didn’t address them until after it had supposedly laid out all the acceptable ‘words.’ Also, in places the language describing them did not make much sense “1-30 subroutine local parameters of call arguments,” for example. Additionally, sometimes o-code is used, and sometimes o-word, but neither was clearly defined nor the interchangeability of the terms addressed.

The reason for this seems benign: this document was started 20 years ago at NIST before the LinuxCNC community extended it to include o-codes.  When that happened, an o-code page was created, and some references were added into the lower parts of this overview document. But it seems attention to integrating an introduction to this functionality didn’t happen.

I also clarified rules on Comments, to move mention of “active” comments like (MSG) to the first mention of commenting.

I propose also changing the page title from “G-code Overview” to “NGC-code Overview” because it’s kind of a misnomer since the language is NGC, and also the page g-code.adoc is titled “G Codes” which is confusingly similar. I checked for another reference to the chapter heading and did not find one, so I also changed the chapter heading from g-code-overview to ngc-code-overview.

On the O-code page, I added reference to the interchangeability of the terms o-code and o-word, and moved the “best practice” note to the introduction. I then changed all references to O-code or O-word to lower case o- to match that best practice.

I’m hopeful the community will accept my efforts to clarify for other newbs who find this page in the future.