### PR TITLE
improve RCS debug output control

### DIFF
--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -218,7 +218,7 @@ Do _not_ use a file extension of '.ini' for included files.
   You can put whatever you want here as long as you make it a single line long.
 * `DEBUG = 0` - Debug level 0 means no messages will be printed when LinuxCNC is run from a <<faq:terminal,terminal>>.
   Debug flags are usually only useful to developers. See src/emc/nml_intf/debugflags.h for other settings.
-* `RCS_DEBUG = 0` RCS debug messages to show. Print nothing (0) by default if EMC_DEBUG_RCS and EMC_DEBUG_RCS bits in
+* `RCS_DEBUG = 1` RCS debug messages to show. Print only errors (1) by default if EMC_DEBUG_RCS and EMC_DEBUG_RCS bits in
   `DEBUG` are unset, otherwise print all (-1). Use this to select RCS debug messages. See src/libnml/rcs/rcs_print.hh for all MODE flags.
 * `RCS_DEBUG_DEST = STDOUT` - how to output RCS_DEBUG messages (NULL, STDOUT, STDERR, FILE, LOGGER, MSGBOX).
 * `RCS_MAX_ERR = -1` - Number after which RCS errors are not reported anymore (-1 = infinite).

--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -218,6 +218,10 @@ Do _not_ use a file extension of '.ini' for included files.
   You can put whatever you want here as long as you make it a single line long.
 * `DEBUG = 0` - Debug level 0 means no messages will be printed when LinuxCNC is run from a <<faq:terminal,terminal>>.
   Debug flags are usually only useful to developers. See src/emc/nml_intf/debugflags.h for other settings.
+* `RCS_DEBUG = 0` RCS debug messages to show. Print nothing (0) by default if EMC_DEBUG_RCS and EMC_DEBUG_RCS bits in
+  `DEBUG` are unset, otherwise print all (-1). Use this to select RCS debug messages. See src/libnml/rcs/rcs_print.hh for all MODE flags.
+* `RCS_DEBUG_DEST = STDOUT` - how to output RCS_DEBUG messages (NULL, STDOUT, STDERR, FILE, LOGGER, MSGBOX).
+* `RCS_MAX_ERR = -1` - Number after which RCS errors are not reported anymore (-1 = infinite).
 * `NML_FILE = /usr/share/linuxcnc/linuxcnc.nml` - Set this if you want to use a non-default NML configuration file.
 
 [[sub:ini:sec:display]]

--- a/src/emc/task/emcsvr.cc
+++ b/src/emc/task/emcsvr.cc
@@ -73,7 +73,7 @@ static int iniLoad(const char *filename)
     }
 
     // NML/RCS debugging flags
-    set_rcs_print_flag(0);  // (disabled by default)
+    set_rcs_print_flag(PRINT_RCS_ERRORS);  // only print errors by default
     // enable all debug messages by default if RCS or NML debugging is enabled
     if ((emc_debug & EMC_DEBUG_RCS) || (emc_debug & EMC_DEBUG_NML)) {
         // output all RCS debug messages

--- a/src/emc/task/emcsvr.cc
+++ b/src/emc/task/emcsvr.cc
@@ -87,6 +87,9 @@ static int iniLoad(const char *filename)
         if (sscanf(inistring, "%lx", &flags) < 1) {
             perror("failed to parse [EMC] RCS_DEBUG");
         }
+        // clear all flags
+        clear_rcs_print_flag(PRINT_EVERYTHING);
+        // set parsed flags
         set_rcs_print_flag(flags);
     }
     // output infinite RCS errors by default

--- a/src/emc/task/emcsvr.cc
+++ b/src/emc/task/emcsvr.cc
@@ -35,6 +35,7 @@ static int iniLoad(const char *filename)
 {
     IniFile inifile;
     const char *inistring;
+    char version[LINELEN], machine[LINELEN];
 
     // open it
     if (inifile.Open(filename) == false) {
@@ -95,6 +96,19 @@ static int iniLoad(const char *filename)
             perror("failed to parse [EMC] RCS_MAX_ERR");
         }
     }
+
+    if (NULL != (inistring = inifile.Find("VERSION", "EMC"))) {
+	    if(sscanf(inistring, "$Revision: %s", version) != 1) {
+            strncpy(version, "unknown", LINELEN-1);
+	    }
+    }
+
+    if (NULL != (inistring = inifile.Find("MACHINE", "EMC"))) {
+	    strncpy(machine, inistring, LINELEN-1);
+    } else {
+	    strncpy(machine, "unknown", LINELEN-1);
+    }
+    rcs_print("task: machine: '%s'  version '%s'\n", machine, version);
 
     if (NULL != (inistring = inifile.Find("NML_FILE", "EMC"))) {
 	// copy to global

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -3071,13 +3071,10 @@ static int iniLoad(const char *filename)
         }
     }
 
-    if (emc_debug & EMC_DEBUG_VERSIONS) {
-	if (NULL != (inistring = inifile.Find("VERSION", "EMC"))) {
-	    if(sscanf(inistring, "$Revision: %s", version) != 1) {
-		strncpy(version, "unknown", LINELEN-1);
-	    }
-	} else {
-	    strncpy(version, "unknown", LINELEN-1);
+
+    if (NULL != (inistring = inifile.Find("VERSION", "EMC"))) {
+	if(sscanf(inistring, "$Revision: %s", version) != 1) {
+            strncpy(version, "unknown", LINELEN-1);
 	}
     }
 

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -3061,6 +3061,9 @@ static int iniLoad(const char *filename)
         if (sscanf(inistring, "%lx", &flags) < 1) {
             perror("failed to parse [EMC] RCS_DEBUG");
         }
+        // clear all flags
+        clear_rcs_print_flag(PRINT_EVERYTHING);
+        // set parsed flags
         set_rcs_print_flag(flags);
     }
     // output infinite RCS errors by default

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -3048,7 +3048,7 @@ static int iniLoad(const char *filename)
     }
 
     // NML/RCS debugging flags
-    set_rcs_print_flag(0);  // (disabled by default)
+    set_rcs_print_flag(PRINT_RCS_ERRORS);  // only print errors by default
     // enable all debug messages by default if RCS or NML debugging is enabled
     if ((emc_debug & EMC_DEBUG_RCS) || (emc_debug & EMC_DEBUG_NML)) {
         // output all RCS debug messages

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -2791,10 +2791,6 @@ static int emctask_startup()
     // emcStatus = new EMC_STAT;
 
     // get the NML command buffer
-    if (!(emc_debug & EMC_DEBUG_NML)) {
-	set_rcs_print_destination(RCS_PRINT_TO_NULL);	// inhibit diag
-	// messages
-    }
     end = RETRY_TIME;
     good = 0;
     do {
@@ -2815,8 +2811,7 @@ static int emctask_startup()
 	    exit(1);
 	}
     } while (end > 0.0);
-    set_rcs_print_destination(RCS_PRINT_TO_STDOUT);	// restore diag
-    // messages
+
     if (!good) {
 	rcs_print_error("can't get emcCommand buffer\n");
 	return -1;
@@ -2825,10 +2820,6 @@ static int emctask_startup()
     emcCommand = emcCommandBuffer->get_address();
 
     // get the NML status buffer
-    if (!(emc_debug & EMC_DEBUG_NML)) {
-	set_rcs_print_destination(RCS_PRINT_TO_NULL);	// inhibit diag
-	// messages
-    }
     end = RETRY_TIME;
     good = 0;
     do {
@@ -2849,17 +2840,13 @@ static int emctask_startup()
 	    exit(1);
 	}
     } while (end > 0.0);
-    set_rcs_print_destination(RCS_PRINT_TO_STDOUT);	// restore diag
-    // messages
+
     if (!good) {
 	rcs_print_error("can't get emcStatus buffer\n");
 	return -1;
     }
 
-    if (!(emc_debug & EMC_DEBUG_NML)) {
-	set_rcs_print_destination(RCS_PRINT_TO_NULL);	// inhibit diag
-	// messages
-    }
+    // get the NML error buffer
     end = RETRY_TIME;
     good = 0;
     do {
@@ -2879,8 +2866,7 @@ static int emctask_startup()
 	    exit(1);
 	}
     } while (end > 0.0);
-    set_rcs_print_destination(RCS_PRINT_TO_STDOUT);	// restore diag
-    // messages
+
     if (!good) {
 	rcs_print_error("can't get emcError buffer\n");
 	return -1;
@@ -2902,6 +2888,7 @@ static int emctask_startup()
         return -1;
     }
 
+    // initialize motion
     end = RETRY_TIME;
     good = 0;
     do {
@@ -3029,18 +3016,59 @@ static int iniLoad(const char *filename)
 	joints = 0;
     }
 
+    // EMC debugging flags
+    emc_debug = 0;  // disabled by default
     if (NULL != (inistring = inifile.Find("DEBUG", "EMC"))) {
-	// copy to global
-	if (1 != sscanf(inistring, "%i", &emc_debug)) {
-	    emc_debug = 0;
-	}
-    } else {
-	// not found, use default
-	emc_debug = 0;
+        // parse to global
+        if (sscanf(inistring, "%x", &emc_debug) < 1) {
+            perror("failed to parse [EMC] DEBUG");
+        }
     }
-    if (emc_debug & EMC_DEBUG_RCS) {
-	// set_rcs_print_flag(PRINT_EVERYTHING);
-	max_rcs_errors_to_print = -1;
+
+    // set output for RCS messages
+    set_rcs_print_destination(RCS_PRINT_TO_STDOUT);   // use stdout by default
+    if (NULL != (inistring = inifile.Find("RCS_DEBUG_DEST", "EMC"))) {
+        static RCS_PRINT_DESTINATION_TYPE type;
+        if (!strcmp(inistring, "STDOUT")) {
+            type = RCS_PRINT_TO_STDOUT;
+        } else if (!strcmp(inistring, "STDERR")) {
+            type = RCS_PRINT_TO_STDERR;
+        } else if (!strcmp(inistring, "FILE")) {
+            type = RCS_PRINT_TO_FILE;
+        } else if (!strcmp(inistring, "LOGGER")) {
+            type = RCS_PRINT_TO_LOGGER;
+        } else if (!strcmp(inistring, "MSGBOX")) {
+            type = RCS_PRINT_TO_MESSAGE_BOX;
+        } else if (!strcmp(inistring, "NULL")) {
+            type = RCS_PRINT_TO_NULL;
+        } else {
+             type = RCS_PRINT_TO_STDOUT;
+        }
+        set_rcs_print_destination(type);
+    }
+
+    // NML/RCS debugging flags
+    set_rcs_print_flag(0);  // (disabled by default)
+    // enable all debug messages by default if RCS or NML debugging is enabled
+    if ((emc_debug & EMC_DEBUG_RCS) || (emc_debug & EMC_DEBUG_NML)) {
+        // output all RCS debug messages
+        set_rcs_print_flag(PRINT_EVERYTHING);
+    }
+
+    // set flags if RCS_DEBUG in ini file
+    if (NULL != (inistring = inifile.Find("RCS_DEBUG", "EMC"))) {
+        static long int flags;
+        if (sscanf(inistring, "%lx", &flags) < 1) {
+            perror("failed to parse [EMC] RCS_DEBUG");
+        }
+        set_rcs_print_flag(flags);
+    }
+    // output infinite RCS errors by default
+    max_rcs_errors_to_print = -1;
+    if (NULL != (inistring = inifile.Find("RCS_MAX_ERR", "EMC"))) {
+        if (sscanf(inistring, "%d", &max_rcs_errors_to_print) < 1) {
+            perror("failed to parse [EMC] RCS_MAX_ERR");
+        }
     }
 
     if (emc_debug & EMC_DEBUG_VERSIONS) {
@@ -3051,7 +3079,6 @@ static int iniLoad(const char *filename)
 	} else {
 	    strncpy(version, "unknown", LINELEN-1);
 	}
-
     }
 
     if (NULL != (inistring = inifile.Find("MACHINE", "EMC"))) {
@@ -3186,6 +3213,7 @@ int main(int argc, char *argv[])
 
     // set print destination to stdout, for console apps
     set_rcs_print_destination(RCS_PRINT_TO_STDOUT);
+
     // process command line args
     if (0 != emcGetArgs(argc, argv)) {
 	rcs_print_error("error in argument list\n");
@@ -3223,7 +3251,6 @@ int main(int argc, char *argv[])
 	}
     rtapi_strxcpy(emcStatus->task.ini_filename, emc_inifile);
     if (task_methods == NULL) {
-	set_rcs_print_destination(RCS_PRINT_TO_STDOUT);	// restore diag
 	rcs_print_error("can't initialize Task methods\n");
 	emctask_shutdown();
 	exit(1);

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -3052,13 +3052,15 @@ static int iniLoad(const char *filename)
 	    strncpy(version, "unknown", LINELEN-1);
 	}
 
-	if (NULL != (inistring = inifile.Find("MACHINE", "EMC"))) {
-	    strncpy(machine, inistring, LINELEN-1);
-	} else {
-	    strncpy(machine, "unknown", LINELEN-1);
-	}
-	rcs_print("task: machine: '%s'  version '%s'\n", machine, version);
     }
+
+    if (NULL != (inistring = inifile.Find("MACHINE", "EMC"))) {
+	strncpy(machine, inistring, LINELEN-1);
+    } else {
+	strncpy(machine, "unknown", LINELEN-1);
+    }
+    rcs_print("task: machine: '%s'  version '%s'\n", machine, version);
+
 
     if (NULL != (inistring = inifile.Find("NML_FILE", "EMC"))) {
 	// copy to global

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -1366,6 +1366,7 @@ static int iniLoad(const char *filename)
 {
     IniFile inifile;
     const char *inistring;
+    char version[LINELEN], machine[LINELEN];
     double d;
     int i;
 
@@ -1428,6 +1429,19 @@ static int iniLoad(const char *filename)
             perror("failed to parse [EMC] RCS_MAX_ERR");
         }
     }
+
+    if (NULL != (inistring = inifile.Find("VERSION", "EMC"))) {
+	    if(sscanf(inistring, "$Revision: %s", version) != 1) {
+            strncpy(version, "unknown", LINELEN-1);
+	    }
+    }
+
+    if (NULL != (inistring = inifile.Find("MACHINE", "EMC"))) {
+	    strncpy(machine, inistring, LINELEN-1);
+    } else {
+	    strncpy(machine, "unknown", LINELEN-1);
+    }
+    rcs_print("task: machine: '%s'  version '%s'\n", machine, version);
 
     if (NULL != (inistring = inifile.Find("NML_FILE", "EMC"))) {
 	// copy to global

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -328,48 +328,34 @@ static int tryNml()
 #define RETRY_TIME 10.0		// seconds to wait for subsystems to come up
 #define RETRY_INTERVAL 1.0	// seconds between wait tries for a subsystem
 
-    if ((emc_debug & EMC_DEBUG_NML) == 0) {
-	set_rcs_print_destination(RCS_PRINT_TO_NULL);	// inhibit diag
-	// messages
-    }
     end = RETRY_TIME;
     good = 0;
     do {
-	if (0 == emcTaskNmlGet()) {
-	    good = 1;
-	    break;
-	}
-	esleep(RETRY_INTERVAL);
-	end -= RETRY_INTERVAL;
+        if (0 == emcTaskNmlGet()) {
+            good = 1;
+            break;
+        }
+        esleep(RETRY_INTERVAL);
+        end -= RETRY_INTERVAL;
     } while (end > 0.0);
-    if ((emc_debug & EMC_DEBUG_NML) == 0) {
-	set_rcs_print_destination(RCS_PRINT_TO_STDOUT);	// inhibit diag
-	// messages
-    }
+
     if (!good) {
-	return -1;
+        return -1;
     }
 
-    if ((emc_debug & EMC_DEBUG_NML) == 0) {
-	set_rcs_print_destination(RCS_PRINT_TO_NULL);	// inhibit diag
-	// messages
-    }
     end = RETRY_TIME;
     good = 0;
     do {
-	if (0 == emcErrorNmlGet()) {
-	    good = 1;
-	    break;
-	}
-	esleep(RETRY_INTERVAL);
-	end -= RETRY_INTERVAL;
+        if (0 == emcErrorNmlGet()) {
+            good = 1;
+            break;
+        }
+        esleep(RETRY_INTERVAL);
+        end -= RETRY_INTERVAL;
     } while (end > 0.0);
-    if ((emc_debug & EMC_DEBUG_NML) == 0) {
-	set_rcs_print_destination(RCS_PRINT_TO_STDOUT);	// inhibit diag
-	// messages
-    }
+
     if (!good) {
-	return -1;
+        return -1;
     }
 
     return 0;
@@ -1388,14 +1374,59 @@ static int iniLoad(const char *filename)
 	return -1;
     }
 
+    // EMC debugging flags
+	emc_debug = 0;  // disabled by default
     if (NULL != (inistring = inifile.Find("DEBUG", "EMC"))) {
-	// copy to global
-	if (1 != sscanf(inistring, "%i", &emc_debug)) {
-	    emc_debug = 0;
-	}
-    } else {
-	// not found, use default
-	emc_debug = 0;
+        // parse to global
+        if (sscanf(inistring, "%x", &emc_debug) < 1) {
+            perror("failed to parse [EMC] DEBUG");
+        }
+    }
+
+    // set output for RCS messages
+    set_rcs_print_destination(RCS_PRINT_TO_STDOUT);   // use stdout by default
+    if (NULL != (inistring = inifile.Find("RCS_DEBUG_DEST", "EMC"))) {
+        static RCS_PRINT_DESTINATION_TYPE type;
+        if (!strcmp(inistring, "STDOUT")) {
+            type = RCS_PRINT_TO_STDOUT;
+        } else if (!strcmp(inistring, "STDERR")) {
+            type = RCS_PRINT_TO_STDERR;
+        } else if (!strcmp(inistring, "FILE")) {
+            type = RCS_PRINT_TO_FILE;
+        } else if (!strcmp(inistring, "LOGGER")) {
+            type = RCS_PRINT_TO_LOGGER;
+        } else if (!strcmp(inistring, "MSGBOX")) {
+            type = RCS_PRINT_TO_MESSAGE_BOX;
+        } else if (!strcmp(inistring, "NULL")) {
+            type = RCS_PRINT_TO_NULL;
+        } else {
+             type = RCS_PRINT_TO_STDOUT;
+        }
+        set_rcs_print_destination(type);
+    }
+
+    // NML/RCS debugging flags
+    set_rcs_print_flag(0);  // (disabled by default)
+    // enable all debug messages by default if RCS or NML debugging is enabled
+    if ((emc_debug & EMC_DEBUG_RCS) || (emc_debug & EMC_DEBUG_NML)) {
+        // output all RCS debug messages
+        set_rcs_print_flag(PRINT_EVERYTHING);
+    }
+
+    // set flags if RCS_DEBUG in ini file
+    if (NULL != (inistring = inifile.Find("RCS_DEBUG", "EMC"))) {
+        static long int flags;
+        if (sscanf(inistring, "%lx", &flags) < 1) {
+            perror("failed to parse [EMC] RCS_DEBUG");
+        }
+        set_rcs_print_flag(flags);
+    }
+    // output infinite RCS errors by default
+    max_rcs_errors_to_print = -1;
+    if (NULL != (inistring = inifile.Find("RCS_MAX_ERR", "EMC"))) {
+        if (sscanf(inistring, "%d", &max_rcs_errors_to_print) < 1) {
+            perror("failed to parse [EMC] RCS_MAX_ERR");
+        }
     }
 
     if (NULL != (inistring = inifile.Find("NML_FILE", "EMC"))) {

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -1406,7 +1406,7 @@ static int iniLoad(const char *filename)
     }
 
     // NML/RCS debugging flags
-    set_rcs_print_flag(0);  // (disabled by default)
+    set_rcs_print_flag(PRINT_RCS_ERRORS);  // only print errors by default
     // enable all debug messages by default if RCS or NML debugging is enabled
     if ((emc_debug & EMC_DEBUG_RCS) || (emc_debug & EMC_DEBUG_NML)) {
         // output all RCS debug messages

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -1420,6 +1420,9 @@ static int iniLoad(const char *filename)
         if (sscanf(inistring, "%lx", &flags) < 1) {
             perror("failed to parse [EMC] RCS_DEBUG");
         }
+        // clear all flags
+        clear_rcs_print_flag(PRINT_EVERYTHING);
+        // set parsed flags
         set_rcs_print_flag(flags);
     }
     // output infinite RCS errors by default

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -1235,7 +1235,7 @@ int iniLoad(const char *filename)
     }
 
     // NML/RCS debugging flags
-    set_rcs_print_flag(0);  // (disabled by default)
+    set_rcs_print_flag(PRINT_RCS_ERRORS);  // only print errors by default
     // enable all debug messages by default if RCS or NML debugging is enabled
     if ((emc_debug & EMC_DEBUG_RCS) || (emc_debug & EMC_DEBUG_NML)) {
         // output all RCS debug messages

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -1194,6 +1194,7 @@ int iniLoad(const char *filename)
 {
     IniFile inifile;
     const char *inistring;
+    char version[LINELEN], machine[LINELEN];
     char displayString[LINELEN] = "";
     int t;
     int i;
@@ -1257,6 +1258,19 @@ int iniLoad(const char *filename)
             perror("failed to parse [EMC] RCS_MAX_ERR");
         }
     }
+
+    if (NULL != (inistring = inifile.Find("VERSION", "EMC"))) {
+	    if(sscanf(inistring, "$Revision: %s", version) != 1) {
+            strncpy(version, "unknown", LINELEN-1);
+	    }
+    }
+
+    if (NULL != (inistring = inifile.Find("MACHINE", "EMC"))) {
+	    strncpy(machine, inistring, LINELEN-1);
+    } else {
+	    strncpy(machine, "unknown", LINELEN-1);
+    }
+    rcs_print("task: machine: '%s'  version '%s'\n", machine, version);
 
     if (NULL != (inistring = inifile.Find("NML_FILE", "EMC"))) {
 	// copy to global

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -131,48 +131,34 @@ int tryNml(double retry_time, double retry_interval)
     double end;
     int good;
 
-    if ((emc_debug & EMC_DEBUG_NML) == 0) {
-	set_rcs_print_destination(RCS_PRINT_TO_NULL);	// inhibit diag
-	// messages
-    }
     end = retry_time;
     good = 0;
     do {
-	if (0 == emcTaskNmlGet()) {
-	    good = 1;
-	    break;
-	}
-	esleep(retry_interval);
-	end -= retry_interval;
+        if (0 == emcTaskNmlGet()) {
+            good = 1;
+            break;
+        }
+        esleep(retry_interval);
+        end -= retry_interval;
     } while (end > 0.0);
-    if ((emc_debug & EMC_DEBUG_NML) == 0) {
-	set_rcs_print_destination(RCS_PRINT_TO_STDOUT);	// inhibit diag
-	// messages
-    }
+
     if (!good) {
-	return -1;
+	    return -1;
     }
 
-    if ((emc_debug & EMC_DEBUG_NML) == 0) {
-	set_rcs_print_destination(RCS_PRINT_TO_NULL);	// inhibit diag
-	// messages
-    }
     end = retry_time;
     good = 0;
     do {
-	if (0 == emcErrorNmlGet()) {
-	    good = 1;
-	    break;
-	}
-	esleep(retry_interval);
-	end -= retry_interval;
+        if (0 == emcErrorNmlGet()) {
+            good = 1;
+            break;
+        }
+        esleep(retry_interval);
+        end -= retry_interval;
     } while (end > 0.0);
-    if ((emc_debug & EMC_DEBUG_NML) == 0) {
-	set_rcs_print_destination(RCS_PRINT_TO_STDOUT);	// inhibit diag
-	// messages
-    }
+
     if (!good) {
-	return -1;
+	    return -1;
     }
 
     return 0;
@@ -1217,14 +1203,59 @@ int iniLoad(const char *filename)
 	return -1;
     }
 
+    // EMC debugging flags
+	emc_debug = 0;  // disabled by default
     if (NULL != (inistring = inifile.Find("DEBUG", "EMC"))) {
-	// copy to global
-	if (1 != sscanf(inistring, "%i", &emc_debug)) {
-	    emc_debug = 0;
-	}
-    } else {
-	// not found, use default
-	emc_debug = 0;
+        // parse to global
+        if (sscanf(inistring, "%x", &emc_debug) < 1) {
+            perror("failed to parse [EMC] DEBUG");
+        }
+    }
+
+    // set output for RCS messages
+    set_rcs_print_destination(RCS_PRINT_TO_STDOUT);   // use stdout by default
+    if (NULL != (inistring = inifile.Find("RCS_DEBUG_DEST", "EMC"))) {
+        static RCS_PRINT_DESTINATION_TYPE type;
+        if (!strcmp(inistring, "STDOUT")) {
+            type = RCS_PRINT_TO_STDOUT;
+        } else if (!strcmp(inistring, "STDERR")) {
+            type = RCS_PRINT_TO_STDERR;
+        } else if (!strcmp(inistring, "FILE")) {
+            type = RCS_PRINT_TO_FILE;
+        } else if (!strcmp(inistring, "LOGGER")) {
+            type = RCS_PRINT_TO_LOGGER;
+        } else if (!strcmp(inistring, "MSGBOX")) {
+            type = RCS_PRINT_TO_MESSAGE_BOX;
+        } else if (!strcmp(inistring, "NULL")) {
+            type = RCS_PRINT_TO_NULL;
+        } else {
+             type = RCS_PRINT_TO_STDOUT;
+        }
+        set_rcs_print_destination(type);
+    }
+
+    // NML/RCS debugging flags
+    set_rcs_print_flag(0);  // (disabled by default)
+    // enable all debug messages by default if RCS or NML debugging is enabled
+    if ((emc_debug & EMC_DEBUG_RCS) || (emc_debug & EMC_DEBUG_NML)) {
+        // output all RCS debug messages
+        set_rcs_print_flag(PRINT_EVERYTHING);
+    }
+
+    // set flags if RCS_DEBUG in ini file
+    if (NULL != (inistring = inifile.Find("RCS_DEBUG", "EMC"))) {
+        static long int flags;
+        if (sscanf(inistring, "%lx", &flags) < 1) {
+            perror("failed to parse [EMC] RCS_DEBUG");
+        }
+        set_rcs_print_flag(flags);
+    }
+    // output infinite RCS errors by default
+    max_rcs_errors_to_print = -1;
+    if (NULL != (inistring = inifile.Find("RCS_MAX_ERR", "EMC"))) {
+        if (sscanf(inistring, "%d", &max_rcs_errors_to_print) < 1) {
+            perror("failed to parse [EMC] RCS_MAX_ERR");
+        }
     }
 
     if (NULL != (inistring = inifile.Find("NML_FILE", "EMC"))) {

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -1249,6 +1249,9 @@ int iniLoad(const char *filename)
         if (sscanf(inistring, "%lx", &flags) < 1) {
             perror("failed to parse [EMC] RCS_DEBUG");
         }
+        // clear all flags
+        clear_rcs_print_flag(PRINT_EVERYTHING);
+        // set parsed flags
         set_rcs_print_flag(flags);
     }
     // output infinite RCS errors by default


### PR DESCRIPTION
Currently a lot of rcs_print*() calls are "commented out" by blocks of 
```
set_rcs_print_destination(RCS_PRINT_TO_NULL);
...
set_rcs_print_destination(RCS_PRINT_TO_STDOUT);
```
which supresses output completely. On the other hand, ```DEBUG |= EMC_DEBUG_RCS``` or ```DEBUG |= EMC_DEBUG_NML``` in the INI file will result in ```set_rcs_print_flag(PRINT_EVERYTHING);``` which naturally generates very noisy output.

This PR introduces the config options
* ```RCS_DEBUG``` to control [print mode flags](https://github.com/LinuxCNC/linuxcnc/blob/master/src/libnml/rcs/rcs_print.hh#L107) similar to the current ```DEBUG``` option
* ```RCS_DEBUG_DEST``` to control the destionation of rcs_print*() output
* ```RCS_MAX_ERR``` to limit the amount of errors printed by ```rcs_print_error()```
