### PR TITLE
allow multiple parallel linuxcnc instances

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -732,7 +732,7 @@ function Cleanup() {
 
 # Name of lock file to check for that signifies that LinuxCNC is up,
 # to prevent multiple copies of controller
-LOCKFILE=/tmp/linuxcnc.lock
+LOCKFILE=/tmp/linuxcnc-$LINUXCNC_INSTANCE.lock
 
 # Check for lock file
 if [ -f $LOCKFILE ]; then

--- a/src/hal/utils/halcmd_main.c
+++ b/src/hal/utils/halcmd_main.c
@@ -356,8 +356,17 @@ static int release_HAL_mutex(void)
         rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: rtapi init failed\n");
         return -EINVAL;
     }
+
+    unsigned long key = HAL_KEY;
+    /* get instance env variable */
+    const char *instance = getenv("LINUXCNC_INSTANCE");
+    if (instance) {
+        long offset = strtol(instance, NULL, 10) * 16;
+        key += offset;
+    }
+    
     /* get HAL shared memory block from RTAPI */
-    mem_id = rtapi_shmem_new(HAL_KEY, comp_id, HAL_SIZE);
+    mem_id = rtapi_shmem_new(key, comp_id, HAL_SIZE);
     if (mem_id < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR,
             "ERROR: could not open shared memory\n");

--- a/src/libnml/buffer/shmem.cc
+++ b/src/libnml/buffer/shmem.cc
@@ -73,6 +73,13 @@ SHMEM::SHMEM(const char *n, long s, int nt, key_t k, int m):CMS(s)
     master = m;
     key = k;
 
+    /* get instance env variable */
+    const char* instance = getenv("LINUXCNC_INSTANCE");
+    if (instance) {
+        long offset = strtol(instance, NULL, 10) * 16;
+        key += offset;
+    }
+
     /* open the shared mem buffer and create mutual exclusion semaphore */
     open();
 }
@@ -101,6 +108,13 @@ SHMEM::SHMEM(const char *bufline, const char *procline, int set_to_server,
     if (sscanf(bufline, "%*s %*s %*s %*s %*s %*s %*s %*s %*s %d", &key) != 1) {
 	rcs_print_error("SHMEM: Invalid configuration file format.\n");
 	return;
+    }
+
+    /* get instance env variable */
+    const char* instance = getenv("LINUXCNC_INSTANCE");
+    if (instance) {
+        long offset = strtol(instance, NULL, 10) * 16;
+        key += offset;
     }
 
     master = is_local_master;

--- a/src/libnml/buffer/tcpmem.cc
+++ b/src/libnml/buffer/tcpmem.cc
@@ -102,6 +102,13 @@ TCPMEM::TCPMEM(const char *_bufline, const char *_procline):CMS(_bufline, _procl
     }
     server_host_entry = NULL;
 
+    /* get instance env variable */
+    const char* instance = getenv("LINUXCNC_INSTANCE");
+    if (instance) {
+        long offset = strtol(instance, NULL, 10) * 16;
+        tcp_port_number += offset;
+    }
+
     /* Set up the socket address structure. */
     memset(&server_socket_address, 0, sizeof(server_socket_address));
     server_socket_address.sin_family = AF_INET;

--- a/src/libnml/cms/tcp_srv.cc
+++ b/src/libnml/cms/tcp_srv.cc
@@ -242,18 +242,24 @@ int CMS_SERVER_REMOTE_TCP_PORT::accept_local_port_cms(CMS * _cms)
     if (_cms->total_subdivisions > max_total_subdivisions) {
 	max_total_subdivisions = _cms->total_subdivisions;
     }
+  /* get instance env variable */
+  const char *instance = getenv("LINUXCNC_INSTANCE");
+  long offset = 0;
+  if (instance) {
+    offset = strtol(instance, NULL, 10) * 16;
+  }
     if (server_socket_address.sin_port == 0) {
 	server_socket_address.sin_port =
-	    htons(((u_short) _cms->tcp_port_number));
-	port_num = _cms->tcp_port_number;
-	return 1;
-    }
-    if (server_socket_address.sin_port ==
-	htons(((u_short) _cms->tcp_port_number))) {
-	port_num = _cms->tcp_port_number;
-	return 1;
-    }
-    return 0;
+        htons(((u_short)_cms->tcp_port_number) + (u_short)offset);
+    port_num = _cms->tcp_port_number + offset;
+    return 1;
+  }
+  if (server_socket_address.sin_port ==
+      htons(((u_short)_cms->tcp_port_number + (u_short)offset))) {
+    port_num = _cms->tcp_port_number + offset;
+    return 1;
+  }
+  return 0;
 }
 
 void CMS_SERVER_REMOTE_TCP_PORT::register_port()

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -65,8 +65,15 @@ int rtapi_shmem_new(int key, int module_id, unsigned long int size)
   rtapi_shmem_handle *shmem;
   int i;
 
-  for (i=0,shmem=0 ; i < MAX_SHM; i++) {
-    if(shmem_array[i].magic == SHMEM_MAGIC) {
+  /* get instance env variable */
+    const char* instance = getenv("LINUXCNC_INSTANCE");
+    if (instance) {
+        long offset = strtol(instance, NULL, 10) * 16;
+        key += offset;
+    }
+
+  for (i = 0, shmem = 0; i < MAX_SHM; i++) {
+    if (shmem_array[i].magic == SHMEM_MAGIC) {
       if (shmem_array[i].key == key) {
         shmem_array[i].count ++;
         return i;

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -488,9 +488,13 @@ _get_fifo_path() {
            "rtapi_app: RTAPI_FIFO_PATH and HOME are unset.  rtapi fifo creation is unsafe.");
        return NULL;
     }
-    if(s.size() + 1 > sizeof(sockaddr_un::sun_path)) {
-       rtapi_print_msg(RTAPI_MSG_ERR,
-           "rtapi_app: rtapi fifo path is too long (arch limit %zd): %s",
+    if (getenv("LINUXCNC_INSTANCE")) {
+        s += "-";
+        s += getenv("LINUXCNC_INSTANCE");
+    }
+    if (s.size() + 1 > sizeof(sockaddr_un::sun_path)) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+                        "rtapi_app: rtapi fifo path is too long (arch limit %zd): %s",
                sizeof(sockaddr_un::sun_path), s.c_str());
        return NULL;
     }


### PR DESCRIPTION
Set environment variable LINUXCNC_INSTANCE to some numeric value. This value times 16 is added to shared memory keys and to tcp port numbers. If unset it is treated as 0. issue #2716 
This is a draft and has probably unresolved issues.