### PR TITLE
Fix missing G59.(1,2,3) decimal in combi_dro.py

### DIFF
--- a/lib/python/gladevcp/combi_dro.py
+++ b/lib/python/gladevcp/combi_dro.py
@@ -350,7 +350,7 @@ class Combi_DRO(Gtk.Box):
                 if code >= 540 and code <= 590:
                     return "G%s" % int((code / 10))
                 elif code > 590 and code <= 593:
-                    return "G%s" % int((code / 10.0))
+                    return "G%.1f" % (code / 10.0)
             return "Rel"
 
     # Get the units used according to gcode

--- a/lib/python/gladevcp/combi_dro.py
+++ b/lib/python/gladevcp/combi_dro.py
@@ -350,7 +350,7 @@ class Combi_DRO(Gtk.Box):
                 if code >= 540 and code <= 590:
                     return "G%s" % int((code / 10))
                 elif code > 590 and code <= 593:
-                    return "G%.1f" % (code / 10.0)
+                    return "G%s" % (code / 10.0)
             return "Rel"
 
     # Get the units used according to gcode


### PR DESCRIPTION
Fixes gladevcp 'combi_dro' from this:
![DRO missing decimal](https://github.com/LinuxCNC/linuxcnc/assets/46067220/10e3eac8-7c65-4e36-bafc-e4853b024768)
to this:

![combi_dro](https://github.com/LinuxCNC/linuxcnc/assets/46067220/2c3a9409-233a-4cce-a5fa-81380c6d2051)

