### PR TITLE
Fixes two bugs in gmoccapy and in gladevcp combi dro widget

### DIFF
--- a/lib/python/gladevcp/combi_dro.py
+++ b/lib/python/gladevcp/combi_dro.py
@@ -350,7 +350,7 @@ class Combi_DRO(Gtk.Box):
                 if code >= 540 and code <= 590:
                     return "G%s" % int((code / 10))
                 elif code > 590 and code <= 593:
-                    return "G%s" % int((code / 10.0))
+                    return "G%s" % (code / 10.0)
             return "Rel"
 
     # Get the units used according to gcode

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -3656,7 +3656,7 @@ class gmoccapy(object):
     def on_chk_turtle_jog_toggled(self, widget, data=None):
         state = widget.get_active()
         self.prefs.putpref("hide_turtle_jog_button", state)
-        self.widgets.tbl_turtle_jog_factor.set_sensitive(not state)
+        self.widgets.spbtn_turtle_jog_factor.set_sensitive(not state)
         if state:
             self.widgets.tbtn_turtle_jog.hide()
         else:


### PR DESCRIPTION
commit e82be23 fixes this error when trying to hide the turtle-jog button in gmoccapy:
![error_hide_turtle_button](https://github.com/LinuxCNC/linuxcnc/assets/46067220/a2bfb48f-afdd-4ccf-84ee-82d98e25e782)


commit 6cb167f fixes missing decimals when using G59.(1,2,3) in the gladevcp combi_dro widget:

![DRO missing decimal](https://github.com/LinuxCNC/linuxcnc/assets/46067220/ae95ecd8-2bee-485a-96c6-5595167f0a28)

Fix:

![combi_dro](https://github.com/LinuxCNC/linuxcnc/assets/46067220/2cd97393-4955-4873-83ac-415b86f702c0)
