### PR TITLE
Fixes db_demo simulation and adds back DB_PROGRAM functionality

### DIFF
--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -28,7 +28,6 @@
 #include "taskclass.hh"
 #include <rtapi_string.h>
 
-#include "tooldata.hh"
 #include "hal.hh"
 
 /********************************************************************
@@ -144,6 +143,17 @@ Task::Task(EMC_IO_STAT & emcioStatus_in) :
         const char *t;
         if ((t = inifile.Find("TOOL_TABLE", "EMCIO")) != NULL)
             tooltable_filename = strdup(t);
+
+        if ((t = inifile.Find("DB_PROGRAM", "EMCIO")) != NULL) {
+            db_mode = tooldb_t::DB_ACTIVE;
+            tooldata_set_db(db_mode);
+            strncpy(db_program, t, LINELEN - 1);
+        }
+
+        if (tooltable_filename != NULL && db_program[0] != '\0') {
+            fprintf(stderr,"DB_PROGRAM active: IGNORING tool table file %s\n",
+                    tooltable_filename);
+        }
         inifile.Close();
     }
 
@@ -154,9 +164,19 @@ Task::Task(EMC_IO_STAT & emcioStatus_in) :
     tool_mmap_user();
     // initialize database tool finder:
 #endif //}
-    emcioStatus.status = RCS_STATUS::DONE;//TODO??
+
     tooldata_init(random_toolchanger);
+    if (db_mode == tooldb_t::DB_ACTIVE) {
+        if (0 != tooldata_db_init(db_program, random_toolchanger)) {
+            rcs_print_error("can't initialize DB_PROGRAM.\n");
+            db_mode = tooldb_t::DB_NOTUSED;
+            tooldata_set_db(db_mode);
+        }
+    }
+
+    emcioStatus.status = RCS_STATUS::DONE;//TODO??
     emcioStatus.tool.pocketPrepped = -1;
+
     if(!random_toolchanger) {
         CANON_TOOL_TABLE tdata = tooldata_entry_init();
         tdata.pocketno =  0; //nonrandom init
@@ -165,6 +185,7 @@ Task::Task(EMC_IO_STAT & emcioStatus_in) :
             UNEXPECTED_MSG;
         }
     }
+
     if (0 != tooldata_load(tooltable_filename)) {
         rcs_print_error("can't load tool table.\n");
     }

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -129,7 +129,6 @@ struct _inittab builtin_modules[] = {
 
 Task::Task(EMC_IO_STAT & emcioStatus_in) :
     emcioStatus(emcioStatus_in),
-    random_toolchanger(0),
     ini_filename(emc_inifile),
     iocontrol("iocontrol.0")
     {

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -129,13 +129,11 @@ struct _inittab builtin_modules[] = {
 
 Task::Task(EMC_IO_STAT & emcioStatus_in) :
     emcioStatus(emcioStatus_in),
-    ini_filename(emc_inifile),
-    iocontrol("iocontrol.0")
+    iocontrol("iocontrol.0"),
+    ini_filename(emc_inifile)
     {
 
     IniFile inifile;
-
-    ini_filename = emc_inifile;
 
     if (inifile.Open(ini_filename)) {
         inifile.Find(&random_toolchanger, "RANDOM_TOOLCHANGER", "EMCIO");

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -140,12 +140,12 @@ Task::Task(EMC_IO_STAT & emcioStatus_in) :
     ini_filename = emc_inifile;
 
     if (inifile.Open(ini_filename)) {
-	inifile.Find(&random_toolchanger, "RANDOM_TOOLCHANGER", "EMCIO");
-	const char *t;
-	if ((t = inifile.Find("TOOL_TABLE", "EMCIO")) != NULL)
-	    tooltable_filename = strdup(t);
+        inifile.Find(&random_toolchanger, "RANDOM_TOOLCHANGER", "EMCIO");
+        const char *t;
+        if ((t = inifile.Find("TOOL_TABLE", "EMCIO")) != NULL)
+            tooltable_filename = strdup(t);
     }
-	    
+
 #ifdef TOOL_NML //{
     tool_nml_register( (CANON_TOOL_TABLE*)&emcStatus->io.tool.toolTable);
 #else //}{

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -144,6 +144,7 @@ Task::Task(EMC_IO_STAT & emcioStatus_in) :
         const char *t;
         if ((t = inifile.Find("TOOL_TABLE", "EMCIO")) != NULL)
             tooltable_filename = strdup(t);
+        inifile.Close();
     }
 
 #ifdef TOOL_NML //{

--- a/src/emc/task/taskclass.hh
+++ b/src/emc/task/taskclass.hh
@@ -78,7 +78,7 @@ public:
     void hal_init_pins(void);
 
     EMC_IO_STAT &emcioStatus;
-    int random_toolchanger;
+    int random_toolchanger {0};
     iocontrol_str iocontrol_data;
     hal_comp iocontrol;
     const char *ini_filename;

--- a/src/emc/task/taskclass.hh
+++ b/src/emc/task/taskclass.hh
@@ -81,7 +81,7 @@ public:
     iocontrol_str iocontrol_data;
     hal_comp iocontrol;
     const char *ini_filename;
-    const char *tooltable_filename;
+    const char *tooltable_filename {};
     int tool_status;
 };
 

--- a/src/emc/task/taskclass.hh
+++ b/src/emc/task/taskclass.hh
@@ -21,6 +21,7 @@
 #include "emc.hh"
 #include "inifile.hh"
 #include "hal.hh"
+#include "tooldata.hh"
 
 #define UNEXPECTED_MSG fprintf(stderr,"UNEXPECTED %s %d\n",__FILE__,__LINE__);
 
@@ -82,6 +83,8 @@ public:
     hal_comp iocontrol;
     const char *ini_filename;
     const char *tooltable_filename {};
+    char db_program[LINELEN] {};
+    tooldb_t db_mode {tooldb_t::DB_NOTUSED};
     int tool_status;
 };
 

--- a/src/emc/tooldata/tooldata_common.cc
+++ b/src/emc/tooldata/tooldata_common.cc
@@ -300,7 +300,8 @@ int tooldata_load(const char *filename)
 
     // open tool table file
     if (NULL == (fp = fopen(filename, "r"))) {
-        // can't open file
+        fprintf(stderr, "%s, %d: Failed to open tool table file '%s': %s\n",
+                __FILE__, __LINE__, filename, strerror(errno));
         return -1;
     }
 
@@ -385,7 +386,8 @@ int tooldata_save(const char *filename)
 
     // open tool table file
     if (NULL == (fp = fopen(filename, "w"))) {
-        // can't open file
+        fprintf(stderr, "%s, %d: Failed to open tool table file '%s': %s\n",
+                __FILE__, __LINE__, filename, strerror(errno));
         return -1;
     }
 


### PR DESCRIPTION
The should add back the missing functionality to use DB_PROGRAM, it seems this was forgotten in 7ebe7d91fced459729c84a4265556692010379c9. This also adds two error messages and  initializes variables in the header file.

The simulation `db_demo`, both random and nonrandom should be fixed with this PR.

Fixes #2719