### PR TITLE
refactor interpl linked list to use std::unique_ptr

### DIFF
--- a/src/emc/nml_intf/interpl.cc
+++ b/src/emc/nml_intf/interpl.cc
@@ -93,7 +93,7 @@ std::unique_ptr<NMLmsg> NML_INTERP_LIST::get()
 
 void NML_INTERP_LIST::clear()
 {
-    if (true /*emc_debug & EMC_DEBUG_INTERP_LIST*/) {
+    if (emc_debug & EMC_DEBUG_INTERP_LIST) {
         rcs_print("NML_INTERP_LIST(%p)::clear(): discarding %lu items\n", this, linked_list.size());
     }
     linked_list.clear();

--- a/src/emc/nml_intf/interpl.cc
+++ b/src/emc/nml_intf/interpl.cc
@@ -1,33 +1,28 @@
 /********************************************************************
-* Description: interpl.cc
-*   Mechanism for queueing NML messages, used by the interpreter and
-*   canonical interface to report list of NML statements from program
-*   files to HME.
-*
-*   Derived from a work by Fred Proctor & Will Shackleford
-*
-* Author:
-* License: GPL Version 2
-* System: Linux
-*    
-* Copyright (c) 2004 All rights reserved.
-*
-* Last change:
-********************************************************************/
+ * Description: interpl.cc
+ *   Mechanism for queueing NML messages, used by the interpreter and
+ *   canonical interface to report list of NML statements from program
+ *   files to HME.
+ *
+ *   Derived from a work by Fred Proctor & Will Shackleford
+ *
+ * Author:
+ * License: GPL Version 2
+ * System: Linux
+ *
+ * Copyright (c) 2004 All rights reserved.
+ *
+ * Last change:
+ ********************************************************************/
 
-#include "rcs.hh"		// LinkedList
-#include "interpl.hh"		// these decls
+#include "interpl.hh"   // these decls
 #include "emc.hh"
 #include "emcglb.h"
-#include "nmlmsg.hh"            /* class NMLmsg */
+#include "nmlmsg.hh"    // class NMLmsg
 #include "rcs_print.hh"
 
-NML_INTERP_LIST interp_list;	/* NML Union, for interpreter */
+NML_INTERP_LIST interp_list; /* NML Union, for interpreter */
 
-int NML_INTERP_LIST::append(NMLmsg & nml_msg)
-{
-    return append(&nml_msg);
-}
 
 // sets the line number used for subsequent appends
 void NML_INTERP_LIST::set_line_number(int line)
@@ -35,110 +30,88 @@ void NML_INTERP_LIST::set_line_number(int line)
     next_line_number = line;
 }
 
-int NML_INTERP_LIST::append(NMLmsg * nml_msg_ptr)
+int NML_INTERP_LIST::append(std::unique_ptr<NMLmsg>&& nml_msg_ptr)
 {
     /* check for invalid data */
     if (NULL == nml_msg_ptr) {
-	rcs_print_error
-	    ("NML_INTERP_LIST::append : attempt to append NULL msg\n");
-	return -1;
+        rcs_print_error("NML_INTERP_LIST::append : attempt to append NULL msg\n");
+        return -1;
     }
 
     if (0 == nml_msg_ptr->type) {
-	rcs_print_error
-	    ("NML_INTERP_LIST::append : attempt to append 0 type\n");
-	return -1;
+        rcs_print_error("NML_INTERP_LIST::append : attempt to append 0 type\n");
+        return -1;
     }
 
     if (nml_msg_ptr->size < 4) {
-	rcs_print_error
-	    ("NML_INTERP_LIST::append : command size is invalid.");
-	return -1;
+        rcs_print_error("NML_INTERP_LIST::append : command size is invalid.");
+        return -1;
     }
-#ifdef DEBUG_INTERPL
-    if (sizeof(temp_node) < MAX_NML_COMMAND_SIZE + 4 ||
-	sizeof(temp_node) > MAX_NML_COMMAND_SIZE + 16 ||
-	((uintptr_t) &temp_node.line_number) >
-	((uintptr_t) &temp_node.command.commandbuf)) {
-	rcs_print_error
-	    ("NML_INTERP_LIST::append : assumptions about NML_INTERP_LIST_NODE have been violated.");
-	return -1;
-    }
-#endif
 
-    NML_INTERP_LIST_NODE node;
-    node.line_number = next_line_number;
-    node.command.reserve(nml_msg_ptr->size);
-    // fill in the NML_INTERP_LIST_NODE
-    node.command.insert(node.command.begin(), (char*)nml_msg_ptr, (char*)nml_msg_ptr + nml_msg_ptr->size);
+    NML_INTERP_LIST_NODE node {next_line_number, std::move(nml_msg_ptr)};
 
     // stick it on the list
-    linked_list.push_back(node);
+    linked_list.emplace_back(std::move(node));
 
     if (emc_debug & EMC_DEBUG_INTERP_LIST) {
-	rcs_print
-	    ("NML_INTERP_LIST(%p)::append(nml_msg_ptr{size=%ld,type=%s}) : list_size=%lu, line_number=%d\n",
-             this,
-	     nml_msg_ptr->size, emc_symbol_lookup(nml_msg_ptr->type),
-	     linked_list.size(), node.line_number);
+        rcs_print("NML_INTERP_LIST(%p)::append(nml_msg_ptr{size=%ld,type=%s}) : list_size=%lu, "
+                  "line_number=%d\n",
+                  this,
+                  linked_list.front().command->size,
+                  emc_symbol_lookup(linked_list.front().command->type),
+                  linked_list.size(),
+                  linked_list.front().line_number);
     }
 
     return 0;
 }
 
-NMLmsg *NML_INTERP_LIST::get()
+std::unique_ptr<NMLmsg> NML_INTERP_LIST::get()
 {
-    NMLmsg *ret;
-
-    if(linked_list.empty()){
+    if (linked_list.empty()) {
         line_number = 0;
         return NULL;
     }
 
     // get it off the front
-    node = linked_list.front();
+    auto node = std::move(linked_list.front());
     linked_list.pop_front();
 
     // save line number of this one, for use by get_line_number
     line_number = node.line_number;
-    ret = (NMLmsg *) node.command.data();
 
     if (emc_debug & EMC_DEBUG_INTERP_LIST) {
-        rcs_print(
-            "NML_INTERP_LIST(%p)::get(): {size=%ld, type=%s}, list_size=%lu\n",
-            this,
-            ret->size,
-            emc_symbol_lookup(ret->type),
-            linked_list.size()
-        );
+        rcs_print("NML_INTERP_LIST(%p)::get(): {size=%ld, type=%s}, list_size=%lu\n",
+                  this,
+                  node.command->size,
+                  emc_symbol_lookup(node.command->type),
+                  linked_list.size());
     }
 
-    return ret;
+    return std::move(node.command);
 }
 
 void NML_INTERP_LIST::clear()
 {
-    if (emc_debug & EMC_DEBUG_INTERP_LIST) {
+    if (true /*emc_debug & EMC_DEBUG_INTERP_LIST*/) {
         rcs_print("NML_INTERP_LIST(%p)::clear(): discarding %lu items\n", this, linked_list.size());
     }
-	linked_list.clear();
+    linked_list.clear();
 }
 
 void NML_INTERP_LIST::print()
 {
-    NMLmsg *msg;
-
-    rcs_print("NML_INTERP_LIST::print(): list size=%lu\n",linked_list.size());
-    for(auto &i:linked_list){
-        msg = (NMLmsg *) i.command.data();
-        rcs_print("--> type=%s,  line_number=%d\n", emc_symbol_lookup(msg->type), i.line_number);
+    rcs_print("NML_INTERP_LIST::print(): list size=%lu\n", linked_list.size());
+    for (auto& i : linked_list) {
+        auto& msg = *(i.command);
+        rcs_print("--> type=%s,  line_number=%d\n", emc_symbol_lookup(msg.type), i.line_number);
     }
     rcs_print("\n");
 }
 
 int NML_INTERP_LIST::len()
 {
-    return ((int) linked_list.size());
+    return ((int)linked_list.size());
 }
 
 int NML_INTERP_LIST::get_line_number()

--- a/src/emc/nml_intf/interpl.hh
+++ b/src/emc/nml_intf/interpl.hh
@@ -1,50 +1,54 @@
 /********************************************************************
-* Description: interpl.hh
-*   Mechanism for building lists of arbitrary NML messages, used by
-*   the canonical interface and interpreter to pass planned sequences
-*   to the HME.
-*
-*   Derived from a work by Fred Proctor & Will Shackleford
-*
-* Author:
-* License: GPL Version 2
-* System: Linux
-*    
-* Copyright (c) 2004 All rights reserved.
-*
-* Last change:
-********************************************************************/
+ * Description: interpl.hh
+ *   Mechanism for building lists of arbitrary NML messages, used by
+ *   the canonical interface and interpreter to pass planned sequences
+ *   to the HME.
+ *
+ *   Derived from a work by Fred Proctor & Will Shackleford
+ *
+ * Author:
+ * License: GPL Version 2
+ * System: Linux
+ *
+ * Copyright (c) 2004 All rights reserved.
+ *
+ * Last change:
+ ********************************************************************/
 #ifndef INTERP_LIST_HH
 #define INTERP_LIST_HH
 
 #include <deque>
-#include <vector>
+#include <memory>
+
+class NMLmsg;
 
 // these go on the interp list
-struct NML_INTERP_LIST_NODE {
-  int line_number;		// line number it was on
-  std::vector<char> command;
+struct NML_INTERP_LIST_NODE
+{
+    int line_number;  // line number it was on
+    // std::vector<char> command;
+    std::unique_ptr<NMLmsg> command;
 };
 
 // here's the interp list itself
-class NML_INTERP_LIST {
-  public:
+class NML_INTERP_LIST
+{
+public:
     void set_line_number(int line);
     int get_line_number();
-    int append(NMLmsg &);
-    int append(NMLmsg *);
-    NMLmsg *get();
+    int append(std::unique_ptr<NMLmsg>&& command);
+    std::unique_ptr<NMLmsg> get();
     void clear();
     void print();
     int len();
 
-  private:
+private:
     std::deque<NML_INTERP_LIST_NODE> linked_list;
-    int next_line_number = 0;	// line number used to fill temp_node
-    int line_number = 0;		// line number of node from get()
-    NML_INTERP_LIST_NODE node; // pointer returned by get
+    int next_line_number = 0;  // line number used to fill temp_node
+    int line_number = 0;       // line number of node from get()
+                               // NML_INTERP_LIST_NODE node; // pointer returned by get
 };
 
-extern NML_INTERP_LIST interp_list;	/* NML Union, for interpreter */
+extern NML_INTERP_LIST interp_list; /* NML Union, for interpreter */
 
 #endif

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -144,20 +144,15 @@ static PM_QUATERNION quat(1, 0, 0, 0);
 
 static void flush_segments(void);
 
-static inline void add_tag_to_msg(NMLmsg * msg, StateTag const &tag){
-    //FIXME this better be an EMC_TRAJ message or bad things will happen
-    ((EMC_TRAJ_CMD_MSG *) msg)->tag = tag;
-}
-
 
 /**
  * Add the the given line number and append the message to the interp list.
  * Note that the append function takes the message by reference, so this also
  * needs to have the message passed in by reference or it barfs.
  */
-static inline void tag_and_send(NMLmsg &msg, StateTag const &tag) {
-    add_tag_to_msg(&msg,tag);
-    interp_list.append(msg);
+static inline void tag_and_send(std::unique_ptr<EMC_TRAJ_CMD_MSG> &&msg, StateTag const &tag) {
+    msg->tag = tag;
+    interp_list.append(std::move(msg));
 }
 
 /*
@@ -433,18 +428,18 @@ static void send_g5x_msg(int index) {
 
     /* append it to interp list so it gets updated at the right time, not at
        read-ahead time */
-    EMC_TRAJ_SET_G5X set_g5x_msg;
+    auto set_g5x_msg = std::make_unique<EMC_TRAJ_SET_G5X>();
 
-    set_g5x_msg.g5x_index = index;
+    set_g5x_msg->g5x_index = index;
 
-    set_g5x_msg.origin = to_ext_pose(canon.g5xOffset);
+    set_g5x_msg->origin = to_ext_pose(canon.g5xOffset);
 
     for (int s = 0; s < emcStatus->motion.traj.spindles; s++){
         if(canon.spindle[s].css_maximum) {
             SET_SPINDLE_SPEED(s, canon.spindle[s].speed);
         }
     }
-    interp_list.append(set_g5x_msg);
+    interp_list.append(std::move(set_g5x_msg));
 }
 
 static void send_g92_msg(void) {
@@ -452,22 +447,22 @@ static void send_g92_msg(void) {
 
     /* append it to interp list so it gets updated at the right time, not at
        read-ahead time */
-    EMC_TRAJ_SET_G92 set_g92_msg;
+    auto set_g92_msg = std::make_unique<EMC_TRAJ_SET_G92>();
 
-    set_g92_msg.origin = to_ext_pose(canon.g92Offset);
+    set_g92_msg->origin = to_ext_pose(canon.g92Offset);
 
     for (int s = 0; s < emcStatus->motion.traj.spindles; s++){
         if(canon.spindle[s].css_maximum) {
             SET_SPINDLE_SPEED(s, canon.spindle[s].speed);
         }
     }
-    interp_list.append(set_g92_msg);
+    interp_list.append(std::move(set_g92_msg));
 }
 
 void SET_XY_ROTATION(double t) {
-    EMC_TRAJ_SET_ROTATION sr;
-    sr.rotation = t;
-    interp_list.append(sr);
+    auto sr = std::make_unique<EMC_TRAJ_SET_ROTATION>();
+    sr->rotation = t;
+    interp_list.append(std::move(sr));
 
     canon.xy_rotation = t;
 }
@@ -914,34 +909,34 @@ static void flush_segments(void) {
     }
 
 
-    EMC_TRAJ_LINEAR_MOVE linearMoveMsg;
-    linearMoveMsg.feed_mode = canon.feed_mode;
+    auto linearMoveMsg = std::make_unique<EMC_TRAJ_LINEAR_MOVE>();
+    linearMoveMsg->feed_mode = canon.feed_mode;
 
     // now x, y, z, and b are in absolute mm or degree units
-    linearMoveMsg.end.tran.x = TO_EXT_LEN(x);
-    linearMoveMsg.end.tran.y = TO_EXT_LEN(y);
-    linearMoveMsg.end.tran.z = TO_EXT_LEN(z);
+    linearMoveMsg->end.tran.x = TO_EXT_LEN(x);
+    linearMoveMsg->end.tran.y = TO_EXT_LEN(y);
+    linearMoveMsg->end.tran.z = TO_EXT_LEN(z);
 
-    linearMoveMsg.end.u = TO_EXT_LEN(u);
-    linearMoveMsg.end.v = TO_EXT_LEN(v);
-    linearMoveMsg.end.w = TO_EXT_LEN(w);
+    linearMoveMsg->end.u = TO_EXT_LEN(u);
+    linearMoveMsg->end.v = TO_EXT_LEN(v);
+    linearMoveMsg->end.w = TO_EXT_LEN(w);
 
     // fill in the orientation
-    linearMoveMsg.end.a = TO_EXT_ANG(a);
-    linearMoveMsg.end.b = TO_EXT_ANG(b);
-    linearMoveMsg.end.c = TO_EXT_ANG(c);
+    linearMoveMsg->end.a = TO_EXT_ANG(a);
+    linearMoveMsg->end.b = TO_EXT_ANG(b);
+    linearMoveMsg->end.c = TO_EXT_ANG(c);
 
-    linearMoveMsg.vel = toExtVel(vel);
-    linearMoveMsg.ini_maxvel = toExtVel(linedata.vel);
+    linearMoveMsg->vel = toExtVel(vel);
+    linearMoveMsg->ini_maxvel = toExtVel(linedata.vel);
     AccelData lineaccdata = getStraightAcceleration(x, y, z, a, b, c, u, v, w);
     double acc = lineaccdata.acc;
-    linearMoveMsg.acc = toExtAcc(acc);
+    linearMoveMsg->acc = toExtAcc(acc);
 
-    linearMoveMsg.type = EMC_MOTION_TYPE_FEED;
-    linearMoveMsg.indexer_jnum = -1;
+    linearMoveMsg->type = EMC_MOTION_TYPE_FEED;
+    linearMoveMsg->indexer_jnum = -1;
     if ((vel && acc) || canon.spindle[canon.spindle_num].synched) {
         interp_list.set_line_number(line_no);
-        tag_and_send(linearMoveMsg,pos.tag);
+        tag_and_send(std::move(linearMoveMsg), pos.tag);
     }
     canonUpdateEndPoint(x, y, z, a, b, c, u, v, w);
 
@@ -1032,20 +1027,20 @@ void ON_RESET() {
 
 void STRAIGHT_TRAVERSE(int line_number,
                        double x, double y, double z,
-		       double a, double b, double c,
+		               double a, double b, double c,
                        double u, double v, double w)
 {
     double vel, acc;
 
     flush_segments();
 
-    EMC_TRAJ_LINEAR_MOVE linearMoveMsg;
+    auto linearMoveMsg = std::make_unique<EMC_TRAJ_LINEAR_MOVE>();
 
-    linearMoveMsg.feed_mode = 0;
+    linearMoveMsg->feed_mode = 0;
     if (canon.rotary_unlock_for_traverse != -1)
-        linearMoveMsg.type = EMC_MOTION_TYPE_INDEXROTARY;
+        linearMoveMsg->type = EMC_MOTION_TYPE_INDEXROTARY;
     else
-        linearMoveMsg.type = EMC_MOTION_TYPE_TRAVERSE;
+        linearMoveMsg->type = EMC_MOTION_TYPE_TRAVERSE;
 
     from_prog(x,y,z,a,b,c,u,v,w);
     rotate_and_offset_pos(x,y,z,a,b,c,u,v,w);
@@ -1056,10 +1051,10 @@ void STRAIGHT_TRAVERSE(int line_number,
     vel = veldata.vel;
     acc = accdata.acc;
 
-    linearMoveMsg.end = to_ext_pose(x,y,z,a,b,c,u,v,w);
-    linearMoveMsg.vel = linearMoveMsg.ini_maxvel = toExtVel(vel);
-    linearMoveMsg.acc = toExtAcc(acc);
-    linearMoveMsg.indexer_jnum = canon.rotary_unlock_for_traverse;
+    linearMoveMsg->end = to_ext_pose(x,y,z,a,b,c,u,v,w);
+    linearMoveMsg->vel = linearMoveMsg->ini_maxvel = toExtVel(vel);
+    linearMoveMsg->acc = toExtAcc(acc);
+    linearMoveMsg->indexer_jnum = canon.rotary_unlock_for_traverse;
 
     int old_feed_mode = canon.feed_mode;
     if(canon.feed_mode)
@@ -1067,7 +1062,7 @@ void STRAIGHT_TRAVERSE(int line_number,
 
     if(vel && acc)  {
         interp_list.set_line_number(line_number);
-        tag_and_send(linearMoveMsg, _tag);
+        tag_and_send(std::move(linearMoveMsg), _tag);
     }
 
     if(old_feed_mode)
@@ -1078,8 +1073,8 @@ void STRAIGHT_TRAVERSE(int line_number,
 
 void STRAIGHT_FEED(int line_number, double x, double y, double z, double a, double b, double c, double u, double v, double w)
 {
-    EMC_TRAJ_LINEAR_MOVE linearMoveMsg;
-    linearMoveMsg.feed_mode = canon.feed_mode;
+    //EMC_TRAJ_LINEAR_MOVE linearMoveMsg;
+    //linearMoveMsg.feed_mode = canon.feed_mode;
 
     from_prog(x,y,z,a,b,c,u,v,w);
     rotate_and_offset_pos(x,y,z,a,b,c,u,v,w);
@@ -1090,7 +1085,7 @@ void STRAIGHT_FEED(int line_number, double x, double y, double z, double a, doub
 void RIGID_TAP(int line_number, double x, double y, double z, double scale)
 {
     double ini_maxvel,acc;
-    EMC_TRAJ_RIGID_TAP rigidTapMsg;
+    auto rigidTapMsg = std::make_unique<EMC_TRAJ_RIGID_TAP>();
     double unused=0;
 
     from_prog(x,y,z,unused,unused,unused,unused,unused,unused);
@@ -1106,19 +1101,19 @@ void RIGID_TAP(int line_number, double x, double y, double z, double scale)
                                   canon.endPoint.u, canon.endPoint.v, canon.endPoint.w);
     acc = accdata.acc;
     
-    rigidTapMsg.pos = to_ext_pose(x,y,z,
+    rigidTapMsg->pos = to_ext_pose(x,y,z,
                                  canon.endPoint.a, canon.endPoint.b, canon.endPoint.c,
                                  canon.endPoint.u, canon.endPoint.v, canon.endPoint.w);
 
-    rigidTapMsg.vel = toExtVel(ini_maxvel);
-    rigidTapMsg.ini_maxvel = toExtVel(ini_maxvel);
-    rigidTapMsg.acc = toExtAcc(acc);
-    rigidTapMsg.scale = scale;
+    rigidTapMsg->vel = toExtVel(ini_maxvel);
+    rigidTapMsg->ini_maxvel = toExtVel(ini_maxvel);
+    rigidTapMsg->acc = toExtAcc(acc);
+    rigidTapMsg->scale = scale;
     flush_segments();
 
     if(ini_maxvel && acc)  {
         interp_list.set_line_number(line_number);
-        interp_list.append(rigidTapMsg);
+        interp_list.append(std::move(rigidTapMsg));
     }
 
     // don't move the endpoint because after this move, we are back where we started
@@ -1137,7 +1132,7 @@ void STRAIGHT_PROBE(int line_number,
                     unsigned char probe_type)
 {
     double ini_maxvel, vel, acc;
-    EMC_TRAJ_PROBE probeMsg;
+    auto probeMsg = std::make_unique<EMC_TRAJ_PROBE>();
 
     from_prog(x,y,z,a,b,c,u,v,w);
     rotate_and_offset_pos(x,y,z,a,b,c,u,v,w);
@@ -1164,18 +1159,18 @@ void STRAIGHT_PROBE(int line_number,
     AccelData accdata = getStraightAcceleration(x, y, z, a, b, c, u, v, w);
     acc = accdata.acc;
 
-    probeMsg.vel = toExtVel(vel);
-    probeMsg.ini_maxvel = toExtVel(ini_maxvel);
-    probeMsg.acc = toExtAcc(acc);
+    probeMsg->vel = toExtVel(vel);
+    probeMsg->ini_maxvel = toExtVel(ini_maxvel);
+    probeMsg->acc = toExtAcc(acc);
 
-    probeMsg.type = EMC_MOTION_TYPE_PROBING;
-    probeMsg.probe_type = probe_type;
+    probeMsg->type = EMC_MOTION_TYPE_PROBING;
+    probeMsg->probe_type = probe_type;
 
-    probeMsg.pos = to_ext_pose(x,y,z,a,b,c,u,v,w);
+    probeMsg->pos = to_ext_pose(x,y,z,a,b,c,u,v,w);
 
     if(vel && acc)  {
         interp_list.set_line_number(line_number);
-        interp_list.append(probeMsg);
+        interp_list.append(std::move(probeMsg));
     }
     canonUpdateEndPoint(x, y, z, a, b, c, u, v, w);
 }
@@ -1184,7 +1179,7 @@ void STRAIGHT_PROBE(int line_number,
 
 void SET_MOTION_CONTROL_MODE(CANON_MOTION_MODE mode, double tolerance)
 {
-    EMC_TRAJ_SET_TERM_COND setTermCondMsg;
+    auto setTermCondMsg = std::make_unique<EMC_TRAJ_SET_TERM_COND>();
 
     flush_segments();
 
@@ -1193,20 +1188,20 @@ void SET_MOTION_CONTROL_MODE(CANON_MOTION_MODE mode, double tolerance)
 
     switch (mode) {
     case CANON_CONTINUOUS:
-        setTermCondMsg.cond = EMC_TRAJ_TERM_COND_BLEND;
-        setTermCondMsg.tolerance = TO_EXT_LEN(canon.motionTolerance);
+        setTermCondMsg->cond = EMC_TRAJ_TERM_COND_BLEND;
+        setTermCondMsg->tolerance = TO_EXT_LEN(canon.motionTolerance);
         break;
     case CANON_EXACT_PATH:
-        setTermCondMsg.cond = EMC_TRAJ_TERM_COND_EXACT;
+        setTermCondMsg->cond = EMC_TRAJ_TERM_COND_EXACT;
         break;
 
     case CANON_EXACT_STOP:
     default:
-        setTermCondMsg.cond = EMC_TRAJ_TERM_COND_STOP;
+        setTermCondMsg->cond = EMC_TRAJ_TERM_COND_STOP;
         break;
     }
 
-    interp_list.append(setTermCondMsg);
+    interp_list.append(std::move(setTermCondMsg));
 }
 
 void SET_NAIVECAM_TOLERANCE(double tolerance)
@@ -1239,21 +1234,17 @@ void STOP_CUTTER_RADIUS_COMPENSATION()
 void START_SPEED_FEED_SYNCH(int spindle, double feed_per_revolution, bool velocity_mode)
 {
     flush_segments();
-    EMC_TRAJ_SET_SPINDLESYNC spindlesyncMsg;
-    spindlesyncMsg.spindle = spindle;
-    spindlesyncMsg.feed_per_revolution = TO_EXT_LEN(FROM_PROG_LEN(feed_per_revolution));
-    spindlesyncMsg.velocity_mode = velocity_mode;
-    interp_list.append(spindlesyncMsg);
+    auto spindleSyncMsg = std::make_unique<EMC_TRAJ_SET_SPINDLESYNC>();
+    spindleSyncMsg->spindle = spindle;
+    spindleSyncMsg->feed_per_revolution = TO_EXT_LEN(FROM_PROG_LEN(feed_per_revolution));
+    spindleSyncMsg->velocity_mode = velocity_mode;
+    interp_list.append(std::move(spindleSyncMsg));
     canon.spindle[spindle].synched = 1;
 }
 
 void STOP_SPEED_FEED_SYNCH()
 {
-    flush_segments();
-    EMC_TRAJ_SET_SPINDLESYNC spindlesyncMsg;
-    spindlesyncMsg.feed_per_revolution = 0.0;
-    spindlesyncMsg.velocity_mode = false;
-    interp_list.append(spindlesyncMsg);
+    START_SPEED_FEED_SYNCH(0, 0, false);
     canon.spindle[canon.spindle_num].synched = 0;
 }
 
@@ -1389,7 +1380,7 @@ biarc(int lineno, double p0x, double p0y, double tsx, double tsy,
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_G5_FEED(int lineno,
-		   std::vector < NURBS_CONTROL_POINT >
+		   std::vector<NURBS_CONTROL_POINT>
 		   nurbs_control_points, unsigned int nurbs_order,
 		   CANON_PLANE plane)
 {
@@ -1399,7 +1390,7 @@ void NURBS_G5_FEED(int lineno,
 	double umax = n - nurbs_order + 2;
 	unsigned int div = nurbs_control_points.size() * 4;
 
-	std::vector < unsigned int >knot_vector =
+	std::vector<unsigned int> knot_vector =
 	    nurbs_G5_knot_vector_creator(n, nurbs_order);
 	NURBS_PLANE_POINT P0, P0T, P1, P1T;
 
@@ -1427,24 +1418,23 @@ void NURBS_G5_FEED(int lineno,
 // G6.2 Q_option=3=NICL NURBS interpolation with linear motion
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_FEED_G6_2_WITH_LINEAR_MOTION(int lineno,
-					std::vector <
-					NURBS_G6_CONTROL_POINT >
+					std::vector<NURBS_G6_CONTROL_POINT>
 					nurbs_control_points,
-					std::vector < double >knot_vector,
+					std::vector<double>knot_vector,
 					unsigned int k, double feedrate)
 {
 	flush_segments();
 	unsigned int n = nurbs_control_points.size() - 1 - k;
-	std::vector < double >span_knot_vector =
+	std::vector<double> span_knot_vector =
 	    nurbs_interval_span_knot_vector_creator(n, k, knot_vector);
-	std::vector < double >lenght_vector =
+	std::vector<double> lenght_vector =
 	    nurbs_lenght_vector_creator(k, nurbs_control_points,
 					knot_vector, span_knot_vector);
-	std::vector < double >Du_span_knot_vector =
+	std::vector<double> Du_span_knot_vector =
 	    nurbs_Du_span_knot_vector_creator(k, nurbs_control_points,
 					      knot_vector,
 					      span_knot_vector);
-	std::vector < double >nurbs_costant =
+	std::vector<double> nurbs_costant =
 	    nurbs_costant_crator(span_knot_vector, lenght_vector,
 				 Du_span_knot_vector);
 	NURBS_PLANE_POINT P1, P1x;
@@ -1655,25 +1645,23 @@ void NURBS_FEED_G6_2_WITH_LINEAR_MOTION(int lineno,
 // G6.2 Q_option=2=NICC NURBS interpolation with circular motion
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_FEED_G6_2_WITH_CIRCULAR_MOTION(int lineno,
-					  std::vector <
-					  NURBS_G6_CONTROL_POINT >
+					  std::vector<NURBS_G6_CONTROL_POINT>
 					  nurbs_control_points,
-					  std::vector <
-					  double >knot_vector,
+					  std::vector<double> knot_vector,
 					  unsigned int k, double feedrate)
 {
 	flush_segments();
 	unsigned int n = nurbs_control_points.size() - 1 - k;
 	std::vector < double >span_knot_vector =
 	    nurbs_interval_span_knot_vector_creator(n, k, knot_vector);
-	std::vector < double >lenght_vector =
+	std::vector<double> lenght_vector =
 	    nurbs_lenght_vector_creator(k, nurbs_control_points,
 					knot_vector, span_knot_vector);
-	std::vector < double >Du_span_knot_vector =
+	std::vector<double> Du_span_knot_vector =
 	    nurbs_Du_span_knot_vector_creator(k, nurbs_control_points,
 					      knot_vector,
 					      span_knot_vector);
-	std::vector < double >nurbs_costant =
+	std::vector<double> nurbs_costant =
 	    nurbs_costant_crator(span_knot_vector, lenght_vector,
 				 Du_span_knot_vector);
 	NURBS_PLANE_POINT P0, P1, P0T, P1T;
@@ -1868,11 +1856,9 @@ void NURBS_FEED_G6_2_WITH_CIRCULAR_MOTION(int lineno,
 // G6.2/G6.3 Q_option=1=NICU NURBS interpolation with biarc, du=const
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_FEED_G6_2_WITH_BIARCH_DU_CONST(int lineno,
-					  std::vector <
-					  NURBS_G6_CONTROL_POINT >
+					  std::vector<NURBS_G6_CONTROL_POINT>
 					  nurbs_control_points,
-					  std::vector <
-					  double >knot_vector,
+					  std::vector<double> knot_vector,
 					  unsigned int k, double feedrate)
 {
 	double u = knot_vector[0];
@@ -1881,7 +1867,7 @@ void NURBS_FEED_G6_2_WITH_BIARCH_DU_CONST(int lineno,
 	double umax = knot_vector[knot_vector.size() - 1];
 	unsigned int div = (dim - k) * 15;
 
-	std::vector < std::vector < double >>A6;
+	std::vector<std::vector<double>> A6;
 	if (k >= 3) {
 		NURBS_PLANE_POINT P1, P0, P0T, P1T;
 		CANON_POSITION p =
@@ -2008,13 +1994,13 @@ void NURBS_FEED_G6_2_WITH_BIARCH_DU_CONST(int lineno,
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_FEED_DIVIDE(int lineno,
-		       std::vector < NURBS_G6_CONTROL_POINT >
+		       std::vector<NURBS_G6_CONTROL_POINT>
 		       nurbs_control_points,
-		       std::vector < double >knot_vector,
+		       std::vector<double> knot_vector,
 		       unsigned int nurbs_order, double feedrate,
 		       int Q_option)
 {
-	std::vector < double >knot_vector_new = knot_vector;
+	std::vector<double> knot_vector_new = knot_vector;
 	int k1 = knot_vector.size() / 2 - 1;
 	double ut;
 	ut = (knot_vector[k1] + 1);
@@ -2043,12 +2029,12 @@ void NURBS_FEED_DIVIDE(int lineno,
 	//Secondo segmento NURBS
 	// si passa il valore u in corrispondenza del quale suddividere la curva
 	// der u-Wert wird übergeben, bei dem die Kurve geteilt werden soll
-	std::vector < double >control_point_nurbs2_new2 =
+	std::vector<double> control_point_nurbs2_new2 =
 	    nurbs_G6_new_control_point_nurbs2(ut, nurbs_order,
 					      nurbs_control_points,
 					      knot_vector);
 
-	std::vector < NURBS_CONTROL_POINT > nurbs_control_points2;
+	std::vector<NURBS_CONTROL_POINT> nurbs_control_points2;
 	NURBS_CONTROL_POINT C_P2;
 	for (long unsigned int i = 0; i < control_point_nurbs2_new2.size();
 	     i = i + 3) {
@@ -2154,9 +2140,9 @@ void NURBS_FEED_DIVIDE(int lineno,
 //Non viene realizzata alcuna suddivisione in quanto il numero dei punti di controllo è <2*k =due volte l'ordine
 //No subdivision is made as the number of control points is <3*k = twice the order
 void NURBS_FEED_NO_SUBDIVISION(int lineno,
-			       std::vector < NURBS_G6_CONTROL_POINT >
+			       std::vector<NURBS_G6_CONTROL_POINT>
 			       nurbs_control_points,
-			       std::vector < double >knot_vector,
+			       std::vector<double> knot_vector,
 			       unsigned int nurbs_order, double feedrate,
 			       int Q_option)
 {
@@ -2203,12 +2189,12 @@ void NURBS_FEED_NO_SUBDIVISION(int lineno,
 /* Canon calls G_6_2 */
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_G6_FEED(int lineno,
-		   std::vector < NURBS_G6_CONTROL_POINT >
+		   std::vector<NURBS_G6_CONTROL_POINT>
 		   nurbs_control_points, unsigned int nurbs_order,
 		   double feedrate, int Q_option, CANON_PLANE plane)
 {				// (L_option: NICU, NICL, NICC see publication from Lo Valvo and Drago) 
 	int n = nurbs_control_points.size() - 1 - nurbs_order;
-	std::vector < double >knot_vector =
+	std::vector<double> knot_vector =
 	    nurbs_g6_knot_vector_creator(n, nurbs_order,
 					 nurbs_control_points);
 
@@ -2331,10 +2317,10 @@ void ARC_FEED(int line_number,
 				double axis_end_point, 
 				double a, double b, double c,
 				double u, double v, double w)
-	{
+{
 
-	EMC_TRAJ_CIRCULAR_MOVE circularMoveMsg;
-	EMC_TRAJ_LINEAR_MOVE linearMoveMsg;
+	auto circularMoveMsg = std::make_unique<EMC_TRAJ_CIRCULAR_MOVE>();
+	auto linearMoveMsg = std::make_unique<EMC_TRAJ_LINEAR_MOVE>();
 
 	canon_debug("line = %d\n", line_number);
 	canon_debug("first_end = %f, second_end = %f\n", first_end,second_end);
@@ -2372,9 +2358,9 @@ void ARC_FEED(int line_number,
 			}
 		}
 
-  linearMoveMsg.feed_mode = canon.feed_mode;
-  circularMoveMsg.feed_mode = canon.feed_mode;
-  flush_segments();
+    linearMoveMsg->feed_mode = canon.feed_mode;
+    circularMoveMsg->feed_mode = canon.feed_mode;
+    flush_segments();
 
     // Start by defining 3D points for the motion end and center.
     PM_CARTESIAN end_cart(first_end, second_end, axis_end_point);
@@ -2651,41 +2637,41 @@ void ARC_FEED(int line_number,
         // linear move
         // FIXME (Rob) Am I missing something? the P word should never be zero,
         // or we wouldn't be calling ARC_FEED
-        linearMoveMsg.end = to_ext_pose(endpt);
-        linearMoveMsg.type = EMC_MOTION_TYPE_ARC;
-        linearMoveMsg.vel = toExtVel(vel);
-        linearMoveMsg.ini_maxvel = toExtVel(v_max);
-        linearMoveMsg.acc = toExtAcc(a_max);
-        linearMoveMsg.indexer_jnum = -1;
+        linearMoveMsg->end = to_ext_pose(endpt);
+        linearMoveMsg->type = EMC_MOTION_TYPE_ARC;
+        linearMoveMsg->vel = toExtVel(vel);
+        linearMoveMsg->ini_maxvel = toExtVel(v_max);
+        linearMoveMsg->acc = toExtAcc(a_max);
+        linearMoveMsg->indexer_jnum = -1;
         if(vel && a_max){
             interp_list.set_line_number(line_number);
-            tag_and_send(linearMoveMsg, _tag);
+            tag_and_send(std::move(linearMoveMsg), _tag);
         }
     } else {
-        circularMoveMsg.end = to_ext_pose(endpt);
+        circularMoveMsg->end = to_ext_pose(endpt);
 
         // Convert internal center and normal to external units
-        circularMoveMsg.center = to_ext_len(center_cart);
-        circularMoveMsg.normal = to_ext_len(normal_cart);
+        circularMoveMsg->center = to_ext_len(center_cart);
+        circularMoveMsg->normal = to_ext_len(normal_cart);
 
         if (rotation > 0)
-            circularMoveMsg.turn = rotation - 1;
+            circularMoveMsg->turn = rotation - 1;
         else
             // reverse turn
-            circularMoveMsg.turn = rotation;
+            circularMoveMsg->turn = rotation;
 
-        circularMoveMsg.type = EMC_MOTION_TYPE_ARC;
+        circularMoveMsg->type = EMC_MOTION_TYPE_ARC;
 
-        circularMoveMsg.vel = toExtVel(vel);
-        circularMoveMsg.ini_maxvel = toExtVel(v_max);
-        circularMoveMsg.acc = toExtAcc(a_max);
+        circularMoveMsg->vel = toExtVel(vel);
+        circularMoveMsg->ini_maxvel = toExtVel(v_max);
+        circularMoveMsg->acc = toExtAcc(a_max);
 
         //FIXME what happens if accel or vel is zero?
         // The end point is still updated, but nothing is added to the interp list
         // seems to be a crude way to indicate a zero length segment?
         if(vel && a_max) {
             interp_list.set_line_number(line_number);
-            tag_and_send(circularMoveMsg, _tag);
+            tag_and_send(std::move(circularMoveMsg), _tag);
         }
     }
     // update the end point
@@ -2695,13 +2681,13 @@ void ARC_FEED(int line_number,
 
 void DWELL(double seconds)
 {
-    EMC_TRAJ_DELAY delayMsg;
+    auto delayMsg = std::make_unique<EMC_TRAJ_DELAY>();
 
     flush_segments();
 
-    delayMsg.delay = seconds;
+    delayMsg->delay = seconds;
 
-    interp_list.append(delayMsg);
+    interp_list.append(std::move(delayMsg));
 }
 
 /* Spindle Functions */
@@ -2716,86 +2702,88 @@ void SET_SPINDLE_MODE(int spindle, double css_max) {
 
 void START_SPINDLE_CLOCKWISE(int s, int wait_for_atspeed)
 {
-    EMC_SPINDLE_ON emc_spindle_on_msg;
+    auto emc_spindle_on_msg = std::make_unique<EMC_SPINDLE_ON>();
 
     flush_segments();
     canon.spindle[s].dir = 1;
-    emc_spindle_on_msg.spindle = s;
+    emc_spindle_on_msg->spindle = s;
     if(canon.spindle[s].css_maximum) {
         if(canon.lengthUnits == CANON_UNITS_INCHES){
             canon.spindle[s].css_factor = 12 / (2 * M_PI) * canon.spindle[s].speed * TO_EXT_LEN(25.4);
         } else {
             canon.spindle[s].css_factor = 1000 / (2 * M_PI) * canon.spindle[s].speed * TO_EXT_LEN(1);
 		}
-		emc_spindle_on_msg.speed = canon.spindle[s].dir * canon.spindle[s].css_maximum;
-		emc_spindle_on_msg.factor = canon.spindle[s].dir * canon.spindle[s].css_factor;
-		emc_spindle_on_msg.xoffset = TO_EXT_LEN(canon.g5xOffset.x + canon.g92Offset.x + canon.toolOffset.tran.x);
+		emc_spindle_on_msg->speed = canon.spindle[s].dir * canon.spindle[s].css_maximum;
+		emc_spindle_on_msg->factor = canon.spindle[s].dir * canon.spindle[s].css_factor;
+		emc_spindle_on_msg->xoffset = TO_EXT_LEN(canon.g5xOffset.x + canon.g92Offset.x + canon.toolOffset.tran.x);
     } else {
-        emc_spindle_on_msg.speed = canon.spindle[s].dir * canon.spindle[s].speed;
+        emc_spindle_on_msg->speed = canon.spindle[s].dir * canon.spindle[s].speed;
      //   canon.css_numerator = 0; FIXME: Do we need this?
     }
-    emc_spindle_on_msg.wait_for_spindle_at_speed = wait_for_atspeed;
-    interp_list.append(emc_spindle_on_msg);
+    emc_spindle_on_msg->wait_for_spindle_at_speed = wait_for_atspeed;
+    interp_list.append(std::move(emc_spindle_on_msg));
 }
 
+// RS: TODO: extract common code with START_SPINDLE_CLOCKWISE
 void START_SPINDLE_COUNTERCLOCKWISE(int s, int wait_for_atspeed)
 {
-    EMC_SPINDLE_ON emc_spindle_on_msg;
+    auto emc_spindle_on_msg = std::make_unique<EMC_SPINDLE_ON>();
 
     flush_segments();
     canon.spindle[s].dir = -1;
-    emc_spindle_on_msg.spindle = s;
+    emc_spindle_on_msg->spindle = s;
     if(canon.spindle[s].css_maximum) {
         if(canon.lengthUnits == CANON_UNITS_INCHES){
             canon.spindle[s].css_factor = 12 / (2 * M_PI) * canon.spindle[s].speed * TO_EXT_LEN(25.4);
         } else {
             canon.spindle[s].css_factor = 1000 / (2 * M_PI) * canon.spindle[s].speed * TO_EXT_LEN(1);
 		}
-		emc_spindle_on_msg.speed = canon.spindle[s].dir * canon.spindle[s].css_maximum;
-		emc_spindle_on_msg.factor = canon.spindle[s].dir * canon.spindle[s].css_factor;
-		emc_spindle_on_msg.xoffset = TO_EXT_LEN(canon.g5xOffset.x + canon.g92Offset.x + canon.toolOffset.tran.x);
+		emc_spindle_on_msg->speed = canon.spindle[s].dir * canon.spindle[s].css_maximum;
+		emc_spindle_on_msg->factor = canon.spindle[s].dir * canon.spindle[s].css_factor;
+		emc_spindle_on_msg->xoffset = TO_EXT_LEN(canon.g5xOffset.x + canon.g92Offset.x + canon.toolOffset.tran.x);
     } else {
-        emc_spindle_on_msg.speed = canon.spindle[s].dir * canon.spindle[s].speed;
+        emc_spindle_on_msg->speed = canon.spindle[s].dir * canon.spindle[s].speed;
      //   canon.css_numerator = 0; FIXME: Do we need this?
     }
-    emc_spindle_on_msg.wait_for_spindle_at_speed = wait_for_atspeed;
-    interp_list.append(emc_spindle_on_msg);
+    emc_spindle_on_msg->wait_for_spindle_at_speed = wait_for_atspeed;
+    interp_list.append(std::move(emc_spindle_on_msg));
 }
 
+// RS: TODO: extract common code with START_SPINDLE_CLOCKWISE
 void SET_SPINDLE_SPEED(int s, double r)
 {
     // speed is in RPMs everywhere
 
 	canon.spindle[s].speed = fabs(r); // interp will never send negative anyway ...
 
-    EMC_SPINDLE_SPEED emc_spindle_speed_msg;
+    auto emc_spindle_speed_msg = std::make_unique<EMC_SPINDLE_SPEED>();
 
     flush_segments();
 
-    emc_spindle_speed_msg.spindle = s;
+    emc_spindle_speed_msg->spindle = s;
     if(canon.spindle[s].css_maximum) {
 		if(canon.lengthUnits == CANON_UNITS_INCHES){
 			canon.spindle[s].css_factor = 12 / (2 * M_PI) * canon.spindle[s].speed * TO_EXT_LEN(25.4);
 		} else {
 			canon.spindle[s].css_factor = 1000 / (2 * M_PI) * canon.spindle[s].speed * TO_EXT_LEN(1);
 		}
-		emc_spindle_speed_msg.speed =  canon.spindle[s].dir * canon.spindle[s].css_maximum;
-		emc_spindle_speed_msg.factor =  canon.spindle[s].dir * canon.spindle[s].css_factor;
-		emc_spindle_speed_msg.xoffset = TO_EXT_LEN(canon.g5xOffset.x + canon.g92Offset.x + canon.toolOffset.tran.x);
+		emc_spindle_speed_msg->speed =  canon.spindle[s].dir * canon.spindle[s].css_maximum;
+		emc_spindle_speed_msg->factor =  canon.spindle[s].dir * canon.spindle[s].css_factor;
+		emc_spindle_speed_msg->xoffset = TO_EXT_LEN(canon.g5xOffset.x + canon.g92Offset.x + canon.toolOffset.tran.x);
 	} else {
-        emc_spindle_speed_msg.speed = canon.spindle[s].dir * canon.spindle[s].speed;
+        emc_spindle_speed_msg->speed = canon.spindle[s].dir * canon.spindle[s].speed;
 		//   canon.css_numerator = 0; FIXME: Do we need this?
     }
-    interp_list.append(emc_spindle_speed_msg);
+    interp_list.append(std::move(emc_spindle_speed_msg));
 }
 
 void STOP_SPINDLE_TURNING(int s)
 {
-    EMC_SPINDLE_OFF emc_spindle_off_msg;
+    auto emc_spindle_off_msg = std::make_unique<EMC_SPINDLE_OFF>();
 
     flush_segments();
-    emc_spindle_off_msg.spindle = s;
-    interp_list.append(emc_spindle_off_msg);
+    emc_spindle_off_msg->spindle = s;
+    interp_list.append(std::move(emc_spindle_off_msg));
     // Added by atp 6/1/18 not sure this is right. There is a problem that the _second_ S word starts the spindle without M3/M4
     canon.spindle[s].dir = 0;
 }
@@ -2807,23 +2795,23 @@ void SPINDLE_RETRACT()
 
 void ORIENT_SPINDLE(int s, double orientation, int mode)
 {
-    EMC_SPINDLE_ORIENT o;
+    auto o = std::make_unique<EMC_SPINDLE_ORIENT>();
 
     flush_segments();
-    o.spindle = s;
-    o.orientation = orientation;
-    o.mode = mode;
-    interp_list.append(o);
+    o->spindle = s;
+    o->orientation = orientation;
+    o->mode = mode;
+    interp_list.append(std::move(o));
 }
 
 void WAIT_SPINDLE_ORIENT_COMPLETE(int s, double timeout)
 {
-    EMC_SPINDLE_WAIT_ORIENT_COMPLETE o;
+    auto o = std::make_unique<EMC_SPINDLE_WAIT_ORIENT_COMPLETE>();
 
     flush_segments();
-    o.spindle = s;
-    o.timeout = timeout;
-    interp_list.append(o);
+    o->spindle = s;
+    o->timeout = timeout;
+    interp_list.append(std::move(o));
 }
 
 void USE_SPINDLE_FORCE(void)
@@ -2846,16 +2834,16 @@ void USE_NO_SPINDLE_FORCE(void)
 /* this is called with distances in external (machine) units */
 void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diameter,
                           double frontangle, double backangle, int orientation) {
-    EMC_TOOL_SET_OFFSET o;
+    auto o = std::make_unique<EMC_TOOL_SET_OFFSET>();
     flush_segments();
-    o.pocket = pocket;
-    o.toolno = toolno;
-    o.offset = offset;
-    o.diameter = diameter;
-    o.frontangle = frontangle;
-    o.backangle = backangle;
-    o.orientation = orientation;
-    interp_list.append(o);
+    o->pocket = pocket;
+    o->toolno = toolno;
+    o->offset = offset;
+    o->diameter = diameter;
+    o->frontangle = frontangle;
+    o->backangle = backangle;
+    o->orientation = orientation;
+    interp_list.append(std::move(o));
 }
 
 /*
@@ -2864,7 +2852,7 @@ void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diamete
   */
 void USE_TOOL_LENGTH_OFFSET(EmcPose offset)
 {
-    EMC_TRAJ_SET_OFFSET set_offset_msg;
+    auto set_offset_msg = std::make_unique<EMC_TRAJ_SET_OFFSET>();
 
     flush_segments();
 
@@ -2881,30 +2869,28 @@ void USE_TOOL_LENGTH_OFFSET(EmcPose offset)
 
     /* append it to interp list so it gets updated at the right time, not at
        read-ahead time */
-    set_offset_msg.offset.tran.x = TO_EXT_LEN(canon.toolOffset.tran.x);
-    set_offset_msg.offset.tran.y = TO_EXT_LEN(canon.toolOffset.tran.y);
-    set_offset_msg.offset.tran.z = TO_EXT_LEN(canon.toolOffset.tran.z);
-    set_offset_msg.offset.a = TO_EXT_ANG(canon.toolOffset.a);
-    set_offset_msg.offset.b = TO_EXT_ANG(canon.toolOffset.b);
-    set_offset_msg.offset.c = TO_EXT_ANG(canon.toolOffset.c);
-    set_offset_msg.offset.u = TO_EXT_LEN(canon.toolOffset.u);
-    set_offset_msg.offset.v = TO_EXT_LEN(canon.toolOffset.v);
-    set_offset_msg.offset.w = TO_EXT_LEN(canon.toolOffset.w);
+    set_offset_msg->offset.tran.x = TO_EXT_LEN(canon.toolOffset.tran.x);
+    set_offset_msg->offset.tran.y = TO_EXT_LEN(canon.toolOffset.tran.y);
+    set_offset_msg->offset.tran.z = TO_EXT_LEN(canon.toolOffset.tran.z);
+    set_offset_msg->offset.a = TO_EXT_ANG(canon.toolOffset.a);
+    set_offset_msg->offset.b = TO_EXT_ANG(canon.toolOffset.b);
+    set_offset_msg->offset.c = TO_EXT_ANG(canon.toolOffset.c);
+    set_offset_msg->offset.u = TO_EXT_LEN(canon.toolOffset.u);
+    set_offset_msg->offset.v = TO_EXT_LEN(canon.toolOffset.v);
+    set_offset_msg->offset.w = TO_EXT_LEN(canon.toolOffset.w);
 
     for (int s = 0; s < emcStatus->motion.traj.spindles; s++){
         if(canon.spindle[s].css_maximum) {
             SET_SPINDLE_SPEED(s, canon.spindle[s].speed);
         }
     }
-    interp_list.append(set_offset_msg);
+    interp_list.append(std::move(set_offset_msg));
 }
 
 /* CHANGE_TOOL results from M6 */
 void CHANGE_TOOL()
 {
-    EMC_TRAJ_LINEAR_MOVE linearMoveMsg;
-    linearMoveMsg.feed_mode = canon.feed_mode;
-    EMC_TOOL_LOAD load_tool_msg;
+    auto load_tool_msg = std::make_unique<EMC_TOOL_LOAD>();
 
     flush_segments();
 
@@ -2946,56 +2932,59 @@ void CHANGE_TOOL()
         vel = veldata.vel;
         acc = accdata.acc;
 
-        linearMoveMsg.end = to_ext_pose(x, y, z, a, b, c, u, v, w);
+        auto linearMoveMsg = std::make_unique<EMC_TRAJ_LINEAR_MOVE>();
+        linearMoveMsg->feed_mode = canon.feed_mode;
 
-        linearMoveMsg.vel = linearMoveMsg.ini_maxvel = toExtVel(vel);
-        linearMoveMsg.acc = toExtAcc(acc);
-        linearMoveMsg.type = EMC_MOTION_TYPE_TOOLCHANGE;
-	linearMoveMsg.feed_mode = 0;
-        linearMoveMsg.indexer_jnum = -1;
+        linearMoveMsg->end = to_ext_pose(x, y, z, a, b, c, u, v, w);
 
-	int old_feed_mode = canon.feed_mode;
-	if(canon.feed_mode)
-	    STOP_SPEED_FEED_SYNCH();
+        linearMoveMsg->vel = linearMoveMsg->ini_maxvel = toExtVel(vel);
+        linearMoveMsg->acc = toExtAcc(acc);
+        linearMoveMsg->type = EMC_MOTION_TYPE_TOOLCHANGE;
+	    linearMoveMsg->feed_mode = 0;
+        linearMoveMsg->indexer_jnum = -1;
 
-    if(vel && acc)
-        tag_and_send(linearMoveMsg, _tag);
+	    int old_feed_mode = canon.feed_mode;
+	    if(canon.feed_mode)
+	       STOP_SPEED_FEED_SYNCH();
 
-    if(old_feed_mode)
-        START_SPEED_FEED_SYNCH(canon.spindle_num, canon.linearFeedRate, 1);
+        if(vel && acc)
+            tag_and_send(std::move(linearMoveMsg), _tag);
 
-    canonUpdateEndPoint(x, y, z, a, b, c, u, v, w);
+        if(old_feed_mode)
+            START_SPEED_FEED_SYNCH(canon.spindle_num, canon.linearFeedRate, 1);
+
+        canonUpdateEndPoint(x, y, z, a, b, c, u, v, w);
     }
 
     /* regardless of optional moves above, we'll always send a load tool
        message */
-    interp_list.append(load_tool_msg);
+    interp_list.append(std::move(load_tool_msg));
 }
 
 /* SELECT_TOOL results from Tn */
 void SELECT_TOOL(int tool)
 {
-    EMC_TOOL_PREPARE prep_for_tool_msg;
+    auto prep_for_tool_msg = std::make_unique<EMC_TOOL_PREPARE>();
 
-    prep_for_tool_msg.tool = tool;
+    prep_for_tool_msg->tool = tool;
 
-    interp_list.append(prep_for_tool_msg);
+    interp_list.append(std::move(prep_for_tool_msg));
 }
 
 /* CHANGE_TOOL_NUMBER results from M61 */
 void CHANGE_TOOL_NUMBER(int pocket_number)
 {
-    EMC_TOOL_SET_NUMBER emc_tool_set_number_msg;
+    auto emc_tool_set_number_msg = std::make_unique<EMC_TOOL_SET_NUMBER>();
     
-    emc_tool_set_number_msg.tool = pocket_number;
+    emc_tool_set_number_msg->tool = pocket_number;
 
-    interp_list.append(emc_tool_set_number_msg);
+    interp_list.append(std::move(emc_tool_set_number_msg));
 }
 
 void RELOAD_TOOLDATA(void)
 {
-    EMC_TOOL_LOAD_TOOL_TABLE load_tool_table_msg;
-    interp_list.append(load_tool_table_msg);
+    auto load_tool_table_msg = std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>();
+    interp_list.append(std::move(load_tool_table_msg));
 }
 
 /* Misc Functions */
@@ -3102,108 +3091,109 @@ void COMMENT(const char *comment)
 // refers to feed rate
 void DISABLE_FEED_OVERRIDE()
 {
-    EMC_TRAJ_SET_FO_ENABLE set_fo_enable_msg;
+    auto set_fo_enable_msg = std::make_unique<EMC_TRAJ_SET_FO_ENABLE>();
     flush_segments();
     
-    set_fo_enable_msg.mode = 0;
-    interp_list.append(set_fo_enable_msg);
+    set_fo_enable_msg->mode = 0;
+    interp_list.append(std::move(set_fo_enable_msg));
 }
 
 void ENABLE_FEED_OVERRIDE()
 {
-    EMC_TRAJ_SET_FO_ENABLE set_fo_enable_msg;
+    auto set_fo_enable_msg = std::make_unique<EMC_TRAJ_SET_FO_ENABLE>();
     flush_segments();
     
-    set_fo_enable_msg.mode = 1;
-    interp_list.append(set_fo_enable_msg);
+    set_fo_enable_msg->mode = 1;
+    interp_list.append(std::move(set_fo_enable_msg));
 }
 
 
 //refers to adaptive feed override (HAL input, useful for EDM for example)
 void DISABLE_ADAPTIVE_FEED()
 {
-    EMC_MOTION_ADAPTIVE emcmotAdaptiveMsg;
+    auto emcmotAdaptiveMsg = std::make_unique<EMC_MOTION_ADAPTIVE>();
     flush_segments();
 
-    emcmotAdaptiveMsg.status = 0;
-    interp_list.append(emcmotAdaptiveMsg);
+    emcmotAdaptiveMsg->status = 0;
+    interp_list.append(std::move(emcmotAdaptiveMsg));
 }
 
 void ENABLE_ADAPTIVE_FEED()
 {
-    EMC_MOTION_ADAPTIVE emcmotAdaptiveMsg;
+    auto emcmotAdaptiveMsg = std::make_unique<EMC_MOTION_ADAPTIVE>();
     flush_segments();
 
-    emcmotAdaptiveMsg.status = 1;
-    interp_list.append(emcmotAdaptiveMsg);
+    emcmotAdaptiveMsg->status = 1;
+    interp_list.append(std::move(emcmotAdaptiveMsg));
 }
 
+void SPEED_OVERRIDE_(int spindle, int mode)
+{
+    auto set_so_enable_msg = std::make_unique<EMC_TRAJ_SET_SO_ENABLE>();
+    flush_segments();
+    
+    set_so_enable_msg->mode = mode;
+    set_so_enable_msg->spindle = spindle;
+    interp_list.append(std::move(set_so_enable_msg));
+}
 //refers to spindle speed
 void DISABLE_SPEED_OVERRIDE(int spindle)
 {
-    EMC_TRAJ_SET_SO_ENABLE set_so_enable_msg;
-    flush_segments();
-    
-    set_so_enable_msg.mode = 0;
-    set_so_enable_msg.spindle = spindle;
-    interp_list.append(set_so_enable_msg);
+    SPEED_OVERRIDE_(spindle, 0);
 }
-
 
 void ENABLE_SPEED_OVERRIDE(int spindle)
 {
-    EMC_TRAJ_SET_SO_ENABLE set_so_enable_msg;
-    flush_segments();
-    
-    set_so_enable_msg.mode = 1;
-    set_so_enable_msg.spindle = spindle;
-    interp_list.append(set_so_enable_msg);
+    SPEED_OVERRIDE_(spindle, 1);
 }
 
+void FEED_HOLD_(int mode)
+{
+    auto set_feed_hold_msg = std::make_unique<EMC_TRAJ_SET_FH_ENABLE>();
+    flush_segments();
+
+    set_feed_hold_msg->mode = mode;
+    interp_list.append(std::move(set_feed_hold_msg));
+}
 void ENABLE_FEED_HOLD()
 {
-    EMC_TRAJ_SET_FH_ENABLE set_feed_hold_msg;
-    flush_segments();
-    
-    set_feed_hold_msg.mode = 1;
-    interp_list.append(set_feed_hold_msg);
+    FEED_HOLD_(1);
 }
 
 void DISABLE_FEED_HOLD()
 {
-    EMC_TRAJ_SET_FH_ENABLE set_feed_hold_msg;
-    flush_segments();
-    
-    set_feed_hold_msg.mode = 0;
-    interp_list.append(set_feed_hold_msg);
+    FEED_HOLD_(0);
+}
+
+template <typename T, bool flush_segments_ = true>
+void SIMPLE_COMMAND_()
+{
+    auto msg = std::make_unique<T>();
+
+    if (flush_segments_)
+        flush_segments();
+
+    interp_list.append(std::move(msg));
 }
 
 void FLOOD_OFF()
 {
-    EMC_COOLANT_FLOOD_OFF flood_off_msg;
-
-    flush_segments();
-
-    interp_list.append(flood_off_msg);
+    SIMPLE_COMMAND_<EMC_COOLANT_FLOOD_OFF>();
 }
 
 void FLOOD_ON()
 {
-    EMC_COOLANT_FLOOD_ON flood_on_msg;
-
-    flush_segments();
-
-    interp_list.append(flood_on_msg);
+    SIMPLE_COMMAND_<EMC_COOLANT_FLOOD_ON>();
 }
 
 void MESSAGE(char *s)
 {
-    EMC_OPERATOR_DISPLAY operator_display_msg;
+    auto operator_display_msg = std::make_unique<EMC_OPERATOR_DISPLAY>();
 
     flush_segments();
-    strncpy(operator_display_msg.display, s, LINELEN);
-    operator_display_msg.display[LINELEN - 1] = 0;
-    interp_list.append(operator_display_msg);
+    strncpy(operator_display_msg->display, s, LINELEN);
+    operator_display_msg->display[LINELEN - 1] = 0;
+    interp_list.append(std::move(operator_display_msg));
 }
 
 static FILE *logfile = NULL;
@@ -3236,20 +3226,12 @@ void LOGCLOSE() {
 
 void MIST_OFF()
 {
-    EMC_COOLANT_MIST_OFF mist_off_msg;
-
-    flush_segments();
-
-    interp_list.append(mist_off_msg);
+    SIMPLE_COMMAND_<EMC_COOLANT_MIST_OFF>();
 }
 
 void MIST_ON()
 {
-    EMC_COOLANT_MIST_ON mist_on_msg;
-
-    flush_segments();
-
-    interp_list.append(mist_on_msg);
+    SIMPLE_COMMAND_<EMC_COOLANT_MIST_ON>();
 }
 
 void PALLET_SHUTTLE()
@@ -3264,9 +3246,7 @@ void TURN_PROBE_OFF()
 
 void TURN_PROBE_ON()
 {
-    EMC_TRAJ_CLEAR_PROBE_TRIPPED_FLAG clearMsg;
-
-    interp_list.append(clearMsg);
+    SIMPLE_COMMAND_<EMC_TRAJ_CLEAR_PROBE_TRIPPED_FLAG, false>();
 }
 
 void UNCLAMP_AXIS(CANON_AXIS axis)
@@ -3280,11 +3260,7 @@ void PROGRAM_STOP()
 {
     /* 
        implement this as a pause. A resume will cause motion to proceed. */
-    EMC_TASK_PLAN_PAUSE pauseMsg;
-
-    flush_segments();
-
-    interp_list.append(pauseMsg);
+    SIMPLE_COMMAND_<EMC_TASK_PLAN_PAUSE>();
 }
 
 void SET_BLOCK_DELETE(bool state)
@@ -3310,20 +3286,13 @@ bool GET_OPTIONAL_PROGRAM_STOP()
 
 void OPTIONAL_PROGRAM_STOP()
 {
-    EMC_TASK_PLAN_OPTIONAL_STOP stopMsg;
-
-    flush_segments();
-
-    interp_list.append(stopMsg);
+    SIMPLE_COMMAND_<EMC_TASK_PLAN_OPTIONAL_STOP>();
 }
 
 void PROGRAM_END()
 {
     flush_segments();
-
-    EMC_TASK_PLAN_END endMsg;
-
-    interp_list.append(endMsg);
+    SIMPLE_COMMAND_<EMC_TASK_PLAN_END, false>();
 }
 
 double GET_EXTERNAL_TOOL_LENGTH_XOFFSET()
@@ -3446,19 +3415,19 @@ void INIT_CANON()
 void CANON_ERROR(const char *fmt, ...)
 {
     va_list ap;
-    EMC_OPERATOR_ERROR operator_error_msg;
+    auto operator_error_msg = std::make_unique<EMC_OPERATOR_ERROR>();
 
     flush_segments();
 
     if (fmt != NULL) {
-	va_start(ap, fmt);
-	vsnprintf(operator_error_msg.error,sizeof(operator_error_msg.error), fmt, ap);
-	va_end(ap);
+	    va_start(ap, fmt);
+	    vsnprintf(operator_error_msg->error, sizeof(operator_error_msg->error), fmt, ap);
+	    va_end(ap);
     } else {
-	operator_error_msg.error[0] = 0;
+	    operator_error_msg->error[0] = 0;
     }
 
-    interp_list.append(operator_error_msg);
+    interp_list.append(std::move(operator_error_msg));
 }
 
 /*
@@ -3957,6 +3926,22 @@ int USER_DEFINED_FUNCTION_ADD(USER_DEFINED_FUNCTION_TYPE func, int num)
     return 0;
 }
 
+void MOTION_OUTPUT_BIT_(int index, int start, int end, int now)
+{
+    auto dout_msg = std::make_unique<EMC_MOTION_SET_DOUT>();
+
+    flush_segments();
+
+    dout_msg->index = index;
+    dout_msg->start = start;
+    dout_msg->end = end;
+    dout_msg->now = now;
+
+    interp_list.append(std::move(dout_msg));
+
+    return;
+}
+
 /*! \function SET_MOTION_OUTPUT_BIT
 
   sets a DIO pin
@@ -3971,18 +3956,10 @@ int USER_DEFINED_FUNCTION_ADD(USER_DEFINED_FUNCTION_TYPE func, int num)
 */
 void SET_MOTION_OUTPUT_BIT(int index)
 {
-  EMC_MOTION_SET_DOUT dout_msg;
-
-  flush_segments();
-
-  dout_msg.index = index;
-  dout_msg.start = 1;		// startvalue = 1
-  dout_msg.end = 1;		// endvalue = 1, means it doesn't get reset after current motion
-  dout_msg.now = 0;		// not immediate, but synched with motion (goes to the TP)
-
-  interp_list.append(dout_msg);
-
-  return;
+    MOTION_OUTPUT_BIT_(index, 
+                       1,       // startvalue = 1
+                       1,       // endvalue = 1, means it doesn't get reset after current motion
+                       0);      // not immediate, but synched with motion (goes to the TP)
 }
 
 /*! \function CLEAR_MOTION_OUTPUT_BIT
@@ -3999,18 +3976,10 @@ void SET_MOTION_OUTPUT_BIT(int index)
 */
 void CLEAR_MOTION_OUTPUT_BIT(int index)
 {
-  EMC_MOTION_SET_DOUT dout_msg;
-
-  flush_segments();
-
-  dout_msg.index = index;
-  dout_msg.start = 0;           // startvalue = 1
-  dout_msg.end = 0;		// endvalue = 0, means it stays 0 after current motion
-  dout_msg.now = 0;		// not immediate, but synched with motion (goes to the TP)
-
-  interp_list.append(dout_msg);
-
-  return;
+    MOTION_OUTPUT_BIT_(index,
+                       0,       // startvalue = 1
+                       0,       // endvalue = 0, means it stays 0 after current motion
+                       0);      // not immediate, but synched with motion (goes to the TP)
 }
 
 /*! \function SET_AUX_OUTPUT_BIT
@@ -4024,19 +3993,10 @@ void CLEAR_MOTION_OUTPUT_BIT(int index)
 */
 void SET_AUX_OUTPUT_BIT(int index)
 {
-
-  EMC_MOTION_SET_DOUT dout_msg;
-
-  flush_segments();
-
-  dout_msg.index = index;
-  dout_msg.start = 1;		// startvalue = 1
-  dout_msg.end = 1;		// endvalue = 1, means it doesn't get reset after current motion
-  dout_msg.now = 1;		// immediate, we don't care about syncing for AUX
-
-  interp_list.append(dout_msg);
-
-  return;
+    MOTION_OUTPUT_BIT_(index,
+                       1,       // startvalue = 1
+                       1,       // endvalue = 1, means it doesn't get reset after current motion
+                       1);      // immediate, we don't care about syncing for AUX
 }
 
 /*! \function CLEAR_AUX_OUTPUT_BIT
@@ -4050,18 +4010,22 @@ void SET_AUX_OUTPUT_BIT(int index)
 */
 void CLEAR_AUX_OUTPUT_BIT(int index)
 {
-  EMC_MOTION_SET_DOUT dout_msg;
+    MOTION_OUTPUT_BIT_(index,
+                       0,       // startvalue = 1
+                       0,       // endvalue = 0, means it stays 0 after current motion
+                       1);      // immediate, we don't care about syncing for AUX
+}
 
-  flush_segments();
+void MOTION_OUTPUT_VALUE_(int index, double start, double end, int now)
+{
+    auto aout_msg = std::make_unique<EMC_MOTION_SET_AOUT>();
 
-  dout_msg.index = index;
-  dout_msg.start = 0;           // startvalue = 1
-  dout_msg.end = 0;		// endvalue = 0, means it stays 0 after current motion
-  dout_msg.now = 1;		// immediate, we don't care about syncing for AUX
+    aout_msg->index = index;
+    aout_msg->start = start;
+    aout_msg->end = end;
+    aout_msg->now = now;
 
-  interp_list.append(dout_msg);
-
-  return;
+    interp_list.append(std::move(aout_msg));
 }
 
 /*! \function SET_MOTION_OUTPUT_VALUE
@@ -4071,18 +4035,10 @@ void CLEAR_AUX_OUTPUT_BIT(int index)
 */
 void SET_MOTION_OUTPUT_VALUE(int index, double value)
 {
-  EMC_MOTION_SET_AOUT aout_msg;
-
-  flush_segments();
-
-  aout_msg.index = index;	// which output
-  aout_msg.start = value;	// start value
-  aout_msg.end = value;		// end value
-  aout_msg.now = 0;		// immediate=1, or synched when motion start=0
-
-  interp_list.append(aout_msg);
-
-  return;
+    MOTION_OUTPUT_VALUE_(index,     // which output
+                         value,     // start value
+                         value,     // end value
+                        0);         // immediate=1, or synched when motion start=0
 }
 
 /*! \function SET_AUX_OUTPUT_VALUE
@@ -4092,18 +4048,10 @@ void SET_MOTION_OUTPUT_VALUE(int index, double value)
 */
 void SET_AUX_OUTPUT_VALUE(int index, double value)
 {
-  EMC_MOTION_SET_AOUT aout_msg;
-
-  flush_segments();
-
-  aout_msg.index = index;	// which output
-  aout_msg.start = value;	// start value
-  aout_msg.end = value;		// end value
-  aout_msg.now = 1;		// immediate=1, or synched when motion start=0
-
-  interp_list.append(aout_msg);
-
-  return;
+    MOTION_OUTPUT_VALUE_(index,     // which output
+                         value,     // start value
+                         value,	    // end value
+                         1);        // immediate=1, or synched when motion start=0
 }
 
 /*! \function WAIT
@@ -4116,44 +4064,47 @@ int WAIT(int index, /* index of the motion exported input */
 	 int wait_type,  /* 0 - immediate, 1 - rise, 2 - fall, 3 - be high, 4 - be low */
 	 double timeout) /* time to wait [in seconds], if the input didn't change the value -1 is returned */
 {
-  if (input_type == DIGITAL_INPUT) {
-    if ((index < 0) || (index >= EMCMOT_MAX_DIO))
-	return -1;
-  } else if (input_type == ANALOG_INPUT) {
-    if ((index < 0) || (index >= EMCMOT_MAX_AIO))
-	return -1;
-  }
+    if (input_type == DIGITAL_INPUT) {
+        if ((index < 0) || (index >= EMCMOT_MAX_DIO))
+	    return -1;
+    } else if (input_type == ANALOG_INPUT) {
+        if ((index < 0) || (index >= EMCMOT_MAX_AIO))
+	    return -1;
+    }
 
- EMC_AUX_INPUT_WAIT wait_msg;
+    auto wait_msg = std::make_unique<EMC_AUX_INPUT_WAIT>();
  
- flush_segments();
+    flush_segments();
  
- wait_msg.index = index;
- wait_msg.input_type = input_type;
- wait_msg.wait_type = wait_type;
- wait_msg.timeout = timeout;
+    wait_msg->index = index;
+    wait_msg->input_type = input_type;
+    wait_msg->wait_type = wait_type;
+    wait_msg->timeout = timeout;
  
- interp_list.append(wait_msg);
- return 0;
+    interp_list.append(std::move(wait_msg));
+    return 0;
 }
 
-int UNLOCK_ROTARY(int line_number, int joint_num) {
-    EMC_TRAJ_LINEAR_MOVE m;
+int UNLOCK_ROTARY(int line_number, int joint_num)
+{
+    auto m = std::make_unique<EMC_TRAJ_LINEAR_MOVE>();
+
     // first, set up a zero length move to interrupt blending and get to final position
-    m.type = EMC_MOTION_TYPE_TRAVERSE;
-    m.feed_mode = 0;
-    m.end = to_ext_pose(canon.endPoint.x, canon.endPoint.y, canon.endPoint.z,
-                        canon.endPoint.a, canon.endPoint.b, canon.endPoint.c,
-                        canon.endPoint.u, canon.endPoint.v, canon.endPoint.w);
-    m.vel = m.acc = 1; // nonzero but otherwise doesn't matter
-    m.indexer_jnum = -1;
+    m->type = EMC_MOTION_TYPE_TRAVERSE;
+    m->feed_mode = 0;
+    m->end = to_ext_pose(canon.endPoint.x, canon.endPoint.y, canon.endPoint.z,
+                         canon.endPoint.a, canon.endPoint.b, canon.endPoint.c,
+                         canon.endPoint.u, canon.endPoint.v, canon.endPoint.w);
+    m->vel = m->acc = 1; // nonzero but otherwise doesn't matter
+    m->indexer_jnum = -1;
 
     // issue it
     int old_feed_mode = canon.feed_mode;
     if(canon.feed_mode)
 	STOP_SPEED_FEED_SYNCH();
     interp_list.set_line_number(line_number);
-    interp_list.append(m);
+    interp_list.append(std::move(m));
+    
     // no need to update endpoint
     if(old_feed_mode)
 	START_SPEED_FEED_SYNCH(canon.spindle_num, canon.linearFeedRate, 1);

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -458,27 +458,27 @@ static int max_mdi_queued_commands = MAX_MDI_QUEUE;
 static int checkInterpList(NML_INTERP_LIST * il, EMC_STAT * stat)
 {
     while (il->len() > 0) {
-		auto cmd = il->get();
+	auto cmd = il->get();
 
-		switch (cmd->type) {
+	switch (cmd->type) {
 
-		case EMC_OPERATOR_ERROR_TYPE: {
-			auto error_msg = static_cast<EMC_OPERATOR_ERROR*>(cmd.get());
-	    	emcOperatorError("%s", error_msg->error);
-	    	break;
-		}
-	
-		//FIXME: there was limit checking tests below, see if they were needed
-		case EMC_TRAJ_LINEAR_MOVE_TYPE:
-	    	break;
-
-		case EMC_TRAJ_CIRCULAR_MOVE_TYPE:
-	    	break;
-
-		default:
-	    	break;
-		}
+	case EMC_OPERATOR_ERROR_TYPE: {
+	    auto error_msg = static_cast<EMC_OPERATOR_ERROR*>(cmd.get());
+    	    emcOperatorError("%s", error_msg->error);
+    	    break;
 	}
+	
+	//FIXME: there was limit checking tests below, see if they were needed
+	case EMC_TRAJ_LINEAR_MOVE_TYPE:
+	    break;
+
+	case EMC_TRAJ_CIRCULAR_MOVE_TYPE:
+	    break;
+
+	default:
+	    break;
+	}
+    }
 
     return 0;
 }
@@ -716,8 +716,8 @@ void readahead_waiting(void)
 			("emcTaskPlanClose() called at %s:%d\n",
 			 __FILE__, __LINE__);
 		}
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
+		// then resynch interpreter
+		emcTaskQueueTaskPlanSynchCmd();
 	    } else {
 		emcStatus->task.interpState = EMC_TASK_INTERP::IDLE;
 	    }
@@ -756,20 +756,20 @@ static int emcTaskPlan(void)
 
     // check for new command
     if (emcCommand->serial_number != emcStatus->echo_serial_number) {
-		// flag it here locally as a new command
-		type = emcCommand->type;
+        // flag it here locally as a new command
+	type = emcCommand->type;
     } else {
-		// no new command-- reset local flag
-		type = 0;
+	// no new command-- reset local flag
+	type = 0;
     }
 
     // Always display messages
-	switch (type) {
+    switch (type) {
     case EMC_OPERATOR_ERROR_TYPE:
-	case EMC_OPERATOR_TEXT_TYPE:
-	case EMC_OPERATOR_DISPLAY_TYPE:
-		retval = emcTaskIssueCommand(emcCommand);
-		return retval;
+    case EMC_OPERATOR_TEXT_TYPE:
+    case EMC_OPERATOR_DISPLAY_TYPE:
+	retval = emcTaskIssueCommand(emcCommand);
+	return retval;
     }
 
     // handle any new command
@@ -837,33 +837,33 @@ static int emcTaskPlan(void)
 		break;
 
 	    case EMC_TOOL_LOAD_TOOL_TABLE_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
+		// send to IO
+		emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
+		// signify no more reading
+		emcTaskPlanSetWait();
+		// then resynch interpreter
+		emcTaskQueueTaskPlanSynchCmd();
+		break;
+	    }
 	    case EMC_TOOL_SET_OFFSET_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
+		// send to IO
+		emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
+		// signify no more reading
+		emcTaskPlanSetWait();
+		// then resynch interpreter
+		emcTaskQueueTaskPlanSynchCmd();
+		break;
+	    }
 
 	    case EMC_TOOL_SET_NUMBER_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_NUMBER>(*static_cast<EMC_TOOL_SET_NUMBER*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
+		// send to IO
+		emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_NUMBER>(*static_cast<EMC_TOOL_SET_NUMBER*>(emcCommand)));
+		// signify no more reading
+		emcTaskPlanSetWait();
+		// then resynch interpreter
+		emcTaskQueueTaskPlanSynchCmd();
+		break;
+	    }
 
 	    default:
 		emcOperatorError(_("command (%s) cannot be executed until the machine is out of E-stop and turned on"), emc_symbol_lookup(type));
@@ -966,33 +966,33 @@ static int emcTaskPlan(void)
 		break;
 
 	    case EMC_TOOL_LOAD_TOOL_TABLE_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
+		// send to IO
+		emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
+		// signify no more reading
+		emcTaskPlanSetWait();
+		// then resynch interpreter
+		emcTaskQueueTaskPlanSynchCmd();
+		break;
+	    }
 	    case EMC_TOOL_SET_OFFSET_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
+		// send to IO
+		emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
+		// signify no more reading
+		emcTaskPlanSetWait();
+		// then resynch interpreter
+		emcTaskQueueTaskPlanSynchCmd();
+		break;
+	    }
 
 	    case EMC_TOOL_SET_NUMBER_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_NUMBER>(*static_cast<EMC_TOOL_SET_NUMBER*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
+		// send to IO
+		emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_NUMBER>(*static_cast<EMC_TOOL_SET_NUMBER*>(emcCommand)));
+		// signify no more reading
+		emcTaskPlanSetWait();
+		// then resynch interpreter
+		emcTaskQueueTaskPlanSynchCmd();
+		break;
+	    }
 
 	    case EMC_TASK_PLAN_RUN_TYPE:
                 if (GET_EXTERNAL_OFFSET_APPLIED()) {
@@ -1035,7 +1035,7 @@ static int emcTaskPlan(void)
 		case EMC_TRAJ_SET_MAX_VELOCITY_TYPE:
 		case EMC_TRAJ_SET_SPINDLE_SCALE_TYPE:
 		case EMC_TRAJ_SET_FO_ENABLE_TYPE:
-        case EMC_TRAJ_SET_FH_ENABLE_TYPE:
+        	case EMC_TRAJ_SET_FH_ENABLE_TYPE:
 		case EMC_TRAJ_SET_SO_ENABLE_TYPE:
 		case EMC_SPINDLE_SPEED_TYPE:
 		case EMC_SPINDLE_ORIENT_TYPE:
@@ -1090,29 +1090,29 @@ static int emcTaskPlan(void)
 		    retval = 0;
 		    break;
 
-	    case EMC_TOOL_LOAD_TOOL_TABLE_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
-	    case EMC_TOOL_SET_OFFSET_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
+		case EMC_TOOL_LOAD_TOOL_TABLE_TYPE: {
+		    // send to IO
+		    emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
+		    // signify no more reading
+		    emcTaskPlanSetWait();
+		    // then resynch interpreter
+		    emcTaskQueueTaskPlanSynchCmd();
+		    break;
+	        }
+	    	case EMC_TOOL_SET_OFFSET_TYPE: {
+		    // send to IO
+		    emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
+		    // signify no more reading
+		    emcTaskPlanSetWait();
+		    // then resynch interpreter
+		    emcTaskQueueTaskPlanSynchCmd();
+		    break;
+	        }
 
-		    // otherwise we can't handle it
-		default:
-	            //EMC_TASK_MODE::AUTO(2) && EMC_TASK_INTERP::IDLE(1)
-                    if ( allow_while_idle_type() ) {
+		// otherwise we can't handle it
+	    	default:
+		    //EMC_TASK_MODE::AUTO(2) && EMC_TASK_INTERP::IDLE(1)
+        	    if ( allow_while_idle_type() ) {
                         retval = emcTaskIssueCommand(emcCommand);
 		        break;
                     }
@@ -1122,7 +1122,7 @@ static int emcTaskPlan(void)
 
 		}		// switch (type) in ON, AUTO, IDLE
 
-		break;		// EMC_TASK_INTERP::IDLE
+	        break;		// EMC_TASK_INTERP::IDLE
 
 	    case EMC_TASK_INTERP::READING:	// ON, AUTO, READING
 		switch (type) {
@@ -1316,7 +1316,7 @@ static int emcTaskPlan(void)
 		case EMC_TRAJ_PROBE_TYPE:
 		case EMC_AUX_INPUT_WAIT_TYPE:
 	        case EMC_TRAJ_RIGID_TAP_TYPE:
-			case EMC_SET_DEBUG_TYPE:
+		case EMC_SET_DEBUG_TYPE:
                 case EMC_COOLANT_MIST_ON_TYPE:
                 case EMC_COOLANT_MIST_OFF_TYPE:
                 case EMC_COOLANT_FLOOD_ON_TYPE:
@@ -1393,8 +1393,8 @@ static int emcTaskPlan(void)
 	    case EMC_TASK_PLAN_OPEN_TYPE:
 	    case EMC_TASK_PLAN_CLOSE_TYPE:
 	    case EMC_TASK_PLAN_PAUSE_TYPE:
-		case EMC_TASK_PLAN_REVERSE_TYPE:
-		case EMC_TASK_PLAN_FORWARD_TYPE:
+	    case EMC_TASK_PLAN_REVERSE_TYPE:
+	    case EMC_TASK_PLAN_FORWARD_TYPE:
 	    case EMC_TASK_PLAN_SET_OPTIONAL_STOP_TYPE:
 	    case EMC_TASK_PLAN_SET_BLOCK_DELETE_TYPE:
 	    case EMC_TASK_PLAN_RESUME_TYPE:
@@ -1408,7 +1408,7 @@ static int emcTaskPlan(void)
 	    case EMC_MOTION_SET_AOUT_TYPE:
 	    case EMC_MOTION_ADAPTIVE_TYPE:
 	    case EMC_TRAJ_RIGID_TAP_TYPE:
-		case EMC_SET_DEBUG_TYPE:
+	    case EMC_SET_DEBUG_TYPE:
 		retval = emcTaskIssueCommand(emcCommand);
 		break;
 
@@ -1426,8 +1426,8 @@ static int emcTaskPlan(void)
                 ) {
                     retval = emcTaskIssueCommand(emcCommand);
                 } else {
-					auto cmd = std::make_unique<EMC_TASK_PLAN_EXECUTE>();
-					rtapi_strlcpy(cmd->command, static_cast<EMC_TASK_PLAN_EXECUTE*>(emcCommand)->command, sizeof(cmd->command));
+		    auto cmd = std::make_unique<EMC_TASK_PLAN_EXECUTE>();
+		    rtapi_strlcpy(cmd->command, static_cast<EMC_TASK_PLAN_EXECUTE*>(emcCommand)->command, sizeof(cmd->command));
                     mdi_execute_queue.append(std::move(cmd));
                     emcStatus->task.queuedMDIcommands = mdi_execute_queue.len();
                     retval = 0;
@@ -1435,23 +1435,23 @@ static int emcTaskPlan(void)
                 break;
 
 	    case EMC_TOOL_LOAD_TOOL_TABLE_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
+		// send to IO
+		emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
+		// signify no more reading
+		emcTaskPlanSetWait();
+		// then resynch interpreter
+		emcTaskQueueTaskPlanSynchCmd();
+		break;
+	    }
 	    case EMC_TOOL_SET_OFFSET_TYPE: {
-			// send to IO
-			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
-			// signify no more reading
-			emcTaskPlanSetWait();
-			// then resynch interpreter
-			emcTaskQueueTaskPlanSynchCmd();
-			break;
-		}
+		// send to IO
+		emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
+		// signify no more reading
+		emcTaskPlanSetWait();
+		// then resynch interpreter
+		emcTaskQueueTaskPlanSynchCmd();
+		break;
+	    }
 
 		// otherwise we can't handle it
 	    default:
@@ -1618,7 +1618,7 @@ static EMC_TASK_EXEC emcTaskCheckPreconditions(NMLmsg * cmd)
 int emcTaskQueueCommand(std::unique_ptr<NMLmsg> &&cmd)
 {
     if (nullptr == cmd) {
-		return 0;
+	return 0;
     }
     interp_list.append(std::move(cmd));
 
@@ -2551,34 +2551,34 @@ static int emcTaskExecute(void)
 	STEPPING_CHECK();
 	if (!emcStatus->motion.traj.queueFull &&
 	    emcStatus->task.interpState != EMC_TASK_INTERP::PAUSED) {
-	    	if (0 == emcTaskCommand) {
-			// need a new command
-			emcTaskCommand = interp_list.get();
-			// interp_list now has line number associated with this-- get
-			// it
-			if (0 != emcTaskCommand) {
-		    	emcTaskEager = 1;
-		    	emcStatus->task.currentLine = interp_list.get_line_number();
-		    	emcStatus->task.callLevel = emcTaskPlanLevel();
-		    	// and set it for all subsystems which use queued ids
-		    	emcTrajSetMotionId(emcStatus->task.currentLine);
-		    	if (emcStatus->motion.traj.queueFull) {
-					emcStatus->task.execState =
-			    	EMC_TASK_EXEC::WAITING_FOR_MOTION_QUEUE;
-		    	} else {
-					emcStatus->task.execState = emcTaskCheckPreconditions(emcTaskCommand.get());
-		    	}
-			}
+	    if (0 == emcTaskCommand) {
+		// need a new command
+		emcTaskCommand = interp_list.get();
+		// interp_list now has line number associated with this-- get
+		// it
+		if (0 != emcTaskCommand) {
+		    emcTaskEager = 1;
+		    emcStatus->task.currentLine = interp_list.get_line_number();
+		    emcStatus->task.callLevel = emcTaskPlanLevel();
+		    // and set it for all subsystems which use queued ids
+		    emcTrajSetMotionId(emcStatus->task.currentLine);
+		    if (emcStatus->motion.traj.queueFull) {
+			emcStatus->task.execState =
+			    EMC_TASK_EXEC::WAITING_FOR_MOTION_QUEUE;
+		    } else {
+			emcStatus->task.execState = emcTaskCheckPreconditions(emcTaskCommand.get());
+		    }
+		}
 	    } else {
-			// have an outstanding command
-			if (0 != emcTaskIssueCommand(emcTaskCommand.get())) {
-		    	emcStatus->task.execState = EMC_TASK_EXEC::ERROR;
-		    	retval = -1;
-			} else {
-		    	emcStatus->task.execState = emcTaskCheckPostconditions(emcTaskCommand.get());
-		    	emcTaskEager = 1;
-			}
-			emcTaskCommand = 0;	// reset it
+		// have an outstanding command
+		if (0 != emcTaskIssueCommand(emcTaskCommand.get())) {
+		    emcStatus->task.execState = EMC_TASK_EXEC::ERROR;
+		    retval = -1;
+		} else {
+		    emcStatus->task.execState = emcTaskCheckPostconditions(emcTaskCommand.get());
+		    emcTaskEager = 1;
+		}
+		emcTaskCommand = 0;	// reset it
 	    }
 	}
 	break;
@@ -3316,9 +3316,9 @@ int main(int argc, char *argv[])
 	    if (emcStatus->motion.traj.enabled) {
 		emcTrajDisable();
 		emcTaskAbort();
-        emcIoAbort(EMC_ABORT_AUX_ESTOP);
-        for (int s = 0; s < emcStatus->motion.traj.spindles; s++) emcSpindleAbort(s);
-        emcJointUnhome(-2); // only those joints which are volatile_home
+		emcIoAbort(EMC_ABORT_AUX_ESTOP);
+		for (int s = 0; s < emcStatus->motion.traj.spindles; s++) emcSpindleAbort(s);
+		emcJointUnhome(-2); // only those joints which are volatile_home
 		mdi_execute_abort();
 		emcAbortCleanup(EMC_ABORT_AUX_ESTOP);
 		emcTaskPlanSynch();
@@ -3397,7 +3397,7 @@ int main(int argc, char *argv[])
             // abort everything
             emcTaskAbort();
             emcIoAbort(EMC_ABORT_MOTION_OR_IO_RCS_ERROR);
-        for (int s = 0; s < emcStatus->motion.traj.spindles; s++) emcSpindleAbort(s);;
+            for (int s = 0; s < emcStatus->motion.traj.spindles; s++) emcSpindleAbort(s);;
 	    mdi_execute_abort();
 	    // without emcTaskPlanClose(), a new run command resumes at
 	    // aborted line-- feature that may be considered later
@@ -3425,7 +3425,7 @@ int main(int argc, char *argv[])
 	    steppingWait = 0;
 
 	    // now queue up command to resynch interpreter
-		emcTaskQueueTaskPlanSynchCmd();
+	    emcTaskQueueTaskPlanSynchCmd();
 	}
 
 	// update task-specific status

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -282,7 +282,7 @@ static int argvize(const char *src, char *dst, char *argv[], int len)
     char inquote;
     char looking;
 
-    strncpy(dst, src, len-1);
+    strncpy(dst, src, len);
     dst[len - 1] = 0;
     bufptr = dst;
     inquote = 0;
@@ -837,9 +837,8 @@ static int emcTaskPlan(void)
 		break;
 
 	    case EMC_TOOL_LOAD_TOOL_TABLE_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter
@@ -847,9 +846,8 @@ static int emcTaskPlan(void)
 			break;
 		}
 	    case EMC_TOOL_SET_OFFSET_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter
@@ -858,9 +856,8 @@ static int emcTaskPlan(void)
 		}
 
 	    case EMC_TOOL_SET_NUMBER_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_SET_NUMBER>(*static_cast<EMC_TOOL_SET_NUMBER*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_NUMBER>(*static_cast<EMC_TOOL_SET_NUMBER*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter
@@ -969,9 +966,8 @@ static int emcTaskPlan(void)
 		break;
 
 	    case EMC_TOOL_LOAD_TOOL_TABLE_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter
@@ -979,9 +975,8 @@ static int emcTaskPlan(void)
 			break;
 		}
 	    case EMC_TOOL_SET_OFFSET_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter
@@ -990,9 +985,8 @@ static int emcTaskPlan(void)
 		}
 
 	    case EMC_TOOL_SET_NUMBER_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_SET_NUMBER>(*static_cast<EMC_TOOL_SET_NUMBER*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_NUMBER>(*static_cast<EMC_TOOL_SET_NUMBER*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter
@@ -1097,9 +1091,8 @@ static int emcTaskPlan(void)
 		    break;
 
 	    case EMC_TOOL_LOAD_TOOL_TABLE_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter
@@ -1107,9 +1100,8 @@ static int emcTaskPlan(void)
 			break;
 		}
 	    case EMC_TOOL_SET_OFFSET_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter
@@ -1443,9 +1435,8 @@ static int emcTaskPlan(void)
                 break;
 
 	    case EMC_TOOL_LOAD_TOOL_TABLE_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_LOAD_TOOL_TABLE>(*static_cast<EMC_TOOL_LOAD_TOOL_TABLE*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter
@@ -1453,9 +1444,8 @@ static int emcTaskPlan(void)
 			break;
 		}
 	    case EMC_TOOL_SET_OFFSET_TYPE: {
-			auto cmd = std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand));
 			// send to IO
-			emcTaskQueueCommand(std::move(cmd));
+			emcTaskQueueCommand(std::make_unique<EMC_TOOL_SET_OFFSET>(*static_cast<EMC_TOOL_SET_OFFSET*>(emcCommand)));
 			// signify no more reading
 			emcTaskPlanSetWait();
 			// then resynch interpreter

--- a/src/emc/task/task.hh
+++ b/src/emc/task/task.hh
@@ -17,10 +17,12 @@
 #define EMC_TASK_HH
 #include "taskclass.hh"
 #include "emc_nml.hh"
-extern NMLmsg *emcTaskCommand;
+#include <memory>
+
+extern std::unique_ptr<NMLmsg> emcTaskCommand;
 extern int stepping;
 extern int steppingWait;
-extern int emcTaskQueueCommand(NMLmsg *cmd);
+extern int emcTaskQueueCommand(std::unique_ptr<NMLmsg> &&cmd);
 extern int emcTaskOnce(const char *inifile, EMC_IO_STAT &emcioStatus);
 
 // Returns 0 if all joints are homed, 1 if any joints are un-homed.


### PR DESCRIPTION
continuing the work from https://github.com/LinuxCNC/linuxcnc/pull/2486 this refactors NML_INTERP_LIST

* use std::unique_ptr<NMLmsg> instead of NMLmsg*
* adapt task to allocate message with std::make_unique

improvements:
* avoids multiple copying of message contents
* avoids some dynamic allocations in std::vector
* potentially saves heap space
* clear ownership / lifetime of message
* next step to more idiomatic use of standard library