### PR TITLE
silence debug message

### DIFF
--- a/src/emc/task/emcsvr.cc
+++ b/src/emc/task/emcsvr.cc
@@ -177,13 +177,13 @@ int main(int argc, char *argv[])
 	    || emcErrorChannel == NULL)
 	) {
 	if (NULL == emcCommandChannel) {
-	    rcs_print("emcCommandChannel==NULL, attempt to create\n");
+	    rcs_print_debug(PRINT_NML_CONSTRUCTORS, "emcCommandChannel==NULL, attempt to create\n");
 	    emcCommandChannel =
 		new RCS_CMD_CHANNEL(emcFormat, "emcCommand", "emcsvr",
 				    emc_nmlfile);
 	}
 	if (NULL == emcStatusChannel) {
-	    rcs_print("emcStatusChannel==NULL, attempt to create\n");
+	    rcs_print_debug(PRINT_NML_CONSTRUCTORS, "emcStatusChannel==NULL, attempt to create\n");
 	    emcStatusChannel =
 		new RCS_STAT_CHANNEL(emcFormat, "emcStatus", "emcsvr",
 				     emc_nmlfile);

--- a/src/emc/task/emcsvr.cc
+++ b/src/emc/task/emcsvr.cc
@@ -122,6 +122,9 @@ static int iniLoad(const char *filename)
     // close it
     inifile.Close();
 
+    if(emc_debug & EMC_DEBUG_CONFIG)
+        rcs_print("config file \"%s\" loaded successfully.\n", filename);
+
     return 0;
 }
 
@@ -166,9 +169,6 @@ int main(int argc, char *argv[])
     }
     // get configuration information
     iniLoad(emc_inifile);
-
-    rcs_print("after iniLoad()\n");
-
 
     start_time = etime();
 


### PR DESCRIPTION
As [promised](https://github.com/LinuxCNC/linuxcnc/pull/2717#issuecomment-1793357001):

* silence NML constructor debug output when not debugging
* improve iniLoad() debug output and move inside iniLoad()