### PR TITLE
add code formatting target to makefile

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,79 @@
+BasedOnStyle: LLVM
+#AccessModifierOffset: -4
+AlignAfterOpenBracket: BlockIndent
+AlignArrayOfStructures: Left
+#AlignConsecutiveAssignments: None
+#AlignConsecutiveBitFields: AcrossComments
+#AlignConsecutiveDeclarations: AcrossComments
+#AlignConsecutiveMacros: AcrossComments
+#AlignEscapedNewlines: Left
+#AlignOperands: DontAlign
+AlignTrailingComments: true
+#AllowAllArgumentsOnNextLine: false
+#AllowAllParametersOfDeclarationOnNextLine: false
+#AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+#AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+#AllowShortIfStatementsOnASingleLine: WithoutElse
+#AllowShortLambdasOnASingleLine: Empty
+#AllowShortLoopsOnASingleLine: false
+#AlwaysBreakAfterReturnType: None
+#AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+#BraceWrapping:
+#    AfterCaseLabel: false
+#    AfterClass: true
+#    AfterStruct: false
+#    AfterControlStatement: Never
+#    AfterEnum: true
+#    AfterFunction: true
+#    AfterNamespace: true
+#    AfterUnion: true
+#    BeforeCatch: true
+#    BeforeElse: false
+#    BeforeWhile: false
+#    IndentBraces: false
+#    SplitEmptyFunction: false
+#    SplitEmptyRecord: true
+#BreakBeforeBraces: Custom
+BreakBeforeBinaryOperators: None
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializers: BeforeComma
+#BreakInheritanceList: BeforeColon
+ColumnLimit: 80
+#CompactNamespaces: false
+ContinuationIndentWidth: 4
+#IncludeBlocks: Preserve
+#IndentCaseLabels: false
+#IndentPPDirectives: None
+IndentWidth: 4
+#InsertBraces: false
+#KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2
+#NamespaceIndentation: None
+#ObjCSpaceAfterProperty: false
+#ObjCSpaceBeforeProtocolList: true
+#PackConstructorInitializers: Never
+#PointerAlignment: Left
+ReflowComments: false
+SortIncludes: Never
+#SpaceAfterCStyleCast: false
+#SpaceAfterLogicalNot: false
+#SpaceAfterTemplateKeyword: false
+#SpaceBeforeAssignmentOperators: true
+#SpaceBeforeCpp11BracedList: true
+#SpaceBeforeCtorInitializerColon: true
+#SpaceBeforeInheritanceColon: false
+#SpaceBeforeParens: ControlStatements
+#SpaceBeforeRangeBasedForLoopColon: true
+#SpaceInEmptyParentheses: false
+#SpacesBeforeTrailingComments: 2
+#SpacesInAngles: false
+#SpacesInCStyleCastParentheses: false
+#SpacesInContainerLiterals: false
+#SpacesInParentheses: false
+#SpacesInSquareBrackets: false
+TabWidth: 4
+UseTab: Never

--- a/src/Makefile
+++ b/src/Makefile
@@ -1421,4 +1421,16 @@ cscope:
 
 cscopeclean:
 	bash -c 'for f in `find ./ -name "cscope.*out"`;do rm $$f;done'
+
+.PHONY: format
+format: format-cpp format-python
+
+format-cpp:
+	$(ECHO) -n "formatting C/C++ files..."
+	@find -regex '.*\.\(cc\|cpp\|hpp\|cu\|c\|h\)' -exec clang-format -style=file -i "{}" \;
+	$(ECHO) "done"
+
+format-python:
+	$(ECHO) "formatting python files..."
+	@black .
 # vim:ts=8:sts=8:sw=8:noet:


### PR DESCRIPTION
This PR adds 3 new targets to the Makefile:
* ```format-python``` - that uses [black](https://black.readthedocs.io/en/stable/) to format all python code within ```src```
* ```format-cpp``` - that uses [clang-format](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) to format C/C++ files within ```src```
* ```format```- to combine the above targets

the ```.clang-format``` config is based on @rmu75's [work](https://gist.githubusercontent.com/rmu75/08966863b9d10a51d2cb172a83aff0f5/raw/103df8f3b7c2cd18229881b8638f85d09ba760f8/.clang-format) with minor changes and lots of commented disabled options with the goal to
- invoke as little changes to the source as possible while
- gaining readability and
- gaining uniformity

I'd like to suggest the following steps:

1. test the output  of the formatting and adjust the config accordingly.
2. reformat the whole codebase in one giant commit
3. wait for dev feedback and adjust the config accordingly, if needed
4. reformat the whole codebase again, if needed
