### PR TITLE
S code fix

### DIFF
--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -1609,12 +1609,14 @@ void emcmotCommandHandler_locked(void *arg, long servo_period)
 	        emcmotStatus->spindle_status[n].speed = emcmotCommand->vel;
 	        emcmotStatus->spindle_status[n].css_factor = emcmotCommand->ini_maxvel;
 	        emcmotStatus->spindle_status[n].xoffset = emcmotCommand->acc;
-	        if (emcmotCommand->vel >= 0) {
-		    emcmotStatus->spindle_status[n].direction = 1;
-	        } else {
-		    emcmotStatus->spindle_status[n].direction = -1;
-	        }
-	        emcmotStatus->spindle_status[n].brake = 0; //disengage brake
+            if (emcmotCommand->state) {
+	            if (emcmotCommand->vel >= 0) {
+		        emcmotStatus->spindle_status[n].direction = 1;
+	            } else {
+		        emcmotStatus->spindle_status[n].direction = -1;
+	            }
+	            emcmotStatus->spindle_status[n].brake = 0; //disengage brake
+            }
             apply_spindle_limits(&emcmotStatus->spindle_status[n]);
         }
         emcmotStatus->atspeed_next_feed = emcmotCommand->wait_for_spindle_at_speed;

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -1906,7 +1906,7 @@ static void output_to_hal(void)
 	*(emcmot_hal_data->spindle[spindle_num].spindle_speed_out_abs) = fabs(speed);
 	*(emcmot_hal_data->spindle[spindle_num].spindle_speed_out_rps_abs) = fabs(speed / 60);
 	*(emcmot_hal_data->spindle[spindle_num].spindle_on) = 
-        ((emcmotStatus->spindle_status[spindle_num].state * speed) !=0) ? 1 : 0;
+        ((emcmotStatus->spindle_status[spindle_num].state) !=0) ? 1 : 0;
 	*(emcmot_hal_data->spindle[spindle_num].spindle_forward) = (speed > 0) ? 1 : 0;
 	*(emcmot_hal_data->spindle[spindle_num].spindle_reverse) = (speed < 0) ? 1 : 0;
 	*(emcmot_hal_data->spindle[spindle_num].spindle_brake) =


### PR DESCRIPTION
Setting a S code to anything before M3 or M4 releases the brake and (internally) sets the direction.
Setting S to 0 will not actually set the spindle speed to 0 - it will turn off the spindle.