### PR TITLE
Fix reloading file with axis

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1895,6 +1895,7 @@ def run_warn():
     return 0
 
 def reload_file(refilter=True):
+    global loaded_file
     if running(): return
     s.poll()
     if not loaded_file:
@@ -1902,7 +1903,7 @@ def reload_file(refilter=True):
         return
     line = vars.highlight_line.get()
     o.set_highlight_line(None)
-
+    orig_loaded_file = loaded_file
     if refilter or not get_filter(loaded_file):
         # we copy the file to a temporary file so that even if it subsequently
         # changes on disk, LinuxCNC is parsing the file contents from the time
@@ -1913,6 +1914,7 @@ def reload_file(refilter=True):
     else:
         tempfile = os.path.join(tempdir, "filtered-" + os.path.basename(loaded_file))
         open_file_guts(tempfile, True, False)
+    loaded_file = orig_loaded_file
     if line:
         o.set_highlight_line(line)
 


### PR DESCRIPTION
This fixes following error:

Exception in Tkinter callback
Traceback (most recent call last):
File "/usr/lib/python3.7/tkinter/init.py", line 1705, in call return self.func(*args)
File "/home/sundtek/devel/linuxcnc/bin/axis", line 2796, in touch_off_system reload_file(False)
File "/home/sundtek/devel/linuxcnc/bin/axis", line 1911, in reload_file shutil.copyfile(loaded_file, tempfile)
File "/usr/lib/python3.7/shutil.py", line 104, in copyfile raise SameFileError("{!r} and {!r} are the same file".format(src, dst)) shutil.SameFileError: '/tmp/tmp3d2pd26j/sidewall.nc' and '/tmp/tmp3d2pd26j/sidewall.nc' are the same file

opening the tmp file will overwrite loaded_file, the patch backups the original loaded_file and sets loaded_file back to the original name after loading the temp file.