### PR TITLE
Update updating-linuxcnc.adoc

### DIFF
--- a/docs/src/getting-started/updating-linuxcnc.adoc
+++ b/docs/src/getting-started/updating-linuxcnc.adoc
@@ -102,7 +102,7 @@ are available for Bookworm and Buster but not currently for Bullseye.
 
 [options="header"]
 |===
-| Debian Buster - preempt   | `deb https://linuxcnc.org buster base 2.9-rtpreempt`
+| Debian Buster - preempt   | `deb https://linuxcnc.org buster base 2.9-uspace`
 | Debian Buster - RTAI      | `deb https://linuxcnc.org buster base 2.9-rt`
 | Debian Bullseye - preempt | `deb https://linuxcnc.org bullseye base 2.9-uspace`
 | Debian Bookworm - preempt | `deb https://linuxcnc.org bookworm base 2.9-uspace`


### PR DESCRIPTION
I guess this is a copy past error. It seems to be 2.9-uspace instead of 2.9-rtpreempt. Apt threw me an error when I tried it with 2.9-rtpreempt.