### PR TITLE
fix loading GCode task files from remote processes

### DIFF
--- a/src/Makefile.inc.in
+++ b/src/Makefile.inc.in
@@ -17,6 +17,7 @@ LIB_DIR=@EMC2_HOME@/lib
 #used for install stuff
 #but have them here as reference
 #build system only uses EMC2_RTLIB_DIR when creating rtapi.conf
+EMC2_TMP_DIR=@EMC2_TMP_DIR@
 EMC2_BIN_DIR=@EMC2_BIN_DIR@
 EMC2_TCL_DIR=@EMC2_TCL_DIR@
 EMC2_HELP_DIR=@EMC2_HELP_DIR@

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -748,6 +748,7 @@ AC_DEFINE_UNQUOTED([EMC2_PO_DIR], "$EMC2_PO_DIR", [Directory for po/mo translati
 AC_DEFINE_UNQUOTED([EMC2_NCFILES_DIR], "$EMC2_NCFILES_DIR", [Directory for nc files])
 AC_DEFINE_UNQUOTED([EMC2_IMAGE_DIR], "$EMC2_IMAGE_DIR", [Directory for images])
 
+AC_SUBST([EMC2_TMP_DIR])
 AC_SUBST([EMC2_BIN_DIR])
 AC_SUBST([EMC2_TCL_DIR])
 AC_SUBST([EMC2_TCL_LIB_DIR])
@@ -770,6 +771,14 @@ LINUXCNC_AUX_GLADEVCP=/usr/share/linuxcnc/aux_gladevcp
 LINUXCNC_AUX_EXAMPLES=/usr/share/linuxcnc/aux_examples
 AC_SUBST([LINUXCNC_AUX_GLADEVCP])
 AC_SUBST([LINUXCNC_AUX_EXAMPLES])
+
+# define temporary directory
+AC_ARG_WITH(tmpdir,
+   [  --with-tmpdir=PATH      Specify path for temporary files],
+   tmpdir="$withval",
+   tmpdir="/tmp")
+AC_DEFINE_UNQUOTED(EMC2_TMP_DIR, "$tmpdir/linuxcnc", [Temporary files directory])
+AC_SUBST(EMC2_TMP_DIR, [$tmpdir])
 
 ##############################################################################
 # Subsection 3.5 - check for GTK                                             #

--- a/src/emc/nml_intf/emc.cc
+++ b/src/emc/nml_intf/emc.cc
@@ -1900,8 +1900,10 @@ void EMC_TASK_PLAN_OPEN::update(CMS * cms)
 {
 
     EMC_TASK_CMD_MSG::update(cms);
-    cms->update(file, 256);
-
+    cms->update(file, LINELEN);
+    cms->update(remote_filesize);
+    cms->update(remote_buffersize);
+    cms->update(remote_buffer, sizeof(remote_buffer));
 }
 
 /*

--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -1012,7 +1012,14 @@ class EMC_TASK_PLAN_OPEN:public EMC_TASK_CMD_MSG {
     // For internal NML/CMS use only.
     void update(CMS * cms);
 
+    // (local) path to file
     char file[LINELEN];
+    // total size of file in bytes (if issued from remote process, 0 otherwise)
+    size_t remote_filesize;
+    // amount of bytes currently in buffer (if issued from remote process, 0 otherwise)
+    size_t remote_buffersize;
+    // buffer used to transfer send a chunk of file contents (if loaded from remote process)
+    char remote_buffer[4096];
 };
 
 class EMC_TASK_PLAN_RUN:public EMC_TASK_CMD_MSG {

--- a/src/emc/task/backtrace.cc
+++ b/src/emc/task/backtrace.cc
@@ -21,6 +21,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <signal.h>
+#include "config.h"
 
 extern int done;
 extern int emcOperatorError(const char *fmt, ...);
@@ -34,7 +35,7 @@ void backtrace(int signo)
 
     signal(signo, SIG_IGN); // prevent multiple invocations on same signal
     snprintf(pid_buf, sizeof(pid_buf), "%d", getpid());
-    snprintf(filename, sizeof(filename),"/tmp/backtrace.%s", pid_buf);
+    snprintf(filename, sizeof(filename), EMC2_TMP_DIR "/backtrace.%s", pid_buf);
 
     name_buf[readlink("/proc/self/exe", name_buf, 511)]=0;
     int child_pid = fork();

--- a/src/emc/task/signalhandler.cc
+++ b/src/emc/task/signalhandler.cc
@@ -40,7 +40,7 @@ static void call_gdb(int sig, int start_gdb_in_window)
     FILE *f;
     char tmp_gdbrc[PATH_MAX];
 
-    snprintf(tmp_gdbrc, sizeof(tmp_gdbrc), "/tmp/gdbrc.%d",getpid());
+    snprintf(tmp_gdbrc, sizeof(tmp_gdbrc), EMC2_TMP_DIR "/gdbrc.%d",getpid());
 
     if ((f = fopen(tmp_gdbrc,"w")) == NULL) {
 	perror(tmp_gdbrc);

--- a/src/emc/tooldata/tooldata_mmap.cc
+++ b/src/emc/tooldata/tooldata_mmap.cc
@@ -22,6 +22,7 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <string.h>
+#include "config.h"
 #include "rtapi_mutex.h"
 #include "tooldata.hh"
 
@@ -73,7 +74,7 @@ typedef struct {
 static char* tool_mmap_fname(void) {
     if (*filename) {return filename;}
     char* hdir = secure_getenv("HOME");
-    if (!hdir) {hdir = (char*)"/tmp";}
+    if (!hdir) { hdir = (char *) EMC2_TMP_DIR; }
     snprintf(filename,sizeof(filename),"%s/%s",hdir,TOOL_MMAP_FILENAME);
     return(filename);
 }

--- a/src/hal/classicladder/files_project.c
+++ b/src/hal/classicladder/files_project.c
@@ -35,6 +35,7 @@
 #include <sys/types.h>
 #endif
 #include "classicladder.h"
+#include "config.h"
 #include "global.h"
 #include "edit.h"
 #include "calc.h"
@@ -107,7 +108,7 @@ void InitTempDir( void )
 {
 	char * TmpEnv = getenv("TMP");
 	if ( TmpEnv==NULL )
-		TmpEnv = "/tmp";
+		TmpEnv = EMC2_TMP_DIR;
 
 	// get a single name directory
 	snprintf(TmpDirectory, sizeof(TmpDirectory), "%s/classicladder_tmp_XXXXXX", TmpEnv );

--- a/tcl/linuxcnc.tcl.in
+++ b/tcl/linuxcnc.tcl.in
@@ -17,6 +17,7 @@
 
 namespace eval linuxcnc {
     variable HOME @EMC2_HOME@
+    variable TMP_DIR @EMC2_TMP_DIR@
     variable BIN_DIR @EMC2_BIN_DIR@
     variable TCL_DIR @EMC2_TCL_DIR@
     variable TCL_LIB_DIR @EMC2_TCL_LIB_DIR@


### PR DESCRIPTION
This pull request enables file loading when the UI is running on a different host than the milltask.
If the .nml config doesn't contain a "REMOTE" process line, it does nothing. It basically detects when we're running remotely and then transfers the file contents in chunks via the NML API for the milltask to store it in a unique, temporary file.

It contains two aspects:

1. It introduces ```EMC2_TMP_DIR``` at configure time (similar to other EMC2_*_DIR macros)
2. When a process that has ```cms->ProcessType == CMS_REMOTE_TYPE``` and is named != "emc", then
* multiple ```EMC_TASK_PLAN_OPEN``` messages will be sent, each containing a chunk of the file's contents, the filename and the size of the chunk.
* each chunk will be written to a temporary file on the host running milltask (with process name == "emc")
* the temporary file will be deleted upon ```EMC_TASK_PLAN_CLOSE```

As a bonus, usage of hardcoded ```/tmp``` has been replaced by the new ```EMC2_TMP_DIR```.