### PR TITLE
introduce hal_export_functf()

### DIFF
--- a/docs/man/man3/hal_export_functf.3hal
+++ b/docs/man/man3/hal_export_functf.3hal
@@ -1,0 +1,1 @@
+.so man3/hal_export_funct.3hal

--- a/docs/po4a.cfg
+++ b/docs/po4a.cfg
@@ -264,6 +264,7 @@
 [type: man_def] man/man3/hal_del_funct_from_thread.3hal $lang:man/$lang/man3/hal_del_funct_from_thread.3hal
 [type: man_def] man/man3/hal_exit.3hal $lang:man/$lang/man3/hal_exit.3hal
 [type: man_def] man/man3/hal_export_funct.3hal $lang:man/$lang/man3/hal_export_funct.3hal
+[type: man_def] man/man3/hal_export_functf.3hal $lang:man/$lang/man3/hal_export_functf.3hal
 [type: man_def] man/man3/hal_float_t.3hal $lang:man/$lang/man3/hal_float_t.3hal
 [type: man_def] man/man3/hal_get_lock.3hal $lang:man/$lang/man3/hal_get_lock.3hal
 [type: man_def] man/man3/hal_init.3hal $lang:man/$lang/man3/hal_init.3hal

--- a/docs/src/hal/components.adoc
+++ b/docs/src/hal/components.adoc
@@ -339,6 +339,7 @@ hal_create_thread.3hal
 hal_del_funct_from_thread.3hal
 hal_exit.3hal
 hal_export_funct.3hal
+hal_export_functf.3hal
 hal_float_t.3hal
 hal_get_lock.3hal
 hal_init.3hal

--- a/src/hal/components/debounce.c
+++ b/src/hal/components/debounce.c
@@ -229,7 +229,6 @@ static void debounce(void *arg, long period)
 static int export_group(int num, debounce_group_t * addr, int group_size)
 {
     int n, retval, msg;
-    char buf[HAL_NAME_LEN + 1];
 
     /* This function exports a lot of stuff, which results in a lot of
        logging if msg_level is at INFO or ALL. So we save the current value
@@ -246,19 +245,17 @@ static int export_group(int num, debounce_group_t * addr, int group_size)
 	return -1;
     }
     /* export param variable for delay */
-    rtapi_snprintf(buf, sizeof(buf), "debounce.%d.delay", num);
-    retval = hal_param_s32_new(buf, HAL_RW, &(addr->delay), comp_id);
+    retval = hal_param_s32_newf(HAL_RW, &(addr->delay), comp_id, "debounce.%d.delay", num);
     if (retval != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "DEBOUNCE: ERROR: '%s' param export failed\n", buf);
+	    "DEBOUNCE: ERROR: 'debounce.%d.delay' param export failed\n", num);
 	return retval;
     }
     /* export function */
-    rtapi_snprintf(buf, sizeof(buf), "debounce.%d", num);
-    retval = hal_export_funct(buf, debounce, addr, 0, 0, comp_id);
+    retval = hal_export_functf(debounce, addr, 0, 0, comp_id, "debounce.%d", num);
     if (retval != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
-	    "DEBOUNCE: ERROR: '%s' funct export failed\n", buf);
+	    "DEBOUNCE: ERROR: 'debounce.%d' funct export failed\n", num);
 	return -1;
     }
     /* set default parameter values */

--- a/src/hal/components/mux_generic.c
+++ b/src/hal/components/mux_generic.c
@@ -168,12 +168,8 @@ int rtapi_app_main(void){
             inst->out_type = inst->in_type;
         }
 
-        retval = rtapi_snprintf(hal_name, HAL_NAME_LEN, "mux-gen.%02i", i);
-        if (retval >= HAL_NAME_LEN) {
-            goto fail0;
-        }
         if (inst->in_type == HAL_FLOAT || inst->out_type == HAL_FLOAT) {
-            retval = hal_export_funct(hal_name, write_fp, inst, 1, 0, comp_id);
+            retval = hal_export_functf(write_fp, inst, 1, 0, comp_id, "mux-gen.%02i", i);
             if (retval < 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR, "mux_generic: ERROR: function export"
                         " failed\n");
@@ -182,7 +178,7 @@ int rtapi_app_main(void){
         }
         else
         {
-            retval = hal_export_funct(hal_name, write_nofp, inst, 0, 0, comp_id);
+            retval = hal_export_functf(write_nofp, inst, 0, 0, comp_id, "mux-gen.%02i", i);
             if (retval < 0) {
                 rtapi_print_msg(RTAPI_MSG_ERR, "mux_generic: ERROR: function export"
                         " failed\n");

--- a/src/hal/components/pid.c
+++ b/src/hal/components/pid.c
@@ -689,7 +689,6 @@ static void calc_pid(void *arg, long period)
 static int export_pid(hal_pid_t * addr, char * prefix)
 {
     int retval, msg;
-    char buf[HAL_NAME_LEN + 1];
 
     /* This function exports a lot of stuff, which results in a lot of
        logging if msg_level is at INFO or ALL. So we save the current value
@@ -963,9 +962,8 @@ static int export_pid(hal_pid_t * addr, char * prefix)
     *(addr->pTuneStart) = 0;
 #endif /* AUTO_TUNER */
     /* export function for this loop */
-    rtapi_snprintf(buf, sizeof(buf), "%s.do-pid-calcs", prefix);
     retval =
-	hal_export_funct(buf, calc_pid, addr, 1, 0, comp_id);
+	hal_export_functf(calc_pid, addr, 1, 0, comp_id, "%s.do-pid-calcs", prefix);
     if (retval != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    NAME ": ERROR: do_pid_calcs funct export failed\n");

--- a/src/hal/components/sampler.c
+++ b/src/hal/components/sampler.c
@@ -289,8 +289,7 @@ static int init_sampler(int num, sampler_t *str)
 	pptr++;
     }
     /* export update function */
-    rtapi_snprintf(buf, sizeof(buf), "sampler.%d", num);
-    retval = hal_export_funct(buf, sample, str, usefp, 0, comp_id);
+    retval = hal_export_functf(sample, str, usefp, 0, comp_id, "sampler.%d", num);
     if (retval != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "SAMPLER: ERROR: function export failed\n");

--- a/src/hal/components/siggen.c
+++ b/src/hal/components/siggen.c
@@ -277,7 +277,6 @@ static void calc_siggen(void *arg, long period)
 static int export_siggen(int num, hal_siggen_t * addr,char* prefix)
 {
     int retval;
-    char buf[HAL_NAME_LEN + 1];
 
     /* export pins */
     retval = hal_pin_float_newf(HAL_OUT, &(addr->square), comp_id,
@@ -342,10 +341,9 @@ static int export_siggen(int num, hal_siggen_t * addr,char* prefix)
     *(addr->offset) = 0.0;
     addr->index = 0.0;
     /* export function for this loop */
-    rtapi_snprintf(buf, sizeof(buf), "%s.update", prefix);
     retval =
-	hal_export_funct(buf, calc_siggen, &(siggen_array[num]), 1, 0,
-	comp_id);
+	hal_export_functf(calc_siggen, &(siggen_array[num]), 1, 0,
+	comp_id, "%s.update", prefix);
     if (retval != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "SIGGEN: ERROR: update funct export failed\n");

--- a/src/hal/components/streamer.c
+++ b/src/hal/components/streamer.c
@@ -346,8 +346,7 @@ static int init_streamer(int num, streamer_t *str)
 	pptr++;
     }
     /* export update function */
-    rtapi_snprintf(buf, sizeof(buf), "streamer.%d", num);
-    retval = hal_export_funct(buf, update, str, usefp, 0, comp_id);
+    retval = hal_export_functf(update, str, usefp, 0, comp_id, "streamer.%d", num);
     if (retval != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "STREAMER: ERROR: function export failed\n");

--- a/src/hal/components/supply.c
+++ b/src/hal/components/supply.c
@@ -159,7 +159,6 @@ static void update_supply(void *arg, long l)
 static int export_supply(int num, hal_supply_t * addr)
 {
     int retval;
-    char buf[HAL_NAME_LEN + 1];
 
     /* export pins */
     retval = hal_pin_bit_newf(HAL_OUT, &(addr->q), comp_id, "supply.%d.q", num);
@@ -195,10 +194,9 @@ static int export_supply(int num, hal_supply_t * addr)
     *(addr->d) = 0;
     *(addr->value) = 0.0;
     /* export function for this loop */
-    rtapi_snprintf(buf, sizeof(buf), "supply.%d.update", num);
     retval =
-	hal_export_funct(buf, update_supply, &(supply_array[num]), 1, 0,
-	comp_id);
+	hal_export_functf(update_supply, &(supply_array[num]), 1, 0,
+	comp_id, "supply.%d.update", num);
     if (retval != 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "SUPPLY: ERROR: update funct export failed\n");

--- a/src/hal/drivers/hal_ax5214h.c
+++ b/src/hal/drivers/hal_ax5214h.c
@@ -191,7 +191,6 @@ int rtapi_app_main(void)
 {
     char *cp;
     char *argv[MAX_TOK];
-    char name[HAL_NAME_LEN + 1];
     int n, retval;
 
     /* test for config string */
@@ -235,22 +234,18 @@ int rtapi_app_main(void)
     }
     /* export functions for each board */
     for (n = 0; n < num_boards; n++) {
-	/* make read function name */
-	rtapi_snprintf(name, sizeof(name), "ax5214h.%d.read", n);
 	/* export read function */
-	retval = hal_export_funct(name, read_board, &(board_array[n]),
-	    0, 0, comp_id);
+	retval = hal_export_functf(read_board, &(board_array[n]),
+	    0, 0, comp_id, "ax5214h.%d.read", n);
 	if (retval != 0) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"AX5214H: ERROR: port %d read funct export failed\n", n);
 	    hal_exit(comp_id);
 	    return -1;
 	}
-	/* make write function name */
-	rtapi_snprintf(name, sizeof(name), "ax5214h.%d.write", n);
 	/* export write function */
-	retval = hal_export_funct(name, write_board, &(board_array[n]),
-	    0, 0, comp_id);
+	retval = hal_export_functf(write_board, &(board_array[n]),
+	    0, 0, comp_id, "ax5214h.%d.write", n);
 	if (retval != 0) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"AX5214H: ERROR: port %d write funct export failed\n", n);

--- a/src/hal/drivers/hal_bb_gpio.c
+++ b/src/hal/drivers/hal_bb_gpio.c
@@ -126,7 +126,6 @@ int configure_gpio_port(int n) {
 }
 
 int rtapi_app_main(void) {
-    char name[HAL_NAME_LEN + 1];
     int n, retval;
     char *data, *token;
 
@@ -359,16 +358,14 @@ int rtapi_app_main(void) {
 
 
     // export functions
-    rtapi_snprintf(name, sizeof(name), "bb_gpio.write");
-    retval = hal_export_funct(name, write_port, port_data, 0, 0, comp_id);
+    retval = hal_export_funct("bb_gpio.write", write_port, port_data, 0, 0, comp_id);
     if(retval < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: port %d write funct export failed\n", modname, n);
         hal_exit(comp_id);
         return -1;
     }
 
-    rtapi_snprintf(name, sizeof(name), "bb_gpio.read");
-    retval = hal_export_funct(name, read_port, port_data, 0, 0, comp_id);
+    retval = hal_export_funct("bb_gpio.read", read_port, port_data, 0, 0, comp_id);
     if(retval < 0) {
         rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: port %d read funct export failed\n", modname, n);
         hal_exit(comp_id);

--- a/src/hal/drivers/hal_evoreg.c
+++ b/src/hal/drivers/hal_evoreg.c
@@ -134,7 +134,6 @@ static void update_port(void *arg, long period);
 
 int rtapi_app_main(void)
 {
-    char name[HAL_NAME_LEN + 1];
     int n,i , retval, num_dac, num_enc;
 
     unsigned int base=0x300;
@@ -255,9 +254,8 @@ int rtapi_app_main(void)
 
 
     /* STEP 4: export function */
-    rtapi_snprintf(name, sizeof(name), "evoreg.%d.update", n + 1);
-    retval = hal_export_funct(name, update_port, &(port_data_array[n]), 1, 0,
-	comp_id);
+    retval = hal_export_functf(update_port, &(port_data_array[n]), 1, 0,
+	comp_id, "evoreg.%d.update", n + 1);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "EVOREG: ERROR: port %d write funct export failed\n", n + 1);

--- a/src/hal/drivers/hal_gm.c
+++ b/src/hal/drivers/hal_gm.c
@@ -1096,22 +1096,18 @@ ExportMixed(void *arg, int comp_id)
 static int ExportFunctions(void *arg, int comp_id, int boardId)
 {
 	int error;
-	char str[HAL_NAME_LEN + 1];
 	gm_device_t	*device = (gm_device_t *)arg;
 
-	rtapi_snprintf(str, sizeof(str), "gm.%d.write", boardId);
-	error = hal_export_funct(str, write, device, 1, 0, comp_id);
+	error = hal_export_functf(write, device, 1, 0, comp_id, "gm.%d.write", boardId);
 
 	if(error == 0)
 	{
-		rtapi_snprintf(str, sizeof(str), "gm.%d.read", boardId);
-		error = hal_export_funct(str, read, device, 1, 0, comp_id);
+		error = hal_export_functf(read, device, 1, 0, comp_id, "gm.%d.read", boardId);
 	}
 	
 	if(error == 0)
 	{
-		rtapi_snprintf(str, sizeof(str), "gm.%d.RS485", boardId);
-		error = hal_export_funct(str, RS485, device, 1, 0, comp_id);
+		error = hal_export_functf(RS485, device, 1, 0, comp_id, "gm.%d.RS485", boardId);
 	}
 
     	return error;

--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -206,7 +206,6 @@ int build_chips_collection(char *name, hal_gpio_bulk_t **ptr, int *count){
 int rtapi_app_main(void){
     int retval = 0;
     int i, c;
-    char hal_name[HAL_NAME_LEN];
     const char *line_name;
 
 #ifdef __KERNEL__
@@ -277,16 +276,13 @@ int rtapi_app_main(void){
 	}
     }
 
-    rtapi_snprintf(hal_name, HAL_NAME_LEN, "hal_gpio.read");
-    retval += hal_export_funct(hal_name, hal_gpio_read, gpio, 0, 0, comp_id);
-    rtapi_snprintf(hal_name, HAL_NAME_LEN, "hal_gpio.write");
-    retval += hal_export_funct(hal_name, hal_gpio_write, gpio, 0, 0, comp_id);
+    retval += hal_export_funct("hal_gpio.read", hal_gpio_read, gpio, 0, 0, comp_id);
+    retval += hal_export_funct("hal_gpio.write", hal_gpio_write, gpio, 0, 0, comp_id);
 
     if (reset_active){
 	gpio->reset_ns = hal_malloc(sizeof(hal_u32_t));
-	rtapi_snprintf(hal_name, HAL_NAME_LEN, "hal_gpio.reset");
 	retval += hal_param_u32_newf(HAL_RW, gpio->reset_ns, comp_id, "hal_gpio.reset_ns");
-	retval += hal_export_funct(hal_name, hal_gpio_reset, gpio, 0, 0, comp_id);
+	retval += hal_export_funct("hal_gpio.reset", hal_gpio_reset, gpio, 0, 0, comp_id);
     }
     if (retval < 0){
 	rtapi_print_msg(RTAPI_MSG_ERR, "hal_gpio: failed to export functions\n");

--- a/src/hal/drivers/hal_motenc.c
+++ b/src/hal/drivers/hal_motenc.c
@@ -485,7 +485,6 @@ static int
 Device_ExportEncoderPinsParametersFunctions(Device *this, int componentId, int boardId)
 {
     int					halError, channel;
-    char				name[HAL_NAME_LEN + 1];
 
     // Export pins and parameters.
     halError = 0;
@@ -529,8 +528,7 @@ Device_ExportEncoderPinsParametersFunctions(Device *this, int componentId, int b
 
     // Export functions.
     if(!halError){
-	rtapi_snprintf(name, sizeof(name), "motenc.%d.encoder-read", boardId);
-	halError = hal_export_funct(name, Device_EncoderRead, this, 1, 0, componentId);
+	halError = hal_export_functf(Device_EncoderRead, this, 1, 0, componentId, "motenc.%d.encoder-read", boardId);
     }
 
     if(halError){
@@ -546,7 +544,6 @@ static int
 Device_ExportDacPinsParametersFunctions(Device *this, int componentId, int boardId)
 {
     int					halError, channel;
-    char				name[HAL_NAME_LEN + 1];
 
     // Export pins and parameters.
     halError = 0;
@@ -573,8 +570,7 @@ Device_ExportDacPinsParametersFunctions(Device *this, int componentId, int board
 
     // Export functions.
     if(!halError){
-	rtapi_snprintf(name, sizeof(name), "motenc.%d.dac-write", boardId);
-	halError = hal_export_funct(name, Device_DacWrite, this, 1, 0, componentId);
+	halError = hal_export_functf(Device_DacWrite, this, 1, 0, componentId, "motenc.%d.dac-write", boardId);
     }
 
     if(halError){
@@ -590,7 +586,6 @@ static int
 Device_ExportAdcPinsParametersFunctions(Device *this, int componentId, int boardId)
 {
     int					halError, channel;
-    char				name[HAL_NAME_LEN + 1];
 
     // Export pins and parameters.
     halError = 0;
@@ -617,8 +612,7 @@ Device_ExportAdcPinsParametersFunctions(Device *this, int componentId, int board
 
     // Export functions.
     if(!halError){
-	rtapi_snprintf(name, sizeof(name), "motenc.%d.adc-read", boardId);
-	halError = hal_export_funct(name, Device_AdcRead, this, 1, 0, componentId);
+	halError = hal_export_functf(Device_AdcRead, this, 1, 0, componentId, "motenc.%d.adc-read", boardId);
     }
 
     if(halError){
@@ -634,7 +628,6 @@ static int
 Device_ExportDigitalInPinsParametersFunctions(Device *this, int componentId, int boardId)
 {
     int					halError, channel;
-    char				name[HAL_NAME_LEN + 1];
 
     // Export pins and parameters.
     halError = 0;
@@ -655,8 +648,7 @@ Device_ExportDigitalInPinsParametersFunctions(Device *this, int componentId, int
 
     // Export functions.
     if(!halError){
-	rtapi_snprintf(name, sizeof(name), "motenc.%d.digital-in-read", boardId);
-	halError = hal_export_funct(name, Device_DigitalInRead, this, 0, 0, componentId);
+	halError = hal_export_funct(Device_DigitalInRead, this, 0, 0, componentId, "motenc.%d.digital-in-read", boardId);
     }
 
     if(halError){
@@ -672,7 +664,6 @@ static int
 Device_ExportDigitalOutPinsParametersFunctions(Device *this, int componentId, int boardId)
 {
     int					halError, channel;
-    char				name[HAL_NAME_LEN + 1];
 
     // Export pins and parameters.
     halError = 0;
@@ -694,8 +685,7 @@ Device_ExportDigitalOutPinsParametersFunctions(Device *this, int componentId, in
 
     // Export functions.
     if(!halError){
-	rtapi_snprintf(name, sizeof(name), "motenc.%d.digital-out-write", boardId);
-	halError = hal_export_funct(name, Device_DigitalOutWrite, this, 0, 0, componentId);
+	halError = hal_export_functf(Device_DigitalOutWrite, this, 0, 0, componentId, "motenc.%d.digital-out-write", boardId);
     }
 
     if(halError){
@@ -743,8 +733,7 @@ Device_ExportMiscPinsParametersFunctions(Device *this, int componentId, int boar
 
     // Export functions.
     if(!halError){
-	rtapi_snprintf(name, sizeof(name), "motenc.%d.misc-update", boardId);
-	halError = hal_export_funct(name, Device_MiscUpdate, this, 0, 0, componentId);
+	halError = hal_export_functf(Device_MiscUpdate, this, 0, 0, componentId, "motenc.%d.misc-update", boardId);
     }
 
     if(halError){

--- a/src/hal/drivers/hal_parport.c
+++ b/src/hal/drivers/hal_parport.c
@@ -197,7 +197,6 @@ int rtapi_app_main(void)
 {
     char *cp;
     char *argv[MAX_TOK];
-    char name[HAL_NAME_LEN + 1];
     int n, retval;
 
 
@@ -250,33 +249,27 @@ rtapi_print ( "config string '%s'\n", cfg );
     }
     /* export functions for each port */
     for (n = 0; n < num_ports; n++) {
-	/* make read function name */
-	rtapi_snprintf(name, sizeof(name), "parport.%d.read", n);
 	/* export read function */
-	retval = hal_export_funct(name, read_port, &(port_data_array[n]),
-	    0, 0, comp_id);
+	retval = hal_export_functf(read_port, &(port_data_array[n]),
+	    0, 0, comp_id, "parport.%d.read", n);
 	if (retval != 0) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"PARPORT: ERROR: port %d read funct export failed\n", n);
 	    hal_exit(comp_id);
 	    return -1;
 	}
-	/* make write function name */
-	rtapi_snprintf(name, sizeof(name), "parport.%d.write", n);
 	/* export write function */
-	retval = hal_export_funct(name, write_port, &(port_data_array[n]),
-	    0, 0, comp_id);
+	retval = hal_export_functf(write_port, &(port_data_array[n]),
+	    0, 0, comp_id, "parport.%d.write", n);
 	if (retval != 0) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"PARPORT: ERROR: port %d write funct export failed\n", n);
 	    hal_exit(comp_id);
 	    return -1;
 	}
-	/* make reset function name */
-	rtapi_snprintf(name, sizeof(name), "parport.%d.reset", n);
 	/* export write function */
-	retval = hal_export_funct(name, reset_port, &(port_data_array[n]),
-	    0, 0, comp_id);
+	retval = hal_export_functf(reset_port, &(port_data_array[n]),
+	    0, 0, comp_id, "parport.%d.reset", n);
 	if (retval != 0) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"PARPORT: ERROR: port %d reset funct export failed\n", n);

--- a/src/hal/drivers/hal_ppmc.c
+++ b/src/hal/drivers/hal_ppmc.c
@@ -440,7 +440,6 @@ int rtapi_app_main(void)
     int idcode, id, ver;
     bus_data_t *bus;
     slot_data_t *slot;
-    char buf[HAL_NAME_LEN + 1];
 
     /* connect to the HAL */
     comp_id = hal_init("hal_ppmc");
@@ -732,9 +731,8 @@ int rtapi_app_main(void)
 	    continue;
 	}
 	/* export functions */
-	rtapi_snprintf(buf, sizeof(buf), "ppmc.%d.read", busnum);
-	rv1 = hal_export_funct(buf, read_all, &(bus_array[busnum]),
-	    1, 0, comp_id);
+	rv1 = hal_export_functf(read_all, &(bus_array[busnum]),
+	    1, 0, comp_id, "ppmc.%d.read", busnum);
 	if (rv1 != 0) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"PPMC: ERROR: read funct export failed\n");
@@ -742,9 +740,8 @@ int rtapi_app_main(void)
 	    /* skip to next bus */
 	    continue;
 	}
-	rtapi_snprintf(buf, sizeof(buf), "ppmc.%d.write", busnum);
-	rv1 = hal_export_funct(buf, write_all, &(bus_array[busnum]),
-	    1, 0, comp_id);
+	rv1 = hal_export_functf(write_all, &(bus_array[busnum]),
+	    1, 0, comp_id, "ppmc.%d.write", busnum);
 	if (rv1 != 0) {
 	    rtapi_print_msg(RTAPI_MSG_ERR,
 		"PPMC: ERROR: write funct export failed\n");

--- a/src/hal/drivers/hal_skeleton.c
+++ b/src/hal/drivers/hal_skeleton.c
@@ -137,7 +137,6 @@ static void write_port(void *arg, long period);
 
 int rtapi_app_main(void)
 {
-    char name[HAL_NAME_LEN + 1];
     int n, retval;
 
     /* only one port at the moment */
@@ -173,9 +172,8 @@ int rtapi_app_main(void)
     }
 
     /* STEP 4: export write function */
-    rtapi_snprintf(name, sizeof(name), "skeleton.%d.write", n);
-    retval = hal_export_funct(name, write_port, &(port_data_array[n]), 0, 0,
-	comp_id);
+    retval = hal_export_functf(write_port, &(port_data_array[n]), 0, 0,
+	comp_id, "skeleton.%d.write", n);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "SKELETON: ERROR: port %d write funct export failed\n", n);

--- a/src/hal/drivers/hal_speaker.c
+++ b/src/hal/drivers/hal_speaker.c
@@ -145,7 +145,6 @@ static void write_port(void *arg, long period)
 
 int rtapi_app_main(void)
 {
-    char name[HAL_NAME_LEN + 1];
     int i, n, retval;
 
     /* only one port at the moment */
@@ -193,10 +192,9 @@ int rtapi_app_main(void)
     }
 
     /* STEP 4: export write function */
-    rtapi_snprintf(name, sizeof(name), "speaker.%d.write", n);
     retval =
-	hal_export_funct(name, write_port, &(port_data_array[n]), 0, 0,
-	comp_id);
+	hal_export_functf(write_port, &(port_data_array[n]), 0, 0,
+	comp_id, "speaker.%d.write", n);
     if (retval < 0) {
 	rtapi_print_msg(RTAPI_MSG_ERR,
 	    "SPEAKER: ERROR: port %d write funct export failed\n", n);

--- a/src/hal/drivers/mesa-hostmot2/abs_encoder.c
+++ b/src/hal/drivers/mesa-hostmot2/abs_encoder.c
@@ -127,11 +127,8 @@ int hm2_absenc_register_tram(hostmot2_t *hm2){
     // If there is no dpll to link to, then we export the trigger function.
     
     if (hm2->config.num_dplls == 0){
-        char name[HM2_SSERIAL_MAX_STRING_LENGTH+1] = "";
-        rtapi_snprintf(name, sizeof(name),
-                "%s.trigger-encoders", hm2->llio->name);
-        hal_export_funct(name, hm2_absenc_trigger,
-                hm2, 0, 0,hm2->llio->comp_id);
+        hal_export_functf(hm2_absenc_trigger,
+                hm2, 0, 0,hm2->llio->comp_id, "%s.trigger-encoders", hm2->llio->name);
         funct_flag = true;
     }
 

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.c
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.c
@@ -1694,29 +1694,24 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
     //
 
     {
-        char name[HAL_NAME_LEN + 1];
-
         if(hm2->llio->split_read) {
-            rtapi_snprintf(name, sizeof(name), "%s.read-request", hm2->llio->name);
-            r = hal_export_funct(name, hm2_read_request, hm2, 1, 0, hm2->llio->comp_id);
+            r = hal_export_functf(hm2_read_request, hm2, 1, 0, hm2->llio->comp_id, "%s.read-request", hm2->llio->name);
             if (r != 0) {
-                HM2_ERR("error %d exporting read function %s\n", r, name);
+                HM2_ERR("error %d exporting read function %s.read-request\n", r, hm2->llio->name);
                 r = -EINVAL;
                 goto fail1;
             }
         }
-        rtapi_snprintf(name, sizeof(name), "%s.read", hm2->llio->name);
-        r = hal_export_funct(name, hm2_read, hm2, 1, 0, hm2->llio->comp_id);
+        r = hal_export_functf(hm2_read, hm2, 1, 0, hm2->llio->comp_id, "%s.read", hm2->llio->name);
         if (r != 0) {
-            HM2_ERR("error %d exporting read function %s\n", r, name);
+            HM2_ERR("error %d exporting read function %s.read\n", r, hm2->llio->name);
             r = -EINVAL;
             goto fail1;
         }
 
-        rtapi_snprintf(name, sizeof(name), "%s.write", hm2->llio->name);
-        r = hal_export_funct(name, hm2_write, hm2, 1, 0, hm2->llio->comp_id);
+        r = hal_export_functf(hm2_write, hm2, 1, 0, hm2->llio->comp_id, "%s.write", hm2->llio->name);
         if (r != 0) {
-            HM2_ERR("error %d exporting write function %s\n", r, name);
+            HM2_ERR("error %d exporting write function %s.write\n", r, hm2->llio->name);
             r = -EINVAL;
             goto fail1;
         }
@@ -1728,20 +1723,16 @@ int hm2_register(hm2_lowlevel_io_t *llio, char *config_string) {
     //
 
     if (hm2->llio->threadsafe) {
-        char name[HAL_NAME_LEN + 1];
-
-        rtapi_snprintf(name, sizeof(name), "%s.read_gpio", hm2->llio->name);
-        r = hal_export_funct(name, hm2_read_gpio, hm2, 1, 0, hm2->llio->comp_id);
+        r = hal_export_functf(hm2_read_gpio, hm2, 1, 0, hm2->llio->comp_id, "%s.read_gpio", hm2->llio->name);
         if (r != 0) {
-            HM2_ERR("error %d exporting gpio_read function %s\n", r, name);
+            HM2_ERR("error %d exporting gpio_read function %s.read_gpio\n", r, hm2->llio->name);
             r = -EINVAL;
             goto fail1;
         }
 
-        rtapi_snprintf(name, sizeof(name), "%s.write_gpio", hm2->llio->name);
-        r = hal_export_funct(name, hm2_write_gpio, hm2, 1, 0, hm2->llio->comp_id);
+        r = hal_export_functf(hm2_write_gpio, hm2, 1, 0, hm2->llio->comp_id, "%s.write_gpio", hm2->llio->name);
         if (r != 0) {
-            HM2_ERR("error %d exporting gpio_write function %s\n", r, name);
+            HM2_ERR("error %d exporting gpio_write function %s.write_gpio\n", r, hm2->llio->name);
             r = -EINVAL;
             goto fail1;
         }

--- a/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
+++ b/src/hal/drivers/mesa-hostmot2/modbus/mesa_modbus.c.tmpl
@@ -161,7 +161,6 @@ int rtapi_app_main(void){
     int c; // channel loop
     int p; // pin loops
     int j; // generic loops
-    char hal_name[HAL_NAME_LEN];
 
     rtapi_set_msg_level(DEBUG);
 
@@ -207,11 +206,8 @@ int rtapi_app_main(void){
         inst->hal->buff =  (rtapi_s64 *) hal_malloc(inst->num_pins * sizeof(rtapi_s64));
         
         rtapi_strlcpy(inst->port, ports[i], HAL_NAME_LEN);
-        retval = rtapi_snprintf(hal_name, HAL_NAME_LEN, COMP_NAME".%02i", i);
-        if (retval >= HAL_NAME_LEN) {
-            goto fail0;
-        }
-        retval = hal_export_funct(hal_name, process, inst, 1, 0, comp_id);
+
+        retval = hal_export_functf(process, inst, 1, 0, comp_id, COMP_NAME".%02i", i);
         if (retval < 0) {
             rtapi_print_msg(RTAPI_MSG_ERR, COMP_NAME" ERROR: function export failed\n");
             goto fail0;

--- a/src/hal/drivers/opto_ac5.c
+++ b/src/hal/drivers/opto_ac5.c
@@ -237,7 +237,6 @@ static int Device_ExportPinsParametersFunctions(board_data_t *this, int componen
 static int Device_ExportDigitalInPinsParametersFunctions(board_data_t *this, int comp_id, int boardId)
 {
     int					halError=0, channel,mask,portnum=0;
-    char				name[HAL_NAME_LEN + 1];
 
     // Export pins and parameters.
 	while (portnum<2)
@@ -268,8 +267,7 @@ static int Device_ExportDigitalInPinsParametersFunctions(board_data_t *this, int
 
     // Export functions.
     if(!halError){
-	rtapi_snprintf(name, sizeof(name), "opto-ac5.%d.digital-read", boardId);
-	halError = hal_export_funct(name, Device_DigitalInRead, this, 0, 0, comp_id);
+	halError = hal_export_functf(Device_DigitalInRead, this, 0, 0, comp_id, "opto-ac5.%d.digital-read", boardId);
     }
 
     if(halError){
@@ -290,7 +288,6 @@ static int Device_ExportDigitalInPinsParametersFunctions(board_data_t *this, int
 static int Device_ExportDigitalOutPinsParametersFunctions(board_data_t *this, int comp_id, int boardId)
 {
     int					halError=0, channel,mask,portnum=0;
-    char				name[HAL_NAME_LEN + 1];
 
     // Export pins and parameters.
     
@@ -334,8 +331,7 @@ static int Device_ExportDigitalOutPinsParametersFunctions(board_data_t *this, in
 		}
     // Export functions.
     if(!halError){
-	rtapi_snprintf(name, sizeof(name), "opto-ac5.%d.digital-write", boardId);
-	halError = hal_export_funct(name, Device_DigitalOutWrite, this, 0, 0, comp_id);
+	halError = hal_export_functf(Device_DigitalOutWrite, this, 0, 0, comp_id, "opto-ac5.%d.digital-write", boardId);
     }
 
     if(halError){

--- a/src/hal/drivers/pci_8255.c
+++ b/src/hal/drivers/pci_8255.c
@@ -72,7 +72,6 @@ static inline int pci_8255_inb(hal_u32_t base, int offset) {
 
 
 static int export(char *prefix, struct port *inst, int ioaddr, int dir) {
-    char buf[HAL_NAME_LEN + 1];
     int r = 0;
     int i;
     hal_pin_dir_t direction;
@@ -132,11 +131,9 @@ static int export(char *prefix, struct port *inst, int ioaddr, int dir) {
     r = hal_param_u32_newf(HAL_RO, &(inst->dir_), comp_id,
         "%s.dir", prefix);
     if(r != 0) return r;
-    rtapi_snprintf(buf, sizeof(buf), "%s.read", prefix);
-    r = hal_export_funct(buf, (void(*)(void *inst, long))read, inst, 0, 0, comp_id);
+    r = hal_export_functf((void(*)(void *inst, long))read, inst, 0, 0, comp_id, "%s.read", prefix);
     if(r != 0) return r;
-    rtapi_snprintf(buf, sizeof(buf), "%s.write", prefix);
-    r = hal_export_funct(buf, (void(*)(void *inst, long))write, inst, 0, 0, comp_id);
+    r = hal_export_functf((void(*)(void *inst, long))write, inst, 0, 0, comp_id, "%s.write", prefix);
     if(r != 0) return r;
 
     rtapi_print_msg(RTAPI_MSG_DBG, "registering %s ... %x %x\n", prefix,
@@ -208,8 +205,7 @@ int rtapi_app_main(void) {
 	hal_pin_bit_newf(HAL_IN, &(inst[i].relay), comp_id, "pci8255.%d.relay", i);
 	hal_param_bit_newf(HAL_RW, &(inst[i].relay_invert), comp_id, 
 		    "pci8255.%d.relay-invert", i);
-	rtapi_snprintf(buf, sizeof(buf), "pci8255.%d.write-relay", i);
-	r = hal_export_funct(buf, (void(*)(void *inst, long))write_relay, &inst[i], 0, 0, comp_id);
+	r = hal_export_functf((void(*)(void *inst, long))write_relay, &inst[i], 0, 0, comp_id, "pci8255.%d.write-relay", i);
 	r = hal_param_u32_newf(HAL_RO, &(inst->ioaddr), comp_id,
 	    "pci8255.%d.io-addr", i);
 	inst->ioaddr = io[i];

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -739,6 +739,14 @@ extern int hal_get_param_value_by_name(
 extern int hal_export_funct(const char *name, void (*funct) (void *, long),
     void *arg, int uses_fp, int reentrant, int comp_id);
 
+/** hal_export_functf is similar to hal_export_funct except that it also does
+    printf-style formatting to compute the function name.
+    If successful, it returns 0.
+    On failure it returns a negative error code.
+*/
+extern int hal_export_functf(void (*funct) (void *, long),
+    void *arg, int uses_fp, int reentrant, int comp_id, const char *fmt, ...);
+
 /** hal_create_thread() establishes a realtime thread that will
     execute one or more HAL functions periodically.
     'name' is the name of the thread, which must be unique in

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -1878,6 +1878,32 @@ int hal_get_param_value_by_name(
 
 #ifdef RTAPI
 
+static int hal_export_functfv(void (*funct) (void *, long),
+    void *arg, int uses_fp, int reentrant, int comp_id, const char *fmt, va_list ap)
+{
+    char name[HAL_NAME_LEN + 1];
+    int sz;
+    sz = rtapi_vsnprintf(name, sizeof(name), fmt, ap);
+    if(sz == -1 || sz > HAL_NAME_LEN) {
+        rtapi_print_msg(RTAPI_MSG_ERR,
+	    "hal_export_functfv: length %d too long for name starting '%s'\n",
+	    sz, name);
+        return -ENOMEM;
+    }
+    return hal_export_funct(name, funct, arg, uses_fp, reentrant, comp_id);
+}
+
+int hal_export_functf(void (*funct) (void *, long),
+    void *arg, int uses_fp, int reentrant, int comp_id, const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+    va_start(ap, fmt);
+    ret = hal_export_functfv(funct, arg, uses_fp, reentrant, comp_id, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
 int hal_export_funct(const char *name, void (*funct) (void *, long),
     void *arg, int uses_fp, int reentrant, int comp_id)
 {
@@ -4361,6 +4387,7 @@ EXPORT_SYMBOL(hal_param_set);
 EXPORT_SYMBOL(hal_set_constructor);
 
 EXPORT_SYMBOL(hal_export_funct);
+EXPORT_SYMBOL(hal_export_functf);
 
 EXPORT_SYMBOL(hal_create_thread);
 


### PR DESCRIPTION
To deduplicate some repeating code, this PR introduces a formatting ```hal_export_functf()``` similar to the ```hal_*_newf()``` functions.

Existing occurences of ```static char buf[HAL_NAME_LEN+1]; ... ; rtapi_snprintf(buf, ...);  hal_export_funct(buf, ...)``` were replaced.
Additionally, some unused/buggy code was removed from ```boss_plc.c```.