### PR TITLE
Fix SyntaxWarning: invalid escape sequence '\{'

### DIFF
--- a/share/qtvcp/screens/qtplasmac/qtplasmac_handler.py
+++ b/share/qtvcp/screens/qtplasmac/qtplasmac_handler.py
@@ -1,4 +1,4 @@
-VERSION = '001.011'
+VERSION = '001.012'
 LCNCVER = '2.10'
 DOCSVER = LCNCVER
 
@@ -4013,7 +4013,7 @@ class HandlerClass:
                             checked = True
                         self.dualCodeButtons[bNum] = [data[1], data[2], data[3], bLabel, checked]
                         # dualCodeButtons format is: code1 ;; label1 ;; code2 ;; label2 ;; checked
-                    commands = f"{data[1]}\{data[3]}"
+                    commands = f"{data[1]}\\{data[3]}"
                 else:
                     commands = bCode
                 for command in commands.split('\\'):
@@ -4801,7 +4801,7 @@ class HandlerClass:
             except:
                 if not matNum:
                     msg0 = _translate('HandlerClass', 'A material number is required')
-                    msgs = f'{msg0}.\n\n\{msg1}:'
+                    msgs = f'{msg0}.\n\n{msg1}:'
                 else:
                     msg0 = _translate('HandlerClass', 'is not a valid number')
                     msgs = f'{matNum} {msg0}.\n\n{msg1}:'

--- a/share/qtvcp/screens/qtplasmac/versions.html
+++ b/share/qtvcp/screens/qtplasmac/versions.html
@@ -26,6 +26,11 @@
 </table>
 <br>
 <!--- ****** ADD NEXT VERSION BELOW THIS LINE ****** --->
+<br><b><u>001.012 2023 Dec 12</u></b>
+<ul style="margin:0;">
+  <li>fix invalid escape sequences</li>
+</ul>
+
 <br><b><u>001.011 2023 Nov 16</u></b>
 <ul style="margin:0;">
   <li>convert project to f strings</li>


### PR DESCRIPTION
 Fixes the following syntax warning on python 3.12:

 /usr/share/qtvcp/screens/qtplasmac_4x3/qtplasmac_4x3_handler.py:4016:
  SyntaxWarning: invalid escape sequence '\{'
   commands = f"{data[1]}\{data[3]}"
 /usr/share/qtvcp/screens/qtplasmac_4x3/qtplasmac_4x3_handler.py:4804:
  SyntaxWarning: invalid escape sequence '\{'
   msgs = f'{msg0}.\n\n\{msg1}:'