### PR TITLE
Add timings for DM860T stepper driver

### DIFF
--- a/docs/src/integrator/stepper-timing.adoc
+++ b/docs/src/integrator/stepper-timing.adoc
@@ -81,6 +81,8 @@ nanoseconds (ns)
 |Leadshine USA |Brushless servo ACS306 30V 15A |2500 |2500 |10000 |5000 |Rising Edge |http://leadshine.com/UploadFile/Down/ACS306hm.pdf | 
 |Leadshine USA |Brushless servo ACS606 60V 15A |850 |850 |6700 |5000 |Rising Edge |http://leadshineusa.com/UploadFile/Down/ACS606m.pdf | 
 |Leadshine USA |Brushless servo ACS806 80V 20A |850 |850 |6700 |5000 |Rising Edge |http://leadshineusa.com/UploadFile/Down/ACS806m.pdf | 
+|StepperOnline |Digital DM860T v1.0 80VAC/110VDC 7.2A |5000 |5000 |5000 |5000 |Rising Edge |https://www.omc-stepperonline.com/download/DM860T.pdf | 
+|StepperOnline |Digital DM860T v3.0 80VAC/110VDC 7.2A |5000 |5000 |5000 |5000 |Rising Edge |https://www.omc-stepperonline.com/download/DM860T_V3.0.pdf | 
 |Pololu |A4988 Stepper Motor Driver Carrier |1000 |1000 |200 |200 |Rising Edge |http://www.pololu.com/catalog/product/1182/| 
 |Pololu |DRV8825 Stepper Motor Driver Carrier |1900 |1900 |650 |650 |Rising Edge |http://www.pololu.com/catalog/product/2132/| 
 |cnc4you |[[CW5045]]|2000 |8000 |5000 |5000 |Rising Edge |http://cnc4you.co.uk/resources/CW5045.pdf |  

--- a/src/emc/usr_intf/pncconf/private_data.py
+++ b/src/emc/usr_intf/pncconf/private_data.py
@@ -1336,6 +1336,8 @@ class Private_Data:
                             ["jvlsmd41", _("JVL-SMD41 or 42"), 500, 500, 2500, 2500],
                             ["hobbycnc", _("Hobbycnc Pro Chopper"), 2000, 2000, 2000, 2000],
                             ["keling", _("Keling 4030"), 5000, 5000, 20000, 20000],
+                            ["dm860tv10", _("DM860T v1.0"), 5000, 5000, 5000, 5000],
+                            ["dm860tv30", _("DM860T v3.0"), 5000, 5000, 5000, 5000],
                             ]
 
         self.MESA_BOARDNAMES = []

--- a/src/emc/usr_intf/stepconf/stepconf.py
+++ b/src/emc/usr_intf/stepconf/stepconf.py
@@ -167,6 +167,8 @@ class Private_Data:
                             ["jvlsmd41", _("JVL-SMD41 or 42"), 500, 500, 2500, 2500],
                             ["hobbycnc", _("Hobbycnc Pro Chopper"), 2000, 2000, 2000, 2000],
                             ["keling", _("Keling 4030"), 5000, 5000, 20000, 20000],
+                            ["dm860tv10", _("DM860T v1.0"), 5000, 5000, 5000, 5000],
+                            ["dm860tv30", _("DM860T v3.0"), 5000, 5000, 5000, 5000],
                             ]
 
         (   self.XSTEP, self.XDIR, self.YSTEP, self.YDIR,


### PR DESCRIPTION
Adds timings for StepperOnline Digital Stepper
Drive DM860T v1.0 and v.3.0 based on:

 - https://www.omc-stepperonline.com/download/DM860T.pdf

 - https://www.omc-stepperonline.com/download/DM860T_V3.0.pdf