### PR TITLE
motion.c: Correct copy-paste errors in handling of miscellanous error inputs

### DIFF
--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -346,8 +346,8 @@ int rtapi_app_main(void)
     return -1;
   }
   else if(names_misc_errors[0]){
-    num_misc_error = count_names(names_dout);
-    num_misc_error = (num_misc_error > count_names(names_din)) ? num_misc_error : count_names(names_din);
+    num_misc_error = count_names(names_misc_errors);
+    num_misc_error = (num_misc_error > count_names(names_misc_errors)) ? num_misc_error : count_names(names_misc_errors);
   }
   else if(!num_misc_error){
     num_misc_error = DEFAULT_MISC_ERROR;


### PR DESCRIPTION
Correction to lines 348-351 to fix error when using "names_misc_errors" to create named misc error pins.