### PR TITLE
Fix SameFileError exception on axis GUI

### DIFF
--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -1179,8 +1179,6 @@ def open_file_guts(f, filtered=False, addrecent=True):
     if addrecent:
         add_recent_file(f)
     if not filtered:
-        global loaded_file
-        loaded_file = f
         program_filter = get_filter(f)
         if program_filter:
             tempfile = os.path.join(tempdir, "filtered-" + os.path.basename(f))
@@ -2267,6 +2265,8 @@ class TclCommands(nf.TclCommands):
         return ""
 
     def open_file_name(f):
+        global loaded_file
+        loaded_file = f
         open_file_guts(f)
         if str(widgets.view_x['relief']) == "sunken":
             commands.set_view_x()


### PR DESCRIPTION
Fixes the following exception:
 reload file
 Exception in Tkinter callback
 Traceback (most recent call last):
  File "/usr/lib64/python3.12/tkinter/__init__.py", line 1948, in __call__
    return self.func(*args)
           ^^^^^^^^^^^^^^^^
  File "/usr/bin/axis", line 2356, in task_run
    reload_file()
  File "/usr/bin/axis", line 1911, in reload_file
    shutil.copyfile(loaded_file, tempfile)
  File "/usr/lib64/python3.12/shutil.py", line 240, in copyfile
    raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
 shutil.SameFileError: '/tmp/tmp0ym0r2bm/axis.ngc' and '/tmp/tmp0ym0r2bm/axis.ngc' are the same file

This is 100% reproducible when you try stop then play again the same file twice.