### PR TITLE
snprintf uses %d on a double (issue 2784)

### DIFF
--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -1595,7 +1595,7 @@ static cmdResponseType getTool(char *s, connectionRecType *context)
 
 static cmdResponseType getToolOffset(char *s, connectionRecType *context)
 {
-  const char *pToolOffsetStr = "TOOL_OFFSET %d";
+  const char *pToolOffsetStr = "TOOL_OFFSET %f";
   
   sprintf(context->outBuf, pToolOffsetStr, emcStatus->task.toolOffset.tran.z);
   return rtNoError; 


### PR DESCRIPTION
This PR reacts to issue https://github.com/LinuxCNC/linuxcnc/issues/2784 . 