### PR TITLE
Fix warning for possible string truncation

### DIFF
--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -638,7 +638,7 @@ and is not represented here
 
 */
 #define STACK_LEN 50
-#define STACK_ENTRY_LEN 80
+#define STACK_ENTRY_LEN 256
 #define MAX_SUB_DIRS 10
 
 struct setup

--- a/src/emc/rs274ngc/interp_namedparams.cc
+++ b/src/emc/rs274ngc/interp_namedparams.cc
@@ -217,8 +217,7 @@ int Interp::fetch_ini_param( const char *nameBuf, int *status, double *value)
 
 	char capName[LINELEN];
 
-	strncpy(capName, nameBuf, n);
-	capName[n] = '\0';
+	snprintf(capName, LINELEN, "%s", nameBuf);
 	for (char *p = capName; *p != 0; p++)
 	    *p = toupper(*p);
 	capName[closeBracket] = '\0';

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -541,7 +541,7 @@ int Interp::control_back_to( block_pointer block, // pointer to block
 			     setup_pointer settings)   // pointer to machine settings
 {
     static char name[] = "control_back_to";
-    char newFileName[PATH_MAX+1];
+    char newFileName[PATH_MAX];
     FILE *newFP;
     offset_map_iterator it;
     offset_pointer op;
@@ -561,12 +561,12 @@ int Interp::control_back_to( block_pointer block, // pointer to block
 	    newFP = fopen(op->filename, "r");
 	    // set the line number
 	    settings->sequence_number = 0;
-            strncpy(settings->filename, op->filename, sizeof(settings->filename));
-            if (settings->filename[sizeof(settings->filename)-1] != '\0') {
+            if (strlen(op->filename) >= sizeof(settings->filename)) {
                 fclose(settings->file_pointer);
                 logOword("filename too long: %s", op->filename);
                 ERS(NCE_UNABLE_TO_OPEN_FILE, op->filename);
             }
+            strncpy(settings->filename, op->filename, sizeof(settings->filename));
 
 	    if (newFP) {
 		// close the old file...
@@ -597,11 +597,11 @@ int Interp::control_back_to( block_pointer block, // pointer to block
 	if (settings->file_pointer)
 	    fclose(settings->file_pointer);
 	settings->file_pointer = newFP;
-        strncpy(settings->filename, newFileName, sizeof(settings->filename));
-        if (settings->filename[sizeof(settings->filename)-1] != '\0') {
+        if (strlen(newFileName) >= sizeof(settings->filename)) {
             logOword("new filename '%s' is too long (max len %zu)\n", newFileName, sizeof(settings->filename)-1);
-            settings->filename[sizeof(settings->filename)-1] = '\0'; // oh well, truncate the filename
+            ERS(NCE_UNABLE_TO_OPEN_FILE, newFileName);
         }
+        strncpy(settings->filename, newFileName, sizeof(settings->filename));
     } else {
 	char *dirname = getcwd(NULL, 0);
 	logOword("fopen: |%s| failed CWD:|%s|", newFileName,

--- a/src/emc/rs274ngc/interp_read.cc
+++ b/src/emc/rs274ngc/interp_read.cc
@@ -1595,8 +1595,10 @@ int Interp::read_o(    /* ARGUMENTS                                     */
 
 	  // Subroutine name not provided in Fanuc syntax, so pull from
 	  // context
+          if (strlen(_setup.sub_context[_setup.call_level].subName) >= sizeof(oNameBuf))
+              ERS(NCE_UNABLE_TO_OPEN_FILE, _setup.sub_context[_setup.call_level].subName);
 	  strncpy(oNameBuf, _setup.sub_context[_setup.call_level].subName,
-		  LINELEN+1);
+                  sizeof(oNameBuf));
       } else
 	  // any other m-code should have been handled by read_m()
 	  OERR(_("%d: Bug:  Non-m98/m99 M-code passed to read_o(): '%s'"),

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -294,7 +294,7 @@ int Interp::add_parameters(setup_pointer settings,
     while (*s) {
 	errored = true;
 	char c  = toupper(*s);
-	strncat(tail,&c,1);
+	strncat(tail,&c,2);
 	if (*(s+1)) rtapi_strxcat(tail,",");
 	s++;
     }

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -2492,12 +2492,12 @@ int Interp::ini_load(const char *filename)
 
     char parameter_file_name[LINELEN]={};
     if (NULL != (inistring = inifile.Find("PARAMETER_FILE", "RS274NGC"))) {
-        strncpy(parameter_file_name, inistring, LINELEN);
-
-        if (parameter_file_name[LINELEN-1] != '\0') {
-            logDebug("%s:[RS274NGC]PARAMETER_FILE is too long (max len %d)", filename, LINELEN-1);
+        if (strlen(inistring) >= sizeof(parameter_file_name)) {
+            logDebug("%s:[RS274NGC]PARAMETER_FILE is too long (max len %zu)",
+                     filename, sizeof(parameter_file_name)-1);
         } else {
-          logDebug("found PARAMETER_FILE:%s:", parameter_file_name);
+            strncpy(parameter_file_name, inistring, sizeof(parameter_file_name));
+            logDebug("found PARAMETER_FILE:%s:", parameter_file_name);
         }
     } else {
       // not found, leave RS274NGC_PARAMETER_FILE alone

--- a/src/emc/task/emctask.cc
+++ b/src/emc/task/emctask.cc
@@ -112,7 +112,7 @@ static void user_defined_add_m_code(int num, double arg1, double arg2)
 
 int emcTaskInit()
 {
-    char mdir[MAX_M_DIRS][PATH_MAX+1];
+    char mdir[MAX_M_DIRS][PATH_MAX];
     int num,dct,dmax;
     char path[EMC_SYSTEM_CMD_LEN];
     struct stat buf;
@@ -123,18 +123,14 @@ int emcTaskInit()
 
     // Identify user_defined_function directories
     if (NULL != (inistring = inifile.Find("PROGRAM_PREFIX", "DISPLAY"))) {
-        strncpy(mdir[0],inistring, sizeof(mdir[0]));
-        if (mdir[0][sizeof(mdir[0])-1] != '\0') {
+        if (strlen(inistring) >= sizeof(mdir[0])) {
             rcs_print("[DISPLAY]PROGRAM_PREFIX too long (max len %zu)\n", sizeof(mdir[0]));
             return -1;
         }
+        strncpy(mdir[0], inistring, sizeof(mdir[0]));
     } else {
         // default dir if no PROGRAM_PREFIX
-        strncpy(mdir[0],"nc_files", sizeof(mdir[0]));
-        if (mdir[0][sizeof(mdir[0])-1] != '\0') {
-            rcs_print("default nc_files too long (max len %zu)\n", sizeof(mdir[0]));
-            return -1;
-        }
+        strncpy(mdir[0], "nc_files", sizeof(mdir[0]));
     }
     dmax = 1; //one directory mdir[0],  USER_M_PATH specifies additional dirs
 
@@ -146,21 +142,22 @@ int emcTaskInit()
 
         for (dct=1; dct < MAX_M_DIRS; dct++) mdir[dct][0] = 0;
 
-        strncpy(tmpdirs,inistring, sizeof(tmpdirs));
-        if (tmpdirs[sizeof(tmpdirs)-1] != '\0') {
+        if (strlen(inistring) >= sizeof(tmpdirs)) {
             rcs_print("[RS274NGC]USER_M_PATH too long (max len %zu)\n", sizeof(tmpdirs));
             return -1;
         }
+        strncpy(tmpdirs, inistring, sizeof(tmpdirs));
 
         nextdir = strtok(tmpdirs,":");  // first token
         dct = 1;
         while (dct < MAX_M_DIRS) {
             if (nextdir == NULL) break; // no more tokens
-            strncpy(mdir[dct],nextdir, sizeof(mdir[dct]));
-            if (mdir[dct][sizeof(mdir[dct])-1] != '\0') {
-                rcs_print("[RS274NGC]USER_M_PATH component (%s) too long (max len %zu)\n", nextdir, sizeof(mdir[dct]));
+            if (strlen(nextdir) >= sizeof(mdir[dct])) {
+                rcs_print("[RS274NGC]USER_M_PATH component (%s) too long (max len %zu)\n",
+                          nextdir, sizeof(mdir[dct]));
                 return -1;
             }
+            strncpy(mdir[dct], nextdir, sizeof(mdir[dct]));
             nextdir = strtok(NULL,":");
             dct++;
         }

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -284,8 +284,7 @@ static int argvize(const char *src, char *dst, char *argv[], int len)
     char inquote;
     char looking;
 
-    strncpy(dst, src, len);
-    dst[len - 1] = 0;
+    snprintf(dst, len, "%s", src);
     bufptr = dst;
     inquote = 0;
     argvix = 0;

--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -609,18 +609,12 @@ static int commandHello(connectionRecType *context)
   if (strcmp(pch, pwd) != 0) return -1;
 
   pch = strtok(NULL, delims);
-  if (pch == NULL) return -1;
+  if (pch == NULL || strlen(pch) >= sizeof(context->hostName)) return -1;
   strncpy(context->hostName, pch, sizeof(context->hostName));
-  if (context->hostName[sizeof(context->hostName)-1] != '\0') {
-    return -1;
-  }
 
   pch = strtok(NULL, delims);
-  if (pch == NULL) return -1;
+  if (pch == NULL|| strlen(pch) >= sizeof(context->version)) return -1;
   strncpy(context->version, pch, sizeof(context->version));
-  if (context->version[sizeof(context->version)-1] != '\0') {
-    return -1;
-  }
 
   context->linked = true;
   printf("Connected to %s\n", context->hostName);
@@ -1169,12 +1163,12 @@ static cmdResponseType setOpen(char *s, connectionRecType *context)
 
   pch = strtok(NULL, "\n\r\0");
   if (pch == NULL) return rtStandardError;
-
-  strncpy(context->progName, pch, sizeof(context->progName));
-  if (context->progName[sizeof(context->progName) - 1] != '\0') {
-    fprintf(stderr, "linuxcncrsh: 'set open' filename too long for context (got %lu bytes, max %lu)", (unsigned long)strlen(pch), (unsigned long)sizeof(context->progName));
+  if (strlen(pch) >= sizeof(context->progName)) {
+    fprintf(stderr, "linuxcncrsh: 'set open' filename too long for context (got %lu bytes, max %lu)",
+            (unsigned long)strlen(pch), (unsigned long)sizeof(context->progName));
     return rtStandardError;
   }
+  strncpy(context->progName, pch, sizeof(context->progName));
 
   if (sendProgramOpen(context->progName) != 0) return rtStandardError;
   return rtNoError;

--- a/src/hal/user_comps/mb2hal/mb2hal_init.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_init.c
@@ -696,7 +696,11 @@ retCode init_mb_links()
             this_mb_link->lp_link_type = this_mb_tx->cfg_link_type;
 
             if (this_mb_link->lp_link_type == linkRTU) { //serial
-                strncpy(this_mb_link->lp_serial_device, this_mb_tx->cfg_serial_device, MB2HAL_MAX_DEVICE_LENGTH-1);
+                if (strlen(this_mb_tx->cfg_serial_device) >= MB2HAL_MAX_DEVICE_LENGTH) {
+                    ERR(gbl.init_dbg, "serial_device name to long [%s]", this_mb_tx->cfg_serial_device);
+                    return retERR;
+                }
+                strncpy(this_mb_link->lp_serial_device, this_mb_tx->cfg_serial_device, MB2HAL_MAX_DEVICE_LENGTH);
                 this_mb_link->lp_serial_baud=this_mb_tx->cfg_serial_baud;
 
                 if (strcasecmp(this_mb_tx->cfg_serial_parity, "even") == 0) {
@@ -723,7 +727,11 @@ retCode init_mb_links()
                 }
             }
             else { //tcp
-                strncpy(this_mb_link->lp_tcp_ip, this_mb_tx->cfg_tcp_ip, sizeof(this_mb_tx->cfg_tcp_ip)-1);
+                if (strlen(this_mb_tx->cfg_tcp_ip) >= sizeof(this_mb_link->lp_tcp_ip)) {
+                    ERR(gbl.init_dbg, "tcp_ip too long [%s]", this_mb_tx->cfg_tcp_ip);
+                    return retERR;
+                }
+                strncpy(this_mb_link->lp_tcp_ip, this_mb_tx->cfg_tcp_ip, sizeof(this_mb_tx->cfg_tcp_ip));
                 this_mb_link->lp_tcp_port=this_mb_tx->cfg_tcp_port;
 
                 this_mb_link->modbus = modbus_new_tcp(this_mb_link->lp_tcp_ip, this_mb_link->lp_tcp_port);

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -1221,8 +1221,7 @@ int do_delsig_cmd(char *mod_name)
 	    sig = SHMPTR(next);
 	    /* we want to unload this signal, remember its name */
 	    if ( n < ( MAX_EXPECTED_SIGS - 1 ) ) {
-	        strncpy(sigs[n], sig->name, HAL_NAME_LEN );
-		sigs[n][HAL_NAME_LEN] = '\0';
+		snprintf(sigs[n], sizeof(sigs[n]), "%s", sig->name);
 		n++;
 	    }
 	    next = sig->next_ptr;
@@ -1315,8 +1314,7 @@ int do_unloadrt_cmd(char *mod_name)
 	    if ( all || ( strcmp(mod_name, comp->name) == 0 )) {
 		/* we want to unload this component, remember its name */
 		if ( n < 63 ) {
-		    strncpy(comps[n], comp->name, HAL_NAME_LEN );
-		    comps[n][HAL_NAME_LEN] = '\0';
+		    snprintf(comps[n], sizeof(comps[n]), "%s", comp->name);
 		    n++;
 		}
 	    }

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -1262,8 +1262,7 @@ static int doDelsig(char *mod_name, connectionRecType *context)
         sig = SHMPTR(next);
         /* we want to unload this signal, remember it's name */
         if (n < ( MAX_EXPECTED_SIGS - 1)) {
-          strncpy(sigs[n], sig->name, HAL_NAME_LEN );
-	  sigs[n][HAL_NAME_LEN] = '\0';
+          snprintf(sigs[n], sizeof(sigs[n]), "%s", sig->name);
 	  n++;
 	  }
         next = sig->next_ptr;
@@ -1318,7 +1317,7 @@ static int doUnload(char *mod_name, connectionRecType *context)
 	    if ( all || ( strcmp(mod_name, comp->name) == 0 )) {
 		/* we want to unload this component, remember its name */
 		if ( n < 63 ) {
-		    strncpy(comps[n], comp->name, HAL_NAME_LEN );
+		    snprintf(comps[n], sizeof(comps[n]), "%s", comp->name);
 		    comps[n][HAL_NAME_LEN] = '\0';
 		    n++;
 		}

--- a/src/hal/utils/scope_vert.c
+++ b/src/hal/utils/scope_vert.c
@@ -765,7 +765,7 @@ static void offset_changed(GtkEditable * editable, struct offset_data *data)
 
     /* maybe user typed something, save it in the buffer */
     text = gtk_entry_get_text(GTK_ENTRY(ctrl_usr->vert.offset_entry));
-    strncpy(data->buf, text, BUFLEN);
+    snprintf(data->buf, BUFLEN, "%s", text);
 }
 
 /*

--- a/src/libnml/cms/cms_cfg.cc
+++ b/src/libnml/cms/cms_cfg.cc
@@ -110,6 +110,11 @@ int load_nml_config_file(const char *file)
 
     CONFIG_FILE_INFO *info = new CONFIG_FILE_INFO();
     info->lines_list = new LinkedList();
+    if (strlen(file) >= 80) {
+        rcs_print_error("cms_config: file name too long\n");
+        loading_config_file = 0;
+        return -1;
+    }
     strncpy(info->file_name, file, 80);
     FILE *fp;
     fp = fopen(file, "r");

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -178,12 +178,12 @@ NML::NML(NML_FORMAT_PTR f_ptr, const char *buf, const char *proc, const char *fi
     blocking_read_poll_interval = -1.0;
     forced_type = 0;
 
-    strncpy(bufname, buf, 40);
-    strncpy(procname, proc, 40);
+    snprintf(bufname, 40, "%s", buf);
+    snprintf(procname, 40, "%s", proc);
     if (NULL == file) {
 	file = default_nml_config_file;
     }
-    strncpy(cfgfilename, file, 160);
+    snprintf(cfgfilename, 160, "%s", file);
 
     if (rcs_errors_printed >= max_rcs_errors_to_print
 	&& max_rcs_errors_to_print > 0 && nml_reset_errors_printed) {
@@ -344,9 +344,9 @@ NML::NML(const char *buf, const char *proc, const char *file, int set_to_server,
     }
     registered_with_server = 0;
     cms_for_msg_string_conversions = 0;
-    strncpy(bufname, buf, 40);
-    strncpy(procname, proc, 40);
-    strncpy(cfgfilename, file, 160);
+    snprintf(bufname, 40 , "%s", buf);
+    snprintf(procname, 40, "%s", proc);
+    snprintf(cfgfilename, 160, "%s", file);
     blocking_read_poll_interval = -1.0;
     info_printed = 0;
     forced_type = 0;
@@ -2132,9 +2132,9 @@ void NML::print_info(const char *bufname, const char *procname, const char *cfg_
 	    && !strncmp(cfg_file, last_cfg_file, 40)) {
 	    return;
 	}
-	strncpy(last_bufname, bufname, 10);
-	strncpy(last_procname, procname, 10);
-	strncpy(last_cfg_file, cfg_file, 40);
+	snprintf(last_bufname, 10, "%s", bufname);
+	snprintf(last_procname, 10, "%s", procname);
+	snprintf(last_cfg_file, 40, "%s", cfg_file);
     }
     if (!info_message_printed) {
 	rcs_print
@@ -2449,8 +2449,8 @@ void nmlSetHostAlias(const char *hostName, const char *hostAlias)
 	cmsHostAliases = new LinkedList;
     }
     CMS_HOST_ALIAS_ENTRY entry;
-    strncpy(entry.host, hostName, 64);
-    strncpy(entry.alias, hostAlias, 64);
+    snprintf(entry.host, 64, "%s", hostName);
+    snprintf(entry.alias, 64,  "%s", hostAlias);
     cmsHostAliases->store_at_tail(&entry, sizeof(entry), 1);
 }
 

--- a/src/libnml/nml/nml_mod.cc
+++ b/src/libnml/nml/nml_mod.cc
@@ -818,7 +818,7 @@ NML_MODULE::write_status_out ()
   statusOutData->source_line = source_line;
   if (NULL != source_file)
     {
-      strncpy (statusOutData->source_file, source_file, 64);
+      snprintf(statusOutData->source_file, 64, "%s", source_file);
     }
 
   // write STATUS


### PR DESCRIPTION
We check the length of the string before using `strncpy()`, we check with `>=` which means that the string must be one smaller and therefore have room for at least one NULL terminating character.

The previous solution also checked for NULL terminated strings but the compiler wasn't satisfied with it happening after the command to `strncpy()`.

For the error message, the unnecessary cast to unsigned long is removed, and the format string has been changed to `zu`.