### PR TITLE
revert changes for strncat()

### DIFF
--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -294,7 +294,7 @@ int Interp::add_parameters(setup_pointer settings,
     while (*s) {
 	errored = true;
 	char c  = toupper(*s);
-	strncat(tail,&c,2);
+	strncat(tail,&c,1);
 	if (*(s+1)) rtapi_strxcat(tail,",");
 	s++;
     }


### PR DESCRIPTION
Fixes the regression with tests `remap/fail/args.1` and `remap/fail/args.2`.