### PR TITLE
Update glcanon.py

### DIFF
--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -592,9 +592,8 @@ class GlCanonDraw:
 
             try:
                 buffer = glRenderMode(GL_RENDER)
-            except OverflowError:
-                self.select_buffer_size *= 2
-                continue
+            except:
+                buffer = []
             break
 
         if buffer:


### PR DESCRIPTION
Fix overflow error when clicking on the zoomed out preview or rapidly clicking on individual lines.