### PR TITLE
Improves named IO pins

### DIFF
--- a/docs/man/man9/motion.9
+++ b/docs/man/man9/motion.9
@@ -1,10 +1,10 @@
-.TH MOTION "9" "" "LinuxCNC Documentation" "HAL Component"
+.TH MOTION "9" "2023-12-22" "LinuxCNC Documentation" "HAL Component"
 
 .SH NAME
 motion \- accepts NML motion commands, interacts with HAL in realtime
 
 .SH SYNOPSIS
-\fBloadrt motmod [base_period_nsec=\fIperiod\fB] [base_thread_fp=\fI0 or 1\fB] [servo_period_nsec=\fIperiod\fB] [traj_period_nsec=\fIperiod\fB] [num_joints=\fI[1-16]\fB] [num_dio=\fI[1-64]\fB] [num_aio=\fI[1-64]\fB] [num_misc_error=\fI[0-64]\fB] [num_spindles=\fI[1-8]\fB]\fR  \fB[unlock_joints_mask=\fR\fIjointmask\fR\fB]\fR \fB[num_extrajoints=\fI[0-16]\fB]\fR
+\fBloadrt motmod [base_period_nsec=\fIperiod\fB] [base_thread_fp=\fI0 or 1\fB] [servo_period_nsec=\fIperiod\fB] [traj_period_nsec=\fIperiod\fB] [num_joints=\fI[1-16]\fB] [num_dio=\fI[1-64]\fB | names_dout=\fIname[,...]\fB names_din=\fIname[,...]\fB] [num_aio=\fI[1-64]\fB | names_aout=\fIname[,...]\fB names_ain=\fIname[,...]\fB] [num_misc_error=\fI[0-64]\fB] [num_spindles=\fI[1-8]\fB]\fR  \fB[unlock_joints_mask=\fR\fIjointmask\fR\fB]\fR \fB[num_extrajoints=\fI[0-16]\fB]\fR
 
 The limits for the following items are compile-time settings:
 .br
@@ -14,11 +14,45 @@ The limits for the following items are compile-time settings:
 .br
 .ns
 .TP
-\fBnum_dio\fR: Maximum number of digital inputs is set by EMCMOT_MAX_DIO.
+\fBnum_dio\fR: Maximum number of digital IO pins is set by \fBEMCMOT_MAX_DIO\fR.
+Minimum is 1, if \fBnum_dio\fR is not specified, it defaults to \fBDEFAULT_DIO\fR.
 .br
 .ns
 .TP
-\fBnum_aio\fR: Maximum number of analog inputs is set by EMCMOT_MAX_AIO.
+\fBnames_dout\fR: A comma-separated list of names for digital output pins.
+This parameter is mutually exclusive with \fBnum_dio\fR, but can be combined with \fBnames_din\fR. A
+maximum of \fBEMCMOT_MAX_DIO\fR names can be specified. The default digital output pin has names
+like \fBmotion.digital-out-00\fR whereas \fBnames_dout=\fIis-homing-x,is-homing-y\fR will create the
+HAL pins \fBmotion.dout-is-homing-x\fR and \fBmotion.dout-is-homing-y\fR.
+.br
+.ns
+.TP
+\fBnames_din\fR: A comma-separated list of names for digital input pins.
+This parameter is mutually exclusive with \fBnum_dio\fR, but can be combined with \fBnames_dout\fR.
+A maximum of \fBEMCMOT_MAX_DIO\fR names can be specified. The default digital input pin has names
+like \fBmotion.digital-in-00\fR whereas \fBnames_din=\fIhomed-x,homed-y\fR will create the HAL pins
+\fBmotion.din-homed-x\fR and \fBmotion.din-homed-y\fR.
+.br
+.ns
+.TP
+\fBnum_aio\fR: Maximum number of analog IO pins is set by \fBEMCMOT_MAX_AIO\fR.
+Minimum is 1, if \fBnum_aio\fR is not specified, it defaults to \fBDEFAULT_AIO\fR.
+.br
+.ns
+.TP
+\fBnames_aout\fR: A comma-separated list of names for analog output pins.
+This parameter is mutually exclusive with \fBnum_aio\fR, but can be combined with \fBnames_ain\fR. A
+maximum of \fBEMCMOT_MAX_AIO\fR names can be specified. The default analog output pin has names like
+\fBmotion.analog-out-00\fR whereas \fBnames_aout=\fIfeedrate1,feedrate2\fR will create the HAL pins
+\fBmotion.aout-feedrate1\fR and \fBmotion.aout-feedrate2\fR.
+.br
+.ns
+.TP
+\fBnames_ain\fR: A comma-separated list of names for analog input pins.
+This parameter is mutually exclusive with \fBnum_aio\fR, but can be combined with \fBnames_aout\fR.
+A maximum of \fBEMCMOT_MAX_AIO\fR names can be specified. The default analog input pin has names
+like \fBmotion.analog-in-00\fR whereas \fBnames_ain=\fIproxy1,proxy2\fR will create the HAL pins
+\fBmotion.ain-proxy1\fR and \fBmotion.ain-proxy2\fR.
 .br
 .ns
 .TP
@@ -27,9 +61,6 @@ The limits for the following items are compile-time settings:
 .ns
 .TP
 \fBnum_spindles\fR: Maximum number of spindles is set by EMCMOT_MAX_SPINDLES
-
-.P
-Optionally the number of Digital I/O is set with num_dio. The number of Analog I/O is set with num_aio. The default is 4 each.
 
 .P
 Pin names starting with "\fBjoint\fR"  or "\fBaxis\fR" are are read and updated by the motion-controller function.
@@ -64,6 +95,14 @@ in the numbering sequence.  For example, specifying [KINS]JOINTS=5 and
 [EMCMOT]motmod num_extrajoints=2 for a 3 joint trivkins configuration
 \fB[KINS] KINEMATICS=trivkins coordinates=xyz\fR uses joints 0,1,2 for
 the kinematic joints and joints 3,4 for the 'extra' joints.
+
+An equal number of digital or analog IO pins will always be created. For
+example, if \fBnames_din\fR is specified with two pins, two named input and two
+default named output pins will be created. In cases where \fBnames_dout\fR is
+specified with two pins and \fBnames_din\fR with three pins, two named output
+and one default named output pin will be created, along with three named input
+pins. This principle applies independently to digital and analog IO pins,
+allowing for scenarios such as having three digital pins and two analog pins.
 
 .SH  MOTION PINS
 

--- a/docs/man/man9/motion.9
+++ b/docs/man/man9/motion.9
@@ -10,7 +10,7 @@ The limits for the following items are compile-time settings:
 .br
 .ns
 .TP
-\fBnum_joints\fR: Maximum number of joints is set by EMCMOT_MAX_JOINTS.
+\fBnum_joints\fR: Maximum number of joints is set by \fBEMCMOT_MAX_JOINTS\fR.
 .br
 .ns
 .TP
@@ -56,14 +56,14 @@ like \fBmotion.analog-in-00\fR whereas \fBnames_ain=\fIproxy1,proxy2\fR will cre
 .br
 .ns
 .TP
-\fBnum_misc_error\fR: Maximum number of extra error inputs is set by EMCMOT_MAX_MISC_ERRORS.
+\fBnum_misc_error\fR: Maximum number of extra error inputs is set by \fBEMCMOT_MAX_MISC_ERRORS\fR.
 .br
 .ns
 .TP
-\fBnum_spindles\fR: Maximum number of spindles is set by EMCMOT_MAX_SPINDLES
+\fBnum_spindles\fR: Maximum number of spindles is set by \fBEMCMOT_MAX_SPINDLES\fR.
 
 .P
-Pin names starting with "\fBjoint\fR"  or "\fBaxis\fR" are are read and updated by the motion-controller function.
+Pin names starting with "\fBjoint\fR"  or "\fBaxis\fR" are read and updated by the motion-controller function.
 
 .SH DESCRIPTION
 By default, the base thread does not support floating point.  Software stepping, software encoder counting, and software pwm do not use floating point.  \fBbase_thread_fp\fR can be used to enable floating point in the base thread (for example for brushless DC motor control).
@@ -89,7 +89,7 @@ joints.
 The \fBnum_joints\fR parameter is conventionally set using the INI file
 setting \fB[KINS]JOINTS=\fRvalue.  The \fBnum_extrajoints\fR is set by
 the additional motmod parameter \fB[EMCMOT]motmod num_extrajoints=\fRvalue.
-Hal pin numbering for all joints is zero based [\fB0 ... num_joints-1\fR].
+HAL pin numbering for all joints is zero based [\fB0 ... num_joints-1\fR].
 When specified, 'extra' joints are assigned the last \fBnum_extrajoints\fR
 in the numbering sequence.  For example, specifying [KINS]JOINTS=5 and
 [EMCMOT]motmod num_extrajoints=2 for a 3 joint trivkins configuration

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -501,7 +501,7 @@ static int init_hal_io(void)
             CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_di[n]), mot_comp_id, "motion.digital-in-%02d", in++));
         }
         if (n < num_dout && names_dout[n]) {
-            CALL_CHECK(hal_pin_bit_newf(HAL_IN, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.dout-%s", names_dout[n]));
+            CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.dout-%s", names_dout[n]));
         } else {
             CALL_CHECK(hal_pin_bit_newf(HAL_OUT, &(emcmot_hal_data->synch_do[n]), mot_comp_id, "motion.digital-out-%02d",out++));
         }

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -61,25 +61,24 @@ RTAPI_MP_INT(num_extrajoints, "number of extra joints (not used in kinematics)")
 static int num_dio = NOT_INITIALIZED;
 RTAPI_MP_INT(num_dio, "number of digital inputs/outputs");
 
-#define MAX_IO 64
-static char *names_din[MAX_IO] = {0,};
-RTAPI_MP_ARRAY_STRING(names_din, MAX_IO, "names of digital inputs");
-static char *names_dout[MAX_IO] = {0,};
-RTAPI_MP_ARRAY_STRING(names_dout, MAX_IO, "names of digital outputs");
+static char *names_din[EMCMOT_MAX_DIO] = {0,};
+RTAPI_MP_ARRAY_STRING(names_din, EMCMOT_MAX_DIO, "names of digital inputs");
+static char *names_dout[EMCMOT_MAX_DIO] = {0,};
+RTAPI_MP_ARRAY_STRING(names_dout, EMCMOT_MAX_DIO, "names of digital outputs");
 
 static int num_aio = NOT_INITIALIZED;
 RTAPI_MP_INT(num_aio, "number of analog inputs/outputs");
 
 
-static char *names_ain[MAX_IO] = {0,};
-RTAPI_MP_ARRAY_STRING(names_ain, MAX_IO, "names of analog inputs");
-static char *names_aout[MAX_IO] = {0,};
-RTAPI_MP_ARRAY_STRING(names_aout, MAX_IO, "names of analog outputs");
+static char *names_ain[EMCMOT_MAX_AIO] = {0,};
+RTAPI_MP_ARRAY_STRING(names_ain, EMCMOT_MAX_AIO, "names of analog inputs");
+static char *names_aout[EMCMOT_MAX_AIO] = {0,};
+RTAPI_MP_ARRAY_STRING(names_aout, EMCMOT_MAX_AIO, "names of analog outputs");
+
 static int num_misc_error = NOT_INITIALIZED;
 RTAPI_MP_INT(num_misc_error, "number of misc error inputs");
-
-static char *names_misc_errors[MAX_IO] = {0,};
-RTAPI_MP_ARRAY_STRING(names_misc_errors, MAX_IO, "names of errors");
+static char *names_misc_errors[EMCMOT_MAX_MISC_ERROR] = {0,};
+RTAPI_MP_ARRAY_STRING(names_misc_errors, EMCMOT_MAX_MISC_ERROR, "names of errors");
 
 static int unlock_joints_mask = 0;/* mask to select joints for unlock pins */
 RTAPI_MP_INT(unlock_joints_mask, "mask to select joints for unlock pins");
@@ -222,10 +221,10 @@ static void emc_message_handler(msg_level_t level, const char *fmt, va_list ap)
     va_end(apc);
 }
 
-int count_names(char *names[])
+int count_names(char *names[], int max_length)
 {
     int count = 0;
-    while (count < MAX_IO && names[count] && *names[count])
+    while (count < max_length && names[count] && *names[count])
         count++;
     return count;
 }
@@ -312,8 +311,8 @@ int rtapi_app_main(void)
       return -1;
     }
     if (names_dout[0] || names_din[0]) {
-      num_dout = count_names(names_dout);
-      num_din = count_names(names_din);
+      num_dout = count_names(names_dout, EMCMOT_MAX_DIO);
+      num_din = count_names(names_din, EMCMOT_MAX_DIO);
       num_dio = (num_din > num_dout) ? num_din : num_dout;
     } else if (num_dio == NOT_INITIALIZED) {
       num_dio = DEFAULT_DIO;
@@ -332,8 +331,8 @@ int rtapi_app_main(void)
     return -1;
   }
   if (names_aout[0] || names_ain[0]) {
-    num_aout = count_names(names_aout);
-    num_ain = count_names(names_ain);
+    num_aout = count_names(names_aout, EMCMOT_MAX_AIO);
+    num_ain = count_names(names_ain, EMCMOT_MAX_AIO);
     num_aio = (num_ain > num_aout) ? num_ain : num_aout;
   } else if (num_aio == NOT_INITIALIZED) {
     num_aio = DEFAULT_AIO;
@@ -351,7 +350,7 @@ int rtapi_app_main(void)
     return -1;
   }
   if (names_misc_errors[0]) {
-    num_misc_error = count_names(names_misc_errors);
+    num_misc_error = count_names(names_misc_errors, EMCMOT_MAX_MISC_ERROR);
   } else if (num_misc_error == NOT_INITIALIZED) {
     num_misc_error = DEFAULT_MISC_ERROR;
   }

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -25,6 +25,8 @@
 // Mark strings for translation, but defer translation to userspace
 #define _(s) (s)
 
+#define NOT_INITIALIZED -1
+
 /***********************************************************************
 *                    KERNEL MODULE PARAMETERS                          *
 ************************************************************************/
@@ -55,7 +57,7 @@ static int num_joints = EMCMOT_MAX_JOINTS;	/* default number of joints present *
 RTAPI_MP_INT(num_joints, "number of joints used in kinematics");
 static int num_extrajoints = 0;	/* default number of extra joints present */
 RTAPI_MP_INT(num_extrajoints, "number of extra joints (not used in kinematics)");
-static int num_dio = 0;	/* default number of motion synched DIO */
+static int num_dio = NOT_INITIALIZED;
 RTAPI_MP_INT(num_dio, "number of digital inputs/outputs");
 
 #define MAX_IO 64
@@ -64,7 +66,7 @@ RTAPI_MP_ARRAY_STRING(names_din, MAX_IO, "names of digital inputs");
 static char *names_dout[MAX_IO] = {0,};
 RTAPI_MP_ARRAY_STRING(names_dout, MAX_IO, "names of digital outputs");
 
-static int num_aio = 0;	/* default number of motion synched AIO */
+static int num_aio = NOT_INITIALIZED;
 RTAPI_MP_INT(num_aio, "number of analog inputs/outputs");
 
 
@@ -72,7 +74,7 @@ static char *names_ain[MAX_IO] = {0,};
 RTAPI_MP_ARRAY_STRING(names_ain, MAX_IO, "names of analog inputs");
 static char *names_aout[MAX_IO] = {0,};
 RTAPI_MP_ARRAY_STRING(names_aout, MAX_IO, "names of analog outputs");
-static int num_misc_error = DEFAULT_MISC_ERROR;	/* default number of misc errors */
+static int num_misc_error = NOT_INITIALIZED;
 RTAPI_MP_INT(num_misc_error, "number of misc error inputs");
 
 static char *names_misc_errors[MAX_IO] = {0,};
@@ -298,15 +300,14 @@ int rtapi_app_main(void)
     }
     motion_num_spindles = num_spindles;
 
-    if(num_dio && (names_dout[0] || names_din[0])){
+    if (num_dio != NOT_INITIALIZED && (names_dout[0] || names_din[0])) {
       rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: Can't specify both names and number for digital pins\n"));
       return -1;
     }
-    else if(names_dout[0] || names_din[0]){
+    if (names_dout[0] || names_din[0]) {
       num_dio = count_names(names_dout);
       num_dio = (num_dio > count_names(names_din)) ? num_dio : count_names(names_din);
-    }
-    else if(!num_dio){
+    } else if (num_dio == NOT_INITIALIZED) {
       num_dio = DEFAULT_DIO;
     }
 
@@ -318,15 +319,14 @@ int rtapi_app_main(void)
 	return -1;
     }
 
-  if(num_aio && (names_aout[0] || names_ain[0])){
+  if (num_aio != NOT_INITIALIZED && (names_aout[0] || names_ain[0])) {
     rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: Can't specify both names and number for analog pins\n"));
     return -1;
   }
-  else if(names_aout[0] || names_ain[0]){
+  if (names_aout[0] || names_ain[0]) {
     num_aio = count_names(names_aout);
     num_aio = (num_aio > count_names(names_ain)) ? num_aio : count_names(names_ain);
-  }
-  else if(!num_aio){
+  } else if (num_aio == NOT_INITIALIZED) {
     num_aio = DEFAULT_AIO;
   }
 
@@ -337,15 +337,13 @@ int rtapi_app_main(void)
 	return -1;
     }
 
-  if(num_misc_error && (names_misc_errors[0])){
+  if (num_misc_error != NOT_INITIALIZED && (names_misc_errors[0])) {
     rtapi_print_msg(RTAPI_MSG_ERR, _("MOTION: Can't specify both names and number for misc error\n"));
     return -1;
   }
-  else if(names_misc_errors[0]){
-    num_misc_error = count_names(names_dout);
-    num_misc_error = (num_misc_error > count_names(names_din)) ? num_misc_error : count_names(names_din);
-  }
-  else if(!num_misc_error){
+  if (names_misc_errors[0]) {
+    num_misc_error = count_names(names_misc_errors);
+  } else if (num_misc_error == NOT_INITIALIZED) {
     num_misc_error = DEFAULT_MISC_ERROR;
   }
 


### PR DESCRIPTION
There is still some limitations to the named arrays. If both `names_dout` and `names_din` is set, they have to be the exact same size. The same is true for `names_ain` and `names_aout`. Currently, we do not verify this.

Marking this as draft to see if the solution is accepted, I also thought to update the man-page for the named pins  `names_dout`, `names_din` and `names_ain`, `names_aout`.

There is also the issue with not sending in the max length to `count_names(), not sure if you want that in 2.9 as well @andypugh?