### PR TITLE
Update build-dependency for OpenGL

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -23,7 +23,7 @@ Build-Depends:
     intltool,
     libboost-python-dev,
     libepoxy-dev,
-    libgl1-mesa-dev | libgl1-mesa-swx11-dev,
+    libgl-dev | libgl1-mesa-dev,
     libglu1-mesa-dev,
     libgtk2.0-dev,
     libgtk-3-dev,


### PR DESCRIPTION
The package 'libgl1-mesa-dev' has been superseded by 'libgl-dev' in unstable, 'libgl-dev' is searched for first. 'libgl1-mesa-swx11-dev' is so old that it does not exist on any supported distribution.

Reported by lintian.