### PR TITLE
Fixes some compiler warnings

### DIFF
--- a/src/hal/classicladder/emc_mods.c
+++ b/src/hal/classicladder/emc_mods.c
@@ -134,7 +134,7 @@ char * ConvVarNameToHalSigName( char * VarNameParam )
             hal_pin_t *pin = halpr_find_pin_by_name(pin_name);
             if(pin && pin->signal) {
                 hal_sig_t *sig = SHMPTR(pin->signal);
-                if(sig->name) {
+                if(0 != sig->name[0]) {
                     static char sig_name[100];
                     // char *arrow = "\xe2\x86\x90";
                     char *arrow = "\xe2\x87\x92";

--- a/src/libnml/nml/nml_mod.cc
+++ b/src/libnml/nml/nml_mod.cc
@@ -163,6 +163,7 @@ NML_MODULE::zero_common_vars ()
   min_run_time = 1e6;
   max_run_time = 0;
   start_cycle_time = 0;
+  proc_name = 0;
   temp_file = 0;
   temp_line = 0;
   Dclock_expiration = 0;
@@ -271,12 +272,7 @@ NML_MODULE::setCmdChannel (RCS_CMD_CHANNEL * cmd_channel)
     }
   if (NULL != commandIn->cms)
     {
-      if (NULL != commandIn->cms->ProcessName)
-	{
-	  proc_name =
-	    (char *) malloc (strlen (commandIn->cms->ProcessName) + 1);
-	  strcpy (proc_name, commandIn->cms->ProcessName);
-	}
+      proc_name = strndup(commandIn->cms->ProcessName, LINELEN);
     }
 }
 

--- a/src/libnml/rcs/rcs_print.cc
+++ b/src/libnml/rcs/rcs_print.cc
@@ -369,9 +369,6 @@ int rcs_fputs(const char *_str)
 	    break;
 	case RCS_PRINT_TO_FILE:
 	    if (NULL == rcs_print_file_stream) {
-		if (NULL == rcs_print_file_name) {
-		    return EOF;
-		}
 		rcs_print_file_stream = fopen(rcs_print_file_name, "a+");
 	    }
 	    if (NULL == rcs_print_file_stream) {


### PR DESCRIPTION
Compiler warning from `emc_mods.c` was originally fixed by Petter in #2215.

For the other warnings, I just removed the check, we could have checked for something else, but it don't seems necessary.

in `nml_mod.c` I changed from malloc() and strcpy() to strdup(), I also made sure the variable `proc_name` is initialized to `0`. However, in master branch, this file was removed since it wasn't necessary or used.