### PR TITLE
gmoccapy: add setting for G-code theme (GtkSourceView)

### DIFF
--- a/lib/python/gladevcp/hal_sourceview.py
+++ b/lib/python/gladevcp/hal_sourceview.py
@@ -126,6 +126,9 @@ class EMC_SourceView(GtkSource.View, _EMC_ActionBase):
             self.sm.set_search_path(path)
         self.buf.set_style_scheme(self.sm.get_scheme(style))
 
+    def get_style_schemes(self):
+        return self.sm.get_scheme_ids()
+
     def get_filename(self):
         return self.filename
 

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -719,6 +719,17 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="lstst_sourceview_themes">
+    <columns>
+      <!-- column-name text -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0">default</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkListStore" id="lstst_themes">
     <columns>
       <!-- column-name text -->
@@ -4237,7 +4248,7 @@ clicking on the DRO</property>
                                 <property name="can-focus">False</property>
                                 <property name="label-xalign">0.5</property>
                                 <child>
-                                  <!-- n-columns=2 n-rows=7 -->
+                                  <!-- n-columns=2 n-rows=10 -->
                                   <object class="GtkGrid" id="grid_themes_sound">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
@@ -4251,7 +4262,7 @@ clicking on the DRO</property>
                                       <object class="GtkLabel" id="lbl_themes">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="label" translatable="yes">Themes</property>
+                                        <property name="label" translatable="yes">Theme</property>
                                       </object>
                                       <packing>
                                         <property name="left-attach">0</property>
@@ -4319,7 +4330,7 @@ clicking on the DRO</property>
                                       </object>
                                       <packing>
                                         <property name="left-attach">1</property>
-                                        <property name="top-attach">6</property>
+                                        <property name="top-attach">9</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -4333,7 +4344,7 @@ clicking on the DRO</property>
                                       </object>
                                       <packing>
                                         <property name="left-attach">0</property>
-                                        <property name="top-attach">6</property>
+                                        <property name="top-attach">9</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -4347,7 +4358,7 @@ clicking on the DRO</property>
                                       </object>
                                       <packing>
                                         <property name="left-attach">0</property>
-                                        <property name="top-attach">5</property>
+                                        <property name="top-attach">8</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -4358,7 +4369,7 @@ clicking on the DRO</property>
                                       </object>
                                       <packing>
                                         <property name="left-attach">1</property>
-                                        <property name="top-attach">5</property>
+                                        <property name="top-attach">8</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -4372,7 +4383,49 @@ clicking on the DRO</property>
                                       </object>
                                       <packing>
                                         <property name="left-attach">0</property>
+                                        <property name="top-attach">7</property>
+                                        <property name="width">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="lbl_sourceview_icon_themes">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="label" translatable="yes">G-code Theme</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
                                         <property name="top-attach">4</property>
+                                        <property name="width">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBox" id="sourceview_theme_choice">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="model">lstst_sourceview_themes</property>
+                                        <signal name="changed" handler="on_sourceview_theme_choice_changed" swapped="no"/>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cellrenderertext3"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">5</property>
+                                        <property name="width">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSeparator" id="sep_themes_sound">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left-attach">0</property>
+                                        <property name="top-attach">6</property>
                                         <property name="width">2</property>
                                       </packing>
                                     </child>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -4588,6 +4588,10 @@ class gmoccapy(object):
 
     def _set_sourceview_theme(self, name):
         self.widgets["gcode_view"].set_style_scheme(name)
+        style  = self.widgets["gcode_view"].get_style_context()
+        color = style.get_background_color(Gtk.StateFlags.SELECTED)
+        color.alpha = 0.5
+        self.widgets["gcode_view"].add_mark_category('motion', color.to_string())
         
     def on_sourceview_theme_choice_changed(self, widget):
         active = widget.get_active_iter()


### PR DESCRIPTION
Adds a setting to Gmoccapy for setting the GtkSourceView theme to avoid problems with dark themes.

Related to: https://forum.linuxcnc.org/gmoccapy/50636-can-i-change-the-colors-scheme-in-the-gcode-editor
and https://forum.linuxcnc.org/gmoccapy/51124-gmocappy-defects-in-release-2-9-2

I hope everybody is fine with the name "G-code Theme" because I think a user would not know what is meant with GtkSourceView :)
![grafik](https://github.com/LinuxCNC/linuxcnc/assets/67957916/baa46c80-6dec-40e2-802e-c3fd57979ba4)