### PR TITLE
Gmoccapy 3.4.7 - some improvements

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -35,6 +35,12 @@
     <property name="page-increment">10</property>
     <signal name="value-changed" handler="on_adj_kbd_height_value_changed" swapped="no"/>
   </object>
+  <object class="GtkAdjustment" id="adj_kbd_width">
+    <property name="upper">2000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+    <signal name="value-changed" handler="on_adj_kbd_width_value_changed" swapped="no"/>
+  </object>
   <object class="GtkAdjustment" id="adj_max_messages">
     <property name="lower">1</property>
     <property name="upper">25</property>
@@ -3060,6 +3066,8 @@
                               <object class="GtkBox" id="key_box">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <property name="halign">center</property>
+                                <property name="valign">center</property>
                                 <property name="homogeneous">True</property>
                                 <child>
                                   <placeholder/>
@@ -3490,42 +3498,90 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkBox">
+                                      <!-- n-columns=2 n-rows=2 -->
+                                      <object class="GtkGrid">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="hexpand">False</property>
                                         <child>
-                                          <object class="GtkLabel" id="lbl_kbd_height">
+                                          <object class="GtkBox" id="box_kbd_height">
                                             <property name="visible">True</property>
                                             <property name="can-focus">False</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="xpad">5</property>
-                                            <property name="ypad">5</property>
-                                            <property name="label" translatable="yes">Height</property>
-                                            <property name="xalign">0</property>
+                                            <property name="hexpand">False</property>
+                                            <child>
+                                              <object class="GtkSpinButton">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="adjustment">adj_kbd_height</property>
+                                                <property name="value">250</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                           <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkSpinButton">
+                                          <object class="GtkBox" id="box_kbd_width">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="adjustment">adj_kbd_height</property>
-                                            <property name="value">250</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="hexpand">False</property>
+                                            <child>
+                                              <object class="GtkSpinButton">
+                                                <property name="visible">True</property>
+                                                <property name="can-focus">True</property>
+                                                <property name="text" translatable="yes">250</property>
+                                                <property name="adjustment">adj_kbd_width</property>
+                                                <property name="value">500</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
                                           </object>
                                           <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="chk_kbd_set_height">
+                                            <property name="label" translatable="yes">Height</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                            <signal name="toggled" handler="on_chk_kb_set_height_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="chk_kbd_set_width">
+                                            <property name="label" translatable="yes">Width</property>
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
+                                            <property name="draw-indicator">True</property>
+                                            <signal name="toggled" handler="on_chk_kb_set_width_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                           </packing>
                                         </child>
                                       </object>
                                       <packing>
-                                        <property name="expand">True</property>
+                                        <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="position">5</property>
                                       </packing>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -464,7 +464,6 @@
   </object>
   <object class="GtkImage" id="img_run_from">
     <property name="visible">True</property>
-    <property name="sensitive">False</property>
     <property name="can-focus">False</property>
   </object>
   <object class="GtkImage" id="img_sel_next">

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -5146,6 +5146,7 @@ class gmoccapy(object):
         self.widgets.ntb_preview.hide()
         self.widgets.grid_DRO.hide()
         self.widgets.vbox14.hide()
+        self.widgets.box_dro_side.hide()
         if not self.widgets.vbx_jog.get_visible():
             self.widgets.vbx_jog.set_visible(True)
         self.widgets.gcode_view.set_sensitive(True)
@@ -5223,6 +5224,7 @@ class gmoccapy(object):
             self.widgets.ntb_preview.show()
             self.widgets.grid_DRO.show()
             self.widgets.vbox14.show()
+            self.widgets.box_dro_side.show()
             self.widgets.hbox2.set_position(self.hbox2_position)
             self.widgets.gcode_view.set_sensitive(False)
             self.widgets.btn_save.set_sensitive(True)

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -592,6 +592,9 @@ class gmoccapy(object):
         self.spindle_start_rpm = self.prefs.getpref( 'spindle_start_rpm', default_spindle_speed, float )
 
         self.kbd_height = self.prefs.getpref("kbd_height", 250, int)
+        self.kbd_width = self.prefs.getpref("kbd_width", 880, int)
+        self.kbd_set_height = self.prefs.getpref("kbd_set_height", False, bool)
+        self.kbd_set_width = self.prefs.getpref("kbd_set_width", False, bool)
 
 ###############################################################################
 ##                     create widgets dynamically                            ##
@@ -2317,7 +2320,6 @@ class gmoccapy(object):
             self.widgets.offsetpage1.mark_active((self.system_list[self.stat.g5x_index]).lower())
             if self.widgets.chk_use_kb_on_offset.get_active():
                 self.widgets.ntb_info.set_current_page(1)
-                self.widgets.ntb_info.set_size_request(-1, self.kbd_height)
         else:
             names = self.widgets.offsetpage1.get_names()
             for system, name in names:
@@ -2328,7 +2330,6 @@ class gmoccapy(object):
             self.touch_button_dic["edit_offsets"].set_active(False)
             self.widgets.ntb_preview.set_current_page(0)
             self.widgets.ntb_info.set_current_page(0)
-            self.widgets.ntb_info.set_size_request(-1, -1)
             if self.widgets.ntb_preview.get_n_pages() <= 4:  # else user tabs are available
                 self.widgets.ntb_preview.set_property("show-tabs", state)
 
@@ -2344,7 +2345,6 @@ class gmoccapy(object):
             self.widgets.tooledit1.set_selected_tool(self.stat.tool_in_spindle)
             if self.widgets.chk_use_kb_on_tooledit.get_active():
                 self.widgets.ntb_info.set_current_page(1)
-                self.widgets.ntb_info.set_size_request(-1, self.kbd_height)
         else:
             page.hide()
             if self.widgets.ntb_preview.get_n_pages() > 4:  # user tabs are available
@@ -2352,7 +2352,6 @@ class gmoccapy(object):
             self.widgets.vbx_jog.show()
             self.widgets.ntb_preview.set_current_page(0)
             self.widgets.ntb_info.set_current_page(0)
-            self.widgets.ntb_info.set_size_request(-1, -1)
 
     def _show_iconview_tab(self, state):
         page = self.widgets.ntb_preview.get_nth_page(3)
@@ -2365,14 +2364,12 @@ class gmoccapy(object):
             if self.widgets.chk_use_kb_on_file_selection.get_active():
                 self.widgets.box_info.show()
                 self.widgets.ntb_info.set_current_page(1)
-                self.widgets.ntb_info.set_size_request(-1, self.kbd_height)
         else:
             page.hide()
             if self.widgets.ntb_preview.get_n_pages() > 4:  # user tabs are available
                 self.widgets.ntb_preview.set_property("show-tabs", not state)
             self.widgets.ntb_preview.set_current_page(0)
             self.widgets.ntb_info.set_current_page(0)
-            self.widgets.ntb_info.set_size_request(-1, -1)
 
     # every 100 milli seconds this gets called
     # check linuxcnc for status, error and then update the readout
@@ -2680,7 +2677,6 @@ class gmoccapy(object):
         self.widgets.ntb_main.set_current_page(0)
         self.widgets.ntb_button.set_current_page(_BB_MANUAL)
         self.widgets.ntb_info.set_current_page(0)
-        self.widgets.ntb_info.set_size_request(-1, -1)
         self.widgets.ntb_jog.set_current_page(0)
 
     def on_hal_status_state_on(self, widget):
@@ -2732,10 +2728,8 @@ class gmoccapy(object):
         if self.widgets.tbtn_user_tabs.get_active():
             self.widgets.tbtn_user_tabs.set_active(False)
         self.widgets.ntb_main.set_current_page(0)
-        self.widgets.ntb_info.set_size_request(-1, -1)
         self.widgets.ntb_button.set_current_page(_BB_MANUAL)
         self.widgets.ntb_info.set_current_page(0)
-        self.widgets.ntb_info.set_size_request(-1, -1)
         self.widgets.ntb_jog.set_current_page(0)
 
         # if the status changed, we reset the key event, otherwise the key press
@@ -2760,7 +2754,6 @@ class gmoccapy(object):
             self.widgets.ntb_main.set_current_page(0)
             self.widgets.ntb_button.set_current_page(_BB_MANUAL)
             self.widgets.ntb_info.set_current_page(0)
-            self.widgets.ntb_info.set_size_request(-1, -1)
             self.widgets.ntb_jog.set_current_page(0)
             return
 
@@ -2779,10 +2772,8 @@ class gmoccapy(object):
                 self.widgets.tbtn_user_tabs.set_active(False)
             if self.widgets.chk_use_kb_on_mdi.get_active():
                 self.widgets.ntb_info.set_current_page(1)
-                self.widgets.ntb_info.set_size_request(-1, self.kbd_height)
             else:
                 self.widgets.ntb_info.set_current_page(0)
-                self.widgets.ntb_info.set_size_request(-1, -1)
             self.widgets.ntb_main.set_current_page(0)
             self.widgets.ntb_button.set_current_page(_BB_MDI)
             self.widgets.ntb_jog.set_current_page(1)
@@ -2812,7 +2803,6 @@ class gmoccapy(object):
             if self.widgets.tbtn_user_tabs.get_active():
                 self.widgets.tbtn_user_tabs.set_active(False)
             self.widgets.ntb_main.set_current_page(0)
-            self.widgets.ntb_info.set_size_request(-1, -1)
             self.widgets.ntb_button.set_current_page(_BB_AUTO)
             self.widgets.ntb_info.set_current_page(0)
             self.widgets.ntb_jog.set_current_page(2)
@@ -2937,11 +2927,17 @@ class gmoccapy(object):
             self.widgets.adj_y_pos.set_value(self.ypos)
             self.widgets.adj_width.set_value(self.width)
             self.widgets.adj_height.set_value(self.height)
-            self.widgets.adj_kbd_height.set_value(self.kbd_height)
-
             # move and resize the window
             self.widgets.window1.move(self.xpos, self.ypos)
             self.widgets.window1.resize(self.width, self.height)
+            
+            # keyboard size
+            self.widgets.chk_kbd_set_height.set_active(self.kbd_set_height)
+            self.widgets.chk_kbd_set_width.set_active(self.kbd_set_width)
+            self.widgets.adj_kbd_height.set_value(self.kbd_height)
+            self.widgets.adj_kbd_width.set_value(self.kbd_width)
+            self._update_kbd_height(self.kbd_set_height)
+            self._update_kbd_width(self.kbd_set_width)
 
         # set initial state of widgets
         self.touch_button_dic["set_active"].set_sensitive(False)
@@ -3010,7 +3006,6 @@ class gmoccapy(object):
         if not self.onboard:
             self.macro_dic["keyboard"].set_sensitive(True)
         self.widgets.ntb_info.set_current_page(0)
-        self.widgets.ntb_info.set_size_request(-1, -1)
 
 # helpers functions start
 # =========================================================
@@ -3813,7 +3808,6 @@ class gmoccapy(object):
                 self.widgets.ntb_main.set_current_page(0)
                 self.widgets.ntb_button.set_current_page(_BB_MANUAL)
                 self.widgets.ntb_info.set_current_page(0)
-                self.widgets.ntb_info.set_size_request(-1, -1)
                 self.widgets.ntb_jog.set_current_page(0)
             else:
                 # restore mode
@@ -4190,10 +4184,8 @@ class gmoccapy(object):
                 self.macro_dic["keyboard"].set_sensitive(False)
         elif self.widgets.ntb_info.get_current_page() == 1:
             self.widgets.ntb_info.set_current_page(0)
-            self.widgets.ntb_info.set_size_request(-1, -1)
         else:
             self.widgets.ntb_info.set_current_page(1)
-            self.widgets.ntb_info.set_size_request(-1, self.kbd_height)
 
         # special case if we are in edit mode
         if self.widgets.ntb_button.get_current_page() == _BB_EDIT:
@@ -4280,7 +4272,6 @@ class gmoccapy(object):
         # show virtual keyboard?
         if state and self.widgets.chk_use_kb_on_offset.get_active():
             self.widgets.ntb_info.set_current_page(1)
-            self.widgets.ntb_info.set_size_request(-1, self.kbd_height)
             self.widgets.ntb_preview.set_current_page(1)
 
     def on_btn_zero_g92_clicked(self, widget, data=None):
@@ -4725,6 +4716,57 @@ class gmoccapy(object):
         value = int(widget.get_value())
         self.prefs.putpref("kbd_height", value, int)
         self.kbd_height = value
+        self._update_kbd_height(self.kbd_set_height)
+
+    def on_adj_kbd_width_value_changed(self, widget, data=None):
+        if not self.initialized:
+            return
+        value = int(widget.get_value())
+        self.prefs.putpref("kbd_width", value, int)
+        self.kbd_width = value
+        self._update_kbd_width(self.kbd_set_width)
+
+    def _update_kbd_height(self, seth):
+        if seth:
+            self.widgets.box_kbd_height.set_sensitive(True)
+            self.widgets.key_box.set_valign(Gtk.Align.CENTER)
+            if self.kbd_set_width:
+                self.widgets.key_box.set_size_request(self.kbd_width, self.kbd_height)
+            else:
+                self.widgets.key_box.set_size_request(-1, self.kbd_height)
+        else:
+            self.widgets.box_kbd_height.set_sensitive(False)
+            self.widgets.key_box.set_valign(Gtk.Align.FILL)
+            if self.kbd_set_width:
+                self.widgets.key_box.set_size_request(self.kbd_width, -1)
+            else:
+                self.widgets.key_box.set_size_request(-1, -1)
+        self.prefs.putpref("kbd_set_height", seth, bool)
+        
+    def _update_kbd_width(self, setw):
+        if setw:
+            self.widgets.box_kbd_width.set_sensitive(True)
+            self.widgets.key_box.set_halign(Gtk.Align.CENTER)
+            if self.kbd_set_height:
+                self.widgets.key_box.set_size_request(self.kbd_width, self.kbd_height)
+            else:
+                self.widgets.key_box.set_size_request(self.kbd_width, -1)
+        else:
+            self.widgets.box_kbd_width.set_sensitive(False)
+            self.widgets.key_box.set_halign(Gtk.Align.FILL)
+            if self.kbd_set_height:
+                self.widgets.key_box.set_size_request(-1, self.kbd_height)
+            else:
+                self.widgets.key_box.set_size_request(-1, -1)
+        self.prefs.putpref("kbd_set_width", setw, bool)
+        
+    def on_chk_kb_set_height_toggled(self, widget):
+        self.kbd_set_height = widget.get_active()
+        self._update_kbd_height(self.kbd_set_height)
+
+    def on_chk_kb_set_width_toggled(self, widget):
+        self.kbd_set_width = widget.get_active()
+        self._update_kbd_width(self.kbd_set_width)
 
     def on_adj_dro_size_value_changed(self, widget, data=None):
         value = int(widget.get_value())
@@ -5153,10 +5195,10 @@ class gmoccapy(object):
         self.widgets.gcode_view.grab_focus()
         if self.widgets.chk_use_kb_on_edit.get_active():
             self.widgets.ntb_info.set_current_page(1)
-            self.widgets.ntb_info.set_size_request(-1, self.kbd_height)
+            
         else:
             self.widgets.ntb_info.hide()
-            self.widgets.ntb_info.set_size_request(-1, -1)
+            
         self.widgets.grid_search.show()
         self.gcodeerror = ""
         self.file_changed = False

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -5144,11 +5144,7 @@ class gmoccapy(object):
         self.widgets.ntb_button.set_current_page(_BB_EDIT)
         self.widgets.ntb_preview.hide()
         self.widgets.grid_DRO.hide()
-        width = self.widgets.window1.get_size().width
-        width -= self.widgets.vbtb_main.get_allocated_width()
-        width -= self.widgets.box_right.get_allocated_width()
-        width -= self.widgets.box_left.get_allocated_width()
-        self.widgets.vbx_jog.set_size_request(width, -1)
+        self.widgets.vbox14.hide()
         if not self.widgets.vbx_jog.get_visible():
             self.widgets.vbx_jog.set_visible(True)
         self.widgets.gcode_view.set_sensitive(True)
@@ -5225,7 +5221,7 @@ class gmoccapy(object):
             LOG.debug("we are in special case")
             self.widgets.ntb_preview.show()
             self.widgets.grid_DRO.show()
-            self.widgets.vbx_jog.set_size_request(360, -1)
+            self.widgets.vbox14.show()
             self.widgets.hbox2.set_position(self.hbox2_position)
             self.widgets.gcode_view.set_sensitive(False)
             self.widgets.btn_save.set_sensitive(True)

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -2026,6 +2026,7 @@ class gmoccapy(object):
             self.widgets.audio_alert_chooser.set_filename(self.alert_sound)
             self.widgets.audio_error_chooser.set_filename(self.error_sound)
         else:
+            self.audio_active = False
             LOG.warning(_("No audio available! PYGST library not installed? "
             "Is python-gstX.XX installed?"))
 

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -1,3 +1,16 @@
+ver 3.4.7
+ - Fixed error on error message when sound is not available (reported on Raspberry Pi)
+ - Fixed increasing of window size when clicking edit button
+ - Added setting for G-code theme (GtkSourceView)
+ - Fixed error when trying to hide the turtle-jog button in gmoccapy
+
+ver 3.4.6
+ - added first steps to solve delay on sound use
+
+ver 3.4.4
+ - 8 and 9 axis made to much ref button due to a show all ccommand. This fixes #2387.
+ - deleted unused code
+
 ver 3.4.3
 
 - fix setting of themes

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -1,4 +1,5 @@
 ver 3.4.7
+ - Fixed box_dro_side is displayed in the G-code editor (#2627)
  - Fixed error on error message when sound is not available (reported on Raspberry Pi)
  - Fixed increasing of window size when clicking edit button
  - Added setting for G-code theme (GtkSourceView)

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -1,4 +1,5 @@
 ver 3.4.7
+ - Added setting to allow smaller width of virtual keyboard (for widescreens)
  - Fixed box_dro_side is displayed in the G-code editor (#2627)
  - Fixed error on error message when sound is not available (reported on Raspberry Pi)
  - Fixed increasing of window size when clicking edit button


### PR DESCRIPTION
 - Added setting to allow smaller width of virtual keyboard (for widescreens)
![grafik](https://github.com/LinuxCNC/linuxcnc/assets/67957916/063a6fa1-3cc9-4f04-a940-4bfea92f34a5)

 - Fixed box_dro_side is displayed in the G-code editor (fixes #2627)
 - Fixed error on error message when sound is not available (reported on Raspberry Pi)
 - Fixed increasing of window size when clicking edit button
