### PR TITLE
Gmoccapy, don't hide recurring error messages

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -2410,11 +2410,8 @@ class gmoccapy(object):
                 self._on_play_sound(None, "alert")
 
     def on_gremlin_gcode_error(self, widget, errortext):
-        if self.gcodeerror == errortext:
-            return
-        else:
-            self.gcodeerror = errortext
-            self.dialogs.warning_dialog(self, _("Important Warning"), errortext)
+        self.gcodeerror = errortext
+        self.dialogs.warning_dialog(self, _("Important Warning"), errortext)
 
 
 # =========================================================


### PR DESCRIPTION
The original code will suppress showing an error message if it is identical to the one shown last. While this seems to make some sense at first glance it leads to confusing situations where the user thinks an error has been fixed while it actually still exists but is hidden by the gui.