### PR TITLE
Fix typos in docs subdirectory

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -187,7 +187,7 @@ At the moment, build rules are created for languages with more than 2
 percent translated
 link:https://hosted.weblate.org/projects/linuxcnc/linuxcnc-docs/[according
 to Weblate] or which have been updated the last 12 months according to
-the PO-Revision-Date field in docs/po/*.po.  Documentaion packages for
+the PO-Revision-Date field in docs/po/*.po.  Documentation packages for
 Debian are build for languages with more than 50 percent translation.
 This ensure translators and proof readers can see the result of their
 effort on https://linuxcnc.org/docs/devel/html/, while we limit the

--- a/docs/man/man9/hostmot2.9
+++ b/docs/man/man9/hostmot2.9
@@ -429,7 +429,7 @@ One pin is created for each SSI instance regardless of data format: (bit, in) hm
 This pin will be set "True" if the module was still transferring data when the value was read.
 When this problem exists there will also be a limited number of error messages printed to the UI.
 This pin should be used to monitor whether the problem has been addressed by config changes.
-Solutions to the problem dpend on whether the encoder read is being triggered by the hm2dpll phase-locked-loop timer (described above) or by the trigger\-encoders function (described below).
+Solutions to the problem depend on whether the encoder read is being triggered by the hm2dpll phase-locked-loop timer (described above) or by the trigger\-encoders function (described below).
 
 The names of the pins created by the SSI module will depend entirely on the format string for each channel specified in the loadrt command line.
 A typical format string might be  \fBssi_chan_0=error%1bposition%24g\fR.
@@ -532,7 +532,7 @@ One pin is created for each BiSS instance regardless of data format:
 This pin will be set "True" if the module was still transferring data when the value was read.
 When this problem exists there will also be a limited number of error messages printed to the UI.
 This pin should be used to monitor whether the problem has been addressed by config changes.
-Solutions to the problem dpend on whether the encoder read is being triggered by the hm2dpll phase-locked-loop timer (described above) or by the trigger\-encoders function (described below).
+Solutions to the problem depend on whether the encoder read is being triggered by the hm2dpll phase-locked-loop timer (described above) or by the trigger\-encoders function (described below).
 
 The names of the pins created by the BiSS module will depend entirely on the format string for each channel specified in the loadrt command line and follow closely the format defined above for SSI.
 Currently data packets of up to 96 bits are supported by the LinuxCNC driver, although the Mesa Hostmot2 module can handle 512 bit packets.
@@ -597,7 +597,7 @@ The Mesa resolver driver has the capability of emulating an absolute encoder usi
 and the single-turn absolute operation of resolvers.
 At startup, and only if the \fBuse-position-file\fR parameter is set to "True",
 the resolver driver will wait for a value to be written by the system to the axis.N.joint-pos-fb pin (which must be netted to this resolver pin)
-and will calculate the number of full turns that best matches the current reolver position.
+and will calculate the number of full turns that best matches the current resolver position.
 It will then pre-load the driver output with this offset.
 This should only be used on systems where axis movement in the unpowered state is unlikely.
 This feature will only work properly if the machine is initially homed to "index" and if the axis home positions are exactly zero.

--- a/docs/man/man9/sserial.9
+++ b/docs/man/man9/sserial.9
@@ -49,7 +49,7 @@ If the increment were to be set to zero then no error would ever be raised, and 
 Conversely setting decrement to zero, threshold to 1 and limit to 1 means that absolutely no errors will be tolerated.
 (This structure is copied directly from vehicle ECU practice.)
 
-Any other parameters than the ones above are created by the card istelf from data in the remote firmware.
+Any other parameters than the ones above are created by the card itself from data in the remote firmware.
 They may be set in the HAL file using "setp" in the usual way.
 
 NOTE: Because a Smart-Serial remote can only communicate non-process data to the host card in setup mode,
@@ -76,7 +76,7 @@ Note that the sserial ports do not necessarily correlate in layout or number to 
 (float in) angle
 The rotor angle of the motor in fractions of a full \fBphase\fR revolution.
 An angle of 0.5 indicates that the motor is half a turn / 180 degrees / \[*p] radians from the zero position.
-The zero position is taken to be the position that the motor adopts under no load with a poitive voltage applied to the A (or U) phase
+The zero position is taken to be the position that the motor adopts under no load with a positive voltage applied to the A (or U) phase
 and both B and C (or V and W) connected to \-V or 0 V.
 A 6 pole motor will have 3 zero positions per physical rotation.
 Note that the 8I20 drive automatically adds the phase lead/lag angle, and that this pin should see the raw rotor angle.

--- a/docs/src/drivers/hal_pi_gpio.txt
+++ b/docs/src/drivers/hal_pi_gpio.txt
@@ -7,7 +7,7 @@ It is only really intended to work on the Raspberry Pi. It may, or may not, work
 
 == Purpose
 
-This driver allows the use of the Rapberry Pi GPIO pins in a way analagous to the parallel port driver on x86 PCs. It can use the same step generators, encoder counters and similar components.
+This driver allows the use of the Rapberry Pi GPIO pins in a way analogous to the parallel port driver on x86 PCs. It can use the same step generators, encoder counters and similar components.
 
 == Usage
 
@@ -15,7 +15,7 @@ This driver allows the use of the Rapberry Pi GPIO pins in a way analagous to th
 loadrt hal_pi_gpio dir=0x13407 exclude=0x1F64BF8
 ----
 
-The "dir" mask determines whether the pins are inputs and outputs, the exclude mask prevents the driver from using the pins (and so allows them to be used for their normal RPi purpses such as SPI or UART)
+The "dir" mask determines whether the pins are inputs and outputs, the exclude mask prevents the driver from using the pins (and so allows them to be used for their normal RPi purposes such as SPI or UART)
 
 The mask can be in decimal or hexadecimal (hex may be easier as there will be no carries)
 

--- a/docs/src/getting-started/getting-linuxcnc.adoc
+++ b/docs/src/getting-started/getting-linuxcnc.adoc
@@ -115,7 +115,7 @@ used to boot a computer.  The image is too large to fit on a CD.
 
 === Raspberry Pi Image
 
-The Raspbery Pi image is a completes SD card image and should be
+The Raspberry Pi image is a complete SD card image and should be
 written to an SD card with the [Raspberry Pi Imager App](https://www.raspberrypi.com/software/).
 
 === AMD-64 (x86-64, PC) Image using GUI tools
@@ -150,14 +150,14 @@ diskutil list
 -----
 . Insert the USB and note the name of the new disk that appears, eg
   /dev/disk5
-. unmount the USB. The number found above should be substitued in place
+. unmount the USB. The number found above should be substituted in place
   of the N
 +
 -----
 diskutil unmountDisk /dev/diskN
 -----
 . Transfer the data with dd, as for Linux above. Note that the disk name
-  has an added "r" at the begining
+  has an added "r" at the beginning
 +
 -----
 sudo dd if=/linuxcnc_2.9.2-amd64.hybrid.iso of=/dev/rdiskN bs=1m
@@ -352,7 +352,7 @@ sudo ./linuxcnc-install.sh
   install, or alternatively on a fresh Install of Debian Bookworm 64-bit
   as described above.
 . You can add the LinuxCNC Archive signing key and repository information
-  by downloading and running the installer script as decribed above. If
+  by downloading and running the installer script as described above. If
   an RTAI kernel is detected it will stop before installing any packages. 
 
 . Update the package list from linuxcnc.org

--- a/docs/src/gui/qtvcp-widgets.adoc
+++ b/docs/src/gui/qtvcp-widgets.adoc
@@ -593,7 +593,7 @@ These set _attributes_ of the selected action (availability depends on the widge
   The button label text can be set with any text after a comma, the `\n` symbol adds a line break.
 
 *`ini_mdi_key`*::
-  (prefered way) +
+  (preferred way) +
   A reference to the _INI file_ `[MDI_COMMAND_LIST]` section. +
   This string will be added to 'MDI_COMMAND_' to form an entry to look for +
   in the INI file, under the heading `[MDI_COMMAND_LIST]`. +

--- a/docs/src/motion/pid-theory.adoc
+++ b/docs/src/motion/pid-theory.adoc
@@ -215,7 +215,7 @@ square wave pattern centered around the 'bias' value on the output pin
 of the PID controller, moving from the positive extreme to the
 negative extreme of the output range.  This can be seen using the HAL
 Scope provided by LinuxCNC.  For a motor controller taking +-10 V as
-its control signal, this might accellerate the motor full speed in one
+its control signal, this might accelerate the motor full speed in one
 direction for a short period before telling it to go full speed in the
 opposite direction.  Make sure to have a lot of room on either side of
 the starting position, and start with a low `tune-effort` value to

--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -3442,7 +3442,7 @@ There are three <<plasma:ext-hal-pin,External HAL Pins>> that are available to t
 the pin names are `qtplasmac.ext_out_0`, `qtplasmac.ext_out_1`, and `qtplasmac.ext_out_2`.
 HAL connections to these HAL pins need to be specified in a postgui HAL file as the HAL pins are not available until the QtPlasmac GUI has loaded.
 
-For toggle-halpin buttons, it is possible for the user to mark the associated HAL pin as being required to be turned "ON" before starting a cut sequence by adding "cutcritical" after the HAL pin in the button code. If *TORCH ENABLE* is checked and *CYCLE START*, *MANUAL CUT*, or *SINGLE CUT* are intiated while the "cutcritical" button is not "ON" then the user will receive a dialog warning them as such and asking to CONTINUE or CANCEL.
+For toggle-halpin buttons, it is possible for the user to mark the associated HAL pin as being required to be turned "ON" before starting a cut sequence by adding "cutcritical" after the HAL pin in the button code. If *TORCH ENABLE* is checked and *CYCLE START*, *MANUAL CUT*, or *SINGLE CUT* are initiated while the "cutcritical" button is not "ON" then the user will receive a dialog warning them as such and asking to CONTINUE or CANCEL.
 
 [source,{ini}]
 ----


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,*.pot,*.svg,*.ts,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es,./src/hal/classicladder -L ans,ba,breal,bu,bulle,busses,childs,componentes,currenty,doubleclick,dout,dum,etxt,extint,faktor,fo,fpr,halp,ihs,inout,inport,mot,parm,parms,propertys,ro,seh,ser,smoe,te,tey,trough,ue,ure,wille,wont,wonte`