### PR TITLE
Update deprecated Pillow constant

### DIFF
--- a/src/emc/usr_intf/axis/scripts/image-to-gcode.py
+++ b/src/emc/usr_intf/axis/scripts/image-to-gcode.py
@@ -519,7 +519,7 @@ def ui(im, nim, im_name):
     nw = int(w / max(r1, r2))
     nh = int(h / max(r1, r2))
 
-    ui_image = im.resize((nw,nh), Image.ANTIALIAS)
+    ui_image = im.resize((nw,nh), Image.LANCZOS)
     ui_image = ImageTk.PhotoImage(ui_image, master = app)
     i = tkinter.Label(app, image=ui_image, compound="top",
         text=_("Image size: %(w)d x %(h)d pixels\n"


### PR DESCRIPTION
The substituted constant, `ANTIALIAS`, was removed in Pillow 10.0.0. The `LANCZOS` constant was introduced in Pillow 2.7.0.
https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants

Fixes #2825