### PR TITLE
Remove unused header files and libraries

### DIFF
--- a/src/hal/user_comps/pi500_vfd/Submakefile
+++ b/src/hal/user_comps/pi500_vfd/Submakefile
@@ -8,7 +8,7 @@ $(call TOOBJSDEPS, $(PI500_SRCS)) : EXTRAFLAGS += $(PI500_CFLAGS)
 
 USERSRCS += $(PI500_SRCS)
 
-../bin/pi500_vfd: $(call TOOBJS, $(PI500_SRCS)) ../lib/liblinuxcnchal.so.0 ../lib/liblinuxcncini.so.0
+../bin/pi500_vfd: $(call TOOBJS, $(PI500_SRCS)) ../lib/liblinuxcnchal.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) $(LDFLAGS) -o $@ $^ $(PI500_LIBS) 
 

--- a/src/hal/user_comps/wj200_vfd/Submakefile
+++ b/src/hal/user_comps/wj200_vfd/Submakefile
@@ -8,7 +8,7 @@ $(call TOOBJSDEPS, $(WJ200_SRCS)) : EXTRAFLAGS += $(WJ200_CFLAGS)
 
 USERSRCS += $(WJ200_SRCS)
 
-../bin/wj200_vfd: $(call TOOBJS, $(WJ200_SRCS)) ../lib/liblinuxcnchal.so.0 ../lib/liblinuxcncini.so.0
+../bin/wj200_vfd: $(call TOOBJS, $(WJ200_SRCS)) ../lib/liblinuxcnchal.so.0
 	$(ECHO) Linking $(notdir $@)
 	$(Q)$(CC) $(LDFLAGS) -o $@ $^ $(WJ200_LIBS) 
 

--- a/src/hal/user_comps/xhc-whb04b-6/Submakefile
+++ b/src/hal/user_comps/xhc-whb04b-6/Submakefile
@@ -2,7 +2,7 @@ GCC_GTEQ_470 := $(shell $(CC) --version | head -n1 | grep gcc >/dev/null && (exp
 ifeq "$(GCC_GTEQ_470)" "1"
 ifdef HAVE_LIBUSB10
 
-XHC_WHB04B6_LIB_DEPENDENCIES = ../lib/liblinuxcnchal.so.0 ../lib/liblinuxcncini.so.0
+XHC_WHB04B6_LIB_DEPENDENCIES = ../lib/liblinuxcnchal.so.0
 XHC_WHB04B6_SRC = hal/user_comps/xhc-whb04b-6/hal.cc \
                   hal/user_comps/xhc-whb04b-6/usb.cc \
                   hal/user_comps/xhc-whb04b-6/pendant-types.cc \

--- a/src/hal/user_comps/xhc-whb04b-6/main.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/main.cc
@@ -33,7 +33,6 @@
 // local includes
 #include "./xhc-whb04b6.h"
 
-#include <inifile.hh>
 #include "config.h"
 
 using std::endl;

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -30,7 +30,6 @@
 #include <errno.h>
 #include <dlfcn.h>
 #include <signal.h>
-#include <iostream>
 #include <vector>
 #include <string>
 #include <map>
@@ -39,7 +38,6 @@
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <errno.h>
 #ifdef HAVE_SYS_IO_H
 #include <sys/io.h>
 #endif


### PR DESCRIPTION
Some of the HAL user components had an unnecessary dependency in the IniFile library.

Also removed one duplicated and one unused header file from `uspace_rtapi_app.cc`.