### PR TITLE
image-to-gcode: Fixes NumPy deprecation warning

### DIFF
--- a/src/emc/usr_intf/axis/scripts/image-to-gcode.py
+++ b/src/emc/usr_intf/axis/scripts/image-to-gcode.py
@@ -769,7 +769,7 @@ def main():
     im = im.convert("L") #grayscale
     w, h = im.size
 
-    nim = numpy.fromstring(tobytes(im), dtype=numpy.uint8).reshape((h, w)).astype(numpy.float32)
+    nim = numpy.frombuffer(tobytes(im), dtype=numpy.uint8).reshape((h, w)).astype(numpy.float32)
     options = ui(im, nim, im_name)
 
     step = options['pixelstep']


### PR DESCRIPTION
I traced the replaced function as far back as buster, so it's good for 2.9 and later.