### PR TITLE
docs: Fix bugs URL in man/man1/*.1 (smoe:Fix_Bugs_URL)

### DIFF
--- a/docs/man/man1/halcmd.1
+++ b/docs/man/man1/halcmd.1
@@ -410,7 +410,7 @@ Original version by John Kasunich, as part of the LinuxCNC project.  Now
 includes major contributions by several members of the project.
 .SH REPORTING BUGS
 Report bugs to the
-.URL http://sf.net/p/emc/bugs/ "LinuxCNC bug tracker" .
+.URL https://github.com/LinuxCNC/linuxcnc/issues "LinuxCNC bug tracker" .
 .SH COPYRIGHT
 Copyright \(co 2003 John Kasunich.
 .br

--- a/docs/man/man1/halrun.1
+++ b/docs/man/man1/halrun.1
@@ -92,7 +92,7 @@ Controller project.  Now includes major contributions by several
 members of the project.
 .SH REPORTING BUGS
 Report bugs to the
-.URL http://sf.net/p/emc/bugs/ "LinuxCNC bug tracker" .
+.URL https://github.com/LinuxCNC/linuxcnc/issues "LinuxCNC bug tracker" .
 .SH COPYRIGHT
 Copyright \(co 2003 John Kasunich.
 .br

--- a/docs/man/man1/haltcl.1
+++ b/docs/man/man1/haltcl.1
@@ -83,7 +83,7 @@ commands, precede them with the keyword 'hal':
 
 .SH REPORTING BUGS
 Report bugs to the
-.URL http://sf.net/p/emc/bugs/ "LinuxCNC bug tracker" .
+.URL https://github.com/LinuxCNC/linuxcnc/issues "LinuxCNC bug tracker" .
 .SH COPYRIGHT
 .br
 This is free software; see the source for copying conditions.  There is NO


### PR DESCRIPTION
Three prominent man pages had references to the sf.net bugs page, still.