### PR TITLE
docs: Corrections on punctuation only for master.

### DIFF
--- a/docs/src/gcode/overview.adoc
+++ b/docs/src/gcode/overview.adoc
@@ -29,8 +29,9 @@ command meaning 'move in a straight line at the programmed feed
 rate to the programmed end point', and 'X3' provides an argument
 value (the value of X should be 3 at the end of the move).
 Most LinuxCNC G-code commands start with either G or M (for
-General and Miscellaneous). The words for these commands are called 'G
-codes' and 'M-codes.' Also common are subroutine codes that begin with 'o-' which are called 'o-codes.'
+General and Miscellaneous).
+The words for these commands are called 'G-codes' and 'M-codes'.
+Also common are subroutine codes that begin with 'o-' which are called 'o-codes'.
 
 The LinuxCNC language has no indicator for the start of a program. The
 Interpreter, however, deals with files. A single program may be in a
@@ -149,11 +150,11 @@ The table includes N and O for completeness, even though, as defined above, line
 
 ==== Parameters(((Parameters)))
 
-Parameters are identified with a "#" symbol in front of them. See <<sec:overview-parameters, Parameters Section>> below. 
+Parameters are identified with a "#" symbol in front of them. See <<sec:overview-parameters,Parameters Section>> below. 
 
 ==== Subroutine Codes(((Subroutine Codes)))
 
-Also called 'o-codes' these provide program flow control (such as if-else logic and callable subroutines) and are covered fully at the page on <<cha:o-codes,o-Codes>> and also below in <<sub:subroutine-parameters,Subroutine Codes and Parameters.>> 
+Also called 'o-codes' these provide program flow control (such as if-else logic and callable subroutines) and are covered fully at the page on <<cha:o-codes,o-Codes>> and also below in <<sub:subroutine-parameters,Subroutine Codes and Parameters>>.
 
 NOTE: o-codes are sometimes also called o-words. 
 


### PR DESCRIPTION
Weblate is based on master and found these issues that are not found in 2.9, which typically hosts our non-release-specific documentation (which maybe we should indeed migrate to master).