### PR TITLE
Casts enum to int, change typdef to using and change a macro

### DIFF
--- a/src/emc/ini/emcIniFile.cc
+++ b/src/emc/ini/emcIniFile.cc
@@ -87,7 +87,7 @@ EmcIniFile::ErrorCode
 EmcIniFile::FindLinearUnits(EmcLinearUnits *result,
                  const char *tag, const char *section, int num)
 {
-    return(IniFile::Find((double *)result, linearUnitsMap, tag, section, num));
+    return(IniFile::Find(result, linearUnitsMap, tag, section, num));
 }
 
 
@@ -108,5 +108,5 @@ EmcIniFile::ErrorCode
 EmcIniFile::FindAngularUnits(EmcAngularUnits *result,
                  const char *tag, const char *section, int num)
 {
-    return(IniFile::Find((double *)result, angularUnitsMap, tag, section, num));
+    return(IniFile::Find(result, angularUnitsMap, tag, section, num));
 }

--- a/src/emc/nml_intf/emc.hh
+++ b/src/emc/nml_intf/emc.hh
@@ -470,7 +470,7 @@ enum EmcJointType {
  * Set the units conversion factor.
  * @see EMC_JOINT_SET_INPUT_SCALE
  */
-typedef double                  EmcLinearUnits;
-typedef double                  EmcAngularUnits;
+using EmcLinearUnits = double;
+using EmcAngularUnits = double;
 
 #endif				// #ifndef EMC_HH

--- a/src/emc/rs274ngc/interp_queue.cc
+++ b/src/emc/rs274ngc/interp_queue.cc
@@ -650,7 +650,7 @@ int Interp::move_endpoint_and_flush(setup_pointer settings, double x, double y) 
                 break;
             default:
                 ERS(_("BUG: Unsupported plane [%d] in cutter compensation"),
-			settings->plane);
+			static_cast<int>(settings->plane));
             }
 
             dot = x1 * x2 + y1 * y2;

--- a/src/emc/tooldata/tooldata.hh
+++ b/src/emc/tooldata/tooldata.hh
@@ -27,7 +27,7 @@
 #include "canon.hh"
 #include "emc_nml.hh"
 
-#ifdef CPLUSPLUS
+#ifdef __cplusplus
 extern"C" {
 #endif
 
@@ -101,7 +101,7 @@ int   tooldata_db_notify(tool_notify_t ntype,
                          int pocketno,
                          CANON_TOOL_TABLE tdata);
 int   tooldata_db_getall(void);
-#ifdef CPLUSPLUS
+#ifdef __cplusplus
 }
 
 #endif


### PR DESCRIPTION
The commits are:
- Cast enum to int, when printing value
- Change to standard `__cplusplus`
- Change from typedef to using