### PR TITLE
limit_axis - Don't check range if not enabled

### DIFF
--- a/src/hal/components/limit_axis.comp
+++ b/src/hal/components/limit_axis.comp
@@ -65,11 +65,11 @@ FUNCTION(_){
 
   // Check all ranges
   for (i = 0; i < personality; i++){
-    if (max_range(i) < min_range(i)){
-      if(! enable(i)){
-        continue;
-      }
+    if(! enable(i)){
+      continue;
+    }
 
+    if (max_range(i) < min_range(i)){
       // Throw Error and skip this range
       if (! error_range(i) ){
         rtapi_print_msg(RTAPI_MSG_ERR,


### PR DESCRIPTION
Enable check inside of an error check means if its disabled it'll only disable when there is an error