### PR TITLE
Virtual destructors and functions marked virtual and override

### DIFF
--- a/src/emc/canterp/canterp.cc
+++ b/src/emc/canterp/canterp.cc
@@ -68,41 +68,41 @@ static char the_command_args[LINELEN] = { 0 };	// just the args part
 class Canterp : public InterpBase {
 public:
     Canterp () : f(0) {}
-    char *error_text(int errcode, char *buf, size_t buflen);
-    char *stack_name(int index, char *buf, size_t buflen);
-    char *line_text(char *buf, size_t buflen);
-    char *file_name(char *buf, size_t buflen);
-    size_t line_length();
-    int sequence_number();
-    int ini_load(const char *inifile);
-    int init();
-    int execute();
-    int execute(const char *line);
-    int execute(const char *line, int line_number);
-    int synch();
-    int exit();
-    int open(const char *filename);
-    int read();
-    int read(const char *line);
-    int close();
-    int reset();
-    int line();
-    int call_level();
-    char *command(char *buf, size_t buflen);
-    char *file(char *buf, size_t buflen);
-    int on_abort(int reason, const char *message);
-    void active_g_codes(int active_gcodes[ACTIVE_G_CODES]);
-    void active_m_codes(int active_mcodes[ACTIVE_M_CODES]);
-    void active_settings(double active_settings[ACTIVE_SETTINGS]);
+    char *error_text(int errcode, char *buf, size_t buflen) override;
+    char *stack_name(int index, char *buf, size_t buflen) override;
+    char *line_text(char *buf, size_t buflen) override;
+    char *file_name(char *buf, size_t buflen) override;
+    size_t line_length() override;
+    int sequence_number() override;
+    int ini_load(const char *inifile) override;
+    int init() override;
+    int execute() override;
+    int execute(const char *line) override;
+    int execute(const char *line, int line_number) override;
+    int synch() override;
+    int exit() override;
+    int open(const char *filename) override;
+    int read() override;
+    int read(const char *line) override;
+    int close() override;
+    int reset() override;
+    int line() override;
+    int call_level() override;
+    char *command(char *buf, size_t buflen) override;
+    char *file(char *buf, size_t buflen) override;
+    int on_abort(int reason, const char *message) override;
+    void active_g_codes(int active_gcodes[ACTIVE_G_CODES]) override;
+    void active_m_codes(int active_mcodes[ACTIVE_M_CODES]) override;
+    void active_settings(double active_settings[ACTIVE_SETTINGS]) override;
     int active_modes(int g_codes[ACTIVE_G_CODES],
             int m_codes[ACTIVE_M_CODES],
             double settings[ACTIVE_SETTINGS],
-            StateTag const &tag);
-    int restore_from_tag(StateTag const &tag);
-    void print_state_tag(StateTag const &tag);
-    void set_loglevel(int level);
-    void set_loop_on_main_m99(bool state);
-    FILE* get_stdout() { return NULL; };
+            StateTag const &tag) override;
+    int restore_from_tag(StateTag const &tag) override;
+    void print_state_tag(StateTag const &tag) override;
+    void set_loglevel(int level) override;
+    void set_loop_on_main_m99(bool state) override;
+    FILE* get_stdout() override { return NULL; };
     FILE *f;
     char filename[PATH_MAX];
 };

--- a/src/emc/rs274ngc/interp_base.hh
+++ b/src/emc/rs274ngc/interp_base.hh
@@ -67,7 +67,7 @@ public:
     virtual void print_state_tag(StateTag const &tag) = 0;
     virtual void set_loglevel(int level) = 0;
     virtual void set_loop_on_main_m99(bool state) = 0;
-    FILE* get_stdout() { return stdout; };
+    virtual FILE* get_stdout() { return stdout; };
 };
 
 InterpBase *interp_from_shlib(const char *shlib);

--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -19,6 +19,7 @@ std::string to_string(T &d)
 ////////////////////////////////////////////////////////////////////////////////
 class motion_base {
 public:
+    virtual ~motion_base() = default;
     virtual void straight_move(std::complex<double> end)=0;
     virtual void straight_rapid(std::complex<double> end)=0;
     virtual void circular_move(bool ccw,std::complex<double> center,
@@ -46,6 +47,7 @@ protected:
 public:
     segment(double sz,double sx,double ez,double ex):start(sz,sx),end(ez,ex) {}
     segment(std::complex<double> s, std::complex<double> e):start(s),end(e) {}
+    virtual ~segment() = default;
     typedef std::deque<double> intersections_t;
     virtual void intersection_z(double x, intersections_t &is)=0;
     virtual bool climb(std::complex<double>&, motion_base*)=0;

--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -233,12 +233,12 @@ public:
 	center=conj(center); }
     void flip_real() override { ccw=!ccw; start=-conj(start);
 	end=-conj(end); center=-conj(center); }
-    virtual void rotate() override {
+    void rotate() override {
 	start=-start*I;
 	end=-end*I;
 	center=-center*I;
     }
-    virtual bool monotonic() override {
+    bool monotonic() override {
 	if(finish!=0)
 	    return true;
 	double entry=imag(start-center);
@@ -249,7 +249,7 @@ public:
 	else
 	    return entry<=1e-3 && exit<=1e-3 && dz<=-1e-3;
     }
-    virtual void move(std::complex<double> d) override { start+=d; center+=d; end+=d; }
+    void move(std::complex<double> d) override { start+=d; center+=d; end+=d; }
 private:
     bool on_segment(std::complex<double> p);
     friend class straight_segment;
@@ -518,7 +518,7 @@ class swapped_motion:public motion_base {
 public:
     swapped_motion(motion_base *motion):orig(motion) {
     }
-    virtual void straight_move(std::complex<double> end) override {
+    void straight_move(std::complex<double> end) override {
 	switch(swap) {
 	case 0: orig->straight_move(end); break;
 	case 1: orig->straight_move(-conj(end)); break;
@@ -530,7 +530,7 @@ public:
 	case 7: orig->straight_move(-I*end); break;
 	}
     }
-    virtual void straight_rapid(std::complex<double> end) override {
+    void straight_rapid(std::complex<double> end) override {
 	switch(swap) {
 	case 0: orig->straight_rapid(end); break;
 	case 1: orig->straight_rapid(-conj(end)); break;
@@ -542,7 +542,7 @@ public:
 	case 7: orig->straight_rapid(-I*end); break;
 	}
     }
-    virtual void circular_move(bool ccw,std::complex<double> center,
+    void circular_move(bool ccw,std::complex<double> center,
 	std::complex<double> end) override
     {
 	switch(swap) {
@@ -914,7 +914,7 @@ public:
     motion_machine(Interp *i, setup_pointer s, block_pointer b):
 	interp(i), settings(s), block(b) { }
 
-    void straight_move(std::complex<double> end) {
+    void straight_move(std::complex<double> end) override {
 	block->x_flag=1;
 	block->x_number=imag(end);
 	block->z_flag=1;
@@ -924,7 +924,7 @@ public:
 	    throw(r);
     }
 
-    void straight_rapid(std::complex<double> end)  {
+    void straight_rapid(std::complex<double> end) override  {
 	block->x_flag=1;
 	block->x_number=imag(end);
 	block->z_flag=1;
@@ -935,7 +935,7 @@ public:
     }
     void circular_move(bool ccw,std::complex<double> center,
 	std::complex<double> end
-    ) {
+    ) override {
 	block->x_flag=1;
 	block->x_number=imag(end);
 	block->z_flag=1;

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -24,40 +24,40 @@ class Interp : public InterpBase {
 
 public:
  Interp();
- ~Interp();
+ ~Interp() override;
 
 /* Interface functions to call to tell the interpreter what to do.
    Return values indicate status of execution.
    These functions may change the state of the interpreter. */
 
 // close the currently open NC code file
- int close();
+ int close() override;
 
 // execute a line of NC code
- int execute(const char *command);
- int execute();
+ int execute(const char *command) override;
+ int execute() override;
 
- int execute(const char *command, int line_no); //used for MDI calls to specify the pseudo MDI line number
+ int execute(const char *command, int line_no) override; //used for MDI calls to specify the pseudo MDI line number
 
 // stop running
- int exit();
+ int exit() override;
 
 // get ready to run
- int init();
- void set_loop_on_main_m99(bool state);
+ int init() override;
+ void set_loop_on_main_m99(bool state) override;
 
 // load a tool table
  int load_tool_table();
 
 // open a file of NC code
- int open(const char *filename);
+ int open(const char *filename) override;
 
 // read the mdi or the next line of the open NC code file
- int read(const char *mdi);
- int read();
+ int read(const char *mdi) override;
+ int read() override;
 
 // reset yourself
- int reset();
+ int reset() override;
 
 // restore interpreter variables from a file
  int restore_parameters(const char *filename);
@@ -67,7 +67,7 @@ public:
                                     const double parameters[]);
 
 // synchronize your internal model with the external world
- int synch();
+ int synch() override;
 
 /* Interface functions to call to get information from the interpreter.
    If a function has a return value, the return value contains the information.
@@ -76,66 +76,67 @@ public:
    the interpreter. */
 
 // copy active G-codes into array [0]..[15]
- void active_g_codes(int *codes);
+ void active_g_codes(int *codes) override;
 
 // copy active M-codes into array [0]..[9]
- void active_m_codes(int *codes);
+ void active_m_codes(int *codes) override;
 
 // copy active F, S settings into array [0]..[2]
- void active_settings(double *settings);
+ void active_settings(double *settings) override;
 
     // Update the state vectors from a state tag
     int active_modes(int *g_codes,
 		     int *mcodes,
 		     double *settings,
-		     StateTag const &tag);
+		     StateTag const &tag) override;
 
     // Print contents of state tag for debugging
-    void print_state_tag(StateTag const &tag);
+    void print_state_tag(StateTag const &tag) override;
 
 // copy the text of the error message whose number is error_code into the
 // error_text array, but stop at max_size if the text is longer.
  char *error_text(int error_code, char *error_text,
-                                size_t max_size);
+                                size_t max_size) override;
 
  void setError(const char *fmt, ...) __attribute__((format(printf,2,3)));
 
 // copy the name of the currently open file into the file_name array,
 // but stop at max_size if the name is longer
- char *file_name(char *file_name, size_t max_size);
+ char *file_name(char *file_name, size_t max_size) override;
 
 // return the length of the most recently read line
- size_t line_length();
+ size_t line_length() override;
 
 // copy the text of the most recently read line into the line_text array,
 // but stop at max_size if the text is longer
- char *line_text(char *line_text, size_t max_size);
+ char *line_text(char *line_text, size_t max_size) override;
 
 // return the current sequence number (how many lines read)
- int sequence_number();
+ int sequence_number() override;
 
 // copy the function name from the stack_index'th position of the
 // function call stack at the time of the most recent error into
 // the function name string, but stop at max_size if the name is longer
  char *stack_name(int stack_index, char *function_name,
-                                size_t max_size);
+                                size_t max_size) override;
 
 // Get the parameter file name from the INI file.
- int ini_load(const char *filename);
+ int ini_load(const char *filename) override;
 
- int line() { return sequence_number(); }
- int call_level();
+ int line() override { return sequence_number(); }
+ int call_level() override;
 
- char *command(char *buf, size_t len) { line_text(buf, len); return buf; }
+ char *command(char *buf, size_t len) override { line_text(buf, len); return buf; }
 
- char *file(char *buf, size_t len) { file_name(buf, len); return buf; }
+ char *file(char *buf, size_t len) override { file_name(buf, len); return buf; }
 
  int init_tool_parameters();
  int default_tool_parameters();
  int set_tool_parameters();
- int on_abort(int reason, const char *message);
 
-    void set_loglevel(int level);
+ int on_abort(int reason, const char *message) override;
+
+    void set_loglevel(int level) override;
 
     // for now, public - for boost.python access
  int find_named_param(const char *nameBuf, int *status, double *value);
@@ -469,7 +470,7 @@ int read_dollar(char *line, int *counter, block_pointer block,
     int free_named_parameters(context_pointer frame);
  int save_settings(setup_pointer settings);
  int restore_settings(setup_pointer settings, int from_level);
- int restore_from_tag(StateTag const &tag);
+ int restore_from_tag(StateTag const &tag) override;
  int gen_settings(
      int *int_current, int *int_saved,
      double *float_current, double *float_saved,


### PR DESCRIPTION
https://github.com/LinuxCNC/linuxcnc/commit/0202d13d46b0a73e5542d7dc258eb655c64da62e squashes some compiler warnings with Clang.

https://github.com/LinuxCNC/linuxcnc/commit/0202d13d46b0a73e5542d7dc258eb655c64da62e is more modernizing the code base.