### PR TITLE
Reorder member variables in 'block_struct'

### DIFF
--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -426,83 +426,82 @@ typedef int_remap_map::iterator int_remap_iterator;
 
 struct block_struct
 {
-  block_struct ();
+  char comment[256]{};
+  double a_number{};
+  double b_number{};
+  double c_number{};
+  double d_number_float{};
+  double e_number{};
+  double f_number{};
+  int h_number{};
+  double i_number{};
+  double j_number{};
+  double k_number{};
+  int l_number{};
+  int n_number{};
+  double p_number{};
+  double q_number{};
+  double r_number{};
+  double s_number{};
+  int t_number{};
+  double u_number{};
+  double v_number{};
+  double w_number{};
+  double x_number{};
+  double y_number{};
+  double z_number{};
 
-  bool a_flag;
-  double a_number;
-  bool b_flag;
-  double b_number;
-  bool c_flag;
-  double c_number;
-  char comment[256];
-  double d_number_float;
-  bool d_flag;
-  int dollar_number;
-  bool dollar_flag;
-  bool e_flag;
-  double e_number;
-  bool f_flag;
-  double f_number;
+  int line_number{};
+  int saved_line_number{};  // value of sequence_number when a remap was encountered
+  int motion_to_be{};
+  int m_count{};
+  int m_modes[11]{};
+  int user_m{};
+  int dollar_number{};
+  int g_modes[GM_MAX_MODAL_GROUPS]{};
 
-  int g_modes[GM_MAX_MODAL_GROUPS];
+  bool a_flag{};
+  bool b_flag{};
+  bool c_flag{};
+  bool d_flag{};
+  bool e_flag{};
+  bool f_flag{};
+  bool h_flag{};
+  bool i_flag{};
+  bool j_flag{};
+  bool k_flag{};
+  bool l_flag{};
+  bool p_flag{};
+  bool q_flag{};
+  bool r_flag{};
+  bool s_flag{};
+  bool t_flag{};
+  bool u_flag{};
+  bool v_flag{};
+  bool w_flag{};
+  bool x_flag{};
+  bool y_flag{};
+  bool z_flag{};
 
-  bool h_flag;
-  int h_number;
-  bool i_flag;
-  double i_number;
-  bool j_flag;
-  double j_number;
-  bool k_flag;
-  double k_number;
-  int l_number;
-  bool l_flag;
-  int line_number;
-  int saved_line_number;  // value of sequence_number when a remap was encountered
-  int n_number;
-  int motion_to_be;
-  int m_count;
-  int m_modes[11];
-  int user_m;
-  double p_number;
-  bool p_flag;
-  double q_number;
-  bool q_flag;
-  bool r_flag;
-  double r_number;
-  bool s_flag;
-  double s_number;
-  bool t_flag;
-  int t_number;
-  bool u_flag;
-  double u_number;
-  bool v_flag;
-  double v_number;
-  bool w_flag;
-  double w_number;
-  bool x_flag;
-  double x_number;
-  bool y_flag;
-  double y_number;
-  bool z_flag;
-  double z_number;
+  bool dollar_flag{};
 
-  int radius_flag;
-  double radius;
-  int theta_flag;
-  double theta;
+  double radius{};
+  double theta{};
+  int radius_flag{};
+  int theta_flag{};
 
   // control (o-word) stuff
-  long     offset;   // start of line in file
-  int      o_type;
-  int      call_type; // oword-sub, python oword-sub, remap
-  const char    *o_name;   // !!!KL be sure to free this
-  double   params[INTERP_SUB_PARAMS];
-  int param_cnt;
+  long     offset{};   // start of line in file
+  int      o_type{};
+  int      call_type{}; // oword-sub, python oword-sub, remap
+  const char    *o_name{};   // !!!KL be sure to free this
+  double   params[INTERP_SUB_PARAMS]{};
+  int param_cnt{};
 
   // bitmap of phases already executed
   // we have some 31 or so different steps in a block. We must remember
   // which one is done when we reexecute a block after a remap.
-  std::bitset<MAX_STEPS>  breadcrumbs;
+  std::bitset<MAX_STEPS>  breadcrumbs{};
 
 #define TICKOFF(step) block->breadcrumbs[step] = 1
 #define TODO(step) (block->breadcrumbs[step] == 0)
@@ -513,9 +512,9 @@ struct block_struct
     // there might be several remapped items in a block, but at any point
     // in time there's only one executing
     // conceptually blocks[1..n] are also the 'remap frames'
-    remap_pointer executing_remap; // refers to config descriptor
-    std::set<int> remappings; // all remappings in this block (enum phases)
-    int phase; // current remap execution phase
+    remap_pointer executing_remap{}; // refers to config descriptor
+    std::set<int> remappings{}; // all remappings in this block (enum phases)
+    int phase{}; // current remap execution phase
 
     // the strategy to get the builtin behaviour of a code in a remap procedure is as follows:
     // if recursion is detected in find_remappings() (called by parse_line()), that *step* 
@@ -529,7 +528,7 @@ struct block_struct
     // referenced, which caused execution of the builtin semantics
     // reason for recording the fact: this permits an epilog to do the
     // right thing depending on whether the builtin was used or not.
-    bool builtin_used; 
+    bool builtin_used{};
 };
 
 // indicates which type of Python handler yielded, and needs reexecution

--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -188,24 +188,3 @@ setup::~setup() {
     assert(!pythis || Py_IsInitialized());
     if(pythis) delete pythis;
 }
-
-block_struct::block_struct ()
-    : a_flag(0), a_number(0), b_flag(0), b_number(0),
-      c_flag(0), c_number(0), comment{}, d_number_float(0), d_flag(0),
-      e_flag(0), e_number(0), f_flag(0), f_number(0),
-    g_modes{}, h_flag(0), h_number(0), i_flag(0), i_number(0),
-    j_flag(0), j_number(0), k_flag(0), k_number(0),
-    l_number(0), l_flag(0), line_number(0), saved_line_number(0),
-    n_number(0), motion_to_be(0), m_count(0), m_modes{},
-    p_number(0), p_flag(0), q_number(0), q_flag(0),
-    r_flag(0), r_number(0), s_flag(0), s_number(0),
-    t_flag(0), t_number(0), u_flag(0), u_number(0),
-    v_flag(0), v_number(0), w_flag(0), w_number(0),
-    x_flag(0), x_number(0), y_flag(0), y_number(0),
-    z_flag(0), z_number(0),
-
-    radius_flag(0), radius(0), theta_flag(0), theta(0),
-    offset(0), o_type(0), call_type(0), o_name(NULL),
-    params{}, param_cnt(0), breadcrumbs(),
-    executing_remap(NULL), remappings(), phase(0), builtin_used(0) {
-    }


### PR DESCRIPTION
The variables were arranged in alphabetical order, resulting in more than 10% of the total struct size being occupied by padding. However, by reorganizing the variables, the size was reduced from 1088 bytes to 960 bytes.

All variables is default initialized in the struct.