### PR TITLE
Restrict libgpiod to < 2.0.0 when configuring

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -3,6 +3,7 @@
 /.tmp_versions
 /Makefile.inc
 /Makefile.modinc
+/aclocal.m4
 /config.guess
 /config.h
 /config.log

--- a/src/autogen.sh
+++ b/src/autogen.sh
@@ -8,6 +8,7 @@ case :$AUTOGEN_TARGET: in
     [ -e config.guess ] || cp $automake_libdir/config.guess .
     [ -e config.sub ] || cp $automake_libdir/config.sub .
     [ -e install-sh ] || cp $automake_libdir/install-sh .
+    aclocal --force
     autoconf
     # autoconf only updates the timestamp if the output actually changed.
     # The target's timestamp must be updated or make is confused

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -80,7 +80,7 @@ AC_PATH_PROG(EGREP, egrep)
 #
 # check for pkg-config
 #
-AC_PATH_PROG([PKG_CONFIG], [pkg-config])
+PKG_PROG_PKG_CONFIG
 if test -z "$PKG_CONFIG"; then
   AC_MSG_ERROR([pkg-config is required to build LinuxCNC])
 fi

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -533,11 +533,12 @@ install with "sudo apt-get install libusb-1.0-0-dev" or disable with
 #
 # check for libgpiod
 #
-AC_MSG_CHECKING([for libgpiod])
-AC_CHECK_LIB(gpiod, main,
+PKG_CHECK_MODULES([LIBGPIOD], [libgpiod < 2.0.0],
             [AC_DEFINE_UNQUOTED([LIBGPIOD_VER], `pkg-config libgpiod --modversion | awk -F. '{print ($1 * 100)+($2) }'`,
             [libgpiod version, undefined if not present])
-            LDFLAGS="$LDFLAGS -lgpiod"
+            LDFLAGS="$LDFLAGS $LIBGPIOD_LIBS"
+            LIBGPIOD_VERSION=`pkg-config libgpiod --modversion`
+            AC_MSG_NOTICE([libgpiod version $LIBGPIOD_VERSION found])
             AC_SUBST([LIBGPIOD_VER], `pkg-config libgpiod --modversion | awk -F. '{print ($1 * 100)+($2) }'`)],
             [AC_MSG_WARN([Could not find libgpiod, not building hal_gpio])])
 


### PR DESCRIPTION
This restricts libgpiod to versions < 2.0.0. mainly to prevent build failures if the system has any later version installed, which LinuxCNC does not support.

This prevents build failure noticed in #2842 but does of course not do anything to support the new API.

Using pkg-config to do the heavy lifting.