### PR TITLE
GCode Graphics - Show Bounding box of part when not showing preview.

### DIFF
--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -15,19 +15,16 @@
 #    along with this program; if not, write to the Free Software
 #    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from rs274 import Translated, ArcsToSegmentsMixin, OpenGLTk
+from rs274 import Translated, ArcsToSegmentsMixin
 from OpenGL.GL import *
 from OpenGL.GLU import *
-import itertools
 import math
-import glnav
 import hershey
 import linuxcnc
 import array
 import gcode
 import os
 import re
-import sys
 from functools import reduce
 
 def minmax(*args):
@@ -1059,11 +1056,6 @@ class GlCanonDraw:
         lim_min = tuple(a-b for a,b in zip(lim_min, tlo_offset))
         lim_max = tuple(a-b for a,b in zip(lim_max, tlo_offset))
 
-        lim_pts = (
-                (lim_min[0], lim_min[1]),
-                (lim_max[0], lim_min[1]),
-                (lim_min[0], lim_max[1]),
-                (lim_max[0], lim_max[1]))
         if self.get_show_relative():
             cos_rot = math.cos(rotation)
             sin_rot = math.sin(rotation)
@@ -1450,7 +1442,6 @@ class GlCanonDraw:
 
         charwidth, linespace, base = self.get_font_info()
 
-        maxlen = max([len(p) for p in posstrs])
         pixel_width = charwidth * max(len(p) for p in posstrs)
 
         if self.show_overlay:
@@ -1753,7 +1744,7 @@ class GlCanonDraw:
     def draw_axes(self, n, letters="XYZ"):
         glNewList(n, GL_COMPILE)
         x,y,z,p = 0,1,2,3
-        s = self.stat
+
         view = self.get_view()
 
 
@@ -1872,16 +1863,12 @@ class GlCanonDraw:
 
             sinmax = math.sin(max_angle)
             cosmax = math.cos(max_angle)
-            tanmax = math.cos(max_angle)
             sinmin = math.sin(min_angle)
             cosmin = math.cos(min_angle)
-            tanmin = math.cos(min_angle)
 
             circleminangle = - math.pi/2 + min_angle
             circlemaxangle = - 3*math.pi/2 + max_angle
-            d0 = 0
 
-            x1 = (w - d0)
 
             sz = max(w, 3*radius)
 
@@ -1891,7 +1878,6 @@ class GlCanonDraw:
                 0,
                 radius * dy + radius * math.cos(circleminangle) + sz * cosmin)
             for i in range(37):
-                #t = circleminangle + i * (circlemaxangle - circleminangle)/36.
                 t = circleminangle + i * (circlemaxangle - circleminangle)/36.
                 glVertex3f(radius*dx + radius * math.sin(t), 0.0, radius*dy + radius * math.cos(t))
 

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -392,7 +392,7 @@ class GLCanon(Translated, ArcsToSegmentsMixin):
         glEnd()
         for line in self.dwells:
             if line[0] != lineno: continue
-            self.draw_dwells([(line[0], c) + line[2:]], 2, 0)
+            self.draw_dwells([(line[0], *self.colors['selected']) + line[2:]], 2, 0)
             coords.append(line[2:5])
         glLineWidth(1)
         if coords:

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -613,14 +613,14 @@ class GlCanonDraw:
         glMatrixMode(GL_MODELVIEW)
 
     def dlist(self, listname, n=1, gen=lambda n: None):
-        if name not in self._dlists:
+        if listname not in self._dlists:
             base = glGenLists(n)
             self._dlists[listname] = base, n
             gen(base)
         return self._dlists[listname][0]
 
     def stale_dlist(self, listname):
-        if name not in self._dlists: return
+        if listname not in self._dlists: return
         base, count = self._dlists.pop(listname)
         glDeleteLists(base, count)
 

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -525,7 +525,9 @@ class GlCanonDraw:
             pass
 
     def set_cone_basesize(self, size):
-        if size >2 or size < .025: size =.5
+        if size > 2 or size < .025:
+            size = 0.5
+            print("Invalid Cone Base size resetting to 0.5")
         self.cone_basesize = size
         self._redraw()
 
@@ -1032,12 +1034,7 @@ class GlCanonDraw:
                 t0, t1 = times[0], times[1] # Take the only two times
             x0, y0 = p0[0] + delta[0]*t0, p0[1] + delta[1]*t0
             x1, y1 = p0[0] + delta[0]*t1, p0[1] + delta[1]*t1
-            xm, ym = (x0+x1)/2, (y0+y1)/2
-            # The computation of k0 and k1 above should mean that
-            # the lines are always in the limits, but I observed
-            # that this wasn't always the case...
-            #if xm < lim_min[0] or xm > lim_max[0]: continue
-            #if ym < lim_min[1] or ym > lim_max[1]: continue
+
             glVertex3f(*inverse_permutation((x0, y0, lim_min[2])))
             glVertex3f(*inverse_permutation((x1, y1, lim_min[2])))
 

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -269,7 +269,7 @@ class GLCanon(Translated, ArcsToSegmentsMixin):
         self.xo = xo
         self.yo = yo
         self.zo = zo
-        self.so = ao
+        self.ao = ao
         self.bo = bo
         self.co = co
         self.uo = uo

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -1285,7 +1285,10 @@ class GlCanonDraw:
 
             if self.get_show_extents():
                 self.show_extents()
-                self.draw_bounding_box()
+        else:
+            self.show_extents()
+            self.draw_bounding_box()
+
         try:
             self.user_plot()
         except:
@@ -1294,8 +1297,8 @@ class GlCanonDraw:
 
             alist = self.dlist(('axes', self.get_view()), gen=self.draw_axes)
             glPushMatrix()
-            if self.get_show_relative() and (s.g5x_offset[0] or s.g5x_offset[1] or s.g5x_offset[2] or
-                                             s.g92_offset[0] or s.g92_offset[1] or s.g92_offset[2] or
+            if self.get_show_relative() and (s.g5x_offset[X] or s.g5x_offset[Y] or s.g5x_offset[Z] or
+                                             s.g92_offset[X] or s.g92_offset[Y] or s.g92_offset[Z] or
                                              s.rotation_xy):
                 olist = self.dlist('draw_small_origin',
                                         gen=self.draw_small_origin)
@@ -1305,7 +1308,7 @@ class GlCanonDraw:
                 g92_offset = self.to_internal_units(s.g92_offset)[:3]
 
 
-                if self.get_show_offsets() and (g5x_offset[0] or g5x_offset[1] or g5x_offset[2]):
+                if self.get_show_offsets() and (g5x_offset[X] or g5x_offset[Y] or g5x_offset[Z]):
                     glBegin(GL_LINES)
                     glVertex3f(0,0,0)
                     glVertex3f(*g5x_offset)

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -951,6 +951,65 @@ class GlCanonDraw:
             self.hershey.plot_string(f, .5)
             glPopMatrix()
 
+    def draw_cube(self, min_extents, max_extents, color=(1, 1, 1)):
+        """
+        Draw a cube
+        :param min_extents: Tuple of X,Y,Z Minimum Limits
+        :param max_extents: Tuple of X,Y,Z Maximum Limits
+        :param color: Tuple of RGB color values
+        """
+        glColor3f(color[0], color[1], color[2])
+        glBegin(GL_LINES)
+        # Bottom of part bounding box
+        glVertex3f(min_extents[X], min_extents[Y], min_extents[Z])
+        glVertex3f(max_extents[X], min_extents[Y], min_extents[Z])
+
+        glVertex3f(max_extents[X], min_extents[Y], min_extents[Z])
+        glVertex3f(max_extents[X], max_extents[Y], min_extents[Z])
+
+        glVertex3f(max_extents[X], max_extents[Y], min_extents[Z])
+        glVertex3f(min_extents[X], max_extents[Y], min_extents[Z])
+
+        glVertex3f(min_extents[X], max_extents[Y], min_extents[Z])
+        glVertex3f(min_extents[X], min_extents[Y], min_extents[Z])
+
+        # Top of part bounding box
+        glVertex3f(min_extents[X], min_extents[Y], max_extents[Z])
+        glVertex3f(max_extents[X], min_extents[Y], max_extents[Z])
+
+        glVertex3f(max_extents[X], min_extents[Y], max_extents[Z])
+        glVertex3f(max_extents[X], max_extents[Y], max_extents[Z])
+
+        glVertex3f(max_extents[X], max_extents[Y], max_extents[Z])
+        glVertex3f(min_extents[X], max_extents[Y], max_extents[Z])
+
+        glVertex3f(min_extents[X], max_extents[Y], max_extents[Z])
+        glVertex3f(min_extents[X], min_extents[Y], max_extents[Z])
+
+        # Middle connections
+        glVertex3f(min_extents[X], min_extents[Y], min_extents[Z])
+        glVertex3f(min_extents[X], min_extents[Y], max_extents[Z])
+
+        glVertex3f(max_extents[X], min_extents[Y], min_extents[Z])
+        glVertex3f(max_extents[X], min_extents[Y], max_extents[Z])
+
+        glVertex3f(max_extents[X], max_extents[Y], min_extents[Z])
+        glVertex3f(max_extents[X], max_extents[Y], max_extents[Z])
+
+        glVertex3f(min_extents[X], max_extents[Y], min_extents[Z])
+        glVertex3f(min_extents[X], max_extents[Y], max_extents[Z])
+
+        glEnd()
+
+    def draw_bounding_box(self):
+        """Draw a bounding box around the extents of the program if we skip loading the entire part."""
+        g = self.canon
+
+        if g is None:
+            return
+
+        self.draw_cube(g.min_extents, g.max_extents, color=(0.57, 0.68, 0.71))
+
     def to_internal_linear_unit(self, v, unit=None):
         if unit is None:
             unit = self.stat.linear_units
@@ -1226,6 +1285,7 @@ class GlCanonDraw:
 
             if self.get_show_extents():
                 self.show_extents()
+                self.draw_bounding_box()
         try:
             self.user_plot()
         except:
@@ -1305,50 +1365,10 @@ class GlCanonDraw:
             glPopMatrix()
 
         if self.get_show_limits():
-            glTranslatef(*[-x for x in self.to_internal_units(s.tool_offset)[:3]])
+            glTranslatef(*[-pos for pos in self.to_internal_units(s.tool_offset)[:3]])
             glLineWidth(1)
-            glColor3f(*self.colors['limits'])
-            glBegin(GL_LINES)
+            self.draw_cube(machine_limit_min, machine_limit_max, color=self.colors['limits'])
 
-            glVertex3f(machine_limit_min[0], machine_limit_min[1], machine_limit_max[2])
-            glVertex3f(machine_limit_min[0], machine_limit_min[1], machine_limit_min[2])
-
-            glVertex3f(machine_limit_min[0], machine_limit_min[1], machine_limit_min[2])
-            glVertex3f(machine_limit_min[0], machine_limit_max[1], machine_limit_min[2])
-
-            glVertex3f(machine_limit_min[0], machine_limit_max[1], machine_limit_min[2])
-            glVertex3f(machine_limit_min[0], machine_limit_max[1], machine_limit_max[2])
-
-            glVertex3f(machine_limit_min[0], machine_limit_max[1], machine_limit_max[2])
-            glVertex3f(machine_limit_min[0], machine_limit_min[1], machine_limit_max[2])
-
-
-            glVertex3f(machine_limit_max[0], machine_limit_min[1], machine_limit_max[2])
-            glVertex3f(machine_limit_max[0], machine_limit_min[1], machine_limit_min[2])
-
-            glVertex3f(machine_limit_max[0], machine_limit_min[1], machine_limit_min[2])
-            glVertex3f(machine_limit_max[0], machine_limit_max[1], machine_limit_min[2])
-
-            glVertex3f(machine_limit_max[0], machine_limit_max[1], machine_limit_min[2])
-            glVertex3f(machine_limit_max[0], machine_limit_max[1], machine_limit_max[2])
-
-            glVertex3f(machine_limit_max[0], machine_limit_max[1], machine_limit_max[2])
-            glVertex3f(machine_limit_max[0], machine_limit_min[1], machine_limit_max[2])
-
-
-            glVertex3f(machine_limit_min[0], machine_limit_min[1], machine_limit_min[2])
-            glVertex3f(machine_limit_max[0], machine_limit_min[1], machine_limit_min[2])
-
-            glVertex3f(machine_limit_min[0], machine_limit_max[1], machine_limit_min[2])
-            glVertex3f(machine_limit_max[0], machine_limit_max[1], machine_limit_min[2])
-
-            glVertex3f(machine_limit_min[0], machine_limit_max[1], machine_limit_max[2])
-            glVertex3f(machine_limit_max[0], machine_limit_max[1], machine_limit_max[2])
-
-            glVertex3f(machine_limit_min[0], machine_limit_min[1], machine_limit_max[2])
-            glVertex3f(machine_limit_max[0], machine_limit_min[1], machine_limit_max[2])
-
-            glEnd()
             glTranslatef(*self.to_internal_units(s.tool_offset)[:3])
 
         if self.get_show_live_plot():

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -583,21 +583,19 @@ class GlCanonDraw:
         glMultMatrixd(pmatrix)
         glMatrixMode(GL_MODELVIEW)
 
-        while 1:
-            glSelectBuffer(self.select_buffer_size)
-            glRenderMode(GL_SELECT)
-            glInitNames()
-            glPushName(0)
+        glSelectBuffer(self.select_buffer_size)
+        glRenderMode(GL_SELECT)
+        glInitNames()
+        glPushName(0)
 
-            if self.get_show_rapids():
-                glCallList(self.dlist('select_rapids', gen=self.make_selection_list))
-            glCallList(self.dlist('select_norapids', gen=self.make_selection_list))
+        if self.get_show_rapids():
+            glCallList(self.dlist('select_rapids', gen=self.make_selection_list))
+        glCallList(self.dlist('select_norapids', gen=self.make_selection_list))
 
-            try:
-                buffer = glRenderMode(GL_RENDER)
-            except:
-                buffer = []
-            break
+        try:
+            buffer = glRenderMode(GL_RENDER)
+        except:
+            buffer = []
 
         if buffer:
             min_depth, max_depth, names = (buffer[0].near, buffer[0].far, buffer[0].names)

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -1336,7 +1336,7 @@ class GlCanonDraw:
                 glRotatef(s.rotation_xy, 0, 0, 1)
 
 
-                if  self.get_show_offsets() and (g92_offset[0] or g92_offset[1] or g92_offset[2]):
+                if  self.get_show_offsets() and (g92_offset[X] or g92_offset[Y] or g92_offset[Z]):
                     glBegin(GL_LINES)
                     glVertex3f(0,0,0)
                     glVertex3f(*g92_offset)
@@ -1345,11 +1345,11 @@ class GlCanonDraw:
                     glPushMatrix()
                     glScalef(0.2,0.2,0.2)
                     if self.is_lathe():
-                        g92rot=math.atan2(g92_offset[0], -g92_offset[2])
+                        g92rot=math.atan2(g92_offset[X], -g92_offset[Z])
                         glRotatef(90, 1, 0, 0)
                         glRotatef(-90, 0, 0, 1)
                     else:
-                        g92rot=math.atan2(g92_offset[1], g92_offset[0])
+                        g92rot=math.atan2(g92_offset[Y], g92_offset[X])
                     glRotatef(math.degrees(g92rot), 0, 0, 1)
                     glTranslatef(0.5, 0.5, 0)
                     self.hershey.plot_string("G92", 0.1)

--- a/lib/python/rs274/glcanon.py
+++ b/lib/python/rs274/glcanon.py
@@ -97,7 +97,7 @@ VP = 3
 
 class GLCanon(Translated, ArcsToSegmentsMixin):
     lineno = -1
-    def __init__(self, colors, geometry, is_foam=0):
+    def __init__(self, colors, geometry, is_foam=0, foam_w=1.5, foam_z=0.0):
         # traverse list of tuples - [(line number, (start position), (end position), (tlo x, tlo y, tlo z))]
         self.traverse = []
         # feed list of tuples - [(line number, (start position), (end position), feedrate, (tlo x, tlo y, tlo z))]
@@ -153,8 +153,8 @@ class GLCanon(Translated, ArcsToSegmentsMixin):
         self.g5x_offset_v = 0.0
         self.g5x_offset_w = 0.0
         self.is_foam = is_foam
-        self.foam_z = 0
-        self.foam_w = 1.5
+        self.foam_z = foam_z
+        self.foam_w = foam_w
         self.notify = 0
         self.notify_message = ""
         self.highlight_line = None
@@ -515,6 +515,9 @@ class GlCanonDraw:
         self.enable_dro = True
         self.cone_basesize = .5
         self.show_small_origin = True
+        self.foam_w_height = 1.5
+        self.foam_z_height = 0
+
         try:
             if os.environ["INI_FILE_NAME"]:
                 self.inifile = linuxcnc.ini(os.environ["INI_FILE_NAME"])
@@ -535,6 +538,8 @@ class GlCanonDraw:
                     else:
                         self.dro_mm = temp
                         self.dro_in = temp
+                self.foam_w_height = float(self.ini_file.find("[DISPLAY]", "FOAM_W") or 1.5)
+                self.foam_z_height = float(self.ini_file.find("[DISPLAY]", "FOAM_Z") or 0)
                 size = (self.inifile.find("DISPLAY", "CONE_BASESIZE") or None)
                 if size is not None:
                     self.set_cone_basesize(float(size))
@@ -578,6 +583,8 @@ class GlCanonDraw:
 
     def set_canon(self, canon):
         self.canon = canon
+        self.canon.foam_z = self.foam_z_height
+        self.canon.foam_w = self.foam_w_height
 
     @with_context
     def basic_lighting(self):
@@ -1038,12 +1045,14 @@ class GlCanonDraw:
                 for i in range(3)]))
 
     def get_foam_z(self):
-        if self.canon: return self.canon.foam_z
-        return 0
+        if self.canon:
+            return self.canon.foam_z
+        return self.foam_z_height
 
     def get_foam_w(self):
-        if self.canon: return self.canon.foam_w
-        return 1.5
+        if self.canon:
+            return self.canon.foam_w
+        return self.foam_w_height
 
     def get_grid(self):
         if self.canon and self.canon.grid: return self.canon.grid


### PR DESCRIPTION
Some files >1000000 lines or so, take a lot of resources to preview. Replacing the preview with a bounding box heavily reduces this issue.

While trying to find a good solution, IDE's are screaming at errors in this file, which I tried only addressing severe ones, such as reusing variables, while loop that was removed, unused imports, using builtin names, removed unused variables.

I tested with axis, qtdragon, our own gui. Foam and Mill versions. 



