### PR TITLE
Encapsulate static arrays, rename function and remove header files

### DIFF
--- a/docs/src/gcode/overview.adoc
+++ b/docs/src/gcode/overview.adoc
@@ -245,7 +245,7 @@ Persistence:: When LinuxCNC is shut down, volatile parameters lose their
 values. All parameters except numbered parameters in the current
 persistent range footnote:[persistent_range,The range of persistent
 parameters may change as development progresses. This range is
-currently 5161- 5390. It is defined in the '_required_parameters array'
+currently 5161- 5390. It is defined in the 'required_parameters array'
 in file the src/emc/rs274ngc/interp_array.cc .]  are volatile.
 Persistent parameters are saved in the .var file and
 restored to their previous values when LinuxCNC is started again. Volatile

--- a/src/emc/rs274ngc/interp_array.cc
+++ b/src/emc/rs274ngc/interp_array.cc
@@ -10,18 +10,9 @@
 *    
 * Copyright (c) 2004 All rights reserved.
 ********************************************************************/
-#include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <math.h>
-#include <string.h>
-#include <ctype.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include "rs274ngc.hh"
+
 #include "rs274ngc_return.hh"
 #include "rs274ngc_interp.hh"
-#include "interp_parameter_def.hh"
 
 using namespace interp_param_global;
 

--- a/src/emc/rs274ngc/interp_array.cc
+++ b/src/emc/rs274ngc/interp_array.cc
@@ -25,7 +25,7 @@
 
 using namespace interp_param_global;
 
-/* Interpreter global arrays for g_codes and m_codes. The nth entry
+/* Interpreter arrays for g_codes and m_codes. The nth entry
 in each array is the modal group number corresponding to the nth
 code. Entries which are -1 represent illegal codes. Remember g_codes
 in this interpreter are multiplied by 10.
@@ -78,7 +78,7 @@ group 16 = {g92.2,g92.3}   - whether g92 offset is applied
 */
 // This stops indent from reformatting the following code.
 // *INDENT-OFF*
-const int Interp::_gees[] = {
+const int Interp::gees[] = {
 /*   0 */   1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
 /*  20 */   1,-1,-1,-1,-1,-1,-1,-1,-1,-1, 1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
 /*  40 */ //0,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
@@ -154,7 +154,7 @@ group 9 = {m48,m49,          - feed and speed override switch bypass
 group 10 = {m100..m199}      - user-defined
 */
 
-const int Interp::_ems[] = {
+const int Interp::ems[] = {
    4,  4,  4,  7,  7,  7,  6,  8,  8,  8,  //  9
   -1, -1, -1, -1, -1, -1, -1, -1, -1,  7,  // 19
   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,  // 29
@@ -185,7 +185,7 @@ Interp::save_parameters function.
 
 */
 
-const int Interp::_required_parameters[] = {
+const int Interp::required_parameters[] = {
  5161, 5162, 5163,   /* G28 home */
  5164, 5165, 5166, /* A, B, & C */
  5167, 5168, 5169, /* U, V, & W */
@@ -236,7 +236,7 @@ const int Interp::_required_parameters[] = {
  RS274NGC_MAX_PARAMETERS
 };
 
-const int Interp::_readonly_parameters[] = {
+const int Interp::readonly_parameters[] = {
  5400, // tool toolno
  5401, // tool x offset
  5402, // tool y offset
@@ -253,7 +253,7 @@ const int Interp::_readonly_parameters[] = {
  5413, // tool orientation
  5420, 5421, 5422, 5423, 5424, 5425, 5426, 5427, 5428, // current X Y ... W
 };
-const int Interp::_n_readonly_parameters = sizeof(_readonly_parameters)/sizeof(int);
+const int Interp::n_readonly_parameters = sizeof(readonly_parameters) / sizeof(int);
 
 /* _readers is an array of pointers to functions that read.
    It is used by read_one_item.
@@ -316,11 +316,3 @@ const read_function_pointer Interp::default_readers[256] = {
 // *INDENT-ON*
 // And now indent can continue.
 /****************************************************************************/
-
-/* There are four global variables*. The first three are _gees, _ems,
-and _readers. */
-
-/* The notion of "global variables" is a misnomer - These last four should only
-   be accessible by the interpreter and not exported to the rest of emc */
-
-

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -3956,12 +3956,12 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
         if(settings->selected_pocket > 0) {
             struct block_struct g43;
             init_block(&g43);
-            block->g_modes[_gees[G_43]] = G_43;
+            block->g_modes[gees[G_43]] = G_43;
             CHP(convert_tool_length_offset(G_43, &g43, settings));
         } else {
             struct block_struct g49;
             init_block(&g49);
-            block->g_modes[_gees[G_49]] = G_49;
+            block->g_modes[gees[G_49]] = G_49;
             CHP(convert_tool_length_offset(G_49, &g49, settings));
         }
     }

--- a/src/emc/rs274ngc/interp_read.cc
+++ b/src/emc/rs274ngc/interp_read.cc
@@ -2190,7 +2190,7 @@ int Interp::read_parameter_setting(
       CHP(read_integer_value(line, counter, &index, parameters));
       CHKS(((index < 1) || (index >= RS274NGC_MAX_PARAMETERS)),
           NCE_PARAMETER_NUMBER_OUT_OF_RANGE);
-      CHKS((isreadonly(index)), NCE_PARAMETER_NUMBER_READONLY);
+      CHKS((is_parameter_readonly(index)), NCE_PARAMETER_NUMBER_READONLY);
       CHKS((line[*counter] != '='),
           NCE_EQUAL_SIGN_MISSING_IN_PARAMETER_SETTING);
       *counter = (*counter + 1);
@@ -3454,11 +3454,10 @@ int Interp::read_z(char *line,   //!< string: line of RS274 code being processed
   return INTERP_OK;
 }
 
-bool Interp::isreadonly(int index)
+bool Interp::is_parameter_readonly(int index)
 {
-  int i;
-  for (i=0; i < n_readonly_parameters; i++) {
-    if (readonly_parameters[i] == index) return 1;
+  for (int i = 0; i < n_readonly_parameters; i++) {
+    if (readonly_parameters[i] == index) return true;
   }
-  return 0;
+  return false;
 }

--- a/src/emc/rs274ngc/interp_read.cc
+++ b/src/emc/rs274ngc/interp_read.cc
@@ -594,7 +594,7 @@ int Interp::read_g(char *line,   //!< string: line of RS274/NGC code being proce
       block->g_modes[mode] = value;
       return INTERP_OK;
   }
-  mode = _gees[value];
+  mode = gees[value];
   CHKS((mode == -1), NCE_UNKNOWN_G_CODE_USED);
   if ((value == G_80) && (block->g_modes[mode] != -1));
   else {
@@ -1133,7 +1133,7 @@ int Interp::read_m(char *line,   //!< string: line of RS274 code being processed
   }
 
   CHKS((value > 199), NCE_M_CODE_GREATER_THAN_199,value);
-  mode = _ems[value];
+  mode = ems[value];
   CHKS((mode == -1), NCE_UNKNOWN_M_CODE_USED,value);
   CHKS((block->m_modes[mode] != -1),
       NCE_TWO_M_CODES_USED_FROM_SAME_MODAL_GROUP);
@@ -3457,8 +3457,8 @@ int Interp::read_z(char *line,   //!< string: line of RS274 code being processed
 bool Interp::isreadonly(int index)
 {
   int i;
-  for (i=0; i< _n_readonly_parameters; i++) {
-    if (_readonly_parameters[i] == index) return 1;
+  for (i=0; i < n_readonly_parameters; i++) {
+    if (readonly_parameters[i] == index) return 1;
   }
   return 0;
 }

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -530,7 +530,6 @@ int read_dollar(char *line, int *counter, block_pointer block,
 		     StateTag &state);
  int write_canon_state_tag(block_pointer block, setup_pointer settings);
  int unwrap_rotary(double *, double, double, double, char);
- bool isreadonly(int index);
 
   // O_word stuff
 
@@ -719,6 +718,8 @@ int read_inputs(setup_pointer settings);
  InterpReturn check_g74_g84_spindle(GCodes motion, CANON_DIRECTION dir);
 
 private:
+    [[nodiscard]] static bool is_parameter_readonly(int index);
+
     static const int gees[];
     static const int ems[];
     static const int required_parameters[];

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -152,9 +152,6 @@ public:
  int find_tool_pocket(setup_pointer settings, int toolno, int *pocket);
  int find_tool_index(setup_pointer settings, int toolno, int *index);
 
-    // private:
-    //protected:  // for boost wrapper access
-
 /* Function prototypes for all  functions */
 
  int arc_data_comp_ijk(int move,
@@ -614,8 +611,8 @@ int read_inputs(setup_pointer settings);
 
     bool has_user_mcode(setup_pointer settings,block_pointer block);
 
-#define M_BUILTIN(m) (_ems[m] != -1)
-#define G_BUILTIN(g) (_gees[g] != -1)
+#define M_BUILTIN(m) (ems[m] != -1)
+#define G_BUILTIN(g) (gees[g] != -1)
 
     // range for user-remapped M-codes
     // and M6,M61
@@ -708,12 +705,6 @@ int read_inputs(setup_pointer settings);
 
  FILE *log_file;
 
-/* Internal arrays */
- static const int _gees[];
- static const int _ems[];
- static const int _required_parameters[];
- static const int _readonly_parameters[];
- static const int _n_readonly_parameters;
  read_function_pointer _readers[256];
  static const read_function_pointer default_readers[256];
 
@@ -726,6 +717,13 @@ int read_inputs(setup_pointer settings);
  };
 
  InterpReturn check_g74_g84_spindle(GCodes motion, CANON_DIRECTION dir);
+
+private:
+    static const int gees[];
+    static const int ems[];
+    static const int required_parameters[];
+    static const int readonly_parameters[];
+    static const int n_readonly_parameters;
 };
 
 #endif

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -1854,7 +1854,7 @@ int Interp::restore_parameters(const char *filename)   //!< name of parameter fi
   pars = _setup.parameters;
   k = 0;
   index = 0;
-  required = _required_parameters[index++];
+  required = required_parameters[index++];
   while (feof(infile) == 0) {
     if (fgets(line, 256, infile) == NULL) {
       break;
@@ -1871,13 +1871,13 @@ int Interp::restore_parameters(const char *filename)   //!< name of parameter fi
         } else if (k == variable) {
           pars[k] = value;
           if (k == required)
-            required = _required_parameters[index++];
+            required = required_parameters[index++];
           k++;
           break;
         } else                  // if (k < variable)
         {
           if (k == required)
-            required = _required_parameters[index++];
+            required = required_parameters[index++];
           pars[k] = 0;
         }
       }
@@ -1947,7 +1947,7 @@ int Interp::save_parameters(const char *filename,      //!< name of file to writ
 
   k = 0;
   index = 0;
-  required = _required_parameters[index++];
+  required = required_parameters[index++];
   while (feof(infile) == 0) {
     if (fgets(line, sizeof(line), infile) == NULL) {
       break;
@@ -1966,14 +1966,14 @@ int Interp::save_parameters(const char *filename,      //!< name of file to writ
           snprintf(line, sizeof(line), "%d\t%f\n", k, parameters[k]);
           fputs(line, outfile);
           if (k == required)
-            required = _required_parameters[index++];
+            required = required_parameters[index++];
           k++;
           break;
         } else if (k == required)       // know (k < variable)
         {
           snprintf(line, sizeof(line), "%d\t%f\n", k, parameters[k]);
           fputs(line, outfile);
-          required = _required_parameters[index++];
+          required = required_parameters[index++];
         }
       }
     }
@@ -1983,7 +1983,7 @@ int Interp::save_parameters(const char *filename,      //!< name of file to writ
     if (k == required) {
       snprintf(line, sizeof(line), "%d\t%f\n", k, parameters[k]);
       fputs(line, outfile);
-      required = _required_parameters[index++];
+      required = required_parameters[index++];
     }
   }
 


### PR DESCRIPTION
Move some of the `static const` arrays to the private section of the class, as the comments suggests. I also renamed the arrays, dropping the leading underscore.

Function `isreadonly()` is renamed to `is_parameter_readonly()`, made static and appended `nodiscard`.

For the removed header files, I would guess that the file was copied with the included headers untouched.