### PR TITLE
Update interp_g7x.cc fix endless loop issue (in axis and in milltask)

### DIFF
--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -1112,6 +1112,31 @@ int Interp::convert_g7x(int mode,
 		    if(old.ijk_distance_mode()==DISTANCE_MODE::INCREMENTAL)
 			center+=start;
 		}
+
+        /* Verify if circular motion is valid */
+        double tpx;
+        double tpy;
+        double tpz;
+        double tAA_p;
+        double tBB_p;
+        double tCC_p;
+        double tu_p;
+        double tv_p;
+        double tw_p;
+        CHP(find_ends(block, settings, &tpx, &tpy, &tpz, &tAA_p, &tBB_p, &tCC_p, &tu_p, &tv_p, &tw_p));
+
+        if(!block->r_flag){
+            double center1, center2;
+            int turn;
+            double radius_tolerance = (settings->length_units == CANON_UNITS_INCHES) ? RADIUS_TOLERANCE_INCH : RADIUS_TOLERANCE_MM;
+            double spiral_abs_tolerance = (settings->length_units == CANON_UNITS_INCHES) ? settings->center_arc_radius_tolerance_inch : settings->center_arc_radius_tolerance_mm;
+            CHP(arc_data_ijk((settings->motion_mode==30)? G_3 : G_2, settings->plane, settings->current_z, settings->current_x, tpz, tpx,
+                             (old.ijk_distance_mode() == DISTANCE_MODE::ABSOLUTE),
+                             (block->k_flag)? block->k_number : 0.0, (block->i_flag)? block->i_number : 0.0, block->p_flag? round_to_int(block->p_number) : 1,
+                             &center1, &center2, &turn, radius_tolerance, spiral_abs_tolerance, SPIRAL_RELATIVE_TOLERANCE));
+        }
+        /*************/
+
 		path.emplace_back(std::make_unique<round_segment>(
 		    settings->motion_mode==30, start, center, end
 		));

--- a/src/rtapi/uspace_xenomai.cc
+++ b/src/rtapi/uspace_xenomai.cc
@@ -1,7 +1,10 @@
 #include "config.h"
 #include "rtapi.h"
 #include "rtapi_uspace.hh"
-#include <posix/pthread.h>
+#include <pthread.h>
+#include  <errno.h>
+#include <stdio.h>
+#include <cstring>
 #include <atomic>
 #ifdef HAVE_SYS_IO_H
 #include <sys/io.h>


### PR DESCRIPTION
Fix issue where G7x is ussed with g3 and g2 inside, and circle has errors inside it, endless loop would occur eating all ram memory and freezing the machine

uspace_xenomai.cc:
Fix dependendencies on POSIX xenomai skin


Also there is another fix to implement but i will not pull request it as it will modify behaviour but is as follows:
When doing the g72 movement reset the control and start over, as G7x code modifies incremental i/k coordinates to absolute coordinates and they will not be back to default incremental, all countour profile will be treated as i/k absolute.
The solution is put in the beginning of the file a g91.1


you can test the following code to see the fix at work:

```
G54 g95 g18 G21 G7 g61 g91.1

t02
g97 s350 m4
g0 x120 z4 m8


o110 sub 
g1 X79.995 Z0
g3 x83.9549 z-1.7176 k-2
g1 x95.25 z-47.4
g1 z-62
g1 x99 z-68
O110 endsub
;o15 call

G71 X104 Z5 Q110 D0 I1.5 R2 F0.3
g0 x200 z100
m30
```


Regards
Franco
