### PR TITLE
Update interp_convert.cc: Fix missing G52/G92 reset on M2/M30

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -5224,8 +5224,11 @@ int Interp::convert_stop(block_pointer block,    //!< pointer to a block of RS27
     }
 
 /*10*/
+    // Clear active G92/G52 offset
+    SET_G92_OFFSET(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    settings->parameters[5210] = 0;
     if (settings->disable_g92_persistence)
-      // Clear G92/G52 offset
+      // Clear persistant G92/G52 offset values
       for (index=5210; index<=5219; index++)
           settings->parameters[index] = 0;
 


### PR DESCRIPTION
Current code does not reset G52/G92 offset to zero on M2/M30 this is contrary to RS274NGC standard:

https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=823374
![RS274NGC_m2](https://github.com/LinuxCNC/linuxcnc/assets/46067220/04452dee-6ce0-4eaf-83dc-b5c22b7cf4df)

and can lead to unexpected behavior due to automatic application of G52/G92 offsets on startup
![g92 note](https://github.com/LinuxCNC/linuxcnc/assets/46067220/0951d728-0b1c-4e8c-a7d8-d46db1133a7e)
