### PR TITLE
Update interp_convert.cc: fix broken G52/G92 reset on M2/M30

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -4681,9 +4681,34 @@ int Interp::convert_stop(block_pointer block,    //!< pointer to a block of RS27
     }
 
 /*10*/
+    // Clear active G92/G52 offset (same as G92.2 command)
+    settings->parameters[5210] = 0.0;
+	  
+    settings->current_x = settings->current_x + settings->axis_offset_x;
+    settings->current_y = settings->current_y + settings->axis_offset_y;
+    settings->current_z = settings->current_z + settings->axis_offset_z;
+    settings->AA_current = (settings->AA_current + settings->AA_axis_offset);
+    settings->BB_current = (settings->BB_current + settings->BB_axis_offset);
+    settings->CC_current = (settings->CC_current + settings->CC_axis_offset);
+    settings->u_current = (settings->u_current + settings->u_axis_offset);
+    settings->v_current = (settings->v_current + settings->v_axis_offset);
+    settings->w_current = (settings->w_current + settings->w_axis_offset);
+
+    SET_G92_OFFSET(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    settings->axis_offset_x = 0.0;
+    settings->axis_offset_y = 0.0;
+    settings->axis_offset_z = 0.0;
+    settings->AA_axis_offset = 0.0;
+    settings->BB_axis_offset = 0.0;
+    settings->CC_axis_offset = 0.0;
+    settings->u_axis_offset = 0.0;
+    settings->v_axis_offset = 0.0;
+    settings->w_axis_offset = 0.0;
+
     if (settings->disable_g92_persistence)
-      // Clear G92/G52 offset
-      for (index=5210; index<=5219; index++)
+      // Clear persistent G92/G52 offset values if persistence has been disabled in the ini
+      for (index=5211; index<=5219; index++)
           settings->parameters[index] = 0;
 
     if (block->m_modes[4] == 30)


### PR DESCRIPTION
Current code does not reset G52/G92 offset to zero on M2/M30 this is contrary to RS274NGC standard (see Point1 below):

https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=823374
![RS274NGC_m2](https://github.com/LinuxCNC/linuxcnc/assets/46067220/93744177-ab4e-41d6-8c82-2682cce5003b)


and can lead to unexpected behavior due to automatic application of G52/G92 offsets on startup:
https://linuxcnc.org/docs/html/gcode/coordinates.html#sec:g52
![g92 note](https://github.com/LinuxCNC/linuxcnc/assets/46067220/f7153f5e-fbb3-4c05-b9f7-6bdb98b01942)


Note: The inserted code is the same as is used for 'G92.2' in the same file:
 
![g92_code](https://github.com/LinuxCNC/linuxcnc/assets/46067220/691e36e5-706d-45fc-bde5-b1610e56f166)
