### PR TITLE
Update interp_convert.cc: fix broken G52/G92 reset on M2/M30

### DIFF
--- a/docs/src/config/ini-config.adoc
+++ b/docs/src/config/ini-config.adoc
@@ -538,7 +538,7 @@ The maximum number of `USER_M_PATH` directories is defined at compile time (typ:
 * `OWORD_WARNONLY = 0` (Default: 0) +
   Warn rather than error in case of errors in O-word subroutines.
 * `DISABLE_G92_PERSISTENCE = 0` (Default: 0)
-  Allow to clear the G92 offset automatically when config start-up.
+  When set, G92/G52 offset values in parameters 5211..5219 will be reset to zero on M2/M30 and shutdown.
 * `DISABLE_FANUC_STYLE_SUB = 0` (Default: 0)
   If there is reason to disable Fanuc subroutines set it to 1.
 

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -4681,9 +4681,34 @@ int Interp::convert_stop(block_pointer block,    //!< pointer to a block of RS27
     }
 
 /*10*/
+    // Clear active G92/G52 offset (same as G92.2 command)
+    settings->parameters[5210] = 0.0;
+	  
+    settings->current_x = settings->current_x + settings->axis_offset_x;
+    settings->current_y = settings->current_y + settings->axis_offset_y;
+    settings->current_z = settings->current_z + settings->axis_offset_z;
+    settings->AA_current = (settings->AA_current + settings->AA_axis_offset);
+    settings->BB_current = (settings->BB_current + settings->BB_axis_offset);
+    settings->CC_current = (settings->CC_current + settings->CC_axis_offset);
+    settings->u_current = (settings->u_current + settings->u_axis_offset);
+    settings->v_current = (settings->v_current + settings->v_axis_offset);
+    settings->w_current = (settings->w_current + settings->w_axis_offset);
+
+    SET_G92_OFFSET(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+
+    settings->axis_offset_x = 0.0;
+    settings->axis_offset_y = 0.0;
+    settings->axis_offset_z = 0.0;
+    settings->AA_axis_offset = 0.0;
+    settings->BB_axis_offset = 0.0;
+    settings->CC_axis_offset = 0.0;
+    settings->u_axis_offset = 0.0;
+    settings->v_axis_offset = 0.0;
+    settings->w_axis_offset = 0.0;
+
     if (settings->disable_g92_persistence)
-      // Clear G92/G52 offset
-      for (index=5210; index<=5219; index++)
+      // Clear persistent G92/G52 offset values if persistence has been disabled in the ini
+      for (index=5211; index<=5219; index++)
           settings->parameters[index] = 0;
 
     if (block->m_modes[4] == 30)


### PR DESCRIPTION
Current code does not reset G52/G92 offset to zero on M2/M30 this is contrary to RS274NGC standard (see Point1 below):

https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=823374

![RS274NGC_m2](https://github.com/LinuxCNC/linuxcnc/assets/46067220/d9a3de60-4e77-4b2d-b859-048ccc994dbb)


and can lead to unexpected behavior due to automatic application of G52/G92 offsets on startup:
https://linuxcnc.org/docs/html/gcode/coordinates.html#sec:g52
![g92 note](https://github.com/LinuxCNC/linuxcnc/assets/46067220/0cd1c65d-3be3-494a-9b6e-db48aceb603e)



Note: The inserted code is the same as is used for 'G92.2' in the same file:
 
![g92_code](https://github.com/LinuxCNC/linuxcnc/assets/46067220/ca45af46-97f8-4448-b697-99c4b0daba37)
