### PR TITLE
2.9 g92, fix tags in modalgroup 16 ('G92.[1,2,3]') and deactivate G92 on start-up

### DIFF
--- a/src/emc/rs274ngc/interp_write.cc
+++ b/src/emc/rs274ngc/interp_write.cc
@@ -123,7 +123,7 @@ int Interp::write_g_codes(block_pointer block,   //!< pointer to a block of RS27
     (settings->spindle_mode[0] == CONSTANT_RPM) ? G_97 : G_96;
   gez[14] = (settings->ijk_distance_mode == MODE_ABSOLUTE) ? G_90_1 : G_91_1;
   gez[15] = (settings->lathe_diameter_mode) ? G_7 : G_8;
-  gez[16] = (settings->parameters[5210])? G_92_3: G_92_2;
+  gez[16] = ((block == NULL) ? -1 : block->g_modes[16]);
   return INTERP_OK;
 }
 

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -1087,6 +1087,7 @@ int Interp::init()
       _setup.origin_index = 1;
       pars[5220] = 1.0;
   }
+  pars[5210] = 0.0;
 
   k = (5200 + (_setup.origin_index * 20));
   _setup.origin_offset_x = USER_TO_PROGRAM_LEN(pars[k + 1]);


### PR DESCRIPTION

see:
https://github.com/LinuxCNC/linuxcnc/issues/2743