### PR TITLE
Use array not pointer to array

### DIFF
--- a/src/emc/rs274ngc/interp_write.cc
+++ b/src/emc/rs274ngc/interp_write.cc
@@ -48,82 +48,80 @@ The correspondence between modal groups and array indexes is as follows
 The group 0 entry is taken from the block (if there is one), since its
 codes are not modal.
 
-group 0  - gez[2]  g4, g10, g28, g30, g53, g92 g92.1, g92.2, g92.3 - misc
-group 1  - gez[1]  g0, g1, g2, g3, g38.2, g80, g81, g82, g83, g84, g85,
-                   g86, g87, g88, g89 - motion
-group 2  - gez[3]  g17, g18, g19 - plane selection
-group 3  - gez[6]  g90, g91 - distance mode
-group 4  - gez[14] g90.1, g91.1 - IJK distance mode for arcs
-group 5  - gez[7]  g93, g94, g95 - feed rate mode
-group 6  - gez[5]  g20, g21 - units
-group 7  - gez[4]  g40, g41, g42 - cutter radius compensation
-group 8  - gez[9]  g43, g49 - tool length offse
+group 0  - array[2]  g4, g10, g28, g30, g53, g92 g92.1, g92.2, g92.3 - misc
+group 1  - array[1]  g0, g1, g2, g3, g38.2, g80, g81, g82, g83, g84, g85,
+                     g86, g87, g88, g89 - motion
+group 2  - array[3]  g17, g18, g19 - plane selection
+group 3  - array[6]  g90, g91 - distance mode
+group 4  - array[14] g90.1, g91.1 - IJK distance mode for arcs
+group 5  - array[7]  g93, g94, g95 - feed rate mode
+group 6  - array[5]  g20, g21 - units
+group 7  - array[4]  g40, g41, g42 - cutter radius compensation
+group 8  - array[9]  g43, g49 - tool length offset
 group 9  - no such group
-group 10 - gez[10] g98, g99 - return mode in canned cycles
+group 10 - array[10] g98, g99 - return mode in canned cycles
 group 11 - no such group
-group 12 - gez[8]  g54, g55, g56, g57, g58, g59, g59.1, g59.2, g59.3
-                   - coordinate system
-group 13 - gez[11] g61, g61.1, g64 - control mode
-group 14 - gez[12] g50, g51 - adaptive feed mode
-group 15 - gez[13] g96, g97 - spindle speed mode
-group 16 - gez[15] g7,g8 - lathe diameter mode
+group 12 - array[8]  g54, g55, g56, g57, g58, g59, g59.1, g59.2, g59.3
+                     - coordinate system
+group 13 - array[11] g61, g61.1, g64 - control mode
+group 14 - array[12] g50, g51 - adaptive feed mode
+group 15 - array[13] g96, g97 - spindle speed mode
+group 16 - array[15] g7,g8 - lathe diameter mode
 
 */
 
 int Interp::write_g_codes(block_pointer block,   //!< pointer to a block of RS274/NGC instructions
                          setup_pointer settings)        //!< pointer to machine settings                 
 {
-  int *gez;
-
-  gez = settings->active_g_codes;
-  gez[0] = settings->sequence_number;
-  gez[1] = settings->motion_mode;
-  gez[2] = ((block == NULL) ? -1 : block->g_modes[0]);
+  settings->active_g_codes[0] = settings->sequence_number;
+  settings->active_g_codes[1] = settings->motion_mode;
+  settings->active_g_codes[2] = ((block == NULL) ? -1 : block->g_modes[0]);
   switch(settings->plane) {
   case CANON_PLANE::XY:
-      gez[3] = G_17;
+      settings->active_g_codes[3] = G_17;
       break;
   case CANON_PLANE::XZ:
-      gez[3] = G_18;
+      settings->active_g_codes[3] = G_18;
       break;
   case CANON_PLANE::YZ:
-      gez[3] = G_19;
+      settings->active_g_codes[3] = G_19;
       break;
   case CANON_PLANE::UV:
-      gez[3] = G_17_1;
+      settings->active_g_codes[3] = G_17_1;
       break;
   case CANON_PLANE::UW:
-      gez[3] = G_18_1;
+      settings->active_g_codes[3] = G_18_1;
       break;
   case CANON_PLANE::VW:
-      gez[3] = G_19_1;
+      settings->active_g_codes[3] = G_19_1;
       break;
   }
-  gez[4] =
+  settings->active_g_codes[4] =
     (settings->cutter_comp_side == CUTTER_COMP::RIGHT) ? G_42 :
     (settings->cutter_comp_side == CUTTER_COMP::LEFT) ? G_41 : G_40;
-  gez[5] = (settings->length_units == CANON_UNITS_INCHES) ? G_20 : G_21;
-  gez[6] = (settings->distance_mode == DISTANCE_MODE::ABSOLUTE) ? G_90 : G_91;
-  gez[7] = (settings->feed_mode == FEED_MODE::INVERSE_TIME) ? G_93 :
-	    (settings->feed_mode == FEED_MODE::UNITS_PER_MINUTE) ? G_94 : G_95;
-  gez[8] =
+  settings->active_g_codes[5] = (settings->length_units == CANON_UNITS_INCHES) ? G_20 : G_21;
+  settings->active_g_codes[6] = (settings->distance_mode == DISTANCE_MODE::ABSOLUTE) ? G_90 : G_91;
+  settings->active_g_codes[7] = (settings->feed_mode == FEED_MODE::INVERSE_TIME) ? G_93 :
+	                        (settings->feed_mode == FEED_MODE::UNITS_PER_MINUTE) ? G_94 : G_95;
+  settings->active_g_codes[8] =
     (settings->origin_index <
      7) ? (530 + (10 * settings->origin_index)) : (584 +
                                                    settings->origin_index);
-  gez[9] = (settings->tool_offset.tran.x || settings->tool_offset.tran.y || settings->tool_offset.tran.z ||
-            settings->tool_offset.a || settings->tool_offset.b || settings->tool_offset.c ||
-            settings->tool_offset.u || settings->tool_offset.v || settings->tool_offset.w) ? G_43 : G_49;
-  gez[10] = (settings->retract_mode == RETRACT_MODE::OLD_Z) ? G_98 : G_99;
+  settings->active_g_codes[9] =
+    (settings->tool_offset.tran.x || settings->tool_offset.tran.y || settings->tool_offset.tran.z ||
+     settings->tool_offset.a || settings->tool_offset.b || settings->tool_offset.c ||
+     settings->tool_offset.u || settings->tool_offset.v || settings->tool_offset.w) ? G_43 : G_49;
+  settings->active_g_codes[10] = (settings->retract_mode == RETRACT_MODE::OLD_Z) ? G_98 : G_99;
   // Three modes:  G_64, G_61, G_61_1 or CANON_CONTINUOUS/EXACT_PATH/EXACT_STOP
-  gez[11] =
+  settings->active_g_codes[11] =
     (settings->control_mode == CANON_CONTINUOUS) ? G_64 :
     (settings->control_mode == CANON_EXACT_PATH) ? G_61 : G_61_1;
-  gez[12] = -1;
-  gez[13] = //I don't even know how to display the mode of an arbitrary number of spindles (andypugh 17/6/16)
+  settings->active_g_codes[12] = -1;
+  settings->active_g_codes[13] = //I don't even know how to display the mode of an arbitrary number of spindles (andypugh 17/6/16)
     (settings->spindle_mode[0] == SPINDLE_MODE::CONSTANT_RPM) ? G_97 : G_96;
-  gez[14] = (settings->ijk_distance_mode == DISTANCE_MODE::ABSOLUTE) ? G_90_1 : G_91_1;
-  gez[15] = (settings->lathe_diameter_mode) ? G_7 : G_8;
-  gez[16] = (settings->parameters[5210])? G_92_3: G_92_2;
+  settings->active_g_codes[14] = (settings->ijk_distance_mode == DISTANCE_MODE::ABSOLUTE) ? G_90_1 : G_91_1;
+  settings->active_g_codes[15] = (settings->lathe_diameter_mode) ? G_7 : G_8;
+  settings->active_g_codes[16] = (settings->parameters[5210])? G_92_3: G_92_2;
   return INTERP_OK;
 }
 
@@ -148,32 +146,29 @@ Might add check of speed override.
 int Interp::write_m_codes(block_pointer block,   //!< pointer to a block of RS274/NGC instructions
                          setup_pointer settings)        //!< pointer to machine settings                 
 {
-  int *emz;
-
-  emz = settings->active_m_codes;
-  emz[0] = settings->sequence_number;   /* 0 seq number  */
-  emz[1] = (block == NULL) ? -1 : block->m_modes[4];    /* 1 stopping    */
-  emz[2] = (settings->spindle_turning[0] == CANON_STOPPED) ? 5 :   /* 2 spindle     */
+  settings->active_m_codes[0] = settings->sequence_number;   /* 0 seq number  */
+  settings->active_m_codes[1] = (block == NULL) ? -1 : block->m_modes[4];    /* 1 stopping    */
+  settings->active_m_codes[2] = (settings->spindle_turning[0] == CANON_STOPPED) ? 5 :   /* 2 spindle     */
     (settings->spindle_turning[0] == CANON_CLOCKWISE) ? 3 : 4;
-  emz[3] =                      /* 3 tool change */
+  settings->active_m_codes[3] =                      /* 3 tool change */
     (block == NULL) ? -1 : block->m_modes[6];
-  emz[4] =                      /* 4 mist        */
+  settings->active_m_codes[4] =                      /* 4 mist        */
     (settings->mist) ? 7 : (settings->flood) ? -1 : 9;
-  emz[5] =                      /* 5 flood       */
+  settings->active_m_codes[5] =                      /* 5 flood       */
     (settings->flood) ? 8 : -1;
   // This only considers spindle 0. This function //
   //doesn't even know how many spindles there are //
   if (settings->feed_override) {
-    if (settings->speed_override[0]) emz[6] =  48;
-    else emz[6] = 50;
+    if (settings->speed_override[0]) settings->active_m_codes[6] =  48;
+    else settings->active_m_codes[6] = 50;
   } else if (settings->speed_override[0]) {
-    emz[6] = 51;
-  } else emz[6] = 49;
-  
-  emz[7] =                      /* 7 overrides   */
+    settings->active_m_codes[6] = 51;
+  } else settings->active_m_codes[6] = 49;
+
+  settings->active_m_codes[7] =                      /* 7 overrides   */
     (settings->adaptive_feed) ? 52 : -1;
 
-  emz[8] =                      /* 8 overrides   */
+  settings->active_m_codes[8] =                      /* 8 overrides   */
     (settings->feed_hold) ? 53 : -1;
 
   return INTERP_OK;
@@ -197,14 +192,11 @@ Called by:
 
 int Interp::write_settings(setup_pointer settings)       //!< pointer to machine settings
 {
-  double *vals;
-
-  vals = settings->active_settings;
-  vals[0] = settings->sequence_number;    /* 0 sequence number */
-  vals[1] = settings->feed_rate;          /* 1 feed rate       */
-  vals[2] = settings->speed[0];           /* 2 spindle speed   */
-  vals[3] = settings->tolerance;          /* 3 blend tolerance */
-  vals[4] = settings->naivecam_tolerance; /* 4 naive CAM tolerance */
+  settings->active_settings[0] = settings->sequence_number;    /* 0 sequence number */
+  settings->active_settings[1] = settings->feed_rate;          /* 1 feed rate       */
+  settings->active_settings[2] = settings->speed[0];           /* 2 spindle speed   */
+  settings->active_settings[3] = settings->tolerance;          /* 3 blend tolerance */
+  settings->active_settings[4] = settings->naivecam_tolerance; /* 4 naive CAM tolerance */
 
   return INTERP_OK;
 }


### PR DESCRIPTION
By using the array, information about the size is available at compile time and the compiler can do proper bound checking, this increases type safety. A small, in my mind, trade-off is that a slightly longer name is necessary.