### PR TITLE
interp: Rewrite macros used for remap to functions

### DIFF
--- a/src/emc/rs274ngc/interp_check.cc
+++ b/src/emc/rs274ngc/interp_check.cc
@@ -235,7 +235,7 @@ int Interp::check_other_codes(block_pointer block)       //!< pointer to a block
   motion = block->motion_to_be;
 
   // bypass ALL checks, argspec takes care of that
-  if (IS_USER_GCODE(motion)) {
+  if (is_user_defined_g_code(motion)) {
       return INTERP_OK;
   }
   // bypass ALL checks, argspec takes care of that

--- a/src/emc/rs274ngc/interp_check.cc
+++ b/src/emc/rs274ngc/interp_check.cc
@@ -239,7 +239,7 @@ int Interp::check_other_codes(block_pointer block)       //!< pointer to a block
       return INTERP_OK;
   }
   // bypass ALL checks, argspec takes care of that
-  if (has_user_mcode(&(_setup),block)) {
+  if (is_any_m_code_remapped(block, &(_setup))) {
       return INTERP_OK;
     }
   if (block->a_flag) {

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -4340,7 +4340,7 @@ int Interp::convert_motion(int motion,   //!< g_code for a line, arc, canned cyc
     enqueue_COMMENT("interpreter: motion mode set to none");
 #endif
     settings->motion_mode = G_80;
-  } else if (IS_USER_GCODE(motion)) {
+  } else if (is_user_defined_g_code(motion)) {
       CHP(convert_remapped_code(block, settings, STEP_MOTION, 'g', motion));
   } else if (is_a_cycle(motion)) {
 

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -3794,7 +3794,7 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
      M67 reads a digital input
      M68 reads an analog input*/
 
-  if (IS_USER_MCODE(block,settings,5) &&
+  if (is_user_defined_m_code(block, settings, 5) &&
       STEP_REMAPPED_IN_BLOCK(block, STEP_M_5) &&
       ONCE_M(5))  {
       return convert_remapped_code(block, settings, STEP_M_5, 'm',
@@ -3908,7 +3908,7 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
 
       switch (block->m_modes[6]) {
       case 6:
-      	  if (IS_USER_MCODE(block,settings,6) && remapped_in_block) {
+      	  if (is_user_defined_m_code(block, settings, 6) && remapped_in_block) {
       		  return convert_remapped_code(block,settings,
       					       STEP_M_6,
       					       'm',
@@ -3922,7 +3922,7 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
       	  break;
 
       case 61:
-	  if (IS_USER_MCODE(block,settings,6) && remapped_in_block) {
+	  if (is_user_defined_m_code(block, settings, 6) && remapped_in_block) {
 	      return convert_remapped_code(block, settings, STEP_M_6,'m',
 					   block->m_modes[6]);
 	  } else {
@@ -3943,7 +3943,7 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
 	  break;
 
       default:
-	  if (IS_USER_MCODE(block,settings,6)) {
+	  if (is_user_defined_m_code(block, settings, 6)) {
 	      return convert_remapped_code(block, settings, STEP_M_6,'m',
 					   block->m_modes[6]);
 	  }
@@ -3967,7 +3967,7 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
     }
   }
 
- if (IS_USER_MCODE(block,settings,7) && ONCE_M(7)) {
+ if (is_user_defined_m_code(block, settings, 7) && ONCE_M(7)) {
     return convert_remapped_code(block, settings, STEP_M_7, 'm',
 				   block->m_modes[7]);
  } else if ((block->m_modes[7] == 3)  && ONCE_M(7)) {
@@ -4068,7 +4068,7 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
       CHP(restore_settings(&_setup, _setup.call_level));
   }
 
-  if (IS_USER_MCODE(block,settings,8) && ONCE_M(8)) {
+  if (is_user_defined_m_code(block, settings, 8) && ONCE_M(8)) {
      return convert_remapped_code(block, settings, STEP_M_8, 'm',
 				   block->m_modes[8]);
   } else if ((block->m_modes[8] == 7) && ONCE_M(8)){
@@ -4100,7 +4100,7 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
       settings->a_axis_clamping = false;
     }
 */
-if (IS_USER_MCODE(block,settings,9) && ONCE_M(9)) {
+if (is_user_defined_m_code(block, settings, 9) && ONCE_M(9)) {
      return convert_remapped_code(block, settings, STEP_M_9, 'm',
 				   block->m_modes[9]);
  } else if ((block->m_modes[9] == 48)  && ONCE_M(9)){
@@ -4193,7 +4193,7 @@ if ((block->m_modes[9] == 53)  && ONCE_M(9)){
     }
   }
 
-if (IS_USER_MCODE(block,settings,10) && ONCE_M(10)) {
+if (is_user_defined_m_code(block, settings, 10) && ONCE_M(10)) {
     return convert_remapped_code(block,settings,STEP_M_10,'m',
 				   block->m_modes[10]);
 

--- a/src/emc/rs274ngc/interp_internal.cc
+++ b/src/emc/rs274ngc/interp_internal.cc
@@ -193,7 +193,7 @@ int Interp::enhance_block(block_pointer block,   //!< pointer to a block to be c
             mode1 != G_70 &&
             mode1 != G_71 && mode1 != G_71_1 && mode1 != G_71_2 &&
             mode1 != G_72 && mode1 != G_72_1 && mode1 != G_72_2 &&
-	          ! IS_USER_GCODE(mode1)),
+                  !is_user_defined_g_code(mode1)),
           NCE_ALL_AXES_MISSING_WITH_MOTION_CODE);
     }
     block->motion_to_be = mode1;

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -34,17 +34,45 @@ namespace bp = boost::python;
 
 
 
+bool Interp::is_m_code_remappable(int m_code)
+{
+    // this is overdue for a bitset
+    return ((m_code > 199 && m_code < 1000) ||
+            (m_code > 0 && m_code < 100 && ems[m_code] == -1) ||
+            m_code == 0 ||
+            m_code == 1 ||
+            m_code == 6 ||
+            m_code == 9 ||
+            m_code == 60 ||
+            m_code == 61 ||
+            m_code == 62 ||
+            m_code == 63 ||
+            m_code == 64 ||
+            m_code == 65 ||
+            m_code == 66 ||
+            m_code == 67 ||
+            m_code == 68);
+}
+
 bool Interp::has_user_mcode(setup_pointer settings,block_pointer block)
 {
     unsigned i;
     for(i = 0; i < sizeof(block->m_modes)/sizeof(int); i++) {
 	if (block->m_modes[i] == -1)
 	    continue;
-	if (M_REMAPPABLE(block->m_modes[i]) &&
+	if (is_m_code_remappable(block->m_modes[i]) &&
 	    settings->m_remapped[block->m_modes[i]])
 	    return true;
     }
     return false;
+}
+
+bool Interp::is_user_defined_m_code(block_pointer block, setup_pointer settings, int m_group)
+{
+    const int m_code = block->m_modes[m_group];
+    if (m_code < 0) return false;
+
+    return (is_m_code_remappable(m_code) && settings->m_remapped[m_code]);
 }
 
 bool Interp::is_g_code_remappable(int g_code)

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -54,14 +54,12 @@ bool Interp::is_m_code_remappable(int m_code)
             m_code == 68);
 }
 
-bool Interp::has_user_mcode(setup_pointer settings,block_pointer block)
+bool Interp::is_any_m_code_remapped(block_pointer block, setup_pointer settings)
 {
-    unsigned i;
-    for(i = 0; i < sizeof(block->m_modes)/sizeof(int); i++) {
-	if (block->m_modes[i] == -1)
-	    continue;
-	if (is_m_code_remappable(block->m_modes[i]) &&
-	    settings->m_remapped[block->m_modes[i]])
+    for (const int m_mode : block->m_modes) {
+	if (m_mode == -1)
+            continue;
+        if (is_m_code_remappable(m_mode) && settings->m_remapped[m_mode])
 	    return true;
     }
     return false;

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -47,6 +47,12 @@ bool Interp::has_user_mcode(setup_pointer settings,block_pointer block)
     return false;
 }
 
+bool Interp::is_g_code_remappable(int g_code)
+{ return g_code > 0 && g_code < 1000 && gees[g_code] == -1; }
+
+bool Interp::is_user_defined_g_code(int g_code)
+{ return is_g_code_remappable(g_code) && _setup.g_remapped[g_code]; }
+
 bool Interp::remap_in_progress(const char *code)
 {
     remap_pointer rp = remapping(code);

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -611,35 +611,6 @@ int read_inputs(setup_pointer settings);
 
     bool has_user_mcode(setup_pointer settings,block_pointer block);
 
-#define M_BUILTIN(m) (ems[m] != -1)
-
-    // range for user-remapped M-codes
-    // and M6,M61
-    // this is overdue for a bitset
-#define M_REMAPPABLE(m)					\
-    (((m > 199) && (m < 1000)) ||			\
-     ((m > 0) && (m < 100) &&				\
-      !M_BUILTIN(m)) ||					\
-     (m == 6) ||					\
-     (m == 9) ||					\
-     (m == 61) ||					\
-     (m == 0) ||					\
-     (m == 1) ||					\
-     (m == 60) ||					\
-     (m == 62) ||					\
-     (m == 63) ||					\
-     (m == 64) ||					\
-     (m == 65) ||					\
-     (m == 66) ||					\
-     (m == 67) ||					\
-     (m == 68))
-
-
-#define IS_USER_MCODE(bp,sp,mgroup) \
-    ((M_REMAPPABLE((bp)->m_modes[mgroup])) && \
-    (((bp)->m_modes[mgroup]) > -1) &&		\
-     ((sp)->m_remapped[(bp)->m_modes[mgroup]]))
-
     bool remap_in_progress(const char *code);
     int convert_remapped_code(block_pointer block,
 			       setup_pointer settings,
@@ -711,6 +682,9 @@ int read_inputs(setup_pointer settings);
 private:
     [[nodiscard]] static bool is_parameter_readonly(int index);
 
+    [[nodiscard]] static bool is_m_code_remappable(int m_code);
+    [[nodiscard]] static bool is_user_defined_m_code(block_pointer block, setup_pointer settings,
+                                                     int m_group);
     [[nodiscard]] static bool is_g_code_remappable(int g_code);
     [[nodiscard]] bool is_user_defined_g_code(int g_code);
 

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -612,7 +612,6 @@ int read_inputs(setup_pointer settings);
     bool has_user_mcode(setup_pointer settings,block_pointer block);
 
 #define M_BUILTIN(m) (ems[m] != -1)
-#define G_BUILTIN(g) (gees[g] != -1)
 
     // range for user-remapped M-codes
     // and M6,M61
@@ -635,15 +634,6 @@ int read_inputs(setup_pointer settings);
      (m == 67) ||					\
      (m == 68))
 
-
-
-    // range for user-remapped G-codes
-#define G_REMAPPABLE(g)	 \
-    ((g > 0) && \
-     (g < 1000) && \
-     !G_BUILTIN(g))
-
-#define IS_USER_GCODE(x) (G_REMAPPABLE(x) && _setup.g_remapped[x])
 
 #define IS_USER_MCODE(bp,sp,mgroup) \
     ((M_REMAPPABLE((bp)->m_modes[mgroup])) && \
@@ -720,6 +710,9 @@ int read_inputs(setup_pointer settings);
 
 private:
     [[nodiscard]] static bool is_parameter_readonly(int index);
+
+    [[nodiscard]] static bool is_g_code_remappable(int g_code);
+    [[nodiscard]] bool is_user_defined_g_code(int g_code);
 
     static const int gees[];
     static const int ems[];

--- a/src/emc/rs274ngc/rs274ngc_interp.hh
+++ b/src/emc/rs274ngc/rs274ngc_interp.hh
@@ -609,8 +609,6 @@ int read_inputs(setup_pointer settings);
  int init_named_parameters();
     int init_python_predef_parameter(const char *name);
 
-    bool has_user_mcode(setup_pointer settings,block_pointer block);
-
     bool remap_in_progress(const char *code);
     int convert_remapped_code(block_pointer block,
 			       setup_pointer settings,
@@ -682,9 +680,10 @@ int read_inputs(setup_pointer settings);
 private:
     [[nodiscard]] static bool is_parameter_readonly(int index);
 
-    [[nodiscard]] static bool is_m_code_remappable(int m_code);
+    [[nodiscard]] static bool is_any_m_code_remapped(block_pointer block, setup_pointer settings);
     [[nodiscard]] static bool is_user_defined_m_code(block_pointer block, setup_pointer settings,
                                                      int m_group);
+    [[nodiscard]] static bool is_m_code_remappable(int m_code);
     [[nodiscard]] static bool is_g_code_remappable(int g_code);
     [[nodiscard]] bool is_user_defined_g_code(int g_code);
 

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -707,7 +707,7 @@ int Interp::find_remappings(block_pointer block, setup_pointer settings)
     // User-defined motion codes (G0 to G3, G33, G73, G76, G80 to G89)
     // as modified (possibly) by G53.
     int mode = block->g_modes[GM_MOTION];
-    if ((mode != -1) && IS_USER_GCODE(mode))
+    if ((mode != -1) && is_user_defined_g_code(mode))
 	block->remappings.insert(STEP_MOTION);
     
     // this makes it possible to call remapped codes like cycles:
@@ -722,7 +722,7 @@ int Interp::find_remappings(block_pointer block, setup_pointer settings)
     //     return INTERP_OK
 
     mode = block->motion_to_be;
-    if ((mode != -1) && IS_USER_GCODE(mode)) {
+    if ((mode != -1) && is_user_defined_g_code(mode)) {
 	block->remappings.insert(STEP_MOTION);
     }
 

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -667,7 +667,7 @@ int Interp::find_remappings(block_pointer block, setup_pointer settings)
 	    block->remappings.insert(STEP_PREPARE);
     }
     // User defined M-Codes in group 5
-    if (IS_USER_MCODE(block,settings,5) &&
+    if (is_user_defined_m_code(block, settings, 5) &&
 	!(((block->m_modes[5] == 62) && remap_in_progress("M62")) ||
 	  ((block->m_modes[5] == 63) && remap_in_progress("M63")) ||
 	  ((block->m_modes[5] == 64) && remap_in_progress("M64")) ||
@@ -682,26 +682,26 @@ int Interp::find_remappings(block_pointer block, setup_pointer settings)
     // call the remap procedure if it the code in that group is remapped unless:
     // it's an M6 or M61 and a remap is in progress
     // (recursion case)
-    if (IS_USER_MCODE(block,settings,6) &&  
+    if (is_user_defined_m_code(block, settings, 6) &&
 	!(((block->m_modes[6] == 6) && remap_in_progress("M6")) ||
-	  ((block->m_modes[6] == 61) && remap_in_progress("M61")))) {  
+	  ((block->m_modes[6] == 61) && remap_in_progress("M61")))) {
 	block->remappings.insert(STEP_M_6); // then call the remap procedure
     } // else we get the builtin behaviour
     
     // User defined M-Codes in group 7
-    if (IS_USER_MCODE(block,settings,7))
+    if (is_user_defined_m_code(block, settings, 7))
 	block->remappings.insert(STEP_M_7);
 
     // User defined M-Codes in group 8
-    if (IS_USER_MCODE(block,settings,8))
+    if (is_user_defined_m_code(block, settings, 8))
 	block->remappings.insert(STEP_M_8);
 
     // User defined M-Codes in group 9
-    if (IS_USER_MCODE(block,settings,9))
+    if (is_user_defined_m_code(block, settings, 9))
 	block->remappings.insert(STEP_M_9);
 
     // User defined M-Codes in group 10
-    if (IS_USER_MCODE(block,settings,10))
+    if (is_user_defined_m_code(block, settings, 10))
 	block->remappings.insert(STEP_M_10);
 
     // User-defined motion codes (G0 to G3, G33, G73, G76, G80 to G89)
@@ -727,7 +727,7 @@ int Interp::find_remappings(block_pointer block, setup_pointer settings)
     }
 
     // User defined M-Codes in group 4 (stopping)
-    if (IS_USER_MCODE(block,settings,4)) {
+    if (is_user_defined_m_code(block, settings, 4)) {
 
 	if (remap_in_progress("M0") ||
 	    remap_in_progress("M1") ||


### PR DESCRIPTION
Rewrites some macros to functions, functionality remains the same.

The functions has gotten new, and hopefully, more descriptive names.