### PR TITLE
streamer: allow only one user comp per channel

### DIFF
--- a/src/hal/components/sampler_usr.c
+++ b/src/hal/components/sampler_usr.c
@@ -170,8 +170,8 @@ int main(int argc, char **argv)
     signal(SIGTERM, quit);
     signal(SIGPIPE, quit);
     /* connect to HAL */
-    /* create a unique module name, to allow for multiple samplers */
-    snprintf(comp_name, sizeof(comp_name), "halsampler%d", getpid());
+    /* create module name for specified channel */
+    snprintf(comp_name, sizeof(comp_name), "halsampler%d", channel);
     /* connect to the HAL */
     ignore_sig = 1;
     comp_id = hal_init(comp_name);

--- a/src/hal/components/streamer_usr.c
+++ b/src/hal/components/streamer_usr.c
@@ -149,8 +149,8 @@ int main(int argc, char **argv)
     signal(SIGTERM, quit);
     signal(SIGPIPE, SIG_IGN);
     /* connect to HAL */
-    /* create a unique module name, to allow for multiple streamers */
-    snprintf(comp_name, sizeof(comp_name), "halstreamer%d", getpid());
+    /* create module name for specified channel */
+    snprintf(comp_name, sizeof(comp_name), "halstreamer%d", channel);
     /* connect to the HAL */
     ignore_sig = 1;
     comp_id = hal_init(comp_name);


### PR DESCRIPTION
A streamer/sampler channel can have at most one reader and one writer. It did not make sense to allow multiple user components using the same channel, as it could only lead to weird and undefined behavior.