### PR TITLE
Update plasmac.comp to include laser_mode

### DIFF
--- a/src/hal/components/plasmac.comp
+++ b/src/hal/components/plasmac.comp
@@ -71,6 +71,7 @@ pin in  float   kerf_width                  "placeholder for better G-code porta
 pin in  bit     override_jog                "override jog inhibit";
 pin in  bit     offset_set_probe            "deploy probe for setting offsets";
 pin in  bit     offset_set_scribe           "deploy scribe for setting offsets";
+pin in  bit     laser_mode                  "laser mode for fiber lasers";
 pin in  s32     laser_recovery_start        "start laser offset for cut recovery";
 pin in  s32     laser_x_offset              "alignment laser x axis offset (scaled units)";
 pin in  s32     laser_y_offset              "alignment laser y axis offset (scaled units)";
@@ -1718,16 +1719,16 @@ FUNCTION(_) {
                         requested_feed_rate = cut_feed_rate * feed_override / gcode_scale;
                     }
                 }
-                /* while cutting and it is not a dry run and mesh mode is not enabled:
+                /* while cutting and it is not a dry run or laser mode is enabled and mesh mode is not enabled:
                  * if thc is enabled then vary the torch height to keep the arc voltage constant
                  * if corner lock enabled, only allow THC if current velocity is greater than the threshold percentage of requested velocity
                  * if voidlock is enabled, only allow THC if the voltage change is less than the threshold voltage
                  * adjust torch height and target voltage to suit if height override requested */
-                if(torch_on && !mesh_enable && !ignore_arc_ok_0 && !ignore_arc_ok_1){
+                if((torch_on || laser_mode) && !mesh_enable && !ignore_arc_ok_0 && !ignore_arc_ok_1){
                     if(target_volts == 0){
                         cornerlock_is_locked = TRUE;
-                        /* wait until velocity reaches 99.9% of requested velocity */
-                        if(current_velocity * 60 > requested_feed_rate * 0.999){
+                        /* wait until velocity reaches 99.9% of requested velocity or if laser mode is enabled */
+                        if((current_velocity * 60 > requested_feed_rate * 0.999) || laser_mode){
                             if(thc_auto && use_auto_volts){
                                 /* test the arc voltage buffer for a stable voltage */
                                 double target = read_arc_voltage_buffer(READ_THC, thc_sampler_samples, arc_voltage_buffer_index - 1, arc_voltage_out, thc_sample_threshold);


### PR DESCRIPTION
Add laser_mode bool to plasmac input pins to create a framework for adapting features for specific use with fiber lasers.

-Activate THC always when laser_mode is set, regardless of torch_on or current velocity