### PR TITLE
qtaxis: Move major window sections into splitters so you can resize

### DIFF
--- a/share/qtvcp/screens/qtaxis/qtaxis.ui
+++ b/share/qtvcp/screens/qtaxis/qtaxis.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>802</width>
-    <height>626</height>
+    <height>634</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -97,1852 +97,1874 @@
               <number>0</number>
              </property>
              <item>
-              <widget class="QFrame" name="frame">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
+              <widget class="QSplitter" name="verticalSplitter">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
                </property>
-               <property name="minimumSize">
-                <size>
-                 <width>300</width>
-                 <height>0</height>
-                </size>
+               <property name="childrenCollapsible">
+                <bool>true</bool>
                </property>
-               <property name="maximumSize">
-                <size>
-                 <width>300</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="frameShape">
-                <enum>QFrame::Box</enum>
-               </property>
-               <property name="frameShadow">
-                <enum>QFrame::Sunken</enum>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_2">
-                <property name="spacing">
-                 <number>4</number>
+               <widget class="QSplitter" name="horizontalSplitter">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
-                <property name="leftMargin">
-                 <number>3</number>
+                <property name="childrenCollapsible">
+                 <bool>false</bool>
                 </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>3</number>
-                </property>
-                <item>
-                 <widget class="QTabWidget" name="leftTab">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
+                <widget class="QFrame" name="frame">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>300</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>400</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="frameShape">
+                  <enum>QFrame::Box</enum>
+                 </property>
+                 <property name="frameShadow">
+                  <enum>QFrame::Sunken</enum>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_2">
+                  <property name="spacing">
+                   <number>4</number>
                   </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>300</width>
-                    <height>0</height>
-                   </size>
+                  <property name="leftMargin">
+                   <number>3</number>
                   </property>
-                  <property name="currentIndex">
+                  <property name="topMargin">
                    <number>0</number>
                   </property>
-                  <widget class="QWidget" name="tab_3">
-                   <property name="focusPolicy">
-                    <enum>Qt::ClickFocus</enum>
-                   </property>
-                   <attribute name="title">
-                    <string>Manual Control [F3]</string>
-                   </attribute>
-                   <layout class="QVBoxLayout" name="verticalLayout_5">
-                    <property name="spacing">
-                     <number>2</number>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>3</number>
+                  </property>
+                  <item>
+                   <widget class="QTabWidget" name="leftTab">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
                     </property>
-                    <property name="leftMargin">
+                    <property name="minimumSize">
+                     <size>
+                      <width>300</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="currentIndex">
                      <number>0</number>
                     </property>
-                    <property name="topMargin">
-                     <number>6</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>0</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>0</number>
-                    </property>
-                    <item>
-                     <layout class="QGridLayout" name="gridLayout">
-                      <property name="sizeConstraint">
-                       <enum>QLayout::SetMinimumSize</enum>
+                    <widget class="QWidget" name="tab_3">
+                     <property name="focusPolicy">
+                      <enum>Qt::ClickFocus</enum>
+                     </property>
+                     <attribute name="title">
+                      <string>Manual Control [F3]</string>
+                     </attribute>
+                     <layout class="QVBoxLayout" name="verticalLayout_5">
+                      <property name="spacing">
+                       <number>2</number>
                       </property>
                       <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
                        <number>6</number>
                       </property>
                       <property name="rightMargin">
-                       <number>6</number>
-                      </property>
-                      <property name="horizontalSpacing">
-                       <number>6</number>
-                      </property>
-                      <property name="verticalSpacing">
                        <number>0</number>
                       </property>
-                      <item row="1" column="1">
-                       <widget class="RadioAxisSelector" name="ras_3">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <layout class="QGridLayout" name="gridLayout">
+                        <property name="sizeConstraint">
+                         <enum>QLayout::SetMinimumSize</enum>
                         </property>
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                        <property name="axis_selection" stdset="0">
-                         <string>A</string>
-                        </property>
-                        <property name="joint_selection" stdset="0">
-                         <number>3</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="5">
-                       <widget class="RadioAxisSelector" name="ras_2">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                        <property name="axis_selection" stdset="0">
-                         <string>Z</string>
-                        </property>
-                        <property name="joint_selection" stdset="0">
-                         <number>2</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="4">
-                       <widget class="QLabel" name="ras_label_1">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="text">
-                         <string>Y</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="6">
-                       <widget class="QLabel" name="ras_label_5">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>C</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="3">
-                       <widget class="RadioAxisSelector" name="ras_1">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                        <property name="axis_selection" stdset="0">
-                         <string>Y</string>
-                        </property>
-                        <property name="joint_selection" stdset="0">
-                         <number>1</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="2">
-                       <widget class="QLabel" name="ras_label_3">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>A</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="3">
-                       <widget class="RadioAxisSelector" name="ras_4">
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                        <property name="axis_selection" stdset="0">
-                         <string>B</string>
-                        </property>
-                        <property name="joint_selection" stdset="0">
-                         <number>4</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="4">
-                       <widget class="QLabel" name="ras_label_4">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>B</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="6">
-                       <widget class="QLabel" name="ras_label_2">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>Z</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="1" column="5">
-                       <widget class="RadioAxisSelector" name="ras_5">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                        <property name="axis_selection" stdset="0">
-                         <string>C</string>
-                        </property>
-                        <property name="joint_selection" stdset="0">
-                         <number>5</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="0">
-                       <widget class="QLabel" name="ras_label_title">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Axis&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="1">
-                       <widget class="RadioAxisSelector" name="ras_0">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="checked">
-                         <bool>true</bool>
-                        </property>
-                        <property name="axis_selection" stdset="0">
-                         <string>X</string>
-                        </property>
-                        <property name="joint_selection" stdset="0">
-                         <number>0</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="2">
-                       <widget class="QLabel" name="ras_label_0">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>X</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="2">
-                       <widget class="QLabel" name="ras_label_6">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>U</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="3">
-                       <widget class="RadioAxisSelector" name="ras_7">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                        <property name="axis_selection" stdset="0">
-                         <string>V</string>
-                        </property>
-                        <property name="joint_selection" stdset="0">
-                         <number>7</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="1">
-                       <widget class="RadioAxisSelector" name="ras_6">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                        <property name="axis_selection" stdset="0">
-                         <string>U</string>
-                        </property>
-                        <property name="joint_selection" stdset="0">
+                        <property name="leftMargin">
                          <number>6</number>
                         </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="4">
-                       <widget class="QLabel" name="ras_label_7">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
+                        <property name="rightMargin">
+                         <number>6</number>
                         </property>
-                        <property name="text">
-                         <string>V</string>
+                        <property name="horizontalSpacing">
+                         <number>6</number>
                         </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="6">
-                       <widget class="QLabel" name="ras_label_8">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>W</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="5">
-                       <widget class="RadioAxisSelector" name="ras_8">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                        <property name="axis_selection" stdset="0">
-                         <string>W</string>
-                        </property>
-                        <property name="joint_selection" stdset="0">
-                         <number>8</number>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
-                      <property name="sizeConstraint">
-                       <enum>QLayout::SetMinimumSize</enum>
-                      </property>
-                      <property name="leftMargin">
-                       <number>6</number>
-                      </property>
-                      <property name="rightMargin">
-                       <number>6</number>
-                      </property>
-                      <property name="spacing">
-                       <number>0</number>
-                      </property>
-                      <item row="1" column="0">
-                       <widget class="ActionButton" name="actionButton_home">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
-                        </property>
-                        <property name="minimumSize">
-                         <size>
-                          <width>108</width>
-                          <height>0</height>
-                         </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>108</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>Home All</string>
-                        </property>
-                        <property name="home_action" stdset="0">
-                         <bool>true</bool>
-                        </property>
-                        <property name="joint_number" stdset="0">
-                         <number>-1</number>
-                        </property>
-                        <property name="incr_imperial_number" stdset="0">
-                         <double>0.010000000000000</double>
-                        </property>
-                        <property name="incr_mm_number" stdset="0">
-                         <double>0.025000000000000</double>
-                        </property>
-                        <property name="incr_angular_number" stdset="0">
-                         <double>-1.000000000000000</double>
-                        </property>
-                        <property name="toggle_float_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="float_num" stdset="0">
-                         <double>100.000000000000000</double>
-                        </property>
-                        <property name="float_alt_num" stdset="0">
-                         <double>50.000000000000000</double>
-                        </property>
-                        <property name="view_type_string" stdset="0">
-                         <string>P</string>
-                        </property>
-                        <property name="command_text_string" stdset="0">
-                         <string/>
-                        </property>
-                        <property name="ini_mdi_number" stdset="0">
+                        <property name="verticalSpacing">
                          <number>0</number>
                         </property>
-                       </widget>
-                      </item>
-                      <item row="0" column="0">
-                       <layout class="QHBoxLayout" name="horizontalLayout_12">
-                        <item>
-                         <widget class="ActionButton" name="actionbutton_2">
+                        <item row="1" column="1">
+                         <widget class="RadioAxisSelector" name="ras_3">
                           <property name="maximumSize">
                            <size>
-                            <width>50</width>
-                            <height>25</height>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="checked">
+                           <bool>false</bool>
+                          </property>
+                          <property name="axis_selection" stdset="0">
+                           <string>A</string>
+                          </property>
+                          <property name="joint_selection" stdset="0">
+                           <number>3</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="5">
+                         <widget class="RadioAxisSelector" name="ras_2">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="checked">
+                           <bool>false</bool>
+                          </property>
+                          <property name="axis_selection" stdset="0">
+                           <string>Z</string>
+                          </property>
+                          <property name="joint_selection" stdset="0">
+                           <number>2</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="4">
+                         <widget class="QLabel" name="ras_label_1">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>Y</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="6">
+                         <widget class="QLabel" name="ras_label_5">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
                            </size>
                           </property>
                           <property name="text">
-                           <string>-</string>
+                           <string>C</string>
                           </property>
-                          <property name="jog_selected_pos_action" stdset="0">
+                         </widget>
+                        </item>
+                        <item row="0" column="3">
+                         <widget class="RadioAxisSelector" name="ras_1">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="checked">
                            <bool>false</bool>
                           </property>
-                          <property name="jog_selected_neg_action" stdset="0">
+                          <property name="axis_selection" stdset="0">
+                           <string>Y</string>
+                          </property>
+                          <property name="joint_selection" stdset="0">
+                           <number>1</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="2">
+                         <widget class="QLabel" name="ras_label_3">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>A</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="3">
+                         <widget class="RadioAxisSelector" name="ras_4">
+                          <property name="checked">
+                           <bool>false</bool>
+                          </property>
+                          <property name="axis_selection" stdset="0">
+                           <string>B</string>
+                          </property>
+                          <property name="joint_selection" stdset="0">
+                           <number>4</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="4">
+                         <widget class="QLabel" name="ras_label_4">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>B</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="6">
+                         <widget class="QLabel" name="ras_label_2">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>Z</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="5">
+                         <widget class="RadioAxisSelector" name="ras_5">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="checked">
+                           <bool>false</bool>
+                          </property>
+                          <property name="axis_selection" stdset="0">
+                           <string>C</string>
+                          </property>
+                          <property name="joint_selection" stdset="0">
+                           <number>5</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="ras_label_title">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Axis&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="1">
+                         <widget class="RadioAxisSelector" name="ras_0">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="checked">
                            <bool>true</bool>
                           </property>
-                          <property name="joint_number" stdset="0">
-                           <number>0</number>
+                          <property name="axis_selection" stdset="0">
+                           <string>X</string>
                           </property>
-                          <property name="incr_imperial_number" stdset="0">
-                           <double>0.010000000000000</double>
-                          </property>
-                          <property name="incr_mm_number" stdset="0">
-                           <double>0.025000000000000</double>
-                          </property>
-                          <property name="incr_angular_number" stdset="0">
-                           <double>-1.000000000000000</double>
-                          </property>
-                          <property name="toggle_float_option" stdset="0">
-                           <bool>false</bool>
-                          </property>
-                          <property name="float_num" stdset="0">
-                           <double>100.000000000000000</double>
-                          </property>
-                          <property name="float_alt_num" stdset="0">
-                           <double>50.000000000000000</double>
-                          </property>
-                          <property name="view_type_string" stdset="0">
-                           <string>P</string>
-                          </property>
-                          <property name="command_text_string" stdset="0">
-                           <string/>
-                          </property>
-                          <property name="ini_mdi_number" stdset="0">
+                          <property name="joint_selection" stdset="0">
                            <number>0</number>
                           </property>
                          </widget>
                         </item>
-                        <item>
-                         <widget class="ActionButton" name="actionbutton">
+                        <item row="0" column="2">
+                         <widget class="QLabel" name="ras_label_0">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
                           <property name="maximumSize">
                            <size>
-                            <width>50</width>
-                            <height>25</height>
+                            <width>16777215</width>
+                            <height>20</height>
                            </size>
                           </property>
                           <property name="text">
-                           <string>+</string>
+                           <string>X</string>
                           </property>
-                          <property name="jog_selected_pos_action" stdset="0">
-                           <bool>true</bool>
+                         </widget>
+                        </item>
+                        <item row="2" column="2">
+                         <widget class="QLabel" name="ras_label_6">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
                           </property>
-                          <property name="joint_number" stdset="0">
-                           <number>0</number>
+                          <property name="text">
+                           <string>U</string>
                           </property>
-                          <property name="incr_imperial_number" stdset="0">
-                           <double>0.010000000000000</double>
+                         </widget>
+                        </item>
+                        <item row="2" column="3">
+                         <widget class="RadioAxisSelector" name="ras_7">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
                           </property>
-                          <property name="incr_mm_number" stdset="0">
-                           <double>0.025000000000000</double>
-                          </property>
-                          <property name="incr_angular_number" stdset="0">
-                           <double>-1.000000000000000</double>
-                          </property>
-                          <property name="toggle_float_option" stdset="0">
+                          <property name="checked">
                            <bool>false</bool>
                           </property>
-                          <property name="float_num" stdset="0">
-                           <double>100.000000000000000</double>
+                          <property name="axis_selection" stdset="0">
+                           <string>V</string>
                           </property>
-                          <property name="float_alt_num" stdset="0">
-                           <double>50.000000000000000</double>
+                          <property name="joint_selection" stdset="0">
+                           <number>7</number>
                           </property>
-                          <property name="view_type_string" stdset="0">
-                           <string>P</string>
+                         </widget>
+                        </item>
+                        <item row="2" column="1">
+                         <widget class="RadioAxisSelector" name="ras_6">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
                           </property>
-                          <property name="command_text_string" stdset="0">
-                           <string/>
+                          <property name="checked">
+                           <bool>false</bool>
                           </property>
-                          <property name="ini_mdi_number" stdset="0">
-                           <number>0</number>
+                          <property name="axis_selection" stdset="0">
+                           <string>U</string>
+                          </property>
+                          <property name="joint_selection" stdset="0">
+                           <number>6</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="4">
+                         <widget class="QLabel" name="ras_label_7">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>V</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="6">
+                         <widget class="QLabel" name="ras_label_8">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>W</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="5">
+                         <widget class="RadioAxisSelector" name="ras_8">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="checked">
+                           <bool>false</bool>
+                          </property>
+                          <property name="axis_selection" stdset="0">
+                           <string>W</string>
+                          </property>
+                          <property name="joint_selection" stdset="0">
+                           <number>8</number>
                           </property>
                          </widget>
                         </item>
                        </layout>
                       </item>
-                      <item row="1" column="1">
-                       <widget class="AxisToolButton" name="axistoolbutton">
-                        <property name="minimumSize">
-                         <size>
-                          <width>100</width>
-                          <height>0</height>
-                         </size>
+                      <item>
+                       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
+                        <property name="sizeConstraint">
+                         <enum>QLayout::SetMinimumSize</enum>
                         </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>100</width>
-                          <height>25</height>
-                         </size>
+                        <property name="leftMargin">
+                         <number>6</number>
                         </property>
-                        <property name="text">
-                         <string>Set Origin</string>
+                        <property name="rightMargin">
+                         <number>6</number>
                         </property>
-                        <property name="joint_number" stdset="0">
-                         <number>-1</number>
+                        <property name="spacing">
+                         <number>0</number>
                         </property>
-                        <property name="halpin_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                       </widget>
+                        <item row="1" column="0">
+                         <widget class="ActionButton" name="actionButton_home">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>108</width>
+                            <height>0</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>108</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>Home All</string>
+                          </property>
+                          <property name="home_action" stdset="0">
+                           <bool>true</bool>
+                          </property>
+                          <property name="joint_number" stdset="0">
+                           <number>-1</number>
+                          </property>
+                          <property name="incr_imperial_number" stdset="0">
+                           <double>0.010000000000000</double>
+                          </property>
+                          <property name="incr_mm_number" stdset="0">
+                           <double>0.025000000000000</double>
+                          </property>
+                          <property name="incr_angular_number" stdset="0">
+                           <double>-1.000000000000000</double>
+                          </property>
+                          <property name="toggle_float_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="float_num" stdset="0">
+                           <double>100.000000000000000</double>
+                          </property>
+                          <property name="float_alt_num" stdset="0">
+                           <double>50.000000000000000</double>
+                          </property>
+                          <property name="view_type_string" stdset="0">
+                           <string>P</string>
+                          </property>
+                          <property name="command_text_string" stdset="0">
+                           <string/>
+                          </property>
+                          <property name="ini_mdi_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="0">
+                         <layout class="QHBoxLayout" name="horizontalLayout_12">
+                          <item>
+                           <widget class="ActionButton" name="actionbutton_2">
+                            <property name="maximumSize">
+                             <size>
+                              <width>50</width>
+                              <height>25</height>
+                             </size>
+                            </property>
+                            <property name="text">
+                             <string>-</string>
+                            </property>
+                            <property name="jog_selected_pos_action" stdset="0">
+                             <bool>false</bool>
+                            </property>
+                            <property name="jog_selected_neg_action" stdset="0">
+                             <bool>true</bool>
+                            </property>
+                            <property name="joint_number" stdset="0">
+                             <number>0</number>
+                            </property>
+                            <property name="incr_imperial_number" stdset="0">
+                             <double>0.010000000000000</double>
+                            </property>
+                            <property name="incr_mm_number" stdset="0">
+                             <double>0.025000000000000</double>
+                            </property>
+                            <property name="incr_angular_number" stdset="0">
+                             <double>-1.000000000000000</double>
+                            </property>
+                            <property name="toggle_float_option" stdset="0">
+                             <bool>false</bool>
+                            </property>
+                            <property name="float_num" stdset="0">
+                             <double>100.000000000000000</double>
+                            </property>
+                            <property name="float_alt_num" stdset="0">
+                             <double>50.000000000000000</double>
+                            </property>
+                            <property name="view_type_string" stdset="0">
+                             <string>P</string>
+                            </property>
+                            <property name="command_text_string" stdset="0">
+                             <string/>
+                            </property>
+                            <property name="ini_mdi_number" stdset="0">
+                             <number>0</number>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <widget class="ActionButton" name="actionbutton">
+                            <property name="maximumSize">
+                             <size>
+                              <width>50</width>
+                              <height>25</height>
+                             </size>
+                            </property>
+                            <property name="text">
+                             <string>+</string>
+                            </property>
+                            <property name="jog_selected_pos_action" stdset="0">
+                             <bool>true</bool>
+                            </property>
+                            <property name="joint_number" stdset="0">
+                             <number>0</number>
+                            </property>
+                            <property name="incr_imperial_number" stdset="0">
+                             <double>0.010000000000000</double>
+                            </property>
+                            <property name="incr_mm_number" stdset="0">
+                             <double>0.025000000000000</double>
+                            </property>
+                            <property name="incr_angular_number" stdset="0">
+                             <double>-1.000000000000000</double>
+                            </property>
+                            <property name="toggle_float_option" stdset="0">
+                             <bool>false</bool>
+                            </property>
+                            <property name="float_num" stdset="0">
+                             <double>100.000000000000000</double>
+                            </property>
+                            <property name="float_alt_num" stdset="0">
+                             <double>50.000000000000000</double>
+                            </property>
+                            <property name="view_type_string" stdset="0">
+                             <string>P</string>
+                            </property>
+                            <property name="command_text_string" stdset="0">
+                             <string/>
+                            </property>
+                            <property name="ini_mdi_number" stdset="0">
+                             <number>0</number>
+                            </property>
+                           </widget>
+                          </item>
+                         </layout>
+                        </item>
+                        <item row="1" column="1">
+                         <widget class="AxisToolButton" name="axistoolbutton">
+                          <property name="minimumSize">
+                           <size>
+                            <width>100</width>
+                            <height>0</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>100</width>
+                            <height>25</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>Set Origin</string>
+                          </property>
+                          <property name="joint_number" stdset="0">
+                           <number>-1</number>
+                          </property>
+                          <property name="halpin_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="1">
+                         <widget class="JogIncrements" name="jogincrements">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>100</width>
+                            <height>0</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>100</width>
+                            <height>25</height>
+                           </size>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="0">
+                         <widget class="ActionButton" name="actionbutton_7">
+                          <property name="text">
+                           <string>Override Limits</string>
+                          </property>
+                          <property name="checkable">
+                           <bool>true</bool>
+                          </property>
+                          <property name="limits_override_action" stdset="0">
+                           <bool>true</bool>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="1">
+                         <widget class="OffsetToolButton" name="offsettoolbutton">
+                          <property name="text">
+                           <string>Set Tool Offset</string>
+                          </property>
+                          <property name="popupMode">
+                           <enum>QToolButton::InstantPopup</enum>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
                       </item>
-                      <item row="0" column="1">
-                       <widget class="JogIncrements" name="jogincrements">
+                      <item>
+                       <layout class="QHBoxLayout" name="horizontalLayout_spindle">
+                        <property name="spacing">
+                         <number>0</number>
+                        </property>
+                        <property name="leftMargin">
+                         <number>6</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>6</number>
+                        </property>
+                        <item>
+                         <widget class="QLabel" name="label_7">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>35</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Spindle:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="ActionButton" name="actionbutton_4">
+                          <property name="maximumSize">
+                           <size>
+                            <width>50</width>
+                            <height>25</height>
+                           </size>
+                          </property>
+                          <property name="icon">
+                           <iconset>
+                            <selectedon>../../../axis/images/spindle_ccw.gif</selectedon>
+                           </iconset>
+                          </property>
+                          <property name="spindle_rev_action" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="spindle_down_action" stdset="0">
+                           <bool>true</bool>
+                          </property>
+                          <property name="joint_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="incr_imperial_number" stdset="0">
+                           <double>0.010000000000000</double>
+                          </property>
+                          <property name="incr_mm_number" stdset="0">
+                           <double>0.025000000000000</double>
+                          </property>
+                          <property name="incr_angular_number" stdset="0">
+                           <double>-1.000000000000000</double>
+                          </property>
+                          <property name="toggle_float_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="float_num" stdset="0">
+                           <double>100.000000000000000</double>
+                          </property>
+                          <property name="float_alt_num" stdset="0">
+                           <double>50.000000000000000</double>
+                          </property>
+                          <property name="view_type_string" stdset="0">
+                           <string>P</string>
+                          </property>
+                          <property name="command_text_string" stdset="0">
+                           <string/>
+                          </property>
+                          <property name="ini_mdi_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="ActionButton" name="actionbutton_5">
+                          <property name="maximumSize">
+                           <size>
+                            <width>50</width>
+                            <height>25</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>Stop</string>
+                          </property>
+                          <property name="checkable">
+                           <bool>false</bool>
+                          </property>
+                          <property name="checked">
+                           <bool>false</bool>
+                          </property>
+                          <property name="spindle_stop_action" stdset="0">
+                           <bool>true</bool>
+                          </property>
+                          <property name="joint_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="incr_imperial_number" stdset="0">
+                           <double>0.010000000000000</double>
+                          </property>
+                          <property name="incr_mm_number" stdset="0">
+                           <double>0.025000000000000</double>
+                          </property>
+                          <property name="incr_angular_number" stdset="0">
+                           <double>-1.000000000000000</double>
+                          </property>
+                          <property name="toggle_float_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="float_num" stdset="0">
+                           <double>100.000000000000000</double>
+                          </property>
+                          <property name="float_alt_num" stdset="0">
+                           <double>50.000000000000000</double>
+                          </property>
+                          <property name="view_type_string" stdset="0">
+                           <string>P</string>
+                          </property>
+                          <property name="command_text_string" stdset="0">
+                           <string/>
+                          </property>
+                          <property name="ini_mdi_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="ActionButton" name="actionbutton_6">
+                          <property name="maximumSize">
+                           <size>
+                            <width>50</width>
+                            <height>25</height>
+                           </size>
+                          </property>
+                          <property name="icon">
+                           <iconset>
+                            <selectedon>../../../axis/images/spindle_cw.gif</selectedon>
+                           </iconset>
+                          </property>
+                          <property name="spindle_fwd_action" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="spindle_up_action" stdset="0">
+                           <bool>true</bool>
+                          </property>
+                          <property name="joint_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="incr_imperial_number" stdset="0">
+                           <double>0.010000000000000</double>
+                          </property>
+                          <property name="incr_mm_number" stdset="0">
+                           <double>0.025000000000000</double>
+                          </property>
+                          <property name="incr_angular_number" stdset="0">
+                           <double>-1.000000000000000</double>
+                          </property>
+                          <property name="toggle_float_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="float_num" stdset="0">
+                           <double>100.000000000000000</double>
+                          </property>
+                          <property name="float_alt_num" stdset="0">
+                           <double>50.000000000000000</double>
+                          </property>
+                          <property name="view_type_string" stdset="0">
+                           <string>P</string>
+                          </property>
+                          <property name="command_text_string" stdset="0">
+                           <string/>
+                          </property>
+                          <property name="ini_mdi_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <spacer name="horizontalSpacer">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>40</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                       </layout>
+                      </item>
+                      <item>
+                       <layout class="QHBoxLayout" name="horizontalLayout_coolant">
+                        <property name="spacing">
+                         <number>0</number>
+                        </property>
+                        <property name="leftMargin">
+                         <number>6</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>6</number>
+                        </property>
+                        <item>
+                         <widget class="QLabel" name="label_12">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>35</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Flood&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="ActionButton" name="actionbutton_8">
+                          <property name="maximumSize">
+                           <size>
+                            <width>50</width>
+                            <height>40</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string/>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="qtaxis.qrc">
+                            <normaloff>:/buttons/images/coolant_flood_inactive.png</normaloff>
+                            <normalon>:/buttons/images/coolant_flood_active.png</normalon>:/buttons/images/coolant_flood_inactive.png</iconset>
+                          </property>
+                          <property name="iconSize">
+                           <size>
+                            <width>48</width>
+                            <height>48</height>
+                           </size>
+                          </property>
+                          <property name="checkable">
+                           <bool>true</bool>
+                          </property>
+                          <property name="indicator_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="indicator_HAL_pin_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="indicator_status_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="checked_state_text_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="python_command_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="on_color" stdset="0">
+                           <color>
+                            <red>255</red>
+                            <green>0</green>
+                            <blue>0</blue>
+                           </color>
+                          </property>
+                          <property name="shape_option" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="off_color" stdset="0">
+                           <color>
+                            <red>0</red>
+                            <green>0</green>
+                            <blue>0</blue>
+                           </color>
+                          </property>
+                          <property name="indicator_size" stdset="0">
+                           <double>0.300000000000000</double>
+                          </property>
+                          <property name="circle_diameter" stdset="0">
+                           <number>10</number>
+                          </property>
+                          <property name="right_edge_offset" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="top_edge_offset" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="corner_radius" stdset="0">
+                           <double>5.000000000000000</double>
+                          </property>
+                          <property name="height_fraction" stdset="0">
+                           <double>0.300000000000000</double>
+                          </property>
+                          <property name="width_fraction" stdset="0">
+                           <double>0.900000000000000</double>
+                          </property>
+                          <property name="true_state_string" stdset="0">
+                           <string>True</string>
+                          </property>
+                          <property name="false_state_string" stdset="0">
+                           <string>False</string>
+                          </property>
+                          <property name="true_python_cmd_string" stdset="0">
+                           <string>print(&quot;true command&quot;)</string>
+                          </property>
+                          <property name="false_python_cmd_string" stdset="0">
+                           <string>print(&quot;false command&quot;)</string>
+                          </property>
+                          <property name="invert_the_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_paused_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_estopped_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_on_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_idle_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_homed_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_flood_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_mist_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_block_delete_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_optional_stop_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_joint_homed_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_limits_overridden_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_manual_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_mdi_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_auto_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_spindle_stopped_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_spindle_fwd_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_spindle_rev_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="joint_number_status" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="spindle_rev_action" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="spindle_down_action" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="flood_action" stdset="0">
+                           <bool>true</bool>
+                          </property>
+                          <property name="template_label_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="joint_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="incr_imperial_number" stdset="0">
+                           <double>0.010000000000000</double>
+                          </property>
+                          <property name="incr_mm_number" stdset="0">
+                           <double>0.025000000000000</double>
+                          </property>
+                          <property name="incr_angular_number" stdset="0">
+                           <double>-1.000000000000000</double>
+                          </property>
+                          <property name="toggle_float_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="float_num" stdset="0">
+                           <double>0.300000000000000</double>
+                          </property>
+                          <property name="float_alt_num" stdset="0">
+                           <double>50.000000000000000</double>
+                          </property>
+                          <property name="view_type_string" stdset="0">
+                           <string>P</string>
+                          </property>
+                          <property name="command_text_string" stdset="0">
+                           <string/>
+                          </property>
+                          <property name="ini_mdi_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="textTemplate" stdset="0">
+                           <string>%1.3f in</string>
+                          </property>
+                          <property name="alt_textTemplate" stdset="0">
+                           <string>%1.2f mm</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <spacer name="horizontalSpacer_3">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>40</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                        <item>
+                         <widget class="QLabel" name="label_13">
+                          <property name="maximumSize">
+                           <size>
+                            <width>16777215</width>
+                            <height>35</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Mist&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="ActionButton" name="actionbutton_10">
+                          <property name="maximumSize">
+                           <size>
+                            <width>50</width>
+                            <height>40</height>
+                           </size>
+                          </property>
+                          <property name="text">
+                           <string/>
+                          </property>
+                          <property name="icon">
+                           <iconset resource="qtaxis.qrc">
+                            <normaloff>:/buttons/images/coolant_mist_inactive.png</normaloff>
+                            <normalon>:/buttons/images/coolant_mist_active.png</normalon>:/buttons/images/coolant_mist_inactive.png</iconset>
+                          </property>
+                          <property name="iconSize">
+                           <size>
+                            <width>48</width>
+                            <height>48</height>
+                           </size>
+                          </property>
+                          <property name="checkable">
+                           <bool>true</bool>
+                          </property>
+                          <property name="indicator_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="indicator_HAL_pin_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="indicator_status_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="checked_state_text_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="python_command_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="on_color" stdset="0">
+                           <color>
+                            <red>255</red>
+                            <green>0</green>
+                            <blue>0</blue>
+                           </color>
+                          </property>
+                          <property name="shape_option" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="off_color" stdset="0">
+                           <color>
+                            <red>0</red>
+                            <green>0</green>
+                            <blue>0</blue>
+                           </color>
+                          </property>
+                          <property name="indicator_size" stdset="0">
+                           <double>0.300000000000000</double>
+                          </property>
+                          <property name="circle_diameter" stdset="0">
+                           <number>10</number>
+                          </property>
+                          <property name="right_edge_offset" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="top_edge_offset" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="corner_radius" stdset="0">
+                           <double>5.000000000000000</double>
+                          </property>
+                          <property name="height_fraction" stdset="0">
+                           <double>0.300000000000000</double>
+                          </property>
+                          <property name="width_fraction" stdset="0">
+                           <double>0.900000000000000</double>
+                          </property>
+                          <property name="true_state_string" stdset="0">
+                           <string>True</string>
+                          </property>
+                          <property name="false_state_string" stdset="0">
+                           <string>False</string>
+                          </property>
+                          <property name="true_python_cmd_string" stdset="0">
+                           <string>print(&quot;true command&quot;)</string>
+                          </property>
+                          <property name="false_python_cmd_string" stdset="0">
+                           <string>print(&quot;false command&quot;)</string>
+                          </property>
+                          <property name="invert_the_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_paused_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_estopped_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_on_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_idle_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_homed_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_flood_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_mist_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_block_delete_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_optional_stop_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_joint_homed_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_limits_overridden_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_manual_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_mdi_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_auto_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_spindle_stopped_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_spindle_fwd_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="is_spindle_rev_status" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="joint_number_status" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="spindle_fwd_action" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="spindle_up_action" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="mist_action" stdset="0">
+                           <bool>true</bool>
+                          </property>
+                          <property name="template_label_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="joint_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="incr_imperial_number" stdset="0">
+                           <double>0.010000000000000</double>
+                          </property>
+                          <property name="incr_mm_number" stdset="0">
+                           <double>0.025000000000000</double>
+                          </property>
+                          <property name="incr_angular_number" stdset="0">
+                           <double>-1.000000000000000</double>
+                          </property>
+                          <property name="toggle_float_option" stdset="0">
+                           <bool>false</bool>
+                          </property>
+                          <property name="float_num" stdset="0">
+                           <double>0.300000000000000</double>
+                          </property>
+                          <property name="float_alt_num" stdset="0">
+                           <double>50.000000000000000</double>
+                          </property>
+                          <property name="view_type_string" stdset="0">
+                           <string>P</string>
+                          </property>
+                          <property name="command_text_string" stdset="0">
+                           <string/>
+                          </property>
+                          <property name="ini_mdi_number" stdset="0">
+                           <number>0</number>
+                          </property>
+                          <property name="textTemplate" stdset="0">
+                           <string>%1.3f in</string>
+                          </property>
+                          <property name="alt_textTemplate" stdset="0">
+                           <string>%1.2f mm</string>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </item>
+                     </layout>
+                    </widget>
+                    <widget class="QWidget" name="tab_4">
+                     <attribute name="title">
+                      <string>MDI [F5]</string>
+                     </attribute>
+                     <layout class="QVBoxLayout" name="verticalLayout_4">
+                      <property name="spacing">
+                       <number>3</number>
+                      </property>
+                      <property name="leftMargin">
+                       <number>3</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>3</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>3</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <widget class="MDIHistory" name="mdihistory">
                         <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                         <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
                           <horstretch>0</horstretch>
                           <verstretch>0</verstretch>
                          </sizepolicy>
                         </property>
                         <property name="minimumSize">
                          <size>
-                          <width>100</width>
-                          <height>0</height>
+                          <width>200</width>
+                          <height>75</height>
                          </size>
-                        </property>
-                        <property name="maximumSize">
-                         <size>
-                          <width>100</width>
-                          <height>25</height>
-                         </size>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="0">
-                       <widget class="ActionButton" name="actionbutton_7">
-                        <property name="text">
-                         <string>Override Limits</string>
-                        </property>
-                        <property name="checkable">
-                         <bool>true</bool>
-                        </property>
-                        <property name="limits_override_action" stdset="0">
-                         <bool>true</bool>
-                        </property>
-                       </widget>
-                      </item>
-                      <item row="2" column="1">
-                       <widget class="OffsetToolButton" name="offsettoolbutton">
-                        <property name="text">
-                         <string>Set Tool Offset</string>
-                        </property>
-                        <property name="popupMode">
-                         <enum>QToolButton::InstantPopup</enum>
                         </property>
                        </widget>
                       </item>
                      </layout>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_spindle">
-                      <property name="spacing">
-                       <number>0</number>
-                      </property>
-                      <property name="leftMargin">
-                       <number>6</number>
-                      </property>
-                      <property name="rightMargin">
-                       <number>6</number>
-                      </property>
-                      <item>
-                       <widget class="QLabel" name="label_7">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>35</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Spindle:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="ActionButton" name="actionbutton_4">
-                        <property name="maximumSize">
-                         <size>
-                          <width>50</width>
-                          <height>25</height>
-                         </size>
-                        </property>
-                        <property name="icon">
-                         <iconset>
-                          <selectedon>../../../axis/images/spindle_ccw.gif</selectedon>
-                         </iconset>
-                        </property>
-                        <property name="spindle_rev_action" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="spindle_down_action" stdset="0">
-                         <bool>true</bool>
-                        </property>
-                        <property name="joint_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="incr_imperial_number" stdset="0">
-                         <double>0.010000000000000</double>
-                        </property>
-                        <property name="incr_mm_number" stdset="0">
-                         <double>0.025000000000000</double>
-                        </property>
-                        <property name="incr_angular_number" stdset="0">
-                         <double>-1.000000000000000</double>
-                        </property>
-                        <property name="toggle_float_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="float_num" stdset="0">
-                         <double>100.000000000000000</double>
-                        </property>
-                        <property name="float_alt_num" stdset="0">
-                         <double>50.000000000000000</double>
-                        </property>
-                        <property name="view_type_string" stdset="0">
-                         <string>P</string>
-                        </property>
-                        <property name="command_text_string" stdset="0">
-                         <string/>
-                        </property>
-                        <property name="ini_mdi_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="ActionButton" name="actionbutton_5">
-                        <property name="maximumSize">
-                         <size>
-                          <width>50</width>
-                          <height>25</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>Stop</string>
-                        </property>
-                        <property name="checkable">
-                         <bool>false</bool>
-                        </property>
-                        <property name="checked">
-                         <bool>false</bool>
-                        </property>
-                        <property name="spindle_stop_action" stdset="0">
-                         <bool>true</bool>
-                        </property>
-                        <property name="joint_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="incr_imperial_number" stdset="0">
-                         <double>0.010000000000000</double>
-                        </property>
-                        <property name="incr_mm_number" stdset="0">
-                         <double>0.025000000000000</double>
-                        </property>
-                        <property name="incr_angular_number" stdset="0">
-                         <double>-1.000000000000000</double>
-                        </property>
-                        <property name="toggle_float_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="float_num" stdset="0">
-                         <double>100.000000000000000</double>
-                        </property>
-                        <property name="float_alt_num" stdset="0">
-                         <double>50.000000000000000</double>
-                        </property>
-                        <property name="view_type_string" stdset="0">
-                         <string>P</string>
-                        </property>
-                        <property name="command_text_string" stdset="0">
-                         <string/>
-                        </property>
-                        <property name="ini_mdi_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="ActionButton" name="actionbutton_6">
-                        <property name="maximumSize">
-                         <size>
-                          <width>50</width>
-                          <height>25</height>
-                         </size>
-                        </property>
-                        <property name="icon">
-                         <iconset>
-                          <selectedon>../../../axis/images/spindle_cw.gif</selectedon>
-                         </iconset>
-                        </property>
-                        <property name="spindle_fwd_action" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="spindle_up_action" stdset="0">
-                         <bool>true</bool>
-                        </property>
-                        <property name="joint_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="incr_imperial_number" stdset="0">
-                         <double>0.010000000000000</double>
-                        </property>
-                        <property name="incr_mm_number" stdset="0">
-                         <double>0.025000000000000</double>
-                        </property>
-                        <property name="incr_angular_number" stdset="0">
-                         <double>-1.000000000000000</double>
-                        </property>
-                        <property name="toggle_float_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="float_num" stdset="0">
-                         <double>100.000000000000000</double>
-                        </property>
-                        <property name="float_alt_num" stdset="0">
-                         <double>50.000000000000000</double>
-                        </property>
-                        <property name="view_type_string" stdset="0">
-                         <string>P</string>
-                        </property>
-                        <property name="command_text_string" stdset="0">
-                         <string/>
-                        </property>
-                        <property name="ini_mdi_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <spacer name="horizontalSpacer">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_coolant">
-                      <property name="spacing">
-                       <number>0</number>
-                      </property>
-                      <property name="leftMargin">
-                       <number>6</number>
-                      </property>
-                      <property name="rightMargin">
-                       <number>6</number>
-                      </property>
-                      <item>
-                       <widget class="QLabel" name="label_12">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>35</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Flood&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="ActionButton" name="actionbutton_8">
-                        <property name="maximumSize">
-                         <size>
-                          <width>50</width>
-                          <height>40</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string/>
-                        </property>
-                        <property name="icon">
-                         <iconset resource="qtaxis.qrc">
-                          <normaloff>:/buttons/images/coolant_flood_inactive.png</normaloff>
-                          <normalon>:/buttons/images/coolant_flood_active.png</normalon>:/buttons/images/coolant_flood_inactive.png</iconset>
-                        </property>
-                        <property name="iconSize">
-                         <size>
-                          <width>48</width>
-                          <height>48</height>
-                         </size>
-                        </property>
-                        <property name="checkable">
-                         <bool>true</bool>
-                        </property>
-                        <property name="indicator_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="indicator_HAL_pin_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="indicator_status_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="checked_state_text_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="python_command_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="on_color" stdset="0">
-                         <color>
-                          <red>255</red>
-                          <green>0</green>
-                          <blue>0</blue>
-                         </color>
-                        </property>
-                        <property name="shape_option" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="off_color" stdset="0">
-                         <color>
-                          <red>0</red>
-                          <green>0</green>
-                          <blue>0</blue>
-                         </color>
-                        </property>
-                        <property name="indicator_size" stdset="0">
-                         <double>0.300000000000000</double>
-                        </property>
-                        <property name="circle_diameter" stdset="0">
-                         <number>10</number>
-                        </property>
-                        <property name="right_edge_offset" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="top_edge_offset" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="corner_radius" stdset="0">
-                         <double>5.000000000000000</double>
-                        </property>
-                        <property name="height_fraction" stdset="0">
-                         <double>0.300000000000000</double>
-                        </property>
-                        <property name="width_fraction" stdset="0">
-                         <double>0.900000000000000</double>
-                        </property>
-                        <property name="true_state_string" stdset="0">
-                         <string>True</string>
-                        </property>
-                        <property name="false_state_string" stdset="0">
-                         <string>False</string>
-                        </property>
-                        <property name="true_python_cmd_string" stdset="0">
-                         <string>print(&quot;true command&quot;)</string>
-                        </property>
-                        <property name="false_python_cmd_string" stdset="0">
-                         <string>print(&quot;false command&quot;)</string>
-                        </property>
-                        <property name="invert_the_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_paused_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_estopped_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_on_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_idle_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_homed_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_flood_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_mist_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_block_delete_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_optional_stop_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_joint_homed_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_limits_overridden_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_manual_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_mdi_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_auto_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_spindle_stopped_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_spindle_fwd_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_spindle_rev_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="joint_number_status" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="spindle_rev_action" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="spindle_down_action" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="flood_action" stdset="0">
-                         <bool>true</bool>
-                        </property>
-                        <property name="template_label_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="joint_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="incr_imperial_number" stdset="0">
-                         <double>0.010000000000000</double>
-                        </property>
-                        <property name="incr_mm_number" stdset="0">
-                         <double>0.025000000000000</double>
-                        </property>
-                        <property name="incr_angular_number" stdset="0">
-                         <double>-1.000000000000000</double>
-                        </property>
-                        <property name="toggle_float_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="float_num" stdset="0">
-                         <double>0.300000000000000</double>
-                        </property>
-                        <property name="float_alt_num" stdset="0">
-                         <double>50.000000000000000</double>
-                        </property>
-                        <property name="view_type_string" stdset="0">
-                         <string>P</string>
-                        </property>
-                        <property name="command_text_string" stdset="0">
-                         <string/>
-                        </property>
-                        <property name="ini_mdi_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="textTemplate" stdset="0">
-                         <string>%1.3f in</string>
-                        </property>
-                        <property name="alt_textTemplate" stdset="0">
-                         <string>%1.2f mm</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <spacer name="horizontalSpacer_3">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="label_13">
-                        <property name="maximumSize">
-                         <size>
-                          <width>16777215</width>
-                          <height>35</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Mist&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="ActionButton" name="actionbutton_10">
-                        <property name="maximumSize">
-                         <size>
-                          <width>50</width>
-                          <height>40</height>
-                         </size>
-                        </property>
-                        <property name="text">
-                         <string/>
-                        </property>
-                        <property name="icon">
-                         <iconset resource="qtaxis.qrc">
-                          <normaloff>:/buttons/images/coolant_mist_inactive.png</normaloff>
-                          <normalon>:/buttons/images/coolant_mist_active.png</normalon>:/buttons/images/coolant_mist_inactive.png</iconset>
-                        </property>
-                        <property name="iconSize">
-                         <size>
-                          <width>48</width>
-                          <height>48</height>
-                         </size>
-                        </property>
-                        <property name="checkable">
-                         <bool>true</bool>
-                        </property>
-                        <property name="indicator_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="indicator_HAL_pin_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="indicator_status_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="checked_state_text_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="python_command_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="on_color" stdset="0">
-                         <color>
-                          <red>255</red>
-                          <green>0</green>
-                          <blue>0</blue>
-                         </color>
-                        </property>
-                        <property name="shape_option" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="off_color" stdset="0">
-                         <color>
-                          <red>0</red>
-                          <green>0</green>
-                          <blue>0</blue>
-                         </color>
-                        </property>
-                        <property name="indicator_size" stdset="0">
-                         <double>0.300000000000000</double>
-                        </property>
-                        <property name="circle_diameter" stdset="0">
-                         <number>10</number>
-                        </property>
-                        <property name="right_edge_offset" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="top_edge_offset" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="corner_radius" stdset="0">
-                         <double>5.000000000000000</double>
-                        </property>
-                        <property name="height_fraction" stdset="0">
-                         <double>0.300000000000000</double>
-                        </property>
-                        <property name="width_fraction" stdset="0">
-                         <double>0.900000000000000</double>
-                        </property>
-                        <property name="true_state_string" stdset="0">
-                         <string>True</string>
-                        </property>
-                        <property name="false_state_string" stdset="0">
-                         <string>False</string>
-                        </property>
-                        <property name="true_python_cmd_string" stdset="0">
-                         <string>print(&quot;true command&quot;)</string>
-                        </property>
-                        <property name="false_python_cmd_string" stdset="0">
-                         <string>print(&quot;false command&quot;)</string>
-                        </property>
-                        <property name="invert_the_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_paused_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_estopped_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_on_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_idle_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_homed_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_flood_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_mist_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_block_delete_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_optional_stop_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_joint_homed_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_limits_overridden_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_manual_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_mdi_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_auto_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_spindle_stopped_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_spindle_fwd_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="is_spindle_rev_status" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="joint_number_status" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="spindle_fwd_action" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="spindle_up_action" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="mist_action" stdset="0">
-                         <bool>true</bool>
-                        </property>
-                        <property name="template_label_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="joint_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="incr_imperial_number" stdset="0">
-                         <double>0.010000000000000</double>
-                        </property>
-                        <property name="incr_mm_number" stdset="0">
-                         <double>0.025000000000000</double>
-                        </property>
-                        <property name="incr_angular_number" stdset="0">
-                         <double>-1.000000000000000</double>
-                        </property>
-                        <property name="toggle_float_option" stdset="0">
-                         <bool>false</bool>
-                        </property>
-                        <property name="float_num" stdset="0">
-                         <double>0.300000000000000</double>
-                        </property>
-                        <property name="float_alt_num" stdset="0">
-                         <double>50.000000000000000</double>
-                        </property>
-                        <property name="view_type_string" stdset="0">
-                         <string>P</string>
-                        </property>
-                        <property name="command_text_string" stdset="0">
-                         <string/>
-                        </property>
-                        <property name="ini_mdi_number" stdset="0">
-                         <number>0</number>
-                        </property>
-                        <property name="textTemplate" stdset="0">
-                         <string>%1.3f in</string>
-                        </property>
-                        <property name="alt_textTemplate" stdset="0">
-                         <string>%1.2f mm</string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                   </layout>
-                  </widget>
-                  <widget class="QWidget" name="tab_4">
-                   <attribute name="title">
-                    <string>MDI [F5]</string>
-                   </attribute>
-                   <layout class="QVBoxLayout" name="verticalLayout_4">
+                    </widget>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_4">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>40</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_11">
                     <property name="spacing">
-                     <number>3</number>
-                    </property>
-                    <property name="leftMargin">
-                     <number>3</number>
-                    </property>
-                    <property name="topMargin">
-                     <number>3</number>
-                    </property>
-                    <property name="rightMargin">
-                     <number>3</number>
-                    </property>
-                    <property name="bottomMargin">
                      <number>0</number>
                     </property>
                     <item>
-                     <widget class="MDIHistory" name="mdihistory">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
+                     <widget class="StatusLabel" name="statuslabel_8">
+                      <property name="textTemplate" stdset="0">
+                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;ACTIVE: &lt;/span&gt;F %0.1f&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>200</width>
-                        <height>75</height>
-                       </size>
+                      <property name="fcode_status" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                      <property name="mcodes_status" stdset="0">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusLabel" name="statuslabel_2">
+                      <property name="mcodes_status" stdset="0">
+                       <bool>true</bool>
                       </property>
                      </widget>
                     </item>
                    </layout>
-                  </widget>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="verticalSpacer_4">
-                  <property name="orientation">
-                   <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>40</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout_11">
+                  </item>
+                  <item>
+                   <widget class="StatusLabel" name="statuslabel">
+                    <property name="scaledContents">
+                     <bool>true</bool>
+                    </property>
+                    <property name="wordWrap">
+                     <bool>true</bool>
+                    </property>
+                    <property name="gcodes_status" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>40</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_feedOverride">
+                    <item>
+                     <widget class="QLabel" name="label_6">
+                      <property name="text">
+                       <string>Feed Override:    </string>
+                      </property>
+                      <property name="margin">
+                       <number>-10</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusLabel" name="statuslabel_3">
+                      <property name="maximumSize">
+                       <size>
+                        <width>50</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>100.0</string>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      </property>
+                      <property name="margin">
+                       <number>-7</number>
+                      </property>
+                      <property name="textTemplate" stdset="0">
+                       <string>%s</string>
+                      </property>
+                      <property name="feed_override_status" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusSlider" name="statusslider">
+                      <property name="maximumSize">
+                       <size>
+                        <width>125</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="rapid_rate" stdset="0">
+                       <bool>false</bool>
+                      </property>
+                      <property name="feed_rate" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_rapidOverride">
+                    <item>
+                     <widget class="QLabel" name="label_8">
+                      <property name="text">
+                       <string>Rapid Override:    </string>
+                      </property>
+                      <property name="margin">
+                       <number>-10</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusLabel" name="statuslabel_4">
+                      <property name="maximumSize">
+                       <size>
+                        <width>50</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>100.0</string>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      </property>
+                      <property name="margin">
+                       <number>-7</number>
+                      </property>
+                      <property name="textTemplate" stdset="0">
+                       <string>%s</string>
+                      </property>
+                      <property name="rapid_override_status" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusSlider" name="statusslider_2">
+                      <property name="maximumSize">
+                       <size>
+                        <width>125</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_spindleOverride">
+                    <item>
+                     <widget class="QLabel" name="label_9">
+                      <property name="text">
+                       <string>Spindle Override:    </string>
+                      </property>
+                      <property name="margin">
+                       <number>-10</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusLabel" name="statuslabel_5">
+                      <property name="maximumSize">
+                       <size>
+                        <width>50</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>100.0</string>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      </property>
+                      <property name="margin">
+                       <number>-7</number>
+                      </property>
+                      <property name="textTemplate" stdset="0">
+                       <string>%s</string>
+                      </property>
+                      <property name="spindle_override_status" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusSlider" name="statusslider_3">
+                      <property name="maximumSize">
+                       <size>
+                        <width>125</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="rapid_rate" stdset="0">
+                       <bool>false</bool>
+                      </property>
+                      <property name="spindle_rate" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_jograte">
+                    <item>
+                     <widget class="QLabel" name="label_10">
+                      <property name="text">
+                       <string>Jog Rate:</string>
+                      </property>
+                      <property name="margin">
+                       <number>-10</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusLabel" name="statuslabel_6">
+                      <property name="maximumSize">
+                       <size>
+                        <width>50</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>100.0</string>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      </property>
+                      <property name="margin">
+                       <number>-7</number>
+                      </property>
+                      <property name="textTemplate" stdset="0">
+                       <string>%s</string>
+                      </property>
+                      <property name="jograte_status" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusSlider" name="statusslider_4">
+                      <property name="maximumSize">
+                       <size>
+                        <width>125</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="rapid_rate" stdset="0">
+                       <bool>false</bool>
+                      </property>
+                      <property name="jograte_rate" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="widget_angular_jog" native="true">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_10">
+                     <property name="spacing">
+                      <number>0</number>
+                     </property>
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <layout class="QHBoxLayout" name="horizontalLayout_jograte_angular">
+                       <item>
+                        <widget class="QLabel" name="label_14">
+                         <property name="text">
+                          <string>AngularJog Rate:</string>
+                         </property>
+                         <property name="margin">
+                          <number>-10</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="StatusLabel" name="statuslabel_9">
+                         <property name="maximumSize">
+                          <size>
+                           <width>50</width>
+                           <height>16777215</height>
+                          </size>
+                         </property>
+                         <property name="text">
+                          <string>100.0</string>
+                         </property>
+                         <property name="alignment">
+                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                         </property>
+                         <property name="margin">
+                          <number>-7</number>
+                         </property>
+                         <property name="textTemplate" stdset="0">
+                          <string>%s</string>
+                         </property>
+                         <property name="jograte_status" stdset="0">
+                          <bool>false</bool>
+                         </property>
+                         <property name="jograte_angular_status" stdset="0">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="StatusSlider" name="statusslider_6">
+                         <property name="maximumSize">
+                          <size>
+                           <width>125</width>
+                           <height>16777215</height>
+                          </size>
+                         </property>
+                         <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                         </property>
+                         <property name="rapid_rate" stdset="0">
+                          <bool>false</bool>
+                         </property>
+                         <property name="jograte_rate" stdset="0">
+                          <bool>false</bool>
+                         </property>
+                         <property name="jograte_angular_rate" stdset="0">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_maxVelocity">
+                    <item>
+                     <widget class="QLabel" name="label_11">
+                      <property name="text">
+                       <string>Max Velocity</string>
+                      </property>
+                      <property name="margin">
+                       <number>-10</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusLabel" name="statuslabel_7">
+                      <property name="maximumSize">
+                       <size>
+                        <width>50</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>100.0</string>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      </property>
+                      <property name="margin">
+                       <number>-7</number>
+                      </property>
+                      <property name="textTemplate" stdset="0">
+                       <string>%s</string>
+                      </property>
+                      <property name="max_velocity_override_status" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="StatusSlider" name="statusslider_5">
+                      <property name="maximumSize">
+                       <size>
+                        <width>125</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="rapid_rate" stdset="0">
+                       <bool>false</bool>
+                      </property>
+                      <property name="jograte_angular_rate" stdset="0">
+                       <bool>false</bool>
+                      </property>
+                      <property name="max_velocity_rate" stdset="0">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+                <widget class="QFrame" name="frameRightTab">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>300</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="frameShape">
+                  <enum>QFrame::Box</enum>
+                 </property>
+                 <property name="frameShadow">
+                  <enum>QFrame::Sunken</enum>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_2">
                   <property name="spacing">
+                   <number>4</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="StatusLabel" name="statuslabel_8">
-                    <property name="textTemplate" stdset="0">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;ACTIVE: &lt;/span&gt;F %0.1f&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <widget class="DetachTabWidget" name="rightTab">
+                    <property name="currentIndex">
+                     <number>1</number>
                     </property>
-                    <property name="fcode_status" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                    <property name="mcodes_status" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusLabel" name="statuslabel_2">
-                    <property name="mcodes_status" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <widget class="StatusLabel" name="statuslabel">
-                  <property name="scaledContents">
-                   <bool>true</bool>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>true</bool>
-                  </property>
-                  <property name="gcodes_status" stdset="0">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="verticalSpacer">
-                  <property name="orientation">
-                   <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>40</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout_feedOverride">
-                  <item>
-                   <widget class="QLabel" name="label_6">
-                    <property name="text">
-                     <string>Feed Override:    </string>
-                    </property>
-                    <property name="margin">
-                     <number>-10</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusLabel" name="statuslabel_3">
-                    <property name="maximumSize">
-                     <size>
-                      <width>50</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>100.0</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                    </property>
-                    <property name="margin">
-                     <number>-7</number>
-                    </property>
-                    <property name="textTemplate" stdset="0">
-                     <string>%s</string>
-                    </property>
-                    <property name="feed_override_status" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusSlider" name="statusslider">
-                    <property name="maximumSize">
-                     <size>
-                      <width>125</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="rapid_rate" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="feed_rate" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout_rapidOverride">
-                  <item>
-                   <widget class="QLabel" name="label_8">
-                    <property name="text">
-                     <string>Rapid Override:    </string>
-                    </property>
-                    <property name="margin">
-                     <number>-10</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusLabel" name="statuslabel_4">
-                    <property name="maximumSize">
-                     <size>
-                      <width>50</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>100.0</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                    </property>
-                    <property name="margin">
-                     <number>-7</number>
-                    </property>
-                    <property name="textTemplate" stdset="0">
-                     <string>%s</string>
-                    </property>
-                    <property name="rapid_override_status" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusSlider" name="statusslider_2">
-                    <property name="maximumSize">
-                     <size>
-                      <width>125</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout_spindleOverride">
-                  <item>
-                   <widget class="QLabel" name="label_9">
-                    <property name="text">
-                     <string>Spindle Override:    </string>
-                    </property>
-                    <property name="margin">
-                     <number>-10</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusLabel" name="statuslabel_5">
-                    <property name="maximumSize">
-                     <size>
-                      <width>50</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>100.0</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                    </property>
-                    <property name="margin">
-                     <number>-7</number>
-                    </property>
-                    <property name="textTemplate" stdset="0">
-                     <string>%s</string>
-                    </property>
-                    <property name="spindle_override_status" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusSlider" name="statusslider_3">
-                    <property name="maximumSize">
-                     <size>
-                      <width>125</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="rapid_rate" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="spindle_rate" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout_jograte">
-                  <item>
-                   <widget class="QLabel" name="label_10">
-                    <property name="text">
-                     <string>Jog Rate:</string>
-                    </property>
-                    <property name="margin">
-                     <number>-10</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusLabel" name="statuslabel_6">
-                    <property name="maximumSize">
-                     <size>
-                      <width>50</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>100.0</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                    </property>
-                    <property name="margin">
-                     <number>-7</number>
-                    </property>
-                    <property name="textTemplate" stdset="0">
-                     <string>%s</string>
-                    </property>
-                    <property name="jograte_status" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusSlider" name="statusslider_4">
-                    <property name="maximumSize">
-                     <size>
-                      <width>125</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="rapid_rate" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="jograte_rate" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <widget class="QWidget" name="widget_angular_jog" native="true">
-                  <property name="enabled">
-                   <bool>true</bool>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_10">
-                   <property name="spacing">
-                    <number>0</number>
-                   </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <layout class="QHBoxLayout" name="horizontalLayout_jograte_angular">
-                     <item>
-                      <widget class="QLabel" name="label_14">
-                       <property name="text">
-                        <string>AngularJog Rate:</string>
-                       </property>
-                       <property name="margin">
-                        <number>-10</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="StatusLabel" name="statuslabel_9">
-                       <property name="maximumSize">
-                        <size>
-                         <width>50</width>
-                         <height>16777215</height>
-                        </size>
-                       </property>
-                       <property name="text">
-                        <string>100.0</string>
-                       </property>
-                       <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                       <property name="margin">
-                        <number>-7</number>
-                       </property>
-                       <property name="textTemplate" stdset="0">
-                        <string>%s</string>
-                       </property>
-                       <property name="jograte_status" stdset="0">
-                        <bool>false</bool>
-                       </property>
-                       <property name="jograte_angular_status" stdset="0">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="StatusSlider" name="statusslider_6">
-                       <property name="maximumSize">
-                        <size>
-                         <width>125</width>
-                         <height>16777215</height>
-                        </size>
-                       </property>
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
-                       <property name="rapid_rate" stdset="0">
-                        <bool>false</bool>
-                       </property>
-                       <property name="jograte_rate" stdset="0">
-                        <bool>false</bool>
-                       </property>
-                       <property name="jograte_angular_rate" stdset="0">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout_maxVelocity">
-                  <item>
-                   <widget class="QLabel" name="label_11">
-                    <property name="text">
-                     <string>Max Velocity</string>
-                    </property>
-                    <property name="margin">
-                     <number>-10</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusLabel" name="statuslabel_7">
-                    <property name="maximumSize">
-                     <size>
-                      <width>50</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>100.0</string>
-                    </property>
-                    <property name="alignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                    </property>
-                    <property name="margin">
-                     <number>-7</number>
-                    </property>
-                    <property name="textTemplate" stdset="0">
-                     <string>%s</string>
-                    </property>
-                    <property name="max_velocity_override_status" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="StatusSlider" name="statusslider_5">
-                    <property name="maximumSize">
-                     <size>
-                      <width>125</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="rapid_rate" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="jograte_angular_rate" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="max_velocity_rate" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="verticalLayout_7">
-               <item>
-                <widget class="DetachTabWidget" name="rightTab">
-                 <property name="currentIndex">
-                  <number>1</number>
-                 </property>
-                 <widget class="QWidget" name="tab">
-                  <attribute name="title">
-                   <string>DRO</string>
-                  </attribute>
-                  <layout class="QVBoxLayout" name="verticalLayout_8">
-                   <property name="spacing">
-                    <number>0</number>
-                   </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QFrame" name="frame_2">
-                     <property name="frameShape">
-                      <enum>QFrame::Box</enum>
-                     </property>
-                     <property name="frameShadow">
-                      <enum>QFrame::Raised</enum>
-                     </property>
-                     <property name="lineWidth">
-                      <number>2</number>
-                     </property>
-                     <layout class="QVBoxLayout" name="verticalLayout_9">
+                    <widget class="QWidget" name="tab">
+                     <attribute name="title">
+                      <string>DRO</string>
+                     </attribute>
+                     <layout class="QVBoxLayout" name="verticalLayout_8">
                       <property name="spacing">
                        <number>0</number>
                       </property>
-                      <property name="sizeConstraint">
-                       <enum>QLayout::SetDefaultConstraint</enum>
-                      </property>
                       <property name="leftMargin">
-                       <number>2</number>
+                       <number>0</number>
                       </property>
                       <property name="topMargin">
                        <number>0</number>
@@ -1954,19 +1976,25 @@
                        <number>0</number>
                       </property>
                       <item>
-                       <widget class="QWidget" name="widget_dro_g53" native="true">
-                        <property name="sizePolicy">
-                         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                          <horstretch>0</horstretch>
-                          <verstretch>0</verstretch>
-                         </sizepolicy>
+                       <widget class="QFrame" name="frame_2">
+                        <property name="frameShape">
+                         <enum>QFrame::Box</enum>
                         </property>
-                        <layout class="QVBoxLayout" name="verticalLayout_3">
+                        <property name="frameShadow">
+                         <enum>QFrame::Raised</enum>
+                        </property>
+                        <property name="lineWidth">
+                         <number>2</number>
+                        </property>
+                        <layout class="QVBoxLayout" name="verticalLayout_9">
                          <property name="spacing">
                           <number>0</number>
                          </property>
+                         <property name="sizeConstraint">
+                          <enum>QLayout::SetDefaultConstraint</enum>
+                         </property>
                          <property name="leftMargin">
-                          <number>0</number>
+                          <number>2</number>
                          </property>
                          <property name="topMargin">
                           <number>0</number>
@@ -1978,378 +2006,448 @@
                           <number>0</number>
                          </property>
                          <item>
-                          <layout class="QVBoxLayout" name="verticalLayout_6">
+                          <widget class="QWidget" name="widget_dro_g53" native="true">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_3">
+                            <property name="spacing">
+                             <number>0</number>
+                            </property>
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_6">
+                              <property name="spacing">
+                               <number>0</number>
+                              </property>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_g53_x">
+                                <property name="spacing">
+                                 <number>0</number>
+                                </property>
+                                <item>
+                                 <widget class="DROLabel" name="dro_label_g53_x">
+                                  <property name="sizePolicy">
+                                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                   </sizepolicy>
+                                  </property>
+                                  <property name="metric_template" stdset="0">
+                                   <string>X %10.3f</string>
+                                  </property>
+                                  <property name="imperial_template" stdset="0">
+                                   <string>X %9.4f</string>
+                                  </property>
+                                 </widget>
+                                </item>
+                               </layout>
+                              </item>
+                              <item>
+                               <widget class="QWidget" name="dro_absolute_y" native="true">
+                                <layout class="QHBoxLayout" name="horizontalLayout_g53_y">
+                                 <property name="spacing">
+                                  <number>0</number>
+                                 </property>
+                                 <property name="leftMargin">
+                                  <number>0</number>
+                                 </property>
+                                 <property name="topMargin">
+                                  <number>0</number>
+                                 </property>
+                                 <property name="rightMargin">
+                                  <number>0</number>
+                                 </property>
+                                 <property name="bottomMargin">
+                                  <number>0</number>
+                                 </property>
+                                 <item>
+                                  <widget class="DROLabel" name="dro_label_g53_y">
+                                   <property name="sizePolicy">
+                                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                     <horstretch>0</horstretch>
+                                     <verstretch>0</verstretch>
+                                    </sizepolicy>
+                                   </property>
+                                   <property name="textSpaceSample" stdset="0">
+                                    <string/>
+                                   </property>
+                                   <property name="Qjoint_number" stdset="0">
+                                    <number>1</number>
+                                   </property>
+                                   <property name="metric_template" stdset="0">
+                                    <string>Y %10.3f</string>
+                                   </property>
+                                   <property name="imperial_template" stdset="0">
+                                    <string>Y %9.4f</string>
+                                   </property>
+                                  </widget>
+                                 </item>
+                                </layout>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_g53_z">
+                                <property name="spacing">
+                                 <number>0</number>
+                                </property>
+                                <item>
+                                 <widget class="DROLabel" name="dro_label_g53_z">
+                                  <property name="sizePolicy">
+                                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                                    <horstretch>0</horstretch>
+                                    <verstretch>0</verstretch>
+                                   </sizepolicy>
+                                  </property>
+                                  <property name="Qjoint_number" stdset="0">
+                                   <number>2</number>
+                                  </property>
+                                  <property name="metric_template" stdset="0">
+                                   <string>Z %10.3f</string>
+                                  </property>
+                                  <property name="imperial_template" stdset="0">
+                                   <string>Z %9.4f</string>
+                                  </property>
+                                 </widget>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item>
+                          <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="0">
                            <property name="spacing">
                             <number>0</number>
                            </property>
                            <item>
-                            <layout class="QHBoxLayout" name="horizontalLayout_g53_x">
-                             <property name="spacing">
-                              <number>0</number>
+                            <widget class="DROLabel" name="dro_label_g5x_x_">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
                              </property>
-                             <item>
-                              <widget class="DROLabel" name="dro_label_g53_x">
-                               <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                 <horstretch>0</horstretch>
-                                 <verstretch>0</verstretch>
-                                </sizepolicy>
-                               </property>
-                               <property name="metric_template" stdset="0">
-                                <string>X %10.3f</string>
-                               </property>
-                               <property name="imperial_template" stdset="0">
-                                <string>X %9.4f</string>
-                               </property>
-                              </widget>
-                             </item>
-                            </layout>
-                           </item>
-                           <item>
-                            <widget class="QWidget" name="dro_absolute_y" native="true">
-                             <layout class="QHBoxLayout" name="horizontalLayout_g53_y">
-                              <property name="spacing">
-                               <number>0</number>
-                              </property>
-                              <property name="leftMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="topMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="rightMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="bottomMargin">
-                               <number>0</number>
-                              </property>
-                              <item>
-                               <widget class="DROLabel" name="dro_label_g53_y">
-                                <property name="sizePolicy">
-                                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                  <horstretch>0</horstretch>
-                                  <verstretch>0</verstretch>
-                                 </sizepolicy>
-                                </property>
-                                <property name="textSpaceSample" stdset="0">
-                                 <string/>
-                                </property>
-                                <property name="Qjoint_number" stdset="0">
-                                 <number>1</number>
-                                </property>
-                                <property name="metric_template" stdset="0">
-                                 <string>Y %10.3f</string>
-                                </property>
-                                <property name="imperial_template" stdset="0">
-                                 <string>Y %9.4f</string>
-                                </property>
-                               </widget>
-                              </item>
-                             </layout>
+                             <property name="frameShape">
+                              <enum>QFrame::NoFrame</enum>
+                             </property>
+                             <property name="text">
+                              <string>%10.3f</string>
+                             </property>
+                             <property name="textFormat">
+                              <enum>Qt::RichText</enum>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                             <property name="textSpaceSample" stdset="0">
+                              <string> -000.0000 X</string>
+                             </property>
+                             <property name="Qreference_type" stdset="0">
+                              <number>1</number>
+                             </property>
+                             <property name="metric_template" stdset="0">
+                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%10.2f&lt;span style=&quot; color:gray;&quot;&gt; X&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                             </property>
+                             <property name="imperial_template" stdset="0">
+                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%9.4f&lt;span style=&quot; color:gray;&quot;&gt; X&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                             </property>
                             </widget>
                            </item>
+                          </layout>
+                         </item>
+                         <item>
+                          <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0">
+                           <property name="spacing">
+                            <number>0</number>
+                           </property>
                            <item>
-                            <layout class="QHBoxLayout" name="horizontalLayout_g53_z">
-                             <property name="spacing">
+                            <widget class="DROLabel" name="dro_label_g5x_y">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                             <property name="frameShape">
+                              <enum>QFrame::NoFrame</enum>
+                             </property>
+                             <property name="text">
+                              <string>%10.3f</string>
+                             </property>
+                             <property name="textFormat">
+                              <enum>Qt::RichText</enum>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                             <property name="textSpaceSample" stdset="0">
+                              <string> -000.0000 X</string>
+                             </property>
+                             <property name="Qjoint_number" stdset="0">
+                              <number>1</number>
+                             </property>
+                             <property name="Qreference_type" stdset="0">
+                              <number>1</number>
+                             </property>
+                             <property name="metric_template" stdset="0">
+                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%10.2f&lt;span style=&quot; color:gray;&quot;&gt; Y&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                             </property>
+                             <property name="imperial_template" stdset="0">
+                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%9.4f&lt;span style=&quot; color:gray;&quot;&gt; Y&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                             </property>
+                            </widget>
+                           </item>
+                          </layout>
+                         </item>
+                         <item>
+                          <layout class="QHBoxLayout" name="horizontalLayout_19" stretch="0">
+                           <property name="spacing">
+                            <number>0</number>
+                           </property>
+                           <item>
+                            <widget class="DROLabel" name="dro_label_g5x_z">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                             <property name="frameShape">
+                              <enum>QFrame::NoFrame</enum>
+                             </property>
+                             <property name="textFormat">
+                              <enum>Qt::RichText</enum>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                             <property name="textSpaceSample" stdset="0">
+                              <string> -000.0000 X</string>
+                             </property>
+                             <property name="Qjoint_number" stdset="0">
+                              <number>2</number>
+                             </property>
+                             <property name="Qreference_type" stdset="0">
+                              <number>1</number>
+                             </property>
+                             <property name="metric_template" stdset="0">
+                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%10.2f&lt;span style=&quot; color:gray;&quot;&gt; Z&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                             </property>
+                             <property name="imperial_template" stdset="0">
+                              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%9.4f&lt;span style=&quot; color:gray;&quot;&gt; Z&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                             </property>
+                            </widget>
+                           </item>
+                          </layout>
+                         </item>
+                         <item>
+                          <layout class="QHBoxLayout" name="horizontalLayout_20">
+                           <property name="spacing">
+                            <number>0</number>
+                           </property>
+                           <item>
+                            <widget class="DROLabel" name="dro_label_g5x_r">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                             <property name="frameShape">
+                              <enum>QFrame::Panel</enum>
+                             </property>
+                             <property name="text">
+                              <string>%10.3f</string>
+                             </property>
+                             <property name="textFormat">
+                              <enum>Qt::RichText</enum>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignCenter</set>
+                             </property>
+                             <property name="Qjoint_number" stdset="0">
+                              <number>10</number>
+                             </property>
+                             <property name="Qreference_type" stdset="0">
                               <number>0</number>
                              </property>
-                             <item>
-                              <widget class="DROLabel" name="dro_label_g53_z">
-                               <property name="sizePolicy">
-                                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                                 <horstretch>0</horstretch>
-                                 <verstretch>0</verstretch>
-                                </sizepolicy>
-                               </property>
-                               <property name="Qjoint_number" stdset="0">
-                                <number>2</number>
-                               </property>
-                               <property name="metric_template" stdset="0">
-                                <string>Z %10.3f</string>
-                               </property>
-                               <property name="imperial_template" stdset="0">
-                                <string>Z %9.4f</string>
-                               </property>
-                              </widget>
-                             </item>
-                            </layout>
+                             <property name="metric_template" stdset="0">
+                              <string>%10.3f</string>
+                             </property>
+                             <property name="imperial_template" stdset="0">
+                              <string>%9.4f</string>
+                             </property>
+                             <property name="angular_template" stdset="0">
+                              <string>%4.2f</string>
+                             </property>
+                            </widget>
                            </item>
                           </layout>
                          </item>
                         </layout>
                        </widget>
                       </item>
+                     </layout>
+                    </widget>
+                    <widget class="QWidget" name="tab_2">
+                     <attribute name="title">
+                      <string>Preview</string>
+                     </attribute>
+                     <layout class="QVBoxLayout" name="verticalLayout">
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
                       <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_14" stretch="0">
-                        <property name="spacing">
-                         <number>0</number>
+                       <widget class="GCodeGraphics" name="gcodegraphics">
+                        <property name="focusPolicy">
+                         <enum>Qt::ClickFocus</enum>
                         </property>
-                        <item>
-                         <widget class="DROLabel" name="dro_label_g5x_x_">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="frameShape">
-                           <enum>QFrame::NoFrame</enum>
-                          </property>
-                          <property name="text">
-                           <string>%10.3f</string>
-                          </property>
-                          <property name="textFormat">
-                           <enum>Qt::RichText</enum>
-                          </property>
-                          <property name="alignment">
-                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                          </property>
-                          <property name="textSpaceSample" stdset="0">
-                           <string> -000.0000 X</string>
-                          </property>
-                          <property name="Qreference_type" stdset="0">
-                           <number>1</number>
-                          </property>
-                          <property name="metric_template" stdset="0">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%10.2f&lt;span style=&quot; color:gray;&quot;&gt; X&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="imperial_template" stdset="0">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%9.4f&lt;span style=&quot; color:gray;&quot;&gt; X&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </item>
-                      <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0">
-                        <property name="spacing">
-                         <number>0</number>
+                        <property name="_view" stdset="0">
+                         <string>p</string>
                         </property>
-                        <item>
-                         <widget class="DROLabel" name="dro_label_g5x_y">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="frameShape">
-                           <enum>QFrame::NoFrame</enum>
-                          </property>
-                          <property name="text">
-                           <string>%10.3f</string>
-                          </property>
-                          <property name="textFormat">
-                           <enum>Qt::RichText</enum>
-                          </property>
-                          <property name="alignment">
-                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                          </property>
-                          <property name="textSpaceSample" stdset="0">
-                           <string> -000.0000 X</string>
-                          </property>
-                          <property name="Qjoint_number" stdset="0">
-                           <number>1</number>
-                          </property>
-                          <property name="Qreference_type" stdset="0">
-                           <number>1</number>
-                          </property>
-                          <property name="metric_template" stdset="0">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%10.2f&lt;span style=&quot; color:gray;&quot;&gt; Y&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="imperial_template" stdset="0">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%9.4f&lt;span style=&quot; color:gray;&quot;&gt; Y&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </item>
-                      <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_19" stretch="0">
-                        <property name="spacing">
-                         <number>0</number>
+                        <property name="_dro" stdset="0">
+                         <bool>true</bool>
                         </property>
-                        <item>
-                         <widget class="DROLabel" name="dro_label_g5x_z">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="frameShape">
-                           <enum>QFrame::NoFrame</enum>
-                          </property>
-                          <property name="textFormat">
-                           <enum>Qt::RichText</enum>
-                          </property>
-                          <property name="alignment">
-                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                          </property>
-                          <property name="textSpaceSample" stdset="0">
-                           <string> -000.0000 X</string>
-                          </property>
-                          <property name="Qjoint_number" stdset="0">
-                           <number>2</number>
-                          </property>
-                          <property name="Qreference_type" stdset="0">
-                           <number>1</number>
-                          </property>
-                          <property name="metric_template" stdset="0">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%10.2f&lt;span style=&quot; color:gray;&quot;&gt; Z&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                          <property name="imperial_template" stdset="0">
-                           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%9.4f&lt;span style=&quot; color:gray;&quot;&gt; Z&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </item>
-                      <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_20">
-                        <property name="spacing">
-                         <number>0</number>
+                        <property name="_dtg" stdset="0">
+                         <bool>false</bool>
                         </property>
-                        <item>
-                         <widget class="DROLabel" name="dro_label_g5x_r">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="frameShape">
-                           <enum>QFrame::Panel</enum>
-                          </property>
-                          <property name="text">
-                           <string>%10.3f</string>
-                          </property>
-                          <property name="textFormat">
-                           <enum>Qt::RichText</enum>
-                          </property>
-                          <property name="alignment">
-                           <set>Qt::AlignCenter</set>
-                          </property>
-                          <property name="Qjoint_number" stdset="0">
-                           <number>10</number>
-                          </property>
-                          <property name="Qreference_type" stdset="0">
-                           <number>0</number>
-                          </property>
-                          <property name="metric_template" stdset="0">
-                           <string>%10.3f</string>
-                          </property>
-                          <property name="imperial_template" stdset="0">
-                           <string>%9.4f</string>
-                          </property>
-                          <property name="angular_template" stdset="0">
-                           <string>%4.2f</string>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
+                        <property name="background_color" stdset="0">
+                         <color>
+                          <red>0</red>
+                          <green>0</green>
+                          <blue>0</blue>
+                         </color>
+                        </property>
+                        <property name="overlay" stdset="0">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
                       </item>
                      </layout>
                     </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                 <widget class="QWidget" name="tab_2">
-                  <attribute name="title">
-                   <string>Preview</string>
-                  </attribute>
-                  <layout class="QVBoxLayout" name="verticalLayout">
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="GCodeGraphics" name="gcodegraphics">
-                     <property name="focusPolicy">
-                      <enum>Qt::ClickFocus</enum>
-                     </property>
-                     <property name="_view" stdset="0">
-                      <string>p</string>
-                     </property>
-                     <property name="_dro" stdset="0">
-                      <bool>true</bool>
-                     </property>
-                     <property name="_dtg" stdset="0">
-                      <bool>false</bool>
-                     </property>
-                     <property name="background_color" stdset="0">
-                      <color>
-                       <red>0</red>
-                       <green>0</green>
-                       <blue>0</blue>
-                      </color>
-                     </property>
-                     <property name="overlay" stdset="0">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
+                   </widget>
+                  </item>
+                 </layout>
                 </widget>
-               </item>
-              </layout>
+               </widget>
+               <widget class="QFrame" name="frameGEditor">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>300</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="frameShape">
+                 <enum>QFrame::Box</enum>
+                </property>
+                <property name="frameShadow">
+                 <enum>QFrame::Sunken</enum>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_2">
+                 <property name="spacing">
+                  <number>4</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="GEditor" name="gcode_editor">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>300</width>
+                     <height>100</height>
+                    </size>
+                   </property>
+                   <property name="iconSize">
+                    <size>
+                     <width>32</width>
+                     <height>32</height>
+                    </size>
+                   </property>
+                   <property name="auto_show_mdi_status" stdset="0">
+                    <bool>false</bool>
+                   </property>
+                   <property name="show_editor" stdset="0">
+                    <bool>false</bool>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </widget>
+             </item>
+             <item>
+              <widget class="QStackedWidget" name="rightPanel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>0</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+              </widget>
              </item>
             </layout>
            </item>
-           <item>
-            <widget class="GEditor" name="gcode_editor">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>300</width>
-               <height>100</height>
-              </size>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>32</height>
-              </size>
-             </property>
-             <property name="auto_show_mdi_status" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="show_editor" stdset="0">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
           </layout>
-         </item>
-         <item>
-          <widget class="QStackedWidget" name="rightPanel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>0</width>
-             <height>16777215</height>
-            </size>
-           </property>
-          </widget>
          </item>
         </layout>
        </item>
@@ -2364,7 +2462,7 @@
      <x>0</x>
      <y>0</y>
      <width>802</width>
-     <height>24</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/share/qtvcp/screens/qtaxis/qtaxis_handler.py
+++ b/share/qtvcp/screens/qtaxis/qtaxis_handler.py
@@ -414,14 +414,10 @@ class HandlerClass:
     def edit(self, widget, state):
         if state:
             self.w.gcode_editor.editMode()
-            self.w.gcode_editor.setMaximumHeight(1000)
-            self.w.frame.hide()
-            self.w.rightTab.hide()
+            self.w.horizontalSplitter.hide()
         else:
             self.w.gcode_editor.readOnlyMode()
-            self.w.gcode_editor.setMaximumHeight(500)
-            self.w.frame.show()
-            self.w.rightTab.show()
+            self.w.horizontalSplitter.show()
 
     def adjust_controls(self):
         if INFO.HAS_ANGULAR_JOINT:


### PR DESCRIPTION
This diff looks a little overwhelming if viewed normally, but viewed with whitespace changes ignored it really is just:

Wrap leftTab and rightTab in a splitter
Wrap that splitter and gcode_editor in a splitter
Wrap rightTab and gcode_editor in a frame/layout combo to make them render properly
Tweak a few default height/width values
Remove height limit on gcode_editor box
Make leftTab adjustable from 300 to 400px wide
Change handler code so edit mode hides the upper portion (as intended)