### PR TITLE
fix float arg passed to QSize, caused Qt designer to crash when loading

### DIFF
--- a/lib/python/qtvcp/widgets/tab_widget.py
+++ b/lib/python/qtvcp/widgets/tab_widget.py
@@ -40,5 +40,5 @@ class TabBar(QTabBar):
     def tabSizeHint(self, index):
         size = QTabBar.tabSizeHint(self, index)
         w = size.height()*self._size
-        return QSize(size.width(), w)
+        return QSize(size.width(), int(w))
 


### PR DESCRIPTION
When loading the qttouchy ui file into Qt Designer, it would crash:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/qtvcp/widgets/tab_widget.py", line 43, in tabSizeHint
    return QSize(size.width(), w)
           ^^^^^^^^^^^^^^^^^^^^^^
TypeError: arguments did not match any overloaded call:
  QSize(): too many arguments
  QSize(w: int, h: int): argument 2 has unexpected type 'float'
  QSize(a0: QSize): argument 1 has unexpected type 'int'
```

Fixed the 'w' argument by converting it to an int.

