### PR TITLE
add missing call to flush_segments() to MOTION_OUTPUT VALUE() in emccanon.cc

### DIFF
--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -3991,6 +3991,8 @@ void MOTION_OUTPUT_VALUE_(int index, double start, double end, int now)
 {
     auto aout_msg = std::make_unique<EMC_MOTION_SET_AOUT>();
 
+    flush_segments();
+
     aout_msg->index = index;
     aout_msg->start = start;
     aout_msg->end = end;


### PR DESCRIPTION
fix for #2987