### PR TITLE
refactor posemath macros

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -4349,7 +4349,6 @@ int Interp::convert_motion(int motion,   //!< g_code for a line, arc, canned cyc
       write_canon_state_tag(block, settings);
       CHP(convert_spline(motion, block, settings));
   } else if ((motion == G_5_2) || (motion == G_6_2)) { // jjf
-    StateTag tag;
     write_canon_state_tag(block, settings);
     CHP(convert_nurbs(motion, block, settings));
   } else if (

--- a/src/libnml/posemath/posemath.h
+++ b/src/libnml/posemath/posemath.h
@@ -71,6 +71,8 @@
 #ifndef POSEMATH_H
 #define POSEMATH_H
 
+#include <math.h>
+
 #ifdef __cplusplus
 
 #define USE_CONST
@@ -682,8 +684,11 @@ extern "C" {
 
 /* quicky macros */
 
-#define pmClose(a, b, eps) ((fabs((a) - (b)) < (eps)) ? 1 : 0)
-#define pmSq(x) ((x)*(x))
+//#define pmClose(a, b, eps) ((fabs((a) - (b)) < (eps)) ? 1 : 0)
+//#define pmSq(x) ((x)*(x))
+
+inline int pmClose(double a, double b, double eps) { return ((fabs((a) - (b)) < (eps)) ? 1 : 0); }
+inline double pmSq(double x) { return x*x; }
 
 #ifdef TO_DEG
 #undef TO_DEG
@@ -953,33 +958,47 @@ extern "C" {
 
 /* slicky macros for item-by-item copying between C and C++ structs */
 
-#define toCart(src,dst) {(dst)->x = (src).x; (dst)->y = (src).y; (dst)->z = (src).z;}
-
-#define toCyl(src,dst) {(dst)->theta = (src).theta; (dst)->r = (src).r; (dst)->z = (src).z;}
-
-#define toSph(src,dst) {(dst)->theta = (src).theta; (dst)->phi = (src).phi; (dst)->r = (src).r;}
-
-#define toQuat(src,dst) {(dst)->s = (src).s; (dst)->x = (src).x; (dst)->y = (src).y; (dst)->z = (src).z;}
-
-#define toRot(src,dst) {(dst)->s = (src).s; (dst)->x = (src).x; (dst)->y = (src).y; (dst)->z = (src).z;}
-
-#define toMat(src,dst) {toCart((src).x, &((dst)->x)); toCart((src).y, &((dst)->y)); toCart((src).z, &((dst)->z));}
-
-#define toEulerZyz(src,dst) {(dst)->z = (src).z; (dst)->y = (src).y; (dst)->zp = (src).zp;}
-
-#define toEulerZyx(src,dst) {(dst)->z = (src).z; (dst)->y = (src).y; (dst)->x = (src).x;}
-
-#define toRpy(src,dst) {(dst)->r = (src).r; (dst)->p = (src).p; (dst)->y = (src).y;}
-
-#define toPose(src,dst) {toCart((src).tran, &((dst)->tran)); toQuat((src).rot, &((dst)->rot));}
-
-#define toHom(src,dst) {toCart((src).tran, &((dst)->tran)); toMat((src).rot, &((dst)->rot));}
-
-#define toLine(src,dst) {toPose((src).start, &((dst)->start)); toPose((src).end, &((dst)->end)); toCart((src).uVec, &((dst)->uVec));}
-
-#define toCircle(src,dst) {toCart((src).center, &((dst)->center)); toCart((src).normal, &((dst)->normal)); toCart((src).rTan, &((dst)->rTan)); toCart((src).rPerp, &((dst)->rPerp)); toCart((src).rHelix, &((dst)->rHelix)); (dst)->radius = (src).radius; (dst)->angle = (src).angle; (dst)->spiral = (src).spiral;}
-
 #ifdef __cplusplus
 }				/* matches extern "C" for C++ */
+
+template <class A, class B>
+void toCart(const A& src, B* dst) {(dst)->x = (src).x; (dst)->y = (src).y; (dst)->z = (src).z;}
+
+template <class A, class B>
+void toCyl(const A& src, B* dst) {(dst)->theta = (src).theta; (dst)->r = (src).r; (dst)->z = (src).z;}
+
+template <class A, class B>
+void toSph(const A& src, B* dst) {(dst)->theta = (src).theta; (dst)->phi = (src).phi; (dst)->r = (src).r;}
+
+template <class A, class B>
+void toQuat(const A& src, B* dst) {(dst)->s = (src).s; (dst)->x = (src).x; (dst)->y = (src).y; (dst)->z = (src).z;}
+
+template <class A, class B>
+void toRot(const A& src, B* dst) {(dst)->s = (src).s; (dst)->x = (src).x; (dst)->y = (src).y; (dst)->z = (src).z;}
+
+template <class A, class B>
+void toMat(const A& src, B* dst) {toCart((src).x, &((dst)->x)); toCart((src).y, &((dst)->y)); toCart((src).z, &((dst)->z));}
+
+template <class A, class B>
+void toEulerZyz(const A& src, B* dst) {(dst)->z = (src).z; (dst)->y = (src).y; (dst)->zp = (src).zp;}
+
+template <class A, class B>
+void toEulerZyx(const A& src, B* dst) {(dst)->z = (src).z; (dst)->y = (src).y; (dst)->x = (src).x;}
+
+template <class A, class B>
+void toRpy(const A& src, B* dst) {(dst)->r = (src).r; (dst)->p = (src).p; (dst)->y = (src).y;}
+
+template <class A, class B>
+void toPose(const A& src, B* dst) {toCart((src).tran, &((dst)->tran)); toQuat((src).rot, &((dst)->rot));}
+
+template <class A, class B>
+void toHom(const A& src, B* dst) {toCart((src).tran, &((dst)->tran)); toMat((src).rot, &((dst)->rot));}
+
+template <class A, class B>
+void toLine(const A& src, B* dst) {toPose((src).start, &((dst)->start)); toPose((src).end, &((dst)->end)); toCart((src).uVec, &((dst)->uVec));}
+
+template <class A, class B>
+void toCircle(const A& src, B* dst) {toCart((src).center, &((dst)->center)); toCart((src).normal, &((dst)->normal)); toCart((src).rTan, &((dst)->rTan)); toCart((src).rPerp, &((dst)->rPerp)); toCart((src).rHelix, &((dst)->rHelix)); (dst)->radius = (src).radius; (dst)->angle = (src).angle; (dst)->spiral = (src).spiral;}
+
 #endif
 #endif				/* #ifndef POSEMATH_H */


### PR DESCRIPTION
posemath.h: replace some macros with function templates.

posemath.h contains some macros for conversion between C structs and C++
classes. Those macros are named like 'toLine' and don't follow usual
convention that #define should use CAPITALIZED_NAMES. To avoid
name collisions, replace macros with function templates and make sure
those are only enabled if compiled as C++.