### PR TITLE
Unset FORTIFY_SOURCE before setting to value 2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -252,7 +252,7 @@ INCLUDE += $(LIBTIRPC_CFLAGS)
 # Compilation options.	Perhaps some of these should come from Makefile.inc? (CXXFLAGS now does)
 INTEGER_OVERFLOW_FLAGS := -fwrapv
 OPT := -Os $(INTEGER_OVERFLOW_FLAGS)
-DEBUG := $(DEBUG) -g -Wall -D_FORTIFY_SOURCE=2
+DEBUG := $(DEBUG) -g -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 CFLAGS := $(INCLUDE) $(OPT) $(DEBUG) $(EXTRA_DEBUG) -DULAPI -std=gnu11 -Werror=implicit-function-declaration $(CFLAGS) $(CPPFLAGS)
 CXXFLAGS := $(INCLUDE) $(EXTRA_DEBUG) -DULAPI $(DEBUG) $(OPT) -Werror=overloaded-virtual $(CXXFLAGS) $(CPPFLAGS)
 CXXFLAGS += -std=gnu++17


### PR DESCRIPTION
On some configurations (whether it's custom {C,CXX}FLAGS on ./configure or Gentoo where users specify -D_FORTIFY_SOURCE in make.conf) you will see many warnings about FORTIFY_SOURCE.

This unsets whatever FORTIFY_SOURCE was set to, then sets it to 2.