### PR TITLE
Pass generated component man pages through preconv for UTF-8 support.

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -13,6 +13,7 @@ Build-Depends:
     docbook-xsl,
     asciidoc,
     ghostscript,
+    groff-base,
     imagemagick,
     asciidoc-dblatex,
     autoconf,

--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -32,7 +32,8 @@ obj-m += $(patsubst hal/drivers/%.comp, %.o, $(patsubst hal/components/%.comp, %
 $(COMP_MANPAGES): ../docs/man/man9/%.9: hal/components/%.comp ../bin/halcompile
 	$(ECHO) Making halcompile manpage $(notdir $@)
 	@mkdir -p $(dir $@)
-	$(Q)../bin/halcompile -U --document -o $@ $<
+	$(Q)../bin/halcompile -U --document -o $@.new $< && preconv -r < $@.new > $@
+	$(RM) $@.new
 
 $(COMP_DRIVER_MANPAGES): ../docs/man/man9/%.9: hal/drivers/%.comp ../bin/halcompile
 	$(ECHO) Making halcompile manpage $(notdir $@)

--- a/src/hal/utils/halcompile.g
+++ b/src/hal/utils/halcompile.g
@@ -886,7 +886,7 @@ def document(filename, outfilename):
         if personality: has_personality = True
         if isinstance(array, tuple): has_personality = True
 
-    print("""
+    print(""".\\" -*- mode: troff; coding: utf-8 -*-
 .\\"*******************************************************************
 .\\"
 .\\" This file was extracted from %s using halcompile.g.


### PR DESCRIPTION
Adjusted halcompile to output UTF-8 header for all generated man pages, to ensure preconv always know the charset, and adjust the component build rules to filter the output through preconv to convert any UTF-8 characters to the format understood by groff.  Added groff-base as a build dependency for preconv.