### PR TITLE
Fixed bug #2939. When fixing the case where there was no leadout move,

### DIFF
--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -1200,7 +1200,7 @@ int Interp::convert_g7x(int mode,
 	switch(cycle) {
 	case 70: path.do_g70(&motion,x,z,d,e,p,&settings->cutter_comp_side); break;
 	case 71:
-	    if(x!=imag(start)) {
+	    if(imag(path.front()->sp()-path.front()->ep())*(x-imag(start))>0) {
 		std::complex<double> end{real(start),x};
 		path.emplace_back(std::make_unique<straight_segment>(
 		    start, end
@@ -1209,7 +1209,7 @@ int Interp::convert_g7x(int mode,
 	    path.do_g71(&motion,subcycle,x,z,u,w,d,i,r);
 	    break;
 	case 72:
-	    if(z!=real(start)) {
+	    if(real(path.front()->sp()-path.front()->ep())*(z-real(start))>0) {
 		std::complex<double> end{z,imag(start)};
 		path.emplace_back(std::make_unique<straight_segment>(
 		    start, end

--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -1195,12 +1195,16 @@ int Interp::convert_g7x(int mode,
     if(i<=0)
 	ERS("G7X error: I must be greater than zero.");
 
+    auto dfront=path.front()->ep()-path.front()->sp();
+    auto dback=path.back()->ep()-path.back()->sp();
     motion_machine motion(this, settings, block);
     try {
 	switch(cycle) {
-	case 70: path.do_g70(&motion,x,z,d,e,p,&settings->cutter_comp_side); break;
+	case 70:
+	    path.do_g70(&motion,x,z,d,e,p,&settings->cutter_comp_side);
+	    break;
 	case 71:
-	    if(imag(path.front()->sp()-path.front()->ep())*(x-imag(start))>0) {
+	    if(std::abs(real(dback))>0 && imag(dfront)*(x-imag(start))<0) {
 		std::complex<double> end{real(start),x};
 		path.emplace_back(std::make_unique<straight_segment>(
 		    start, end
@@ -1209,7 +1213,7 @@ int Interp::convert_g7x(int mode,
 	    path.do_g71(&motion,subcycle,x,z,u,w,d,i,r);
 	    break;
 	case 72:
-	    if(real(path.front()->sp()-path.front()->ep())*(z-real(start))>0) {
+	    if(std::abs(imag(dback))>0 && real(dfront)*(z-real(start))<0) {
 		std::complex<double> end{z,imag(start)};
 		path.emplace_back(std::make_unique<straight_segment>(
 		    start, end


### PR DESCRIPTION
I broke the case where the leadout was exceeding the starting point.

The final fix will probably be that the code will enforce x_start==x_end for G71 and z_start==z_end for G72. And either for G70. Currently G70 will produce unpredictable results otherwise.