### PR TITLE
hal_gpio - fix output length check using invalid inputs variable

### DIFF
--- a/src/hal/drivers/hal_gpio.c
+++ b/src/hal/drivers/hal_gpio.c
@@ -256,7 +256,7 @@ int rtapi_app_main(void){
 	    
     }
     
-    for (i = 0; outputs[i] && strlen(inputs[i]); i++) {
+    for (i = 0; outputs[i] && strlen(outputs[i]); i++) {
 	retval = build_chips_collection(outputs[i], &gpio->out_chips, &gpio->num_out_chips);
 	if (retval < 0) goto fail0;
     }


### PR DESCRIPTION
Using the input length will break if the number of inputs is less than the number of outputs.

Besides, using input length is probably not the intended thing to do.