### PR TITLE
Clean up man page notation and fix a few migration errors.

### DIFF
--- a/docs/src/man/man1/5axisgui.1.adoc
+++ b/docs/src/man/man1/5axisgui.1.adoc
@@ -14,7 +14,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -25,15 +25,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/axis-remote.1.adoc
+++ b/docs/src/man/man1/axis-remote.1.adoc
@@ -34,7 +34,7 @@ Use *axis-remote --help* for further information.::
 
 == SEE ALSO
 
-*axis(1)*
+axis(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/linuxcnc/.
@@ -49,11 +49,12 @@ This man page written by Alex Joni, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2007 Alex Joni. +
+Copyright © 2007 Alex Joni.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/axis.1.adoc
+++ b/docs/src/man/man1/axis.1.adoc
@@ -25,7 +25,7 @@ gets run by the runscript usually.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -40,11 +40,12 @@ This man page written by Alex Joni, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2007 Alex Joni. +
+Copyright © 2007 Alex Joni.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/debuglevel.1.adoc
+++ b/docs/src/man/man1/debuglevel.1.adoc
@@ -15,7 +15,7 @@ of some parts of LinuxCNC.
 
 == SEE ALSO
 
-halcmd(1) - debug subcommand *LinuxCNC(1)*
+halcmd(1) - debug subcommand linuxcnc(1)*
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/elbpcom.1.adoc
+++ b/docs/src/man/man1/elbpcom.1.adoc
@@ -92,6 +92,6 @@ but notice its different treatment of byte order.
 
 == SEE ALSO
 
-*mesaflash*(1), *hostmot2*(9), *hm2_eth*(9),
+mesaflash(1), hostmot2(9), hm2_eth(9),
 http://www.mesanet.com[Mesa's documentation for the Anything I/O
 boards].

--- a/docs/src/man/man1/emccalib.1.adoc
+++ b/docs/src/man/man1/emccalib.1.adoc
@@ -43,7 +43,7 @@ version of emccalib.
 
 == SEE ALSO
 
-*linuxcnc*(1)
+linuxcnc(1)
 
 == AUTHOR
 

--- a/docs/src/man/man1/gladevcp_demo.1.adoc
+++ b/docs/src/man/man1/gladevcp_demo.1.adoc
@@ -14,7 +14,7 @@ gladevcp_demo - used by sample configs to deonstrate Glade Virtual_demo
 
 == SEE ALSO
 
-*https://linuxcnc.org/docs/html/gui/gladevcp.html* *LinuxCNC(1)*
+linuxcnc(1), https://linuxcnc.org/docs/html/gui/gladevcp.html
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -25,15 +25,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/gmoccapy.1.adoc
+++ b/docs/src/man/man1/gmoccapy.1.adoc
@@ -25,7 +25,7 @@ gets run by the runscript usually.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -36,15 +36,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/gremlin_view.1.adoc
+++ b/docs/src/man/man1/gremlin_view.1.adoc
@@ -35,7 +35,7 @@ on_show_limits_clicked
 
 == SEE ALSO
 
-*http://wiki.linuxcnc.org/cgi-bin/wiki.pl?Gremlin* *LinuxCNC(1)*
+linuxcnc(1), http://wiki.linuxcnc.org/cgi-bin/wiki.pl?Gremlin
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -46,15 +46,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/gs2_vfd.1.adoc
+++ b/docs/src/man/man1/gs2_vfd.1.adoc
@@ -6,7 +6,7 @@ gs2_vfd - HAL non-realtime component for Automation Direct GS2 VFDs
 
 == SYNOPSIS
 
-*gs2_vfd* [OPTIONS] +
+*gs2_vfd* [OPTIONS]
 
 == DESCRIPTION
 

--- a/docs/src/man/man1/gscreen.1.adoc
+++ b/docs/src/man/man1/gscreen.1.adoc
@@ -25,7 +25,7 @@ gets run by the runscript usually.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -36,15 +36,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/hal-histogram.1.adoc
+++ b/docs/src/man/man1/hal-histogram.1.adoc
@@ -12,14 +12,11 @@ hal-histogram - plots the value of a HAL pin as a histogram
 
 *hal-histogram* represents the values of a HAL pin graphically.
 
-Details:
-
-....
-....
+Details: http://linuxcnc.org/docs/html/hal/tools.html#_hal_histogram
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -30,15 +27,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/hal_input.1.adoc
+++ b/docs/src/man/man1/hal_input.1.adoc
@@ -186,4 +186,4 @@ or axis.
 
 == SEE ALSO
 
-*udev(8)*, *udev(7)*
+udev(8), udev(7)

--- a/docs/src/man/man1/halcmd.1.adoc
+++ b/docs/src/man/man1/halcmd.1.adoc
@@ -336,18 +336,18 @@ includes major contributions by several members of the project.
 
 == REPORTING BUGS
 
-Report bugs to the LinuxCNC bug tracker ⟨URL:
-https://github.com/LinuxCNC/linuxcnc/issues ⟩.
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2003 John Kasunich. +
+Copyright © 2003 John Kasunich.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 
 == SEE ALSO
 
-*halrun(1)* -- a convenience script to start a realtime environment,
+halrun(1) -- a convenience script to start a realtime environment,
 process a HAL or a .tcl file, and optionally start an interactive
-command session using *halcmd* (described here) or *haltcl*(1).
+command session using *halcmd* (described here) or haltcl(1).

--- a/docs/src/man/man1/halcmd_twopass.1.adoc
+++ b/docs/src/man/man1/halcmd_twopass.1.adoc
@@ -16,7 +16,7 @@ system.
 
 == SEE ALSO
 
-*http://linuxcnc.org/docs/html/hal/twopass.html* *LinuxCNC(1)*
+linuxcnc(1), http://linuxcnc.org/docs/html/hal/twopass.html
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -27,15 +27,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/halmeter.1.adoc
+++ b/docs/src/man/man1/halmeter.1.adoc
@@ -81,11 +81,12 @@ Improvements by several other members of the LinuxCNC development team.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2003 John Kasunich. +
+Copyright © 2003 John Kasunich.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/halreport.1.adoc
+++ b/docs/src/man/man1/halreport.1.adoc
@@ -22,14 +22,11 @@ Identificaion of functions used according to pin name. Default handling
 works for components that: 1) use names=|count= (.comp components
 created with halcompile) 2) have a *single* function
 
-Full docs:
-
-....
-....
+Full docs: http://linuxcnc.org/docs/html/hal/tools.html#_halreport
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -40,15 +37,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/halrmt.1.adoc
+++ b/docs/src/man/man1/halrmt.1.adoc
@@ -234,7 +234,7 @@ Stop
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -245,15 +245,16 @@ It is not known if this interface currently works.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/halrun.1.adoc
+++ b/docs/src/man/man1/halrun.1.adoc
@@ -67,16 +67,16 @@ members of the project.
 
 == REPORTING BUGS
 
-Report bugs to the LinuxCNC bug tracker ⟨URL:
-https://github.com/LinuxCNC/linuxcnc/issues ⟩.
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2003 John Kasunich. +
+Copyright © 2003 John Kasunich.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 
 == SEE ALSO
 
-*halcmd*(1), *haltcl*(1)
+halcmd(1), haltcl(1)

--- a/docs/src/man/man1/halsampler.1.adoc
+++ b/docs/src/man/man1/halsampler.1.adoc
@@ -80,7 +80,7 @@ specified, it will always return failure when terminated.
 
 == SEE ALSO
 
-*sampler*(9) *streamer*(9) *halstreamer*(1)
+sampler(9), streamer(9), halstreamer(1)
 
 == AUTHOR
 
@@ -89,11 +89,12 @@ Improvements by several other members of the LinuxCNC development team.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2006 John Kasunich. +
+Copyright © 2006 John Kasunich.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/halscope.1.adoc
+++ b/docs/src/man/man1/halscope.1.adoc
@@ -17,7 +17,7 @@ signals
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -28,15 +28,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/halshow.1.adoc
+++ b/docs/src/man/man1/halshow.1.adoc
@@ -28,18 +28,18 @@ http://linuxcnc.org/docs/html/hal/halshow.html[]
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
 
 == HISTORY
 
-LinuxCNC 2.9:::
-  - Added buttons for pin/parameter/signal manipulation +
-  - Added menu entries for setting update interval, adding manually +
-  - Added right-click menu for copy, set, unlink pin and remove from
-  view
+LinuxCNC 2.9::
+ - Added buttons for pin/parameter/signal manipulation
+ - Added menu entries for setting update interval, adding manually
+ - Added right-click menu for copy, set, unlink pin and remove from
+   view
 
 == BUGS
 
@@ -51,11 +51,12 @@ Raymond E. Henry
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/halstreamer.1.adoc
+++ b/docs/src/man/man1/halstreamer.1.adoc
@@ -75,7 +75,7 @@ If it is terminated before the input ends, it returns failure.
 
 == SEE ALSO
 
-*streamer*(9) *sampler*(9) *halsampler*(1)
+streamer(9), sampler(9), halsampler(1)
 
 
 == AUTHOR
@@ -86,11 +86,13 @@ Improvements by several other members of the LinuxCNC development team.
 
 == REPORTING BUGS
 
-Report bugs to jmkasunich AT users DOT sourceforge DOT net
-
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
-Copyright © 2006 John Kasunich.  This is free software; see the
-source for copying conditions.  There is NO warranty; not even for
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+Copyright © 2006 John Kasunich.
+
+This is free software; see the source for copying conditions.  There
+is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
 

--- a/docs/src/man/man1/haltcl.1.adoc
+++ b/docs/src/man/man1/haltcl.1.adoc
@@ -55,16 +55,14 @@ hal list hal gets
 
 == REPORTING BUGS
 
-Report bugs to the LinuxCNC bug tracker ⟨URL:
-https://github.com/LinuxCNC/linuxcnc/issues ⟩.
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
- +
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.
 
 == SEE ALSO
 
-*halcmd*(1), *halrun*(1)
+halcmd(1), halrun(1)

--- a/docs/src/man/man1/halui.1.adoc
+++ b/docs/src/man/man1/halui.1.adoc
@@ -455,7 +455,8 @@ Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
 
 == COPYRIGHT
 
-Copyright © 2006 Alex Joni. +
+Copyright © 2006 Alex Joni.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/hbmgui.1.adoc
+++ b/docs/src/man/man1/hbmgui.1.adoc
@@ -15,7 +15,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/hexagui.1.adoc
+++ b/docs/src/man/man1/hexagui.1.adoc
@@ -15,7 +15,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,7 +26,7 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
@@ -34,7 +34,7 @@ Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh. +
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/hy_vfd.1.adoc
+++ b/docs/src/man/man1/hy_vfd.1.adoc
@@ -6,7 +6,7 @@ hy_vfd - HAL non-realtime component for Huanyang VFDs
 
 == SYNOPSIS
 
-*hy_vfd* [OPTIONS] +
+*hy_vfd* [OPTIONS]
 
 == DESCRIPTION
 
@@ -24,37 +24,30 @@ PD002 = 2::
   port).
 
 PD004::
-   +
   Set register PD004 (Base Frequency) according to motor specs. This is
   the rated frequency of the motor from the motor's name plate, in Hz.
 
 PD005::
-   +
   Set register PD005 (max frequency) according to motor specs. This is
   the maximum frequency of the motor's power supply, in Hz.
 
 PD011::
-   +
   Set register PD011 (min frequency) according to motor specs. This is
   the minimum frequency of the motor's power supply, in Hz.
 
 PD141::
-   +
   Set register PD141 (rated motor voltage) according to motor name
   plate. This is the motor's maximum voltage, in Volts.
 
 PD142::
-   +
   Set register PD142 (rated motor current) according to motor name
   plate. This is the motor's maximum current, in Ampere.
 
 PD143::
-   +
   Set register PD143 (Number of Motor Poles) according to motor name
   plate.
 
 PD144::
-   +
   Set register PD144 (rated motor revolutions) according to motor name
   plate. This is the motor's speed in RPM at 50 Hz. Note: This is not
   the motor's max speed (unless the max motor frequency happens to be 50

--- a/docs/src/man/man1/image-to-gcode.1.adoc
+++ b/docs/src/man/man1/image-to-gcode.1.adoc
@@ -18,7 +18,7 @@ http://linuxcnc.org/docs/devel/html/gui/image-to-gcode.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)*
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -29,15 +29,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/inivar.1.adoc
+++ b/docs/src/man/man1/inivar.1.adoc
@@ -56,15 +56,15 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright (c) 2020 andypugh.
+Copyright (c) 2020 Andy Pugh.
 
 This is free software; see the source for copying conditions.  There
 is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A

--- a/docs/src/man/man1/io.1.adoc
+++ b/docs/src/man/man1/io.1.adoc
@@ -64,7 +64,7 @@ unless an absolute path is specified.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues[]
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == AUTHOR
 
@@ -72,7 +72,8 @@ Derived from a work by Fred Proctor & Will Shackleford.
 
 == COPYRIGHT
 
-Copyright © 2004 the LinuxCNC project. +
+Copyright © 2004 the LinuxCNC project.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/iocontrol.1.adoc
+++ b/docs/src/man/man1/iocontrol.1.adoc
@@ -23,3 +23,7 @@ Whether *io* or *iov2* is used can be chosen in the [EMCIO] section of
 the INI file.
 
 See also http://linuxcnc.org/docs/html/config/iov2.html[]
+
+== SEE ALSO
+
+io(1), iov2(1)

--- a/docs/src/man/man1/iov2.1.adoc
+++ b/docs/src/man/man1/iov2.1.adoc
@@ -13,7 +13,8 @@ iov2 - interacts with HAL or G-code in non-realtime
 
 I/O control handles I/O tasks like coolant, toolchange and E-stop. The
 signals are turned on and off in non-realtime with G-code or in the case
-of E-stop in HAL. +
+of E-stop in HAL.
+
 I/O Control V2 (iov2) adds more toolchager support for communication
 with the toolchanger.
 
@@ -97,16 +98,17 @@ for additional information.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues[]
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == AUTHOR
 
-Derived from a work by Fred Proctor & Will Shackleford. +
+Derived from a work by Fred Proctor & Will Shackleford. 
 Rework & adding v2 protocol support by Michael Haberler.
 
 == COPYRIGHT
 
-Copyright © 2011 Michael Haberler. +
+Copyright © 2011 Michael Haberler.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/latency-histogram.1.adoc
+++ b/docs/src/man/man1/latency-histogram.1.adoc
@@ -54,7 +54,7 @@ More details: https://linuxcnc.org/docs/html/install/latency-test.html
 
 == SEE ALSO
 
-*latency-plot*(1), *latency-test*(1), *linuxcnc*(1)
+latency-plot(1), latency-test(1), linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at _/usr/share/doc/linuxcnc/_.
@@ -65,15 +65,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/latency-plot.1.adoc
+++ b/docs/src/man/man1/latency-plot.1.adoc
@@ -48,15 +48,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/latency-test.1.adoc
+++ b/docs/src/man/man1/latency-test.1.adoc
@@ -6,18 +6,18 @@ latency-test - test the realtime system latency
 
 == SYNOPSIS
 
-*latency-test [base-period [servo-period]]*
+*latency-test [--help] [base-period [servo-period]]*
 
 == DESCRIPTION
 
 *latency-test* runs a simple latency test
 http://linuxcnc.org/docs/html/install/latency-test.html
 
+Use *latency-test --help* for a description of available options.
+
 == SEE ALSO
 
-*latency-test --help* for a description of available options.
-
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -28,15 +28,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/lineardelta.1.adoc
+++ b/docs/src/man/man1/lineardelta.1.adoc
@@ -14,7 +14,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -25,15 +25,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/linuxcnc_info.1.adoc
+++ b/docs/src/man/man1/linuxcnc_info.1.adoc
@@ -17,7 +17,7 @@ editor.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -28,15 +28,16 @@ It appears to hang until the text editor is closed.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/linuxcnc_module_helper.1.adoc
+++ b/docs/src/man/man1/linuxcnc_module_helper.1.adoc
@@ -15,7 +15,7 @@ It is not directly useful to users.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/linuxcnc_var.1.adoc
+++ b/docs/src/man/man1/linuxcnc_var.1.adoc
@@ -21,7 +21,7 @@ LINUXCNC_AUX_EXAMPLES REALTIME RTS HALLIB_DIR
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -32,15 +32,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/linuxcnclcd.1.adoc
+++ b/docs/src/man/man1/linuxcnclcd.1.adoc
@@ -27,7 +27,7 @@ a 4 x 20 LCD character display. It is not clear if it has ever worked.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -38,15 +38,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/linuxcncmkdesktop.1.adoc
+++ b/docs/src/man/man1/linuxcncmkdesktop.1.adoc
@@ -15,7 +15,7 @@ for LinuxCNC.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/linuxcncrsh.1.adoc
+++ b/docs/src/man/man1/linuxcncrsh.1.adoc
@@ -7,7 +7,7 @@ network
 
 == SYNOPSIS
 
-*linuxcncrsh [OPTIONS] [-- LINUXCNC_OPTIONS]* +
+*linuxcncrsh [OPTIONS] [-- LINUXCNC_OPTIONS]*
 
 == DESCRIPTION
 

--- a/docs/src/man/man1/linuxcncsvr.1.adoc
+++ b/docs/src/man/man1/linuxcncsvr.1.adoc
@@ -14,7 +14,7 @@ FIXME: Missing
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -25,15 +25,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/linuxcnctop.1.adoc
+++ b/docs/src/man/man1/linuxcnctop.1.adoc
@@ -19,7 +19,7 @@ http://linuxcnc.org/docs/html/gui/axis.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -30,15 +30,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/maho600gui.1.adoc
+++ b/docs/src/man/man1/maho600gui.1.adoc
@@ -15,7 +15,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/max5gui.1.adoc
+++ b/docs/src/man/man1/max5gui.1.adoc
@@ -15,7 +15,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/mb2hal.1.adoc
+++ b/docs/src/man/man1/mb2hal.1.adoc
@@ -69,7 +69,6 @@ information.
 
 *mb2hal.m.num_errors u32 in* Error counter
 
- +
 m = HAL_TX_NAME or transaction number if not set, n = element number
 (NELEMENTS) +
 Example: +

--- a/docs/src/man/man1/mdi.1.adoc
+++ b/docs/src/man/man1/mdi.1.adoc
@@ -23,7 +23,7 @@ interactive session $mdi MDI> m3 s1000 MDI> G0 X100 MDI> ^Z $stopped
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)*
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -34,15 +34,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/mdro.1.adoc
+++ b/docs/src/man/man1/mdro.1.adoc
@@ -103,7 +103,8 @@ Robert Bond
 
 == COPYRIGHT
 
-Copyright © 2022 Robert Bond +
+Copyright © 2022 Robert Bond
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/monitor-xhc-hb04.1.adoc
+++ b/docs/src/man/man1/monitor-xhc-hb04.1.adoc
@@ -20,7 +20,7 @@ Usage is optional; if used it is specified with INI file entry:
 
 == SEE ALSO
 
-*xhc-hb04(1)* *LinuxCNC(1)*
+xhc-hb04(1), linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -31,15 +31,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/motion-logger.1.adoc
+++ b/docs/src/man/man1/motion-logger.1.adoc
@@ -17,7 +17,7 @@ It is largely used by the regression tests and is poorly documented.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -28,15 +28,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/moveoff_gui.1.adoc
+++ b/docs/src/man/man1/moveoff_gui.1.adoc
@@ -156,4 +156,4 @@ moveoff component are located in:
 configs/sim/axis/moveoff (axis-ui) +
 configs/sim/touchy/ngcgui (touchy-ui)
 
-See also *moveoff*(9) for details on the component.
+See also moveoff(9) for details on the component.

--- a/docs/src/man/man1/mqtt-publisher.1.adoc
+++ b/docs/src/man/man1/mqtt-publisher.1.adoc
@@ -114,7 +114,7 @@ are only broken here to avoid too long lines in the documentation.
 
 == SEE ALSO
 
-*hal*(3hal)
+hal(3hal)
 
 == AUTHOR
 
@@ -123,7 +123,9 @@ the LinuxCNC project.
 
 == COPYRIGHT
 
-Copyright © 2023 Petter Reinholdtsen.  This is free software; see the
-source for copying conditions.  There is NO warranty; not even for
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Copyright © 2023 Petter Reinholdtsen.
+
+This is free software; see the source for copying conditions.  There
+is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
 

--- a/docs/src/man/man1/ngcgui.1.adoc
+++ b/docs/src/man/man1/ngcgui.1.adoc
@@ -15,7 +15,7 @@ controller
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)*
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/panelui.1.adoc
+++ b/docs/src/man/man1/panelui.1.adoc
@@ -22,7 +22,7 @@ http://linuxcnc.org/docs/html/gui/panelui.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -33,15 +33,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/pmx485-test.1.adoc
+++ b/docs/src/man/man1/pmx485-test.1.adoc
@@ -6,7 +6,7 @@ pmx485-test - Modbus communications testing with a Powermax Plasma Cutter
 
 == SYNOPSIS
 
-*pmx485-test* +
+*pmx485-test*
 
 == DESCRIPTION
 

--- a/docs/src/man/man1/pncconf.1.adoc
+++ b/docs/src/man/man1/pncconf.1.adoc
@@ -12,14 +12,11 @@ pncconf - configuration wizard for Mesa cards
 
 *pncconf* is used to configure systems that use Mesa cards.
 
-Details:
-
-....
-....
+Details: http://linuxcnc.org/docs/html/config/pncconf.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -30,15 +27,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/puma560gui.1.adoc
+++ b/docs/src/man/man1/puma560gui.1.adoc
@@ -15,7 +15,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/pumagui.1.adoc
+++ b/docs/src/man/man1/pumagui.1.adoc
@@ -15,7 +15,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/pyngcgui.1.adoc
+++ b/docs/src/man/man1/pyngcgui.1.adoc
@@ -11,13 +11,11 @@ pyngcgui - Python implementation of NGCGUI
 == DESCRIPTION
 
 *pyngcgui* is an alternative implenentation of NGCGUI:
-
-....
-....
+http://linuxcnc.org/docs/html/gui/ngcgui.html
 
 == SEE ALSO
 
-*ngcgui* *LinuxCNC(1)*
+ngcgui(1), linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -28,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/pyui.1.adoc
+++ b/docs/src/man/man1/pyui.1.adoc
@@ -17,7 +17,7 @@ print errors to the terminal if found.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -28,15 +28,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/pyvcp_demo.1.adoc
+++ b/docs/src/man/man1/pyvcp_demo.1.adoc
@@ -20,7 +20,7 @@ If not provided, use compname == pyvcp
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -31,15 +31,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/qtplasmac-cfg2prefs.1.adoc
+++ b/docs/src/man/man1/qtplasmac-cfg2prefs.1.adoc
@@ -6,7 +6,7 @@ qtplasmac-cfg2prefs - Convert plasma parameters.
 
 == SYNOPSIS
 
-*qtplasmac-cfg2prefs* +
+*qtplasmac-cfg2prefs*
 
 == DESCRIPTION
 

--- a/docs/src/man/man1/qtvcp.1.adoc
+++ b/docs/src/man/man1/qtvcp.1.adoc
@@ -61,7 +61,7 @@ Example: -g 200x400+0+100.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -72,15 +72,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/rotarydelta.1.adoc
+++ b/docs/src/man/man1/rotarydelta.1.adoc
@@ -14,7 +14,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -25,15 +25,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/rs274.1.adoc
+++ b/docs/src/man/man1/rs274.1.adoc
@@ -38,7 +38,7 @@ command ---- rs274 -g test.ngc -t test.tbl ----
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -49,15 +49,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/rtapi_app.1.adoc
+++ b/docs/src/man/man1/rtapi_app.1.adoc
@@ -17,7 +17,7 @@ simulation).
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -28,15 +28,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/scaragui.1.adoc
+++ b/docs/src/man/man1/scaragui.1.adoc
@@ -15,7 +15,7 @@ http://linuxcnc.org/docs/html/gui/vismach.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/schedrmt.1.adoc
+++ b/docs/src/man/man1/schedrmt.1.adoc
@@ -150,7 +150,7 @@ current poll rate.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -161,15 +161,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/scorbot-er-3.1.adoc
+++ b/docs/src/man/man1/scorbot-er-3.1.adoc
@@ -17,7 +17,7 @@ is close)
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -28,15 +28,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/simulate_probe.1.adoc
+++ b/docs/src/man/man1/simulate_probe.1.adoc
@@ -15,7 +15,7 @@ input. Typically used in sim configs or debugging.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/stepconf.1.adoc
+++ b/docs/src/man/man1/stepconf.1.adoc
@@ -17,7 +17,7 @@ Detailed docs: http://linuxcnc.org/docs/html/config/stepconf.html
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -28,15 +28,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/teach-in.1.adoc
+++ b/docs/src/man/man1/teach-in.1.adoc
@@ -18,7 +18,7 @@ chosen at load time. line format: line-no X Y Z flood mist spindle
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -29,15 +29,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/tooledit.1.adoc
+++ b/docs/src/man/man1/tooledit.1.adoc
@@ -16,7 +16,7 @@ details:
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -27,15 +27,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/touchy.1.adoc
+++ b/docs/src/man/man1/touchy.1.adoc
@@ -25,7 +25,7 @@ gets run by the runscript usually.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -36,15 +36,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/update_ini.1.adoc
+++ b/docs/src/man/man1/update_ini.1.adoc
@@ -19,7 +19,7 @@ file in the pre-joints-axes format is opened.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -30,15 +30,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/vfdb_vfd.1.adoc
+++ b/docs/src/man/man1/vfdb_vfd.1.adoc
@@ -6,7 +6,7 @@ vfdb_vfd - HAL non-realtime component for Delta VFD-B Variable Frequency Drives
 
 == SYNOPSIS
 
-*vfdb_vfd* [OPTIONS] +
+*vfdb_vfd* [OPTIONS]
 
 == DESCRIPTION
 

--- a/docs/src/man/man1/vfs11_vfd.1.adoc
+++ b/docs/src/man/man1/vfs11_vfd.1.adoc
@@ -6,7 +6,7 @@ vfs11_vfd - HAL non-realtime component for Toshiba-Schneider VF-S11 Variable Fre
 
 == SYNOPSIS
 
-*vfs11_vfd* [OPTIONS] +
+*vfs11_vfd* [OPTIONS]
 
 == DESCRIPTION
 

--- a/docs/src/man/man1/xhc-hb04-accels.1.adoc
+++ b/docs/src/man/man1/xhc-hb04-accels.1.adoc
@@ -15,7 +15,7 @@ wheel jogging accels.
 
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -26,15 +26,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/xhc-whb04b-6.1.adoc
+++ b/docs/src/man/man1/xhc-whb04b-6.1.adoc
@@ -587,6 +587,10 @@ The development started with the xhc-whb04 (4-axis wireless pendant) implementat
 73 & many thanks to the developers who delivered provided an excellent preparatory work!
 
 == COPYRIGHT
-Copyright (C) 2018 Raoul Rubien (github.com/rubienr) Updated for Linuxcnc 2020 by alkabal_free.fr.
-This is free software; see the source for copying conditions.
-There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+Copyright (C) 2018 Raoul Rubien (github.com/rubienr) Updated for
+Linuxcnc 2020 by alkabal_free.fr.
+
+This is free software; see the source for copying conditions. There is
+NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.

--- a/docs/src/man/man1/xyzac-trt-gui.1.adoc
+++ b/docs/src/man/man1/xyzac-trt-gui.1.adoc
@@ -11,12 +11,9 @@ simulating a 5-axis milling machine with tool-point kinematics.
 
 See the main LinuxCNC documentation for more details.
 
-....
-....
-
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -27,15 +24,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man1/xyzbc-trt-gui.1.adoc
+++ b/docs/src/man/man1/xyzbc-trt-gui.1.adoc
@@ -11,12 +11,9 @@ simulating a 5-axis milling machine with tool-point kinematics
 
 See the main LinuxCNC documentation for more details.
 
-....
-....
-
 == SEE ALSO
 
-*LinuxCNC(1)*
+linuxcnc(1)*
 
 Much more information about LinuxCNC and HAL is available in the
 LinuxCNC and HAL User Manuals, found at /usr/share/doc/LinuxCNC/.
@@ -27,15 +24,16 @@ None known at this time.
 
 == AUTHOR
 
-This man page written by andypugh, as part of the LinuxCNC project.
+This man page written by Andy Pugh, as part of the LinuxCNC project.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2020 andypugh. +
+Copyright © 2020 Andy Pugh.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man3/PM_ROTATION_VECTOR.3.adoc
+++ b/docs/src/man/man3/PM_ROTATION_VECTOR.3.adoc
@@ -6,9 +6,11 @@ PM_ROTATION_VECTOR - Three-axis cartesian position
 
 == SYNTAX
 
-*#include posemath.h*
+....
+#include <posemath.h>
 
-*struct PM_CARTESIAN;*
+struct PM_CARTESIAN;
+....
 
 == CONSTRUCTORS
 
@@ -54,5 +56,4 @@ PM_ROTATION_VECTOR - Three-axis cartesian position
    +
 
 *PM_CARTESIAN norm(PM_CARTESIAN _v_*)**::
-
-== SEE ALSO
+   +

--- a/docs/src/man/man3/hal.3hal.adoc
+++ b/docs/src/man/man3/hal.3hal.adoc
@@ -80,4 +80,4 @@ values for errors, and non-negative values for success.
 
 == SEE ALSO
 
-*intro(3rtapi)*
+rtapi(3)

--- a/docs/src/man/man3/hal_add_funct_to_thread.3.adoc
+++ b/docs/src/man/man3/hal_add_funct_to_thread.3.adoc
@@ -48,4 +48,4 @@ non-realtime code.
 
 == SEE ALSO
 
-*hal_thread_new(3hal)*, *hal_export_funct(3hal)*
+hal_thread_new(3hal), hal_export_funct(3hal)

--- a/docs/src/man/man3/hal_create_thread.3hal.adoc
+++ b/docs/src/man/man3/hal_create_thread.3hal.adoc
@@ -46,4 +46,4 @@ Returns a HAL status code.
 
 == SEE ALSO
 
-*hal_export_funct(3hal)*
+hal_export_funct(3hal)

--- a/docs/src/man/man3/hal_export_funct.3.adoc
+++ b/docs/src/man/man3/hal_export_funct.3.adoc
@@ -51,4 +51,4 @@ Returns a HAL status code.
 
 == SEE ALSO
 
-*hal_create_thread(3hal)*, *hal_add_funct_to_thread(3hal)*
+hal_create_thread(3hal), hal_add_funct_to_thread(3hal)

--- a/docs/src/man/man3/hal_param_alias.3hal.adoc
+++ b/docs/src/man/man3/hal_param_alias.3hal.adoc
@@ -32,4 +32,4 @@ Returns a HAL status code.
 
 == SEE ALSO
 
-*hal_pin_alias*(3)
+hal_pin_alias(3)

--- a/docs/src/man/man3/hal_param_new.3.adoc
+++ b/docs/src/man/man3/hal_param_new.3.adoc
@@ -67,4 +67,4 @@ Returns a HAL status code.
 
 == SEE ALSO
 
-*hal_type_t(3hal)*
+hal_type_t(3hal)

--- a/docs/src/man/man3/hal_parport.3hal.adoc
+++ b/docs/src/man/man3/hal_parport.3hal.adoc
@@ -6,12 +6,13 @@ hal_parport - portable access to PC-style parallel ports
 
 == SYNTAX
 
+....
 #include "hal_parport.h"
-
-int *hal_parport_get*(int _comp_id_, hal_parport_t *_port_, unsigned
-short _base_, unsigned short _base_hi_, unsigned int _modes_)
-
-void *hal_parport_release*(hal_parport_t *_port_)
+int hal_parport_get(int _comp_id_, hal_parport_t *_port_,
+                      unsigned short _base_, unsigned short _base_hi_,
+		      unsigned int _modes_)
+void hal_parport_release(hal_parport_t *_port_)
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/hal_pin_alias.3hal.adoc
+++ b/docs/src/man/man3/hal_pin_alias.3hal.adoc
@@ -32,4 +32,4 @@ Returns a HAL status code.
 
 == SEE ALSO
 
-*hal_param_alias*(3)
+hal_param_alias(3)

--- a/docs/src/man/man3/hal_pin_new.3.adoc
+++ b/docs/src/man/man3/hal_pin_new.3.adoc
@@ -82,4 +82,4 @@ Returns 0 on success, or a negative errno value on failure.
 
 == SEE ALSO
 
-*hal_type_t(3hal)*, *hal_link(3hal)*
+hal_type_t(3hal), hal_link(3hal)

--- a/docs/src/man/man3/hal_port.3hal.adoc
+++ b/docs/src/man/man3/hal_port.3hal.adoc
@@ -7,31 +7,26 @@ stream
 
 == SYNOPSIS
 
-$*
+....
+#include <hal.h>
+bool hal_port_read(hal_port_t port, char* dest, unsigned count);
+bool hal_port_peek(hal_port_t port, char* dest, unsigned count);
+bool hal_port_peek_commit(hal_port_t port, unsigned count);
+unsigned hal_port_readable(hal_port_t port);
+void hal_port_clear(hal_port_t port);
 
-$* +
+bool hal_port_write(hal_port_t port, const char* src, unsigned count);
+unsigned hal_port_writable(hal_port_t port);
 
-$* +
+unsigned hal_port_buffer_size(hal_port_t port);
 
-$* +
-
-$* +
-
-$*
-
-$* +
-
-$*
-
-$*
-
-$* +
-
-$* +
-
-$* +
-
-$*
+#ifdef ULAPI
+void hal_port_wait_readable(hal_port_t** port, unsigned count,
+                            sig_atomic_t* stop);
+void hal_port_wait_writable(hal_port_t** port, unsigned count,
+                            sig_atomic_t* stop);
+#endif
+....
 
 == DESCRIPTION
 
@@ -142,4 +137,4 @@ ULAPI code.
 
 == SEE ALSO
 
-*raster*(9),
+raster(9)

--- a/docs/src/man/man3/hal_set_constructor.3hal.adoc
+++ b/docs/src/man/man3/hal_set_constructor.3hal.adoc
@@ -33,4 +33,4 @@ Returns a HAL status code.
 
 == SEE ALSO
 
-*halcmd(1)*
+halcmd(1)

--- a/docs/src/man/man3/hal_signal_new.3.adoc
+++ b/docs/src/man/man3/hal_signal_new.3.adoc
@@ -54,4 +54,4 @@ Returns a HAL status code.
 
 == SEE ALSO
 
-*hal_type_t(3hal)*
+hal_type_t(3hal)

--- a/docs/src/man/man3/hal_start_threads.3hal.adoc
+++ b/docs/src/man/man3/hal_start_threads.3hal.adoc
@@ -25,5 +25,4 @@ Returns a HAL status code.
 
 == SEE ALSO
 
-*hal_export_funct(3hal)*, *hal_create_thread(3hal)*,
-*hal_add_funct_to_thread(3hal)*
+hal_export_funct(3hal), hal_create_thread(3hal), hal_add_funct_to_thread(3hal)

--- a/docs/src/man/man3/hal_stream.3hal.adoc
+++ b/docs/src/man/man3/hal_stream.3hal.adoc
@@ -6,43 +6,34 @@ hal_stream - non-blocking realtime streams
 
 == SYNOPSIS
 
-$*
+....
+#include <hal.h>
+int hal_stream_create(hal_stream_t* stream, int comp_id, int key,
+                      int depth, const char* typestring);
+void hal_stream_destroy(hal_stream_t* stream);
+int hal_stream_attach(hal_stream_t* stream, int comp_id, int key,
+                      const char* typestring);
+int hal_stream_detach(hal_stream_t* stream);
 
-$* +
+int hal_stream_element_count(hal_stream_t* stream);
+hal_type_t hal_stream_element_type(hal_stream_t* stream, int idx);
+int hal_stream_depth(hal_stream_t* stream);
+int hal_stream_maxdepth(hal_stream_t* stream);
+int hal_stream_num_underruns(hal_stream_t* stream);
+int hal_stream_num_overruns(hal_stream_t* stream);
 
-$* +
+int hal_stream_read(hal_stream_t* stream, union hal_stream_data* buf,
+                    unsigned* sampleno);
+bool hal_stream_readable(hal_stream_t* stream);
 
-$* +
+int hal_stream_write(hal_stream_t* stream, union hal_stream_data* buf);
+bool hal_stream_writable(hal_stream_t* stream);
 
-$*
-
-$* +
-
-$* +
-
-$* +
-
-$* +
-
-$* +
-
-$*
-
-$* +
-
-$*
-
-$* +
-
-$*
-
-$* +
-
-$* +
-
-$* +
-
-$*
+#ifdef ULAPI
+void hal_stream_wait_writable(hal_stream_t* stream, sig_atomic_t* stop);
+void hal_stream_wait_readable(hal_stream_t* stream, sig_atomic_t* stop);
+#endif
+....
 
 == DESCRIPTION
 
@@ -224,4 +215,4 @@ parameters and signals)
 
 == SEE ALSO
 
-*sampler*(9), *streamer*(9), *halsampler*(1), *halstreamer*(1)
+sampler(9), streamer(9), halsampler(1), halstreamer(1)

--- a/docs/src/man/man3/hal_type_t.3.adoc
+++ b/docs/src/man/man3/hal_type_t.3.adoc
@@ -71,4 +71,4 @@ when using uspace realtime.
 
 == SEE ALSO
 
-*hal_pin_new(3hal)*, *hal_param_new(3hal)*
+hal_pin_new(3hal), hal_param_new(3hal)

--- a/docs/src/man/man3/hm2_allocate_bspi_tram.3hm2.adoc
+++ b/docs/src/man/man3/hm2_allocate_bspi_tram.3hm2.adoc
@@ -35,7 +35,8 @@ Returns 0 on success and -1 on failure.
 
 == SEE ALSO
 
-*hm2_bspi_set_read_function(3hm2)*, *hm2_bspi_setup_chan(3hm2)*,
-*hm2_bspi_set_write_function(3hm2)*, *hm2_bspi_write_chan(3hm2)*,
-*hm2_tram_add_bspi_frame(3hm2)*, See src/hal/drivers mesa_7i65.comp for
-an example usage.
+hm2_bspi_set_read_function(3hm2), hm2_bspi_setup_chan(3hm2),
+hm2_bspi_set_write_function(3hm2), hm2_bspi_write_chan(3hm2),
+hm2_tram_add_bspi_frame(3hm2)
+
+See src/hal/drivers mesa_7i65.comp for an example usage.

--- a/docs/src/man/man3/hm2_bspi_set_read_function.3hm2.adoc
+++ b/docs/src/man/man3/hm2_bspi_set_read_function.3hm2.adoc
@@ -48,7 +48,7 @@ Returns 0 on success and -1 on failure.
 
 == SEE ALSO
 
-*hm2_allocate_bspi_tram(3hm2)*, *hm2_bspi_setup_chan(3hm2)*,
-*hm2_bspi_set_write_function(3hm2)*, *hm2_bspi_write_chan(3hm2)*,
-*hm2_tram_add_bspi_frame(3hm2)*, src/hal/drivers mesa_7i65.comp in the
+hm2_allocate_bspi_tram(3hm2), hm2_bspi_setup_chan(3hm2),
+hm2_bspi_set_write_function(3hm2), hm2_bspi_write_chan(3hm2),
+hm2_tram_add_bspi_frame(3hm2), src/hal/drivers mesa_7i65.comp in the
 LinuxCNC source distribution.

--- a/docs/src/man/man3/hm2_bspi_set_write_function.3hm2.adoc
+++ b/docs/src/man/man3/hm2_bspi_set_write_function.3hm2.adoc
@@ -52,7 +52,7 @@ Returns 0 on success and -1 on failure.
 
 == SEE ALSO
 
-*hm2_allocate_bspi_tram(3hm2)*, *hm2_bspi_set_read_function(3hm2)*,
-*hm2_bspi_setup_chan(3hm2)*, *hm2_bspi_write_chan(3hm2)*,
-*hm2_tram_add_bspi_frame(3hm2)*, src/hal/drivers mesa_7i65.comp in the
+hm2_allocate_bspi_tram(3hm2), hm2_bspi_set_read_function(3hm2),
+hm2_bspi_setup_chan(3hm2), hm2_bspi_write_chan(3hm2),
+hm2_tram_add_bspi_frame(3hm2), src/hal/drivers mesa_7i65.comp in the
 LinuxCNC source distribution.

--- a/docs/src/man/man3/hm2_bspi_setup_chan.3hm2.adoc
+++ b/docs/src/man/man3/hm2_bspi_setup_chan.3hm2.adoc
@@ -8,7 +8,8 @@ hm2_bspi_setup_chan - setup a Hostmot2 bspi channel
 
 ....
 #include <hostmot2-serial.h>
-int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz, int delay, int cpol, int cpha, int noclear, int noecho)
+int hm2_bspi_setup_chan(char *name, int chan, int cs, int bits, float mhz,
+                        int delay, int cpol, int cpha, int noclear, int noecho)
 ....
 
 == DESCRIPTION
@@ -65,7 +66,8 @@ Returns 0 on success and -1 on failure.
 
 == SEE ALSO
 
-*hm2_allocate_bspi_tram(3hm2)*, *hm2_bspi_set_read_function(3hm2)*,
-*hm2_bspi_set_write_function(3hm2)*, *hm2_bspi_write_chan(3hm2)*,
-*hm2_tram_add_bspi_frame(3hm2)*, See src/hal/drivers mesa_7i65.comp for
-an example usage.
+hm2_allocate_bspi_tram(3hm2), hm2_bspi_set_read_function(3hm2),
+hm2_bspi_set_write_function(3hm2), hm2_bspi_write_chan(3hm2),
+hm2_tram_add_bspi_frame(3hm2)
+
+See src/hal/drivers mesa_7i65.comp for an example usage.

--- a/docs/src/man/man3/hm2_bspi_write_chan.3hm2.adoc
+++ b/docs/src/man/man3/hm2_bspi_write_chan.3hm2.adoc
@@ -36,7 +36,8 @@ Returns 0 on success and -1 on failure.
 
 == SEE ALSO
 
-*hm2_allocate_bspi_tram(3hm2)*, *hm2_bspi_set_read_function(3hm2)*,
-*hm2_bspi_setup_chan(3hm2)*, *hm2_bspi_set_write_function(3hm2)*,
-*hm2_tram_add_bspi_frame(3hm2)*, See src/hal/drivers mesa_7i65.comp for
-an example usage.
+hm2_allocate_bspi_tram(3hm2), hm2_bspi_set_read_function(3hm2),
+hm2_bspi_setup_chan(3hm2), hm2_bspi_set_write_function(3hm2),
+hm2_tram_add_bspi_frame(3hm2)
+
+See src/hal/drivers mesa_7i65.comp for an example usage.

--- a/docs/src/man/man3/hm2_pktuart.3.adoc
+++ b/docs/src/man/man3/hm2_pktuart.3.adoc
@@ -6,27 +6,21 @@ hm2_pktuart - functions to access the Mesa FPGA card packeted UARTs
 
 == SYNOPSIS
 
-*#include hostmot2-serial.h*
-
-
-*int hm2_pktuart_setup(char *name, int bitrate, rtapi_s32 tx_mode, rtapi_s32 rx_mode, int txclear, int rxclear)*
-
-*int hm2_pktuart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 frame_sizes[])*
-
-*int hm2_pktuart_read(char *name, unsigned char data[],  rtapi_u8 *num_frames, rtapi_u16 *max_frame_length, rtapi_u16 frame_sizes[])*
-
-*int hm2_pktuart_queue_get_frame_sizes(char *name, rtapi_u32 fsizes[])*
-
-*int hm2_pktuart_queue_read_data(char *name, rtapi_u32 *data, int bytes)*
-
-*int hm2_pktuart_get_clock(char *name)*
-
-*int hm2_pktuart_get_version(char *name)*
-
-*rtapi_u32 hm2_pktuart_get_rx_status(char *name)*
-
-*rtapi_u32 hm2_pktuart_get_tx_status(char *name)*
-
+....
+#include <hostmot2-serial.h>
+int hm2_pktuart_setup(char *name, int bitrate, rtapi_s32 tx_mode,
+                      rtapi_s32 rx_mode, int txclear, int rxclear);
+int hm2_pktuart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames,
+                     rtapi_u16 frame_sizes[]);
+int hm2_pktuart_read(char *name, unsigned char data[],  rtapi_u8 *num_frames,
+                     rtapi_u16 *max_frame_length, rtapi_u16 frame_sizes[]);
+int hm2_pktuart_queue_get_frame_sizes(char *name, rtapi_u32 fsizes[]);
+int hm2_pktuart_queue_read_data(char *name, rtapi_u32 *data, int bytes);
+int hm2_pktuart_get_clock(char *name);
+int hm2_pktuart_get_version(char *name);
+rtapi_u32 hm2_pktuart_get_rx_status(char *name);
+rtapi_u32 hm2_pktuart_get_tx_status(char *name);
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/hm2_pktuart_read.3hm2.adoc
+++ b/docs/src/man/man3/hm2_pktuart_read.3hm2.adoc
@@ -8,7 +8,8 @@ hm2_pktuart_read - read data from a Hostmot2 UART buffer
 
 ....
 #include <hostmot2-serial.h>
-int hm2_pktuart_read(char *name,  unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 *max_frame_length, rtapi_u16 frame_sizes[])
+int hm2_pktuart_read(char *name,  unsigned char data[], rtapi_u8 *num_frames,
+                     rtapi_u16 *max_frame_length, rtapi_u16 frame_sizes[]);
 ....
 
 == DESCRIPTION

--- a/docs/src/man/man3/hm2_pktuart_send.3hm2.adoc
+++ b/docs/src/man/man3/hm2_pktuart_send.3hm2.adoc
@@ -8,7 +8,8 @@ hm2_pktuart_send - write data to a Hostmot2 PktUART
 
 ....
 #include <hostmot2-serial.h>
-int hm2_uart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 frame_sizes[])
+int hm2_uart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames,
+                  rtapi_u16 frame_sizes[]);
 ....
 
 == DESCRIPTION

--- a/docs/src/man/man3/hm2_pktuart_setup.3hm2.adoc
+++ b/docs/src/man/man3/hm2_pktuart_setup.3hm2.adoc
@@ -8,7 +8,8 @@ hm2_pktuart_setup - setup a Hostmot2 PktUART instance
 
 ....
 #include <hostmot2-serial.h>
-int hm2_pktuart_setup(char *name, int bitrate, rtapi_s32 tx_mode, rtapi_s32 rx_mode, int txclear, int rxclear)
+int hm2_pktuart_setup(char *name, int bitrate, rtapi_s32 tx_mode,
+                      rtapi_s32 rx_mode, int txclear, int rxclear)
 ....
 
 == DESCRIPTION

--- a/docs/src/man/man3/hm2_tram_add_bspi_frame.3hm2.adoc
+++ b/docs/src/man/man3/hm2_tram_add_bspi_frame.3hm2.adoc
@@ -8,7 +8,7 @@ hm2_tram_add_bspi_frame - add a register-write to the Hostmot2 TRAM
 
 ....
 #include <hostmot2-serial.h>
-hm2_tram_add_bspi_frame(char *name, int chan, u32 **wbuff, u32 **rbuff)
+hm2_tram_add_bspi_frame(char *name, int chan, u32 **wbuff, u32 **rbuff);
 ....
 
 == DESCRIPTION
@@ -39,7 +39,8 @@ Returns 0 on success and -1 on failure.
 
 == SEE ALSO
 
-*hm2_allocate_bspi_tram(3hm2)*, *hm2_bspi_set_read_function(3hm2)*,
-*hm2_bspi_setup_chan(3hm2)*, *hm2_bspi_set_write_function(3hm2)*,
-*hm2_bspi_write_chan(3hm2)*, See src/hal/drivers mesa_7i65.comp for an
-example usage.
+hm2_allocate_bspi_tram(3hm2), hm2_bspi_set_read_function(3hm2),
+hm2_bspi_setup_chan(3hm2), hm2_bspi_set_write_function(3hm2),
+hm2_bspi_write_chan(3hm2)
+
+See src/hal/drivers mesa_7i65.comp for an example usage.

--- a/docs/src/man/man3/hm2_uart_read.3hm2.adoc
+++ b/docs/src/man/man3/hm2_uart_read.3hm2.adoc
@@ -8,7 +8,7 @@ hm2_uart_read - read data from a Hostmot2 UART buffer
 
 ....
 #include <hostmot2-serial.h>
-int hm2_uart_read(char *name, unsigned char *data)
+int hm2_uart_read(char *name, unsigned char *data);
 ....
 
 == DESCRIPTION
@@ -34,6 +34,6 @@ Returns the number of bytes read on success and -1 on failure.
 
 == SEE ALSO
 
-*hm2_uart_setup*(3hm2), *hm2_uart_send*(3hm2)
+hm2_uart_setup(3hm2), hm2_uart_send(3hm2)
 
 See src/hal/drivers mesa_uart.comp for an example usage.

--- a/docs/src/man/man3/hm2_uart_send.3hm2.adoc
+++ b/docs/src/man/man3/hm2_uart_send.3hm2.adoc
@@ -8,7 +8,7 @@ hm2_uart_send - write data to a Hostmot2 UART
 
 ....
 #include <hostmot2-serial.h>
-int hm2_uart_send(char* name,  unsigned char data[], int count)
+int hm2_uart_send(char* name,  unsigned char data[], int count);
 ....
 
 == DESCRIPTION
@@ -33,6 +33,6 @@ Returns the number of bytes sent on success and -1 on failure.
 
 == SEE ALSO
 
-*hm2_uart_setup*(3hm2), *hm2_uart_read*(3hm2)
+hm2_uart_setup(3hm2), hm2_uart_read(3hm2)
 
 See src/hal/drivers mesa_uart.comp for an example usage.

--- a/docs/src/man/man3/hm2_uart_setup.3hm2.adoc
+++ b/docs/src/man/man3/hm2_uart_setup.3hm2.adoc
@@ -7,8 +7,8 @@ hm2_uart_setup - setup a Hostmot2 UART
 == SYNTAX
 
 ....
-#include +<+hostmot2-serial.h+>+
-int hm2_uart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode){
+#include <hostmot2-serial.h>
+int hm2_uart_setup(char *name, int bitrate, s32 tx_mode, s32 rx_mode);
 ....
 
 == DESCRIPTION
@@ -55,6 +55,6 @@ Returns 0 on success and -1 on failure.
 
 == SEE ALSO
 
-*hm2_uart_send*(3hm2), *hm2_uart_read*(3hm2)
+hm2_uart_send(3hm2), hm2_uart_read(3hm2)
 
 See src/hal/drivers mesa_uart.comp for an example usage.

--- a/docs/src/man/man3/rtapi_app_exit.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_app_exit.3rtapi.adoc
@@ -8,7 +8,7 @@ rtapi_app_exit - User-provided function to shut down a component
 
 ....
 #include <rtapi_app.h>
-void rtapi_app_exit(void) {...}
+void rtapi_app_exit(void);
 ....
 
 == ARGUMENTS
@@ -36,4 +36,4 @@ Called automatically by the rtapi infrastructure in an initialization
 
 == SEE ALSO
 
-*rtapi_app_main(3rtapi)*, *rtapi_exit(3rtapi)*, *hal_exit(3hal)*
+rtapi_app_main(3rtapi), rtapi_exit(3rtapi), hal_exit(3hal)

--- a/docs/src/man/man3/rtapi_app_main.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_app_main.3rtapi.adoc
@@ -8,7 +8,7 @@ rtapi_app_main - User-provided function to initialize a component
 
 ....
 #include <rtapi_app.h>
-int rtapi_app_main(void) {...}
+int rtapi_app_main(void);
 ....
 
 == ARGUMENTS
@@ -34,4 +34,4 @@ Called automatically by the rtapi infrastructure in an initialization
 
 == SEE ALSO
 
-*rtapi_app_exit(3rtapi)*, *rtapi_init(3rtapi)*, *hal_init(3hal)*
+rtapi_app_exit(3rtapi), rtapi_init(3rtapi), hal_init(3hal)

--- a/docs/src/man/man3/rtapi_atomic.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_atomic.3rtapi.adoc
@@ -6,17 +6,14 @@ rtapi_atomic - subset of C11 stdatomic.h
 
 == SYNTAX
 
+....
 #include <rtapi_atomic.h>
-
 enum memory_order \{ ... };
-
 #define atomic_store(obj, desired)...
-
 #define atomic_store_explicit(obj, desired, order)...
-
 #define atomic_load(obj)...
-
 #define atomic_load_explicit(obj, order)...
+....
 
 == ARGUMENTS
 
@@ -73,5 +70,5 @@ the _obj_ argument.
 
 == SEE ALSO
 
-*<stdatomic.h>* (C11), *<rtapi_bitops.h>* (for other atomic memory
+<stdatomic.h> (C11), <rtapi_bitops.h> (for other atomic memory
 operations supported by rtapi)

--- a/docs/src/man/man3/rtapi_bool.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_bool.3rtapi.adoc
@@ -6,7 +6,9 @@ rtapi_bool - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_bool.h>
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_byteorder.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_byteorder.3rtapi.adoc
@@ -6,7 +6,9 @@ rtapi_byteorder - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_byteorder.h>
+....
 
 RTAPI_BIG_ENDIAN::
   Defined to 1 if the platform is big-endian, 0 otherwise

--- a/docs/src/man/man3/rtapi_clock_set_period.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_clock_set_period.3rtapi.adoc
@@ -6,7 +6,9 @@ rtapi_clock_set_period - set the basic time interval for realtime tasks
 
 == SYNTAX
 
-rtapi_clock_set_period(long int _nsec_)
+....
+rtapi_clock_set_period(long int _nsec_);
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/rtapi_delay.3.adoc
+++ b/docs/src/man/man3/rtapi_delay.3.adoc
@@ -8,9 +8,10 @@ rtapi_delay, rtapi_delay_max - Busy-loop for short delays
 
 == SYNTAX
 
-void rtapi_delay(long int _nsec_)
-
-void rtapi_delay_max()
+....
+void rtapi_delay(long int _nsec_);
+void rtapi_delay_max();
+....
 
 == ARGUMENTS
 
@@ -41,4 +42,4 @@ May be called from init/cleanup code, and from within realtime tasks.
 
 == SEE ALSO
 
-*rtapi_clock_set_period(3rtapi)*
+rtapi_clock_set_period(3rtapi)

--- a/docs/src/man/man3/rtapi_device.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_device.3rtapi.adoc
@@ -6,15 +6,13 @@ rtapi_device - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_device.h>
-
 struct rtapi_device;
-
 int rtapi_dev_set_name(struct rtapi_device *dev, const char *name, ...);
-
 int rtapi_device_register(struct rtapi_device *dev);
-
 int rtapi_device_unregister(struct rtapi_device *dev);
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_div_u64.3.adoc
+++ b/docs/src/man/man3/rtapi_div_u64.3.adoc
@@ -8,15 +8,12 @@ rtapi_div_u64, rtapi_div_u64_rem, rtapi_div_s64, rtapi_div_s64_rem - unsigned di
 
 == SYNTAX
 
-__u64 rtapi_div_u64_rem(__u64 _dividend_, __u32 _divisor_, __u32
-*_remainder_)
-
-__u64 rtapi_div_u64(__u64 _dividend_, __u32 _divisor_)
-
-__s64 rtapi_div_s64(__s64 _dividend_, __s32 _divisor_)
-
-__s64 rtapi_div_s64_rem(__s64 _dividend_, __s32 _divisor_, __s32
-*_remainder_)
+....
+__u64 rtapi_div_u64_rem(__u64 _dividend_, __u32 _divisor_, __u32*_remainder_);
+__u64 rtapi_div_u64(__u64 _dividend_, __u32 _divisor_);
+__s64 rtapi_div_s64(__s64 _dividend_, __s32 _divisor_);
+__s64 rtapi_div_s64_rem(__s64 _dividend_, __s32 _divisor_, __s32 *_remainder_);
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/rtapi_exit.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_exit.3rtapi.adoc
@@ -6,7 +6,9 @@ rtapi_exit - Shut down RTAPI
 
 == SYNTAX
 
-int rtapi_exit(int _module_id_)
+....
+int rtapi_exit(int _module_id_);
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/rtapi_firmware.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_firmware.3rtapi.adoc
@@ -6,14 +6,13 @@ rtapi_firmware - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_firmware.h>
-
 struct rtapi_firmware;
-
 int rtapi_request_firmware(const struct rtapi_firmware **fw, const char
-*name, struct rtapi_device *device);
-
+                           *name, struct rtapi_device *device);
 void rtapi_release_firmware(const struct rtapi_firmware *fw);
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_get_msg_level.3.adoc
+++ b/docs/src/man/man3/rtapi_get_msg_level.3.adoc
@@ -8,9 +8,10 @@ rtapi_get_msg_level, rtapi_set_msg_level - Get or set the logging level
 
 == SYNTAX
 
-int rtapi_set_msg_level(int _level_)
-
-int rtapi_get_msg_level()
+....
+int rtapi_set_msg_level(int _level_);
+int rtapi_get_msg_level();
+....
 
 == ARGUMENTS
 
@@ -31,9 +32,9 @@ May be called from non-realtime, init/cleanup, and realtime code.
 
 *rtapi_set_msg_level* returns a status code, and *rtapi_get_msg_level*
 returns the current level. RTAPI_MSG_NONE = 0, RTAPI_MSG_ERR = 1,
-RTAPI_MSG_WARN = 2, RTAPI_MSG_INFO = 3, RTAPI_MSG_DBG = 4 RTAPI_MSG_ALL
-= 5
+RTAPI_MSG_WARN = 2, RTAPI_MSG_INFO = 3, RTAPI_MSG_DBG = 4
+RTAPI_MSG_ALL = 5
 
 == SEE ALSO
 
-*rtapi_print_msg(3rtapi)*
+rtapi_print_msg(3rtapi)

--- a/docs/src/man/man3/rtapi_get_time.3.adoc
+++ b/docs/src/man/man3/rtapi_get_time.3.adoc
@@ -8,9 +8,10 @@ rtapi_get_time, rtapi_get_clocks - get the current time
 
 == SYNTAX
 
-long long rtapi_get_time()
-
-long long rtapi_get_clocks()
+....
+long long rtapi_get_time();
+long long rtapi_get_clocks();
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_gfp.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_gfp.3rtapi.adoc
@@ -6,13 +6,12 @@ rtapi_gfp - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_gfp.h>
-
 enum rtapi_gfp_e;
-
 RTAPI_GFP_xxx
-
 typedef ... rtapi_gfp_t;
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_init.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_init.3rtapi.adoc
@@ -6,7 +6,9 @@ rtapi_init - Sets up RTAPI
 
 == SYNTAX
 
-int rtapi_init(const char *_modname_)
+....
+int rtapi_init(const char *_modname_);
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/rtapi_io.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_io.3rtapi.adoc
@@ -6,23 +6,17 @@ rtapi_io - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_io.h>
-
 unsigned char rtapi_inb(unsigned short int port);
-
 unsigned short rtapi_inw(unsigned short int port);
-
 unsigned int rtapi_inl(unsigned short int port);
-
 unsigned void rtapi_outb(unsigned char value, unsigned short int port);
-
 unsigned void rtapi_outw(unsigned short value, unsigned short int port);
-
 unsigned void rtapi_inl(unsigned int value, unsigned short int port);
-
 int rtapi_ioperm(unsigned long from, unsigned long num, int turn_on);
-
 unsigned void rtapi_outl(unsigned int value, unsigned short int port);
+....
 
 == DESCRIPTION
 
@@ -47,8 +41,7 @@ As in Linux.
 
 == SEE ALSO
 
-*inb(3)*, *inw(3)*, *inl(3)*, *outb(3)*, *outw(3)*, *outl(3)*,
-*ioperm(3)*,
+inb(3), inw(3), inl(3), outb(3), outw(3), outl(3), ioperm(3)
 
 == AUTHOR
 

--- a/docs/src/man/man3/rtapi_is.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_is.3rtapi.adoc
@@ -6,9 +6,10 @@ rtapi_is - details of rtapi configuration
 
 == SYNTAX
 
-int rtapi_is_kernelspace()
-
-int rtapi_is_realtime()
+....
+int rtapi_is_kernelspace();
+int rtapi_is_realtime();
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_list.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_list.3rtapi.adoc
@@ -6,23 +6,18 @@ rtapi_list - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_list.h>
-
 struct rtapi_list_head;
-
-void rtapi_list_add(struct rtapi_list_head *new_, struct rtapi_list_head
-*head);
-
-void rtapi_list_add_tail(struct rtapi_list_head *new_, struct
-rtapi_list_head *head);
-
+void rtapi_list_add(struct rtapi_list_head *new_,
+                    struct rtapi_list_head *head);
+void rtapi_list_add_tail(struct rtapi_list_head *new_,
+                         struct rtapi_list_head *head);
 void rtapi_list_del(struct rtapi_list_head *entry);
-
 void RTAPI_INIT_LIST_HEAD(struct rtapi_list_head *entry);
-
 rtapi_list_for_each(pos, head) \{ ... }
-
 rtapi_list_entry(ptr, type, member)
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_module_param.3.adoc
+++ b/docs/src/man/man3/rtapi_module_param.3.adoc
@@ -11,25 +11,18 @@ MODULE_DESCRIPTION - Specifying module parameters
 
 == SYNTAX
 
-RTAPI_MP_INT(_var_, _description_)
-
-RTAPI_MP_LONG(_var_, _description_)
-
-RTAPI_MP_STRING(_var_, _description_)
-
-RTAPI_MP_ARRAY_INT(_var_, _num_, _description_)
-
-RTAPI_MP_ARRAY_LONG(_var_, _num_, _description_)
-
-RTAPI_MP_ARRAY_STRING(_var_, _num_, _description_)
-
-MODULE_LICENSE(_license_)
-
-MODULE_AUTHOR(_author_)
-
-MODULE_DESCRIPTION(_description_)
-
-EXPORT_FUNCTION(_function_)
+....
+RTAPI_MP_INT(_var_, _description_);
+RTAPI_MP_LONG(_var_, _description_);
+RTAPI_MP_STRING(_var_, _description_);
+RTAPI_MP_ARRAY_INT(_var_, _num_, _description_);
+RTAPI_MP_ARRAY_LONG(_var_, _num_, _description_);
+RTAPI_MP_ARRAY_STRING(_var_, _num_, _description_);
+MODULE_LICENSE(_license_);
+MODULE_AUTHOR(_author_);
+MODULE_DESCRIPTION(_description_);
+EXPORT_FUNCTION(_function_);
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/rtapi_mutex.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_mutex.3rtapi.adoc
@@ -6,11 +6,13 @@ rtapi_mutex - Mutex-related functions
 
 == SYNTAX
 
-*#include <rtapi_mutex.h>*
+....
+#include <rtapi_mutex.h>
 
-*int rtapi_mutex_try(unsigned long **_mutex_*);* +
-*int rtapi_mutex_get(unsigned long **_mutex_*);* +
-*int rtapi_mutex_give(unsigned long **_mutex_*);*
+int rtapi_mutex_try(unsigned long **_mutex_*);
+int rtapi_mutex_get(unsigned long **_mutex_*);
+int rtapi_mutex_give(unsigned long **_mutex_*);
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/rtapi_open_as_root.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_open_as_root.3rtapi.adoc
@@ -8,7 +8,7 @@ rtapi_open_as_root - Open a file with "root" privilege
 
 ....
 #include <rtapi.h>
-int rtapi_open_as_root(const char *filename, int flags)
+int rtapi_open_as_root(const char *filename, int flags);
 ....
 
 == ARGUMENTS
@@ -45,4 +45,4 @@ Call only from realtime initcode in "uspace" realtime.
 
 == SEE ALSO
 
-*open(2)*, *rtapi_pci(3)*
+open(2), rtapi_pci(3)

--- a/docs/src/man/man3/rtapi_outb.3.adoc
+++ b/docs/src/man/man3/rtapi_outb.3.adoc
@@ -8,9 +8,10 @@ rtapi_outb, rtapi_inb - Perform hardware I/O
 
 == SYNTAX
 
-void rtapi_outb(unsigned char _byte_, unsigned int _port_)
-
-unsigned char rtapi_inb(unsigned int _port_)
+....
+void rtapi_outb(unsigned char _byte_, unsigned int _port_);
+unsigned char rtapi_inb(unsigned int _port_);
+....
 
 == ARGUMENTS
 
@@ -41,4 +42,4 @@ kernel might attempt to access the I/O region at the same time.
 
 == SEE ALSO
 
-*rtapi_region(3rtapi)*
+rtapi_region(3rtapi)

--- a/docs/src/man/man3/rtapi_parport.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_parport.3rtapi.adoc
@@ -6,13 +6,14 @@ rtapi_parport - portable access to PC-style parallel ports
 
 == SYNTAX
 
+....
 #include "rtapi_parport.h"
 
-int *rtapi_parport_get*(const char *_module_name_, rtapi_parport_t
-*_port_, unsigned short _base_, unsigned short _base_hi_, unsigned int
-_modes_)
-
-void *rtapi_parport_release*(rtapi_parport_t *_port_)
+int *rtapi_parport_get*(const char *_module_name_, rtapi_parport_t *_port_,
+                        unsigned short _base_, unsigned short _base_hi_,
+			unsigned int _modes_);
+void *rtapi_parport_release*(rtapi_parport_t *_port_);
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/rtapi_pci.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_pci.3rtapi.adoc
@@ -6,46 +6,29 @@ rtapi_pci - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_pci.h>
 
 struct rtapi_pci_device_id \{ ... };
-
 struct rtapi_pci_resource \{ ... };
-
 struct rtapi_pci_dev \{ ... };
-
 struct rtapi_pci_driver \{ ... };
-
 const char *rtapi_pci_name(const struct rtapi_pci_dev *pdev);
-
 int rtapi_pci_enable_device(struct rtapi_pci_dev *dev);
-
-void rtapi__iomem *rtapi_pci_ioremap_bar(struct rtapi_pci_dev *pdev, int
-bar);
-
+void rtapi__iomem *rtapi_pci_ioremap_bar(struct rtapi_pci_dev *pdev, int bar);
 int rtapi_pci_register_driver(struct rtapi_pci_driver *driver);
-
 void rtapi_pci_unregister_driver(struct rtapi_pci_driver *driver);
-
 int rtapi_pci_enable_device(struct rtapi_pci_dev *dev);
-
 int rtapi_pci_disable_device(struct rtapi_pci_dev *dev);
-
 #define rtapi_pci_resource_start(dev, bar) ...
-
 #define rtapi_pci_resource_end(dev, bar) ...
-
 #define rtapi_pci_resource_flags(dev, bar) ...
-
 #define rtapi_pci_resource_len(dev,bar) ....
-
 void rtapi_pci_set_drvdata(struct rtapi_pci_dev *pdev, void *data)
-
 void rtapi_pci_set_drvdata(struct rtapi_pci_dev *pdev, void *data)
-
 void rtapi_iounmap(volatile void *addr);
-
 struct rtapi_pci;
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_print.3.adoc
+++ b/docs/src/man/man3/rtapi_print.3.adoc
@@ -8,16 +8,13 @@ rtapi_print, rtapi_print_msg - print diagnostic messages
 
 == SYNTAX
 
+....
 void rtapi_print(const char *_fmt_, _..._)
-
 void rtapi_print_msg(int level, const char *_fmt_, _..._)
-
-typedef void(**rtapi_msg_handler_t*)(msg_level_t _level_, const char
-*_msg_);
-
+typedef void(**rtapi_msg_handler_t*)(msg_level_t _level_, const char *_msg_);
 void *rtapi_set_msg_handler*(rtapi_msg_handler_t _handler_);
-
 rtapi_msg_handler_t *rtapi_get_msg_handler*(void);
+....
 
 == ARGUMENTS
 
@@ -62,5 +59,5 @@ None.
 
 == SEE ALSO
 
-*rtapi_set_msg_level(3rtapi)*, *rtapi_get_msg_level(3rtapi)*,
-*rtapi_vsnprintf(3rtapi)*
+rtapi_set_msg_level(3rtapi), rtapi_get_msg_level(3rtapi),
+rtapi_vsnprintf(3rtapi)

--- a/docs/src/man/man3/rtapi_prio.3.adoc
+++ b/docs/src/man/man3/rtapi_prio.3.adoc
@@ -8,13 +8,12 @@ rtapi_prio, rtapi_prio_highest, rtapi_prio_lowest, rtapi_prio_next_higher, rtapi
 
 == SYNTAX
 
-int rtapi_prio_highest()
-
-int rtapi_prio_lowest()
-
-int rtapi_prio_next_higher(int _prio_)
-
-int rtapi_prio_next_lower(int _prio_)
+....
+int rtapi_prio_highest();
+int rtapi_prio_lowest();
+int rtapi_prio_next_higher(int _prio_);
+int rtapi_prio_next_lower(int _prio_);
+....
 
 == ARGUMENTS
 
@@ -51,4 +50,4 @@ Returns an opaque real-time priority number.
 
 == SEE ALSO
 
-*rtapi_task_new(3rtapi)*
+rtapi_task_new(3rtapi)

--- a/docs/src/man/man3/rtapi_region.3.adoc
+++ b/docs/src/man/man3/rtapi_region.3.adoc
@@ -8,11 +8,11 @@ rtapi_region, rtapi_request_region, rtapi_release_region - functions to manage I
 
 == SYNTAX
 
-void *rtapi_request_region(unsigned long _base_, unsigned long int
-_size_, const char *_name_)
-
-void rtapi_release_region(unsigned long _base_, unsigned long int
-_size_)
+....
+void *rtapi_request_region(unsigned long _base_, unsigned long int _size_,
+                           const char *_name_)
+void rtapi_release_region(unsigned long _base_, unsigned long int _size_)
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/rtapi_shmem.3.adoc
+++ b/docs/src/man/man3/rtapi_shmem.3.adoc
@@ -8,12 +8,11 @@ rtapi_shmem, rtapi_shmem_new, rtapi_shmem_delete, rtapi_shmem_getptr - Functions
 
 == SYNTAX
 
-int rtapi_shmem_new(int _key_, int _module_id_, unsigned long int
-_size_)
-
-int rtapi_shmem_delete(int _shmem_id_, int _module_id_)
-
-int rtapi_shmem_getptr(int _shmem_id_, void ** _ptr_)
+....
+int rtapi_shmem_new(int _key_, int _module_id_, unsigned long int _size_);
+int rtapi_shmem_delete(int _shmem_id_, int _module_id_);
+int rtapi_shmem_getptr(int _shmem_id_, void ** _ptr_);
+....
 
 == ARGUMENTS
 

--- a/docs/src/man/man3/rtapi_slab.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_slab.3rtapi.adoc
@@ -6,15 +6,14 @@ rtapi_slab - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_slab.h>
 
 void *rtapi_kmalloc(size_t size, gfp_t g);
-
 void *rtapi_kzalloc(size_t size, gfp_t g);
-
 void *rtapi_krealloc(size_t size, gfp_t g);
-
 void rtapi_kfree(void *);
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_snprintf.3.adoc
+++ b/docs/src/man/man3/rtapi_snprintf.3.adoc
@@ -8,11 +8,12 @@ rtapi_snprintf, rtapi_vsnprintf - Perform snprintf-like string formatting
 
 == SYNTAX
 
-int rtapi_snprintf(char *_buf_, unsigned long int _size_, const char
-*_fmt_, _..._)
-
-int rtapi_vsnprintf(char *_buf_, unsigned long int _size_, const char
-*_fmt_, va_list _apfB)_
+....
+int rtapi_snprintf(char *_buf_, unsigned long int _size_,
+                   const char *_fmt_, _..._);
+int rtapi_vsnprintf(char *_buf_, unsigned long int _size_,
+                    const char *_fmt_, va_list _apf);
+....
 
 == ARGUMENTS
 
@@ -37,4 +38,4 @@ The number of characters written to _buf_.
 
 == SEE ALSO
 
-*printf(3)*
+printf(3)

--- a/docs/src/man/man3/rtapi_stdint.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_stdint.3rtapi.adoc
@@ -6,33 +6,23 @@ rtapi_stdint - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_stdint.h>
 
 typedef ... rtapi_s8;
-
 typedef ... rtapi_s16;
-
 typedef ... rtapi_s32;
-
 typedef ... rtapi_s64;
-
 typedef ... rtapi_intptr_t;
-
 typedef ... rtapi_u8;
-
 typedef ... rtapi_u16;
-
 typedef ... rtapi_u32;
-
 typedef ... rtapi_u64;
-
 typedef ... rtapi_uintptr_t;
-
 #define RTAPI_INT__xx___MIN ...
-
 #define RTAPI_INT__xx___MAX ...
-
 #define RTAPI_UINT__xx___MAX ...
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_string.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_string.3rtapi.adoc
@@ -6,13 +6,12 @@ rtapi_string - RTAPI wrappers for linux kernel functionality
 
 == SYNTAX
 
+....
 #include <rtapi_string.h>
-
 char **rtapi_argv_split(rtapi_gfp_t g, const char *argstr, int *argc);
-
 void rtapi_argv_free(char **argv);
-
 char *rtapi_kstrdup(const char *s, rtapi_gfp_t t);
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_strlcpy.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_strlcpy.3rtapi.adoc
@@ -6,11 +6,14 @@ rtapi_strlcpy - RTAPI string manipulation functions
 
 == SYNTAX
 
+....
 #include <rtapi_string.h>
 
-size_t rtapi_strlcpy(char *dst, const char *src, size_t sz); #define
-rtapi_strxcpy(dst, src) ... size_t rtapi_strlcat(char *dst, const char
-*src, size_t sz); #define rtapi_strxcat(dst, src) ...
+size_t rtapi_strlcpy(char *dst, const char *src, size_t sz);
+#define rtapi_strxcpy(dst, src) ...
+size_t rtapi_strlcat(char *dst, const char *src, size_t sz);
+#define rtapi_strxcat(dst, src) ...
+....
 
 == DESCRIPTION
 

--- a/docs/src/man/man3/rtapi_task_new.3.adoc
+++ b/docs/src/man/man3/rtapi_task_new.3.adoc
@@ -8,10 +8,11 @@ rtapi_task_new, rtapi_task_delete - create a realtime task
 
 == SYNTAX
 
+....
 int rtapi_task_new(void (*_taskcode_)(void*), void *_arg_, int _prio_,
-unsigned long _stacksize_, int _uses_fp_)
-
-int rtapi_task_delete(int _task_id_)
+                   unsigned long _stacksize_, int _uses_fp_);
+int rtapi_task_delete(int _task_id_);
+....
 
 == ARGUMENTS
 
@@ -46,5 +47,5 @@ RTAPI status code.
 
 == SEE ALSO
 
-*rtapi_prio(3rtapi)*, *rtapi_task_start(3rtapi)*,
-*rtapi_task_wait(3rtapi)*, *rtapi_task_resume(3rtapi)*
+rtapi_prio(3rtapi), rtapi_task_start(3rtapi), rtapi_task_wait(3rtapi),
+rtapi_task_resume(3rtapi)

--- a/docs/src/man/man3/rtapi_task_pause.3.adoc
+++ b/docs/src/man/man3/rtapi_task_pause.3.adoc
@@ -8,9 +8,10 @@ rtapi_task_pause, rtapi_task_resume - pause and resume real-time tasks
 
 == SYNTAX
 
-void rtapi_task_pause(int _task_id_)
-
-void rtapi_task_resume(int _task_id_)
+....
+void rtapi_task_pause(int _task_id_);
+void rtapi_task_resume(int _task_id_);
+....
 
 == ARGUMENTS
 
@@ -51,4 +52,4 @@ An RTAPI status code.
 
 == SEE ALSO
 
-*rtapi_task_new(3rtapi)*, *rtapi_task_start(3rtapi)*
+rtapi_task_new(3rtapi), rtapi_task_start(3rtapi)

--- a/docs/src/man/man3/rtapi_task_self.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_task_self.3rtapi.adoc
@@ -6,7 +6,9 @@ rtapi_task_self - Retrieve ID of current task
 
 == SYNTAX
 
-void rtapi_task_self()
+....
+void rtapi_task_self();
+....
 
 == DESCRIPTION
 
@@ -23,4 +25,4 @@ The task number previously returned by *rtapi_task_new* or -EINVAL.
 
 == SEE ALSO
 
-*rtapi_task_new(3rtapi)*
+rtapi_task_new(3rtapi)

--- a/docs/src/man/man3/rtapi_task_start.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_task_start.3rtapi.adoc
@@ -6,7 +6,9 @@ rtapi_task_start - start a realtime task in periodic mode
 
 == SYNTAX
 
-int rtapi_task_start(int _task_id_, unsigned long _period_nsec_)
+....
+int rtapi_task_start(int _task_id_, unsigned long _period_nsec_);
+....
 
 == ARGUMENTS
 
@@ -30,5 +32,5 @@ Returns an RTAPI status code.
 
 == SEE ALSO
 
-*rtapi_task_new(3rtapi)*, *rtapi_task_pause(3rtapi)*,
-*rtapi_task_resume(3rtapi)*
+rtapi_task_new(3rtapi), rtapi_task_pause(3rtapi),
+rtapi_task_resume(3rtapi)

--- a/docs/src/man/man3/rtapi_task_wait.3rtapi.adoc
+++ b/docs/src/man/man3/rtapi_task_wait.3rtapi.adoc
@@ -6,7 +6,9 @@ rtapi_task_wait - suspend execution of this periodic task
 
 == SYNTAX
 
-void rtapi_task_wait()
+....
+void rtapi_task_wait();
+....
 
 == DESCRIPTION
 
@@ -23,4 +25,4 @@ None
 
 == SEE ALSO
 
-*rtapi_task_start(3rtapi)*, *rtapi_task_pause(3rtapi)*
+rtapi_task_start(3rtapi), rtapi_task_pause(3rtapi)

--- a/docs/src/man/man9/at_pid.9.adoc
+++ b/docs/src/man/man9/at_pid.9.adoc
@@ -11,4 +11,4 @@ component.
 
 == SEE ALSO
 
-*pid*(9)
+pid(9)

--- a/docs/src/man/man9/counter.9.adoc
+++ b/docs/src/man/man9/counter.9.adoc
@@ -69,4 +69,4 @@ HAL manual.
 
 == SEE ALSO
 
-*encoder(9)*. in the LinuxCNC documentation.
+encoder(9)

--- a/docs/src/man/man9/encoder_ratio.9.adoc
+++ b/docs/src/man/man9/encoder_ratio.9.adoc
@@ -6,8 +6,7 @@ encoder_ratio - an electronic gear to synchronize two axes
 
 == SYNOPSIS
 
-*loadrt encoder_ratio [num_chan=*_num_* |
-names=*_name1_*[,*_name2..._*]]*
+*loadrt encoder_ratio [num_chan=*_num_* | names=*_name1_*[,*_name2..._*]]*
 
 == DESCRIPTION
 
@@ -82,4 +81,4 @@ The *encoder-ratio.N.* format is shown in the following descriptions.
 
 == SEE ALSO
 
-*encoder(9)*
+encoder(9)

--- a/docs/src/man/man9/enum.9.adoc
+++ b/docs/src/man/man9/enum.9.adoc
@@ -89,11 +89,14 @@ defined enumeration.
 Andy Pugh
 
 == REPORTING BUGS
-Report bugs to at the LinuxCNC github issues list:
-https://github.com/LinuxCNC/linuxcnc/issues
+
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
-Copyright © 2023 Andy Pugh.  This is free software; see the
-source for copying conditions.  There is NO warranty; not even for
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+Copyright © 2023 Andy Pugh.
+
+This is free software; see the source for copying conditions.  There
+is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
 

--- a/docs/src/man/man9/gantrykins.9.adoc
+++ b/docs/src/man/man9/gantrykins.9.adoc
@@ -13,4 +13,4 @@ loadrt trivkins coordinates=xyyz *kinstypes=BOTH*
 
 == SEE ALSO
 
-*trivkins*(9)
+trivkins(9)

--- a/docs/src/man/man9/gentrivkins.9.adoc
+++ b/docs/src/man/man9/gentrivkins.9.adoc
@@ -7,4 +7,4 @@ module.
 
 == SEE ALSO
 
-*trivkins*(9)
+trivkins(9)

--- a/docs/src/man/man9/gladevcp.9.adoc
+++ b/docs/src/man/man9/gladevcp.9.adoc
@@ -6,9 +6,7 @@ gladevcp - displays Virtual control Panels built with GTK / GLADE
 
 == SYNOPSIS
 
-*loadusr gladevcp [-c componentname0x*_N_*] [-g
-WxH+Xoffset+Yoffset0x*_N_*] [-H halcmdfile] [-x windowid]
-gladefile.glade*
+*loadusr gladevcp [-c componentname0x*_N_*] [-g WxH+Xoffset+Yoffset0x*_N_*] [-H halcmdfile] [-x windowid] gladefile.glade*
 
 == DESCRIPTION
 

--- a/docs/src/man/man9/hal_bb_gpio.9.adoc
+++ b/docs/src/man/man9/hal_bb_gpio.9.adoc
@@ -6,8 +6,7 @@ hal_bb_gpio - Driver for beaglebone GPIO pins
 
 == SYNOPSIS
 
-*loadrt hal_bb_gpio _user_leds=#,..._ _input_pins=#,..._
-_output_pins=#,..._*
+*loadrt hal_bb_gpio _user_leds=#,..._ _input_pins=#,...__output_pins=#,..._*
 
 == USER LEDS
 

--- a/docs/src/man/man9/hm2_eth.9.adoc
+++ b/docs/src/man/man9/hm2_eth.9.adoc
@@ -181,7 +181,7 @@ Mesa.
 
 == SEE ALSO
 
-*hostmot2*(9), *elbpcom*(1)
+hostmot2(9), elbpcom(1)
 
 == LICENSE
 

--- a/docs/src/man/man9/hm2_rpspi.9.adoc
+++ b/docs/src/man/man9/hm2_rpspi.9.adoc
@@ -146,7 +146,7 @@ warm and crash.
 
 == SEE ALSO
 
-*hostmot2*(9)
+hostmot2(9)
 
 == LICENSE
 

--- a/docs/src/man/man9/hostmot2.9.adoc
+++ b/docs/src/man/man9/hostmot2.9.adoc
@@ -1565,8 +1565,7 @@ the response to the read request to arrive from board 0.
 
 == SEE ALSO
 
-*hm2_pci*(9), *hm2_eth*(9), *hm2_spi*(9), *hm2_rpspi*(9), *hm2_7i43*(9),
-*hm2_7i90*(9)
+hm2_pci(9), hm2_eth(9), hm2_spi(9), hm2_rpspi(9), hm2_7i43(9), hm2_7i90(9)
 
 Mesa's documentation for the Anything I/O boards, at
 link:[http://www.mesanet.com] +

--- a/docs/src/man/man9/motion.9.adoc
+++ b/docs/src/man/man9/motion.9.adoc
@@ -8,7 +8,7 @@ motion, axis - accepts NML motion commands, interacts with HAL in realtime
 
 *loadrt motmod [base_period_nsec=*_period_*] [base_thread_fp=*_0 or 1_*] [servo_period_nsec=*_period_*] [traj_period_nsec=*_period_*] [num_joints=*_[1-16]_*] [num_dio=*_[1-64]_* | names_dout=*_name[,...]_* names_din=*_name[,...]_*] [num_aio=*_[1-64]_* | names_aout=*_name[,...]_* names_ain=*_name[,...]_*] [num_misc_error=*_[0-64]_*] [num_spindles=*_[1-8]_*]* *[unlock_joints_mask=*_jointmask_*]* *[num_extrajoints=*_[0-16]_*]*
 
-The limits for the following items are compile-time settings: +
+The limits for the following items are compile-time settings:
 
 *num_joints*: Maximum number of joints is set by *EMCMOT_MAX_JOINTS*.::
    +
@@ -16,7 +16,7 @@ The limits for the following items are compile-time settings: +
 *num_dio*: Maximum number of digital IO pins is set by
 *EMCMOT_MAX_DIO*.::
   Minimum is 1, if *num_dio* is not specified, it defaults to
-  *DEFAULT_DIO*. +
+  *DEFAULT_DIO*.
 
 *names_dout*: A comma-separated list of names for digital output pins.::
   This parameter is mutually exclusive with *num_dio*, but can be
@@ -24,19 +24,19 @@ The limits for the following items are compile-time settings: +
   specified. The default digital output pin has names like
   *motion.digital-out-00* whereas *names_dout=*_is-homing-x,is-homing-y_
   will create the HAL pins *motion.dout-is-homing-x* and
-  *motion.dout-is-homing-y*. +
+  *motion.dout-is-homing-y*.
 
 *names_din*: A comma-separated list of names for digital input pins.::
   This parameter is mutually exclusive with *num_dio*, but can be
   combined with *names_dout*. A maximum of *EMCMOT_MAX_DIO* names can be
   specified. The default digital input pin has names like
   *motion.digital-in-00* whereas *names_din=*_homed-x,homed-y_ will
-  create the HAL pins *motion.din-homed-x* and *motion.din-homed-y*. +
+  create the HAL pins *motion.din-homed-x* and *motion.din-homed-y*.
 
 *num_aio*: Maximum number of analog IO pins is set by
 *EMCMOT_MAX_AIO*.::
   Minimum is 1, if *num_aio* is not specified, it defaults to
-  *DEFAULT_AIO*. +
+  *DEFAULT_AIO*.
 
 *names_aout*: A comma-separated list of names for analog output pins.::
   This parameter is mutually exclusive with *num_aio*, but can be
@@ -44,14 +44,14 @@ The limits for the following items are compile-time settings: +
   specified. The default analog output pin has names like
   *motion.analog-out-00* whereas *names_aout=*_feedrate1,feedrate2_ will
   create the HAL pins *motion.aout-feedrate1* and
-  *motion.aout-feedrate2*. +
+  *motion.aout-feedrate2*.
 
 *names_ain*: A comma-separated list of names for analog input pins.::
   This parameter is mutually exclusive with *num_aio*, but can be
   combined with *names_aout*. A maximum of *EMCMOT_MAX_AIO* names can be
   specified. The default analog input pin has names like
   *motion.analog-in-00* whereas *names_ain=*_proxy1,proxy2_ will create
-  the HAL pins *motion.ain-proxy1* and *motion.ain-proxy2*. +
+  the HAL pins *motion.ain-proxy1* and *motion.ain-proxy2*.
 
 *num_misc_error*: Maximum number of extra error inputs is set by
 *EMCMOT_MAX_MISC_ERRORS*.::
@@ -63,7 +63,7 @@ inputs.::
   num_misc_error the additional error input pins will have names like
   *motion.misc-error-00* whereas *names_misc_errors=overtemp,undertemp*
   will create hal pins *motion.err-overtemp* and
-  *motion.err-undertemp* +
+  *motion.err-undertemp*
 
 *num_spindles*: Maximum number of spindles is set by
 EMCMOT_MAX_SPINDLES::
@@ -153,14 +153,8 @@ digital pins and two analog pins.
   If this bit is driven FALSE, motion stops, the machine is placed in
   the "machine off" state, and a message is displayed for the operator.
   For normal motion, drive this bit TRUE.
-
- +
-
 *motion.eoffset-active* OUT BIT::
   Indicates external offsets are active (non-zero)
-
- +
-
 *motion.eoffset-limited* OUT BIT::
   Indicates motion with external offsets was limited by a soft limit
   constraint ([AXIS_L]MIN_LIMIT,MAX_LIMIT).
@@ -248,7 +242,7 @@ Note: feed-inhibit applies to G-code commands -- not jogs.
   These values are from src/emc/nml_intf/motion_types.h.
   +
   ____
-  0: Idle (no motion);;
+  0: Idle (no motion)
 
   1: Traverse
 
@@ -289,8 +283,6 @@ Note: feed-inhibit applies to G-code commands -- not jogs.
   the pin value.
 *motion.teleop-mode* OUT BIT::
   Motion mode is teleop (axis coordinate jogging available).
-
- +
 
 *motion.tooloffset.L* OUT FLOAT::
   Current tool offset for each axis where (*L* is the axis letter, one
@@ -478,8 +470,6 @@ required for locking indexers (typically a rotary joint)
 
 The jointmask bits are: (lsb)0:joint0, 1:joint1, 2:joint2, ...
 
- +
-
 Example: loadrt motmod ... **unlock_joints_mask=**0x38 creates unlock
 pins for joints 3,4,5::
 
@@ -554,13 +544,9 @@ command fails with an error message.
 Many of the parameters serve as debugging aids, and are subject to
 change or removal at any time.
 
- +
-
 *motion-command-handler.tmax* RW S32::
   Show information about the execution time of these HAL functions in
   CPU clocks.
-
- +
 
 *motion-command-handler.tmax-increased* RO S32::
    +
@@ -568,8 +554,6 @@ change or removal at any time.
 *motion-controller.tmax* RW S32::
   Show information about the execution time of these HAL functions in
   CPU clocks.
-
- +
 
 *motion-controller.tmax-increased* RO BIT::
 *motion.debug-*_*_::
@@ -592,9 +576,9 @@ order shown.
 
 == BUGS
 
-This manual page is incomplete. +
+This manual page is incomplete.
 
-Identification of pins categorized with *(DEBUG)* is dubious.::
+Identification of pins categorized with *(DEBUG)* is dubious.
 
 == SEE ALSO
 

--- a/docs/src/man/man9/mux_generic.9.adoc
+++ b/docs/src/man/man9/mux_generic.9.adoc
@@ -76,7 +76,7 @@ thread.
 
 == SEE ALSO
 
-*mux2*(9), *mux4*(9), *mux8*(9), *mux16*(9).
+mux2(9), mux4(9), mux8(9), mux16(9)
 
 == AUTHOR
 

--- a/docs/src/man/man9/sampler.9.adoc
+++ b/docs/src/man/man9/sampler.9.adoc
@@ -77,7 +77,7 @@ program.
 
 == SEE ALSO
 
-*halsampler*(1), *streamer*(9), *halstreamer*(1)
+halsampler(1), streamer(9), halstreamer(1)
 
 == AUTHOR
 
@@ -86,11 +86,12 @@ Improvements by several other members of the LinuxCNC development team.
 
 == REPORTING BUGS
 
-Report bugs at https://github.com/LinuxCNC/linuxcnc/issues
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
 
-Copyright © 2006 John Kasunich. +
+Copyright © 2006 John Kasunich.
+
 This is free software; see the source for copying conditions. There is
 NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
 PURPOSE.

--- a/docs/src/man/man9/streamer.9.adoc
+++ b/docs/src/man/man9/streamer.9.adoc
@@ -67,7 +67,8 @@ One function is created per FIFO, numbered from zero.
       * 3 clock on any edge of clock pin
 
 == SEE ALSO
-*halstreamer*(1), *sampler*(9), *halsampler*(1)
+
+halstreamer(1), sampler(9), halsampler(1)
 
 
 == BUGS
@@ -80,10 +81,13 @@ Improvements by several other members of the LinuxCNC development team.
 
 
 == REPORTING BUGS
-Report bugs to jmkasunich AT users DOT sourceforge DOT net
 
+Report bugs at https://github.com/LinuxCNC/linuxcnc/issues.
 
 == COPYRIGHT
-Copyright © 2006 John Kasunich.  This is free software; see the source for copying conditions.
-There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Copyright © 2006 John Kasunich.
+
+This is free software; see the source for copying conditions.  There
+is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
 

--- a/docs/src/man/man9/weighted_sum.9.adoc
+++ b/docs/src/man/man9/weighted_sum.9.adoc
@@ -48,4 +48,4 @@ bits.
 
 == SEE ALSO
 
-*scaled_s32_sums*(9), *sum2*(9).
+scaled_s32_sums(9), sum2(9)


### PR DESCRIPTION
This reduce the number of translation strings and make the presentation more consistent.  Drop bold from man page references in SEE ALSO section.  Show C code examples using fixed with font. Add a few blocks of text text that had disapperared in the groff->adoc migration.  Drop a few useless line breaks.  Standardized bug reporting references and author names.