### PR TITLE
Tool edit widget: backup tool table and add some checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ docs/help/hu/*
 docs/help/nb/*
 docs/help/vi/*
 docs/help/zh_CN/*
+configs/**/*.tbl.bak
+configs/**/halshow.preferences

--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -331,6 +331,10 @@ class ToolEdit(Gtk.Box):
                 self.warning_dialog(line_number)
                 return
 
+        if(locale.getlocale(locale.LC_NUMERIC)[0] is None):
+            raise ExceptionMessage("\n\n"+_("Something wrong with the locale settings. Will not save the tool table."))
+            return
+
         shutil.copy(self.toolfile, self.toolfile + ".bak")
         file = open(self.toolfile, "w")
         #print self.toolfile

--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -15,6 +15,7 @@
 # GNU General Public License for more details.
 
 import sys, os, linuxcnc, hashlib
+import shutil # for backup of tooltable
 datadir = os.path.abspath(os.path.dirname(__file__))
 KEYWORDS = ['S','T', 'P', 'X', 'Y', 'Z', 'A', 'B', 'C', 'U', 'V', 'W', 'D', 'I', 'J', 'Q', ';']
 
@@ -330,6 +331,7 @@ class ToolEdit(Gtk.Box):
                 self.warning_dialog(line_number)
                 return
 
+        shutil.copy(self.toolfile, self.toolfile + ".bak")
         file = open(self.toolfile, "w")
         #print self.toolfile
         for row in liststore:
@@ -345,7 +347,11 @@ class ToolEdit(Gtk.Box):
                     line = line + "%s%s "%(KEYWORDS[num],test)
                 else:
                     test = i.lstrip() # localized floats
-                    line = line + "%s%s "%(KEYWORDS[num], locale.atof(test))
+                    try:
+                        line = line + "%s%s "%(KEYWORDS[num], locale.atof(test))
+                    except ValueError:
+                        raise ExceptionMessage("\n\n"+_("Error converting a float with the given localization setting. A backup file has been created: "
+                                                    + self.toolfile + ".bak"))
 
             print(line, file=file)
         # These lines are required to make sure the OS doesn't cache the data
@@ -694,6 +700,12 @@ class ToolEdit(Gtk.Box):
         else:
             pass
 
+class ExceptionMessage(Exception):
+    """ Exception to display a Message as an Eception.
+    Usage: raise ExceptionMessage(<message>)
+    """
+    def __init__(self, message):
+        super().__init__(message)
 
 # for testing without glade editor:
 # for what ever reason tooledit always shows both display lists,


### PR DESCRIPTION
Resolves https://github.com/LinuxCNC/linuxcnc/issues/2966

Edit: It creates a backup of the tooltable when attempting to save it and some checks if the locale is valid before converting the numbers before saving.

