### PR TITLE
fix restoring of locale setting in interp

### DIFF
--- a/src/emc/rs274ngc/interp_internal.hh
+++ b/src/emc/rs274ngc/interp_internal.hh
@@ -992,9 +992,9 @@ macros totally crash-proof. If the function call stack is deeper than
 
 struct scoped_locale {
     scoped_locale(int category_, const char *locale_) : category(category_), oldlocale(setlocale(category, NULL)) { setlocale(category, locale_); }
-    ~scoped_locale() { setlocale(category, oldlocale); }
+    ~scoped_locale() { setlocale(category, oldlocale.c_str()); }
     int category;
-    const char *oldlocale;
+    std::string oldlocale;
 };
 
 #define FORCE_LC_NUMERIC_C scoped_locale force_lc_numeric_c(LC_NUMERIC, "C")


### PR DESCRIPTION
locale string returned by setlocale needs to be copied, subsequent calls to setlocale overwrite location pointed to by previous call rendering it illegal. 