### PR TITLE
docs: Translation-triggered changes.

### DIFF
--- a/docs/src/code/building-linuxcnc.adoc
+++ b/docs/src/code/building-linuxcnc.adoc
@@ -202,7 +202,7 @@ The `make` command takes two useful optional arguments.
 
 Parallel compilation::
   `make` takes an optional argument `-j` _N_ (where _N_ is a number).
-  This enables parallel compilation with N simultaneous processes, which can significantly speed up your build.
+  This enables parallel compilation with _N_ simultaneous processes, which can significantly speed up your build.
 +
 A useful value for _N_ is the number of CPUs in your build system.
 
@@ -276,7 +276,7 @@ $ dpkg-buildpackage -b -uc
 
 [NOTE]
 ====
-`dpkg-buildpackage` needs to run from the `linuxcnc-source-dir` directory, *not* from `linuxcnc-source-dir/debian`. +
+`dpkg-buildpackage` needs to run from the root of the source tree, which you mave have named `linuxcnc-source-dir`, *not* from within `linuxcnc-source-dir/debian`. +
 `dpkg-buildpackage` takes an optional argument ``-j``_N_ (where _N_ is a number). This enables to run multiple jobs simultaneously.
 ====
 
@@ -350,7 +350,7 @@ execute (from the same directory):
 sudo apt-get build-dep .
 ----
 
-which will install all the dependencies required but available.
+which will install all the dependencies required, not yet installed, but available.
 The '.' is part of the command line, i.e. an instruction to retrieve the dependencies
 for the source tree at hand, not for dependencies of another package.
 This completes the installation of build-dependencies.
@@ -378,7 +378,7 @@ Alternatively, Debian systems provide a program called `dpkg-checkbuilddeps` tha
 parses the package meta-data and compares the packages listed as build
 dependencies against the list of installed packages, and tells you what's missing.
 Also, `dpkg-buildpackage` would inform you about what is missing, and it should be fine.
-However, it reports missing build-deps only after patches in debian/patches are applied (if any).
+However, it reports missing build-deps only after patches in the directory `debian/patches` have been automatically applied (if any).
 If you are new to Linux and git version management, a clean start may be preferable to avoid complications.
 
 The `dpkg-checkbuilddeps` (also from the dpkg-dev package that is installed as part of the build-essential dependencies) program

--- a/docs/src/getting-started/getting-linuxcnc.adoc
+++ b/docs/src/getting-started/getting-linuxcnc.adoc
@@ -13,7 +13,8 @@ go to the <<cha:updating-linuxcnc,Updating LinuxCNC>> section instead.
 NOTE: To operate machinery LinuxCNC requires a special kernel with real-time extensions. There
 are three possibilities here: preempt-rt, RTAI or Xenomai. In addition there are two versions
 of LinuxCNC which work with these kernels. See the table below for details. However for code
-testing and simulation it is possible to run the linuxcnc-uspace application on a stock kernel. 
+testing and simulation it is possible to run the `linuxcnc-uspace` application on a stock kernel
+of the distribution.
 
 Fresh installs of LinuxCNC are most easily created using the Live/Install
 Image. This is a hybrid ISO filesystem image that can be written to a
@@ -98,7 +99,7 @@ md5sum: 1815aceaac0e7861747aa34d61846e79
 sha256sum: 08b3f59233e47c91cf1c9a85c41df48542c97b134efefa7446d3060c9a3e644b
 arm64 (Pi)
 md5sum: 4547e8a72433efb033f0a5cf166a5cd2
-sha256sum: ff3ba9b8dfb93baf1e2232746655f8521a606bc0fab91bffc04ba74cc3be6bf0 
+sha256sum: ff3ba9b8dfb93baf1e2232746655f8521a606bc0fab91bffc04ba74cc3be6bf0
 -----
 
 .Verify md5sum on Windows or Mac
@@ -115,12 +116,12 @@ used to boot a computer.  The image is too large to fit on a CD.
 
 === Raspberry Pi Image
 
-The Raspberry Pi image is a complete SD card image and should be
-written to an SD card with the [Raspberry Pi Imager App](https://www.raspberrypi.com/software/).
+The Raspberry Pi image is a complete SD card image and should be written
+to an SD card with the https://www.raspberrypi.com/software/[Raspberry Pi Imager App].
 
 === AMD-64 (x86-64, PC) Image using GUI tools
 
-Download and install [Balena Etcher](https://etcher.balena.io/#download-etcher)
+Download and install Balena Etcher from https://etcher.balena.io/#download-etcher
 (Linux, Windows, Mac) and write the downloaded image to a USB drive.
 
 If your image fails to boot then please also try https://rufus.ie/[Rufus].
@@ -148,16 +149,14 @@ dd if=linuxcnc_2.9.2-amd64.hybrid.iso of=/dev/sde
 -----
 diskutil list
 -----
-. Insert the USB and note the name of the new disk that appears, eg
-  /dev/disk5
-. unmount the USB. The number found above should be substituted in place
-  of the N
+. Insert the USB and note the name of the new disk that appears, e.g. /dev/disk5.
+. Unmount the USB. The number found above should be substituted in place of the N.
 +
 -----
 diskutil unmountDisk /dev/diskN
 -----
-. Transfer the data with dd, as for Linux above. Note that the disk name
-  has an added "r" at the beginning
+. Transfer the data with dd, as for Linux above.
+  Note that the disk name has an added "r" at the beginning.
 +
 -----
 sudo dd if=/linuxcnc_2.9.2-amd64.hybrid.iso of=/dev/rdiskN bs=1m
@@ -179,18 +178,17 @@ sudo dd if=/linuxcnc_2.9.2-amd64.hybrid.iso of=/dev/rdiskN bs=1m
 .Writing the image to a DVD in Windows
 
 . Download and install Infra Recorder, a free and open source image
-  burning program: http://infrarecorder.org/
+  burning program: http://infrarecorder.org/ .
 . Insert a blank CD in the drive and select Do nothing or Cancel if an
   auto-run dialog pops up.
-. Open Infra Recorder, and select the 
- 'Actions' menu, then 'Burn image'.
+. Open Infra Recorder, and select the 'Actions' menu, then 'Burn image'.
 
 .Writing the image to a DVD in Mac OSX
 
 . Download the .iso file
-. Right-click on the file in the Finder window and select "Burn to disc"
-  (The option to burn to disc  will only appear if the machine has an
-  optical drive fitted or connected)
+. Right-click on the file in the Finder window and select "Burn to disc".
+  (The option to burn to disc will only appear if the machine has an
+  optical drive fitted or connected.)
 
 == Testing LinuxCNC
 
@@ -236,7 +234,7 @@ should accept OS _updates_ however, especially security updates.
 == Install Problems
 
 In rare cases you might have to reset the BIOS to default settings if
-during the Live CD install it cannot recognize the hard drive 
+during the Live CD install it cannot recognize the hard drive
 during the boot up.
 
 == Alternate Install Methods
@@ -352,16 +350,15 @@ sudo ./linuxcnc-install.sh
 . This kernel and LinuxCNC version can be installed on top of the Live DVD
   install, or alternatively on a fresh Install of Debian Bookworm 64-bit
   as described above.
-. You can add the LinuxCNC Archive signing key and repository information
+. You can add the LinuxCNC archive signing key and repository information
   by downloading and running the installer script as described above. If
-  an RTAI kernel is detected it will stop before installing any packages. 
-
+  an RTAI kernel is detected it will stop before installing any packages.
 . Update the package list from linuxcnc.org
 +
 ----
 sudo apt-get update
 ----
-. Install the new realtime kernel, RTAI and the rtai version of linuxcnc.
+. Install the new realtime kernel, RTAI and the RTAI-version of LinuxCNC.
 +
 ----
 sudo apt-get install linuxcnc
@@ -371,8 +368,9 @@ kernel.
 
 === Installing on Raspbian 12
 
-Don't do that. The latencies are too bad with the default kernel and the PREEMPT_RT (the RT is important) kernel of Debian does not boot on the Pi (as of 1/2024).
-Please refer to the images provided online.
+Don't do that.
+The latencies are too bad with the default kernel and the PREEMPT_RT (the RT is important) kernel of Debian does not boot on the Pi (as of 1/2024).
+Please refer to the .iso images provided online on the regular https://linuxcnc.org/downloads/[LinuCNC download page].
 You can create them yourself following the scripts provided https://github.com/rodw-au/rpi-img-builder-lcnc[online].
 
 // vim: set syntax=asciidoc:

--- a/docs/src/getting-started/hardware-interface.adoc
+++ b/docs/src/getting-started/hardware-interface.adoc
@@ -17,14 +17,14 @@ An interface is necessary to transmit (and convert) signals and information betw
 Interfaces include:
 - Parallel Port
 - Ethernet
-- Ethercat
+- EtherCAT
 - PCI / PCIe
 - SPI (where the computer has a native SPI interface, such as Raspberry Pi)
 - USB (_not_ realtime interface)
 
 A mix of different interfaces can be used. For example, a combination of ethercat for servo drives, and parallel port for additional General Purpose Inputs / Outputs (GPIO)
 
-Some of these solutions are usable for all aspects of hardware interfacing, and some have specific roles (e.g. non-realtime GPIO, for an operator interface).
+Some of these solutions are usable for all aspects of hardware interfacing, and some have specific roles (e.g. non-realtime GPIO for an operator interface with switches).
 
 Hardware interface options change over time. This list is not a 100% complete list of all hardware interfaces that can be used with LinuxCNC.
 
@@ -110,7 +110,7 @@ Ethernet interface can be used with a Ethernet to SPI interface.
 https://github.com/multigcs/LinuxCNC-RIO
 
 
-== Ethercat
+== EtherCAT
 Beckhoff EtherCAT(TM) and compatible systems can be made to work with LinuxCNC using the open source etherlab software.
 
 EtherCAT is the open real-time Ethernet network originally developed by Beckhoff.

--- a/docs/src/getting-started/system-requirements.adoc
+++ b/docs/src/getting-started/system-requirements.adoc
@@ -39,7 +39,7 @@ web site for details on the Live CD you're using. Older hardware may
 benefit from selecting an older version of the Live CD when available.
 
 If you plan not to rely on the distribution of readily executable programs ("binaries")
-but aim at contributing to the source tree of LinuxCNC, then there is a good chance
+and/or aim at contributing to the source tree of LinuxCNC, then there is a good chance
 you want a second computer to perform the compilation. Even though LinuxCNC and
 your developments could likely be executed at the same time with respect to disk space,
 RAM and even CPU speed, a machine that is busy will have worse latencies, so you are

--- a/docs/src/gui/qtvcp.adoc
+++ b/docs/src/gui/qtvcp.adoc
@@ -236,10 +236,10 @@ You may still need to use the handler copy dialog to copy the original handler f
 See 'custom handler file'
 
 There should be a folder in the config folder; for screens: named '<CONFIG FOLDER>/qtvcp/screens/<SCREEN NAME>/' +
-add the handle patch file there, named like so <ORIGINAL SCREEN NAME>_handler.py. +
-i.e. for QtDragon the file would be called 'qtdragon_handler.py'.
+add the handle patch file there, named like so <ORIGINAL SCREEN NAME>_handler.py, +
+e.g., for QtDragon the file would be called 'qtdragon_handler.py'.
 
-Here is a sample to add X axis jog pins to a screen like QtDragon: +
+Here is a sample to add X axis jog pins to a screen like QtDragon:
 
 [source,python]
 ----

--- a/docs/src/man/man1/debuglevel.1.adoc
+++ b/docs/src/man/man1/debuglevel.1.adoc
@@ -10,7 +10,7 @@ debuglevel - sets the debug level for the non-realtime part of LinuxCNC
 
 == DESCRIPTION
 
-*debuglevel* displays a checkbox gui to select the current debug level
+*debuglevel* displays a checkbox to select the current debug level
 of some parts of LinuxCNC.
 
 == SEE ALSO

--- a/docs/src/man/man1/gmoccapy.1.adoc
+++ b/docs/src/man/man1/gmoccapy.1.adoc
@@ -10,8 +10,8 @@ gmoccapy - TOUCHY LinuxCNC Graphical User Interface
 
 == DESCRIPTION
 
-*GMOCCAPY* is one of the Graphical User Interfaces (GUI) for LinuxCNC It
-gets run by the runscript usually.
+*GMOCCAPY* is one of the Graphical User Interfaces (GUI) for LinuxCNC.
+It gets run by the runscript usually.
 
 == OPTIONS
 

--- a/docs/src/man/man1/gremlin_view.1.adoc
+++ b/docs/src/man/man1/gremlin_view.1.adoc
@@ -10,8 +10,7 @@ gremlin_view - G-code graphical preview
 
 == DESCRIPTION
 
-*gremlin_view* is a Python wrapper for the gremlin G-code graphical
-preview
+*gremlin_view* is a Python wrapper for the gremlin G-code graphical preview.
 
 PGremlinView for gremlin with buttons for simpler embedding Standalone
 functionality if linuxcnc running A default ui file (gremlin_view.ui) is

--- a/docs/src/man/man1/gscreen.1.adoc
+++ b/docs/src/man/man1/gscreen.1.adoc
@@ -10,8 +10,8 @@ gscreen - TOUCHY LinuxCNC Graphical User Interface
 
 == DESCRIPTION
 
-*gscreen* is one of the Graphical User Interfaces (GUI) for LinuxCNC It
-gets run by the runscript usually.
+*gscreen* is one of the Graphical User Interfaces (GUI) for LinuxCNC.
+It gets run by the runscript usually.
 
 == OPTIONS
 

--- a/docs/src/man/man1/halcmd.1.adoc
+++ b/docs/src/man/man1/halcmd.1.adoc
@@ -66,9 +66,8 @@ used to read commands from a file, *halcmd* reads each line of the file
 as a new command. Anything following '*#*' on a line is a comment.
 
 *loadrt* _modname_::
-  (_load_ __r__eal__t__ime module) Loads a realtime HAL module called
-  _modname_. *halcmd* looks for the module in a directory specified at
-  compile time.
+  (_load_ __r__eal__t__ime module) Loads a realtime HAL module called _modname_.
+  *halcmd* looks for the module in a directory specified at compile time.
 
 In systems with kernel-based realtime support (e.g. RTAI), *halcmd*
 calls the *linuxcnc_module_helper* to load realtime modules.
@@ -96,10 +95,9 @@ requested component with a call to *dlopen(3)*.
   _unix-command_, usually to load a non-realtime component. _[flags]_
   may be one or more of:
   +
-  * *-W* to wait for the component to become ready. The component is
-  assumed to have the same name as the first argument of the command.
-  * *-Wn name* to wait for the component, which will have the given
-  name.
+  * *-W* to wait for the component to become ready.
+    The component is assumed to have the same name as the first argument of the command.
+  * *-Wn name* to wait for the component, which will have the given name.
   * *-w* to wait for the program to exit
   * *-i* to ignore the program return value (with -w)
 *waitusr* _name_::

--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -218,10 +218,10 @@ limits for a pending kinematics type.
 
 [NOTE]
 INI-HAL pins are typically not recognized during a G-code program
-unless a synchronization (queue-buster) command is issued.  See
-the milltask manpage for more information ($ man milltask)
+unless a synchronization (queue-buster) command is issued.
+See the milltask manpage for more information ($ man milltask).
 
-The relevant INI-HAL pins for a joint number (N) are:
+The relevant INI-HAL pins for a joint number (_N_) are:
 
 [source,{hal}]
 ----
@@ -245,8 +245,8 @@ ini.L.max_acceleration
 In general, there are no fixed mappings between joint numbers and
 axis coordinate letters.  There may be specific mappings for some
 kinematics modules especially those that implement identity
-kinematics (trivkins).  See the kins man page for more
-information ($ man kins)
+kinematics (trivkins).
+See the kins man page for more information ($ man kins).
 
 A user-provided M-code can alter any or all of the axis coordinate
 limits prior to changing the motion.switchkins-type pin and
@@ -264,10 +264,9 @@ EOF
 ----
 
 Scripts like this can be invoked as a user M-code and used *prior*
-to the kins switching M-code that updates the
-motion.switchkins-type HAL pin and forces an interp-motion sync.
-Typically, separate scripts would be used for each kinstype
-(0,1,2).
+to the kins switching M-code that updates the `motion.switchkins-type`
+HAL pin and forces an interp-motion sync.
+Typically, separate scripts would be used for each kinstype (0,1,2).
 
 When identity kinematics are provided as a means to control
 individual joints, it may be convenient to set or restore limits
@@ -286,7 +285,7 @@ M-code scripts can be designed as follows:
 . HAL: setp the INI-HAL limit pins for each axis letter ([AXIS_L])
   according to the 'identity-referenced' joint number INI file
   setting ([JOINT_N])
-. HAL: setp motion.switchkins-type 1
+. HAL: `setp motion.switchkins-type 1`
 . MDI: execute a syncing G-code (M66E0L0)
 
 *M128* (restore robot default kinematics type 0)
@@ -294,7 +293,7 @@ M-code scripts can be designed as follows:
 . read and parse INI file
 . HAL: setp the INI-HAL limit pins for each axis letter ([AXIS_L])
   according to the appropriate INI file setting ([AXIS_L])
-. HAL: setp motion.switchkins-type 0
+. HAL: `setp motion.switchkins-type 0`
 . MDI: execute a syncing G-code (M66E0L0)
 
 [NOTE]


### PR DESCRIPTION
@petterreinholdtsen The new man pages trigger many changes to existing translations. The `B<something>` to `*something*` ones, but also many linebreaks mid sentence, which then the translation  needs to match.  And sometimes good linebreaks are also gone.

I guess this all needs fo be adopted manually. But when I see something very ugly, or something misleading, where can I edit the English? Is the .adoc file fine to edit?

