### PR TITLE
We need to turn cutter compensation off for the rapid to the startpoint as well.

### DIFF
--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -1062,7 +1062,10 @@ int Interp::convert_g7x(int mode,
     original_block.x_number=x;
     original_block.z_number=z;
 
+    auto cutter_comp=settings->cutter_comp_side;
+    settings->cutter_comp_side=0;
     int error=convert_straight(G_0, block, settings);
+    settings->cutter_comp_side=cutter_comp;
     if(error!=INTERP_OK)
 	return error;
 


### PR DESCRIPTION
Did not notice this on the first few tests.