### PR TITLE
2.9

### DIFF
--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -1474,7 +1474,7 @@ static void get_pos_cmds(long period)
 	
 	/* Zero values */
 	joint_limit[joint_num][0] = 0;
-	joint_limit[joint_num][0] = 1;
+	joint_limit[joint_num][1] = 0;
 	
 	/* skip inactive or unhomed axes */
 	if ((!GET_JOINT_ACTIVE_FLAG(joint)) || (!get_homed(joint_num))) {

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -341,6 +341,14 @@ static void handle_kinematicsSwitch(void) {
     }
 #endif
     tpSetPos(&emcmotInternal->coord_tp, &emcmotStatus->carte_pos_cmd);
+    
+    /* Also synch teleop mode to avoid change in joint cmd */
+    for (int axis_num = 0; axis_num < MAX_AXIS_AMOUNT; axis_num++) {
+		emcmot_axis_t *axis;
+		axis = &axes[axis_num];
+		axis->teleop_tp.curr_pos = *pcmd_p[axis_num];
+	}
+      
 } //handle_kinematicsSwitch()
 
 static void process_inputs(void)

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -1471,6 +1471,11 @@ static void get_pos_cmds(long period)
     for (joint_num = 0; joint_num < ALL_JOINTS; joint_num++) {
 	/* point to joint data */
 	joint = &joints[joint_num];
+	
+	/* Zero values */
+	joint_limit[joint_num][0] = 0;
+	joint_limit[joint_num][0] = 1;
+	
 	/* skip inactive or unhomed axes */
 	if ((!GET_JOINT_ACTIVE_FLAG(joint)) || (!get_homed(joint_num))) {
 	    continue;


### PR DESCRIPTION
Fix when switching kinematics while in teleop mode with machine enabled. Pos command would just to sync cartesian pos to joint pos instead of sync joint pos to cartesian pos
Previous synch was only in coordinated mode only