### PR TITLE
tooledit_widget - decimal point = dot

### DIFF
--- a/lib/python/gladevcp/tooledit_widget.py
+++ b/lib/python/gladevcp/tooledit_widget.py
@@ -308,7 +308,7 @@ class ToolEdit(Gtk.Box):
                                 print(_("Tooledit widget float error"))
                         else:
                             try:
-                                array[offset]= locale.format_string("%10.4f", float(word.lstrip(i)))
+                                array[offset]= f"{float(word.lstrip(i)):10.4f}"
                             except:
                                 print(_("Tooledit widget float error"))
                         break
@@ -317,7 +317,6 @@ class ToolEdit(Gtk.Box):
             # add array line to liststore
             self.add(None,array)
 
-        # Note we have to save the float info with a decimal even if the locale uses a comma
     def save(self,widget):
         if self.toolfile == None:return
         liststore = self.model
@@ -350,9 +349,9 @@ class ToolEdit(Gtk.Box):
                     test = i.strip()
                     line = line + "%s%s "%(KEYWORDS[num],test)
                 else:
-                    test = i.lstrip() # localized floats
+                    test = i.lstrip()
                     try:
-                        line = line + "%s%s "%(KEYWORDS[num], locale.atof(test))
+                        line = line + "%s%s "%(KEYWORDS[num], float(test))
                     except ValueError:
                         raise ExceptionMessage("\n\n"+_("Error converting a float with the given localization setting. A backup file has been created: "
                                                     + self.toolfile + ".bak"))
@@ -477,7 +476,7 @@ class ToolEdit(Gtk.Box):
         # validate input for float columns
         elif col in range(3,15):
             try:
-                self.model[path][col] = locale.format("%10.4f",locale.atof(new_text))
+                self.model[path][col] = f"{float(new_text.replace(',', '.')):10.4f}"
             except:
                 pass
         # validate input for orientation: check if int and valid range


### PR DESCRIPTION
Previously:
tooledit_widget displayed float numbers with decimal dot for localizations that use decimal dot tooledit_widget displayed float numbers with decimal comma for localizations that use decimal comma

Now:
tooledit_widget displays float numbers with a decimal dot for all localizations

The functionality is preserved, when it is possible to enter a float with both a comma and a dot for localizations with a decimal comma

Reason for change:
Gmoccapy displayed some numbers with a decimal dot and some numbers with a decimal comma. This is a unification. More here: https://github.com/LinuxCNC/linuxcnc/issues/2966#issuecomment-2254394542