### PR TITLE
fix configs/apps/gladevcp: update to gtk3

### DIFF
--- a/configs/apps/gladevcp/animated-backdrop/cairodraw.ui
+++ b/configs/apps/gladevcp/animated-backdrop/cairodraw.ui
@@ -1,18 +1,21 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <!-- interface-requires gladevcp 0.0 -->
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gladevcp" version="0.0"/>
   <object class="GtkWindow" id="window1">
-    <signal name="expose_event" handler="on_expose"/>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkFixed" id="fixed1">
         <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="HAL_LED" id="hal_led1">
-            <property name="width_request">100</property>
-            <property name="height_request">80</property>
+            <property name="width-request">100</property>
+            <property name="height-request">80</property>
             <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="led-blink-rate">0</property>
           </object>
           <packing>
             <property name="x">57</property>
@@ -22,13 +25,13 @@
         <child>
           <object class="HAL_Button" id="hal_button1">
             <property name="label" translatable="yes">button</property>
-            <property name="width_request">100</property>
-            <property name="height_request">80</property>
+            <property name="width-request">100</property>
+            <property name="height-request">80</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="has_tooltip">True</property>
-            <property name="tooltip_text" translatable="yes">a tooltip</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="has-tooltip">True</property>
+            <property name="tooltip-text" translatable="yes">a tooltip</property>
           </object>
           <packing>
             <property name="x">250</property>
@@ -38,11 +41,11 @@
         <child>
           <object class="HAL_ToggleButton" id="hal_togglebutton1">
             <property name="label" translatable="yes">togglebutton</property>
-            <property name="width_request">100</property>
-            <property name="height_request">80</property>
+            <property name="width-request">100</property>
+            <property name="height-request">80</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
           </object>
           <packing>
             <property name="x">29</property>

--- a/configs/apps/gladevcp/by-widget/combobox.demo
+++ b/configs/apps/gladevcp/by-widget/combobox.demo
@@ -4,4 +4,4 @@ thisfile=$(readlink -f "$0")
 thisdir=$(dirname "$thisfile")
 cd "$thisdir"
 
-gladevcp_demo -u ./combobox ./combobox.ui
+gladevcp_demo -u combobox.py combobox.ui

--- a/configs/apps/gladevcp/by-widget/sourceview.py
+++ b/configs/apps/gladevcp/by-widget/sourceview.py
@@ -1,6 +1,7 @@
-
-import gtk
-import gtksourceview2 as gtksourceview
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+from gi.repository import GtkSource
 
 class HandlerClass:
 
@@ -15,23 +16,26 @@ class HandlerClass:
             self.mark = self.textbuffer.create_source_mark('highlight', 'highlight', line)
             self.mark.set_visible(True)
         else:
+            print('3')
             self.textbuffer.move_mark(self.mark, line)
+        print('4')
         self.sourceview.scroll_to_mark(self.mark, 0, True, 0, 0.5)
-
+        print('5')
+        
     def file_set(self,widget,data=None):
         filename = widget.get_filename()
         print("file_set",filename)
         self.textbuffer.set_text(open(filename).read())
         self.line = 1
-        self._set_line(self.line)
+        #self._set_line(self.line)
 
     def on_down(self,widget,data=None):
         self.line += 1
-        self._set_line(self.line)
+        #self._set_line(self.line)
 
     def on_up(self,widget,data=None):
         self.line -= 1
-        self._set_line(self.line)
+        #self._set_line(self.line)
 
     def __init__(self, halcomp,builder,useropts):
         self.halcomp = halcomp
@@ -39,14 +43,14 @@ class HandlerClass:
 
         self.line = 1
         self.sourceview = builder.get_object('gtksourceview1')
-        self.textbuffer = gtksourceview.Buffer()
+        self.textbuffer = GtkSource.Buffer()
         self.sourceview.set_buffer(self.textbuffer)
 
         self.sourceview.set_show_line_numbers(True)
         self.sourceview.set_show_line_marks(True)
         self.sourceview.set_highlight_current_line(True)
-        self.sourceview.set_mark_category_icon_from_icon_name('highlight', 'gtk-forward')
-        self.sourceview.set_mark_category_background('highlight', gtk.gdk.Color('yellow'))
+        #self.sourceview.set_mark_category_icon_from_stock('highlight', 'gtk-forward')
+        #self.sourceview.set_mark_category_background('highlight', gtk.gdk.Color('yellow'))
         self.mark = None
 
 def get_handlers(halcomp,builder,useropts):

--- a/configs/apps/gladevcp/by-widget/sourceview.ui
+++ b/configs/apps/gladevcp/by-widget/sourceview.ui
@@ -1,28 +1,34 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-requires gtksourceview 0.0 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtksourceview" version="0.0"/>
   <object class="GtkWindow" id="window1">
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkVBox" id="vbox1">
         <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="GtkFrame" id="frame1">
             <property name="visible">True</property>
-            <property name="label_xalign">0</property>
-            <property name="shadow_type">none</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">none</property>
             <child>
               <object class="GtkAlignment" id="alignment1">
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can-focus">False</property>
+                <property name="left-padding">12</property>
                 <child>
                   <object class="GtkHButtonBox" id="hbuttonbox1">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkFileChooserButton" id="filechooserbutton1">
                         <property name="visible">True</property>
-                        <signal name="file_set" handler="file_set"/>
+                        <property name="can-focus">False</property>
+                        <signal name="file-set" handler="file_set" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -34,9 +40,9 @@
                       <object class="GtkButton" id="down">
                         <property name="label" translatable="yes">Down</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="receives_default">False</property>
-                        <signal name="pressed" handler="on_down"/>
+                        <property name="can-focus">False</property>
+                        <property name="receives-default">False</property>
+                        <signal name="pressed" handler="on_down" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -48,9 +54,9 @@
                       <object class="GtkButton" id="up">
                         <property name="label" translatable="yes">Up</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <signal name="pressed" handler="on_up"/>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <signal name="pressed" handler="on_up" swapped="no"/>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -65,41 +71,46 @@
             <child type="label">
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;File&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
               </object>
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkFrame" id="frame2">
             <property name="visible">True</property>
-            <property name="label_xalign">0</property>
-            <property name="shadow_type">none</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">none</property>
             <child>
               <object class="GtkAlignment" id="alignment2">
-                <property name="width_request">300</property>
-                <property name="height_request">400</property>
+                <property name="width-request">300</property>
+                <property name="height-request">400</property>
                 <property name="visible">True</property>
-                <property name="left_padding">12</property>
+                <property name="can-focus">False</property>
+                <property name="left-padding">12</property>
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow1">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hscrollbar_policy">automatic</property>
-                    <property name="vscrollbar_policy">automatic</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkSourceView" id="gtksourceview1">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="left_margin">2</property>
-                        <property name="right_margin">2</property>
-                        <property name="tab_width">4</property>
-                        <property name="auto_indent">True</property>
-                        <property name="indent_on_tab">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="left-margin">2</property>
+                        <property name="right-margin">2</property>
+                        <property name="show-line-numbers">True</property>
+                        <property name="show-line-marks">True</property>
+                        <property name="tab-width">4</property>
+                        <property name="auto-indent">True</property>
+                        <property name="indent-on-tab">False</property>
                       </object>
                     </child>
                   </object>
@@ -109,11 +120,14 @@
             <child type="label">
               <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Sourceview Widget</property>
               </object>
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>

--- a/configs/apps/gladevcp/complex/complex.ui
+++ b/configs/apps/gladevcp/complex/complex.ui
@@ -1,127 +1,145 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <!-- interface-requires gladevcp 0.0 -->
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gladevcp" version="0.0"/>
+  <object class="GtkAction" id="action1"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+    <property name="page-size">10</property>
+  </object>
   <object class="GtkWindow" id="window1">
+    <property name="can-focus">False</property>
     <child>
       <object class="HAL_Table" id="hal_table1">
         <property name="visible">True</property>
-        <property name="n_rows">3</property>
-        <property name="n_columns">3</property>
-        <signal name="destroy" handler="on_destroy"/>
+        <property name="can-focus">False</property>
+
+        <signal name="destroy" handler="on_destroy" swapped="no"/>
         <child>
           <object class="HAL_LED" id="hal_led1">
             <property name="visible">True</property>
-            <signal name="hal_pin_changed" handler="on_led_pin_changed"/>
+            <property name="can-focus">False</property>
+            <property name="led-blink-rate">0</property>
+            <signal name="hal-pin-changed" handler="on_led_pin_changed" swapped="no"/>
           </object>
         </child>
         <child>
           <object class="HAL_Button" id="hal_button1">
             <property name="label" translatable="yes">button</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <signal name="pressed" handler="on_button_press"/>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <signal name="pressed" handler="on_button_press" swapped="no"/>
           </object>
           <packing>
-            <property name="left_attach">2</property>
-            <property name="right_attach">3</property>
+            <property name="left-attach">2</property>
+            <property name="right-attach">3</property>
           </packing>
         </child>
         <child>
           <object class="HAL_SpinButton" id="hal_spinbutton1">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="invisible_char">&#x25CF;</property>
+            <property name="can-focus">True</property>
+            <property name="invisible-char">●</property>
             <property name="adjustment">adjustment1</property>
           </object>
           <packing>
-            <property name="top_attach">1</property>
-            <property name="bottom_attach">2</property>
+            <property name="top-attach">1</property>
+            <property name="bottom-attach">2</property>
           </packing>
         </child>
         <child>
           <object class="HAL_ToggleButton" id="hal_togglebutton1">
             <property name="label" translatable="yes">Toggle LED</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <signal name="toggled" handler="on_toggle_button"/>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <signal name="toggled" handler="on_toggle_button" swapped="no"/>
           </object>
           <packing>
-            <property name="left_attach">2</property>
-            <property name="right_attach">3</property>
-            <property name="top_attach">1</property>
-            <property name="bottom_attach">2</property>
+            <property name="left-attach">2</property>
+            <property name="right-attach">3</property>
+            <property name="top-attach">1</property>
+            <property name="bottom-attach">2</property>
           </packing>
         </child>
         <child>
           <object class="HAL_HScale" id="hal_hscale1">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
             <property name="adjustment">adjustment2</property>
           </object>
           <packing>
-            <property name="left_attach">1</property>
-            <property name="right_attach">2</property>
-            <property name="top_attach">2</property>
-            <property name="bottom_attach">3</property>
+            <property name="left-attach">1</property>
+            <property name="right-attach">2</property>
+            <property name="top-attach">2</property>
+            <property name="bottom-attach">3</property>
           </packing>
         </child>
         <child>
           <object class="GtkButton" id="button1">
             <property name="label" translatable="yes">Restore defaults</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <signal name="pressed" handler="on_restore_defaults"/>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <signal name="pressed" handler="on_restore_defaults" swapped="no"/>
           </object>
           <packing>
-            <property name="left_attach">1</property>
-            <property name="right_attach">2</property>
+            <property name="left-attach">1</property>
+            <property name="right-attach">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkButton" id="button2">
             <property name="label" translatable="yes">Save settings</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <signal name="pressed" handler="on_save_settings"/>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <signal name="pressed" handler="on_save_settings" swapped="no"/>
           </object>
           <packing>
-            <property name="left_attach">1</property>
-            <property name="right_attach">2</property>
-            <property name="top_attach">1</property>
-            <property name="bottom_attach">2</property>
+            <property name="left-attach">1</property>
+            <property name="right-attach">2</property>
+            <property name="top-attach">1</property>
+            <property name="bottom-attach">2</property>
           </packing>
         </child>
         <child>
           <object class="HAL_Label" id="message">
             <property name="visible">True</property>
-            <property name="text_template">Total runtime: %s seconds</property>
+            <property name="can-focus">False</property>
+            <property name="text-template">Total runtime: %s seconds</property>
           </object>
           <packing>
-            <property name="left_attach">2</property>
-            <property name="right_attach">3</property>
-            <property name="top_attach">2</property>
-            <property name="bottom_attach">3</property>
+            <property name="left-attach">2</property>
+            <property name="right-attach">3</property>
+            <property name="top-attach">2</property>
+            <property name="bottom-attach">3</property>
           </packing>
         </child>
         <child>
           <object class="GtkVBox" id="vbox1">
             <property name="visible">True</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="HAL_RadioButton" id="hal_radiobutton1">
                 <property name="label" translatable="yes">lemon</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="draw_indicator">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="draw-indicator">True</property>
                 <property name="group">hal_radiobutton2</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -129,12 +147,14 @@
               <object class="HAL_RadioButton" id="hal_radiobutton2">
                 <property name="label" translatable="yes">banana</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="active">True</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -142,33 +162,24 @@
               <object class="HAL_RadioButton" id="hal_radiobutton3">
                 <property name="label" translatable="yes">chocolate</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="draw_indicator">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="draw-indicator">True</property>
                 <property name="group">hal_radiobutton2</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="top_attach">2</property>
-            <property name="bottom_attach">3</property>
+            <property name="top-attach">2</property>
+            <property name="bottom-attach">3</property>
           </packing>
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkAction" id="action1"/>
-  <object class="GtkAdjustment" id="adjustment1">
-    <property name="upper">100</property>
-    <property name="step_increment">1</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment2">
-    <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-    <property name="page_size">10</property>
   </object>
 </interface>

--- a/configs/apps/gladevcp/glade-manual.ui
+++ b/configs/apps/gladevcp/glade-manual.ui
@@ -1,48 +1,53 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-requires gladevcp 0.0 -->
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gladevcp" version="0.0"/>
   <object class="GtkWindow" id="window1">
+    <property name="can-focus">False</property>
     <child>
-      <object class="HAL_Table" id="hal_table1">
+      <object class="HAL_Table">
         <property name="visible">True</property>
-        <property name="n_rows">2</property>
-        <property name="n_columns">2</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="HAL_LED" id="hal_led1">
             <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="led-blink-rate">0</property>
           </object>
         </child>
         <child>
           <object class="HAL_Label" id="hal_label1">
             <property name="visible">True</property>
+            <property name="can-focus">False</property>
             <property name="label" translatable="yes">label</property>
           </object>
           <packing>
-            <property name="left_attach">1</property>
-            <property name="right_attach">2</property>
+            <property name="left-attach">1</property>
+            <property name="right-attach">2</property>
           </packing>
         </child>
         <child>
           <object class="HAL_LED" id="hal_led2">
             <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="led-blink-rate">0</property>
           </object>
           <packing>
-            <property name="top_attach">1</property>
-            <property name="bottom_attach">2</property>
+            <property name="top-attach">1</property>
+            <property name="bottom-attach">2</property>
           </packing>
         </child>
         <child>
           <object class="HAL_HScale" id="hal_hscale1">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
           </object>
           <packing>
-            <property name="left_attach">1</property>
-            <property name="right_attach">2</property>
-            <property name="top_attach">1</property>
-            <property name="bottom_attach">2</property>
+            <property name="left-attach">1</property>
+            <property name="right-attach">2</property>
+            <property name="top-attach">1</property>
+            <property name="bottom-attach">2</property>
           </packing>
         </child>
       </object>

--- a/configs/apps/gladevcp/gladevcp-test.ui
+++ b/configs/apps/gladevcp/gladevcp-test.ui
@@ -1,221 +1,270 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
 <interface>
-  <!-- interface-requires gladevcp 0.0 -->
-  <requires lib="gtk+" version="2.16"/>
-  <!-- interface-naming-policy project-wide -->
+  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gladevcp" version="0.0"/>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+    <property name="page-size">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment2">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+    <property name="page-size">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment3">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment4">
+    <property name="upper">1000</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment5">
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+    <property name="page-size">10</property>
+  </object>
   <object class="GtkWindow" id="window1">
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkHBox" id="hbox1">
         <property name="visible">True</property>
+        <property name="can-focus">False</property>
         <child>
           <object class="HAL_Table" id="hal_table1">
             <property name="visible">True</property>
-            <property name="n_rows">4</property>
-            <property name="n_columns">3</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="HAL_SpinButton" id="hal_spinbutton1">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="invisible_char">&#x25CF;</property>
+                <property name="can-focus">True</property>
+                <property name="invisible-char">●</property>
                 <property name="adjustment">adjustment3</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
+                <property name="left-attach">1</property>
+                <property name="right-attach">2</property>
+                <property name="top-attach">1</property>
+                <property name="bottom-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="HAL_HBox" id="hal_hbox1">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <child>
                   <object class="HAL_LED" id="hal_led1">
                     <property name="visible">True</property>
-                    <property name="pick_color_on">#f88096020000</property>
-                    <property name="pick_color_off">#00002724ffff</property>
+                    <property name="can-focus">False</property>
+                    <property name="led-blink-rate">0</property>
+                    <property name="pick-color-off">#00002724ffff</property>
+                    <property name="pick-color-on">#f88096020000</property>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="HAL_LED" id="hal_led2">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="led-blink-rate">0</property>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="HAL_VBar" id="hal_vbar1">
                     <property name="visible">True</property>
-                    <property name="bg_color">#bebebebebebe</property>
-                    <property name="z1_border">0.80000001192092896</property>
-                    <property name="z0_border">0.69999998807907104</property>
-                    <property name="z1_color">#ffffffff0000</property>
-                    <property name="min">10</property>
-                    <property name="force_width">30</property>
+                    <property name="can-focus">False</property>
+                    <property name="bg-color">#bebebebebebe</property>
+                    <property name="force-width">30</property>
                     <property name="invert">True</property>
-                    <property name="z2_color">#ffff00000000</property>
-                    <property name="z0_color">#0000ffff0000</property>
+                    <property name="min">10</property>
+                    <property name="z0-border">0.699999988079071</property>
+                    <property name="z0-color">#0000ffff0000</property>
+                    <property name="z1-border">0.8000000119209289</property>
+                    <property name="z1-color">#ffffffff0000</property>
+                    <property name="z2-color">#ffff00000000</property>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
+                <property name="left-attach">1</property>
+                <property name="right-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="HAL_VScale" id="hal_vscale1">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="orientation">vertical</property>
+                <property name="can-focus">True</property>
                 <property name="adjustment">adjustment2</property>
               </object>
               <packing>
-                <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
+                <property name="left-attach">2</property>
+                <property name="right-attach">3</property>
               </packing>
             </child>
             <child>
               <object class="HAL_Label" id="hal_label1">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">label</property>
-                <property name="text_template">%.02f</property>
-                <property name="label_pin_type">1</property>
+                <property name="label-pin-type">1</property>
+                <property name="text-template">%.02f</property>
               </object>
               <packing>
-                <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
+                <property name="left-attach">2</property>
+                <property name="right-attach">3</property>
+                <property name="top-attach">1</property>
+                <property name="bottom-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="HAL_Label" id="hal_label2">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">label</property>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
+                <property name="top-attach">1</property>
+                <property name="bottom-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="HAL_RadioButton" id="hal_radiobutton2">
                 <property name="label" translatable="yes">radiobutton</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="draw_indicator">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="draw-indicator">True</property>
                 <property name="group">hal_radiobutton1</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
+                <property name="left-attach">1</property>
+                <property name="right-attach">2</property>
+                <property name="top-attach">3</property>
+                <property name="bottom-attach">4</property>
               </packing>
             </child>
             <child>
               <object class="HAL_RadioButton" id="hal_radiobutton1">
                 <property name="label" translatable="yes">radiobutton</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="active">True</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
+                <property name="left-attach">1</property>
+                <property name="right-attach">2</property>
+                <property name="top-attach">2</property>
+                <property name="bottom-attach">3</property>
               </packing>
             </child>
             <child>
               <object class="HAL_LED" id="hal_led4">
                 <property name="visible">True</property>
-                <property name="on_color">green</property>
+                <property name="can-focus">False</property>
+                <property name="led-blink-rate">0</property>
               </object>
               <packing>
-                <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
+                <property name="left-attach">2</property>
+                <property name="right-attach">3</property>
+                <property name="top-attach">2</property>
+                <property name="bottom-attach">3</property>
               </packing>
             </child>
             <child>
               <object class="HAL_LED" id="hal_led5">
                 <property name="visible">True</property>
-                <property name="led_blink_rate">500</property>
+                <property name="can-focus">False</property>
+                <property name="led-blink-rate">500</property>
               </object>
               <packing>
-                <property name="left_attach">2</property>
-                <property name="right_attach">3</property>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
+                <property name="left-attach">2</property>
+                <property name="right-attach">3</property>
+                <property name="top-attach">3</property>
+                <property name="bottom-attach">4</property>
               </packing>
             </child>
             <child>
               <object class="HAL_CheckButton" id="hal_checkbutton1">
                 <property name="label" translatable="yes">checkbutton</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="draw_indicator">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="draw-indicator">True</property>
               </object>
             </child>
             <child>
               <object class="HAL_HBar" id="hal_hbar1">
                 <property name="visible">True</property>
-                <property name="bg_color">#bebebebebebe</property>
-                <property name="z1_border">0.85000002384185791</property>
-                <property name="z0_border">0.69999998807907104</property>
-                <property name="force_height">20</property>
+                <property name="can-focus">False</property>
+                <property name="bg-color">#bebebebebebe</property>
+                <property name="force-height">20</property>
                 <property name="max">50</property>
-                <property name="z1_color">#ffffffff0000</property>
-                <property name="z2_color">#ffff00000000</property>
-                <property name="z0_color">#0000ffff0000</property>
+                <property name="z0-border">0.699999988079071</property>
+                <property name="z0-color">#0000ffff0000</property>
+                <property name="z1-border">0.8500000238418579</property>
+                <property name="z1-color">#ffffffff0000</property>
+                <property name="z2-color">#ffff00000000</property>
               </object>
               <packing>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
+                <property name="top-attach">2</property>
+                <property name="bottom-attach">3</property>
               </packing>
             </child>
             <child>
               <object class="HAL_HScale" id="hal_hscale2">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="adjustment">adjustment5</property>
               </object>
               <packing>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
+                <property name="top-attach">3</property>
+                <property name="bottom-attach">4</property>
               </packing>
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkVBox" id="vbox1">
             <property name="visible">True</property>
-            <property name="orientation">vertical</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="HAL_Button" id="hal_button1">
                 <property name="label" translatable="yes">button</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -223,10 +272,12 @@
               <object class="HAL_ToggleButton" id="hal_togglebutton1">
                 <property name="label" translatable="yes">togglebutton</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -236,44 +287,55 @@
             <child>
               <object class="HAL_HScale" id="hal_hscale1">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="adjustment">adjustment1</property>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkHBox" id="hbox2">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <child>
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Scale</property>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="HAL_SpinButton" id="hal_spinbutton2">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="invisible_char">&#x25CF;</property>
+                    <property name="can-focus">True</property>
+                    <property name="invisible-char">●</property>
                     <property name="adjustment">adjustment4</property>
                   </object>
                   <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">4</property>
               </packing>
             </child>
             <child>
               <object class="HAL_ProgressBar" id="hal_progressbar1">
                 <property name="visible">True</property>
+                <property name="can-focus">False</property>
                 <property name="scale">180</property>
               </object>
               <packing>
@@ -284,38 +346,12 @@
             </child>
           </object>
           <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkAdjustment" id="adjustment1">
-    <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-    <property name="page_size">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment2">
-    <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-    <property name="page_size">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment3">
-    <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment4">
-    <property name="upper">1000</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment5">
-    <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-    <property name="page_size">10</property>
   </object>
 </interface>


### PR DESCRIPTION
 Probably not the most used examples but since they are referenced in the GladeVCP documentation it would be nice if they are at least functional. 
'sourceview' and 'animated backdrop' still not 100% functional but at least they load ok.