### PR TITLE
Add note about required 'XTerm' to README 'configs/apps/xhc-hb04'

### DIFF
--- a/configs/apps/xhc-hb04/README
+++ b/configs/apps/xhc-hb04/README
@@ -1,5 +1,6 @@
 xhc-hbo4 standalone tests
 
+Imortant Note: This only works with 'XTerm'
 
 Use to test button layouts for a USB wireless xhc-hb04 pendant.
 


### PR DESCRIPTION
The bash script errors out in terminal apps other than 'XTerm'