### PR TITLE
Corrected some missing text to invert an output signal.

### DIFF
--- a/docs/src/config/stepper.adoc
+++ b/docs/src/config/stepper.adoc
@@ -192,7 +192,7 @@ For instance, to invert the spindle control signal:
 
 [source,{hal}]
 ----
-setp parport.0.pin-09-invert TRUE
+setp parport.0.pin-09-out-invert TRUE
 ----
 
 === Adding PWM Spindle Speed Control


### PR DESCRIPTION
-out was missing in the section of inverting an output signal.

When using the example before, linuxcnc would not start. On this page higher up is an example correct. Tested that and it worked as expected.