### PR TITLE
Fix sim config stop lookahead

### DIFF
--- a/configs/sim/axis/remap/stop-lookahead/demo.ini
+++ b/configs/sim/axis/remap/stop-lookahead/demo.ini
@@ -34,7 +34,7 @@ py = python3
 PARAMETER_FILE = sim.var
 SUBROUTINE_PATH = nc_subroutines:../../nc_files/remap_lib/common_nc_subs
 LOG_LEVEL = 0
-REMAP= G70 modalgroup=1   py=queuebuster
+REMAP= G13 modalgroup=1   py=queuebuster
 
 # this is important - read nc_subroutines/on_abort.ngc
 ON_ABORT_COMMAND= O <on_abort> call

--- a/configs/sim/axis/remap/stop-lookahead/nc_files/examples.ngc
+++ b/configs/sim/axis/remap/stop-lookahead/nc_files/examples.ngc
@@ -1,14 +1,14 @@
 ;
 ; demo for stopping interpreter readahead
 ;
-; assuming the G70 line is commented out, what would happen is:
+; assuming the G13 line is commented out, what would happen is:
 ;
 ; the interpreter parses and queues the msg commands, then encounters abort
 ; and immediately flushes the interpreter queue
 ; consequence: the message from (msg,xx) dont appear since they are flushed before they can be executed by
 ; task and the gui.
 ;
-; if G70 is active, this means interpreter readahead stops at that very line until all preceding
+; if G13 is active, this means interpreter readahead stops at that very line until all preceding
 ; commands have been executed 
 ; hence the messages appear in that case
 
@@ -16,9 +16,9 @@
 (msg,two)
 (msg,three)
 
-G70 (dont lookahead further)
-
-(abort, aborting)
+G13 (dont lookahead further)
+o10 if [#<_task> EQ 1] (this avoids an abort message when starting the config)
+ (abort, aborting)
+o10 endif
 m2
-
 


### PR DESCRIPTION
This sim config has been broken since 'G70' has been claimed. The included remap has been moved to 'G13'.
Other minor updates to remove broken links and avoid 'abort' messages on startup.