### PR TITLE
lathe_macros.ini - enable postgui.hal

### DIFF
--- a/configs/sim/gmoccapy/lathe_configs/lathe_macros.ini
+++ b/configs/sim/gmoccapy/lathe_configs/lathe_macros.ini
@@ -72,7 +72,7 @@ HALFILE = spindle_sim.hal
 HALFILE = simulated_home_lathe.hal
 
 # Single file that is executed after the GUI has started.
-#POSTGUI_HALFILE = gmoccapy_postgui.hal
+POSTGUI_HALFILE = gmoccapy_postgui.hal
 
 HALUI = halui
 


### PR DESCRIPTION
Andy cant remember, why it was disabled.
https://github.com/zz912/linuxcnc/commit/63eb5c9cee3628b44d0b72ca16af1d49b4ac172f#r146731461 I think it was ctrl c+v bug.