### PR TITLE
debian/control.top.in - xvfb nocheck (smoe:patch-14)

### DIFF
--- a/debian/control.top.in
+++ b/debian/control.top.in
@@ -45,7 +45,7 @@ Build-Depends:
     tcl@TCLTK_VERSION@-dev,
     tclx,
     tk@TCLTK_VERSION@-dev,
-    xvfb,
+    xvfb <!nocheck>,
     yapps2
 Build-Depends-Indep:
     @DOC_DEPENDS@,


### PR DESCRIPTION
Was cleaning up local branches - after rebasing to master, this "<!nocheck>" addition to a Debian build dependency was left in this one, which I presume to be just fine.