### PR TITLE
Make log level for VCPs configurable

### DIFF
--- a/configs/sim/gmoccapy/gmoccapy.ini
+++ b/configs/sim/gmoccapy/gmoccapy.ini
@@ -17,6 +17,8 @@ DISPLAY = gmoccapy -i
 # VERBOSE     -v
 # ERROR       -q
 
+VCP_LOGLEVEL = ERROR
+
 # Cycle time, in milliseconds, that display will sleep between polls
 CYCLE_TIME = 100
 

--- a/lib/python/qtvcp/qt_istat.py
+++ b/lib/python/qtvcp/qt_istat.py
@@ -56,7 +56,20 @@ class _IStat(object):
         self.ICON = ""
         # this is updated in qtvcp.py on startup
         self.IS_SCREEN = False
-
+        
+        log_level = self.INI.find('DISPLAY', 'VCP_LOGLEVEL')
+        if log_level == "DEBUG":
+            log.setLevel(logger.DEBUG)
+        elif log_level == "INFO":
+            log.setLevel(logger.INFO)
+        elif log_level == "WARNING":
+            log.setLevel(logger.WARNING)
+        elif log_level == "ERROR":
+            log.setLevel(logger.ERROR)
+        elif log_level == "CRITICAL":
+            log.setLevel(logger.CRITICAL)
+        elif log_level == "VERBOSE":
+            log.setLevel(logger.VERBOSE)
 
     def update(self, ini=INIPATH):
         #print('path ini',ini)

--- a/src/hal/user_comps/gladevcp.py
+++ b/src/hal/user_comps/gladevcp.py
@@ -49,7 +49,7 @@ import signal
 #   We have do do this before importing other modules because on import
 #   they set up their own loggers as children of the base logger.
 from qtvcp import logger
-LOG = logger.initBaseLogger('GladeVCP', log_file=None, log_level=logger.INFO)
+LOG = logger.initBaseLogger('GladeVCP', log_file=None, log_level=logger.WARNING)
 
 import gladevcp.makepins
 from gladevcp.gladebuilder import GladeBuilder


### PR DESCRIPTION
Currently in gmocappy you get a lot of warnings from the logger of the QT_ISTAT instances which are not relevant for gmoccapy. 
The more VCPs you are using the more (non-relevant) log messages you get, which makes it hard to focus on the real debug messages you want to see.
So I looked for a way to suppress these warnings.

I added an INI setting which can control this:
`VCP_LOGLEVEL = ERROR`

I am open for other suggestions...

Furthermore I set the default level of the logger itself to WARNING like the default value of all the others which are using the logger.