### PR TITLE
gmoccapy: fix deprecation warning "Gtk.StyleContext.get_background_color is deprecated"

### DIFF
--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -4582,10 +4582,12 @@ class gmoccapy(object):
 
     def _set_sourceview_theme(self, name):
         self.widgets["gcode_view"].set_style_scheme(name)
-        style  = self.widgets["gcode_view"].get_style_context()
-        color = style.get_background_color(Gtk.StateFlags.SELECTED)
-        color.alpha = 0.5
-        self.widgets["gcode_view"].add_mark_category('motion', color.to_string())
+        buffer = self.widgets["gcode_view"].get_buffer()
+        style = buffer.get_style_scheme().get_style('current-line')
+        color = style.props.background
+        rgba = Gdk.RGBA()
+        rgba.parse(color)
+        self.widgets["gcode_view"].add_mark_category('motion', rgba.to_string())
         
     def on_sourceview_theme_choice_changed(self, widget):
         active = widget.get_active_iter()


### PR DESCRIPTION
A bit tricky one that removes the warning
`Gtk.StyleContext.get_background_color is deprecated`
and uses the correct color from the theme: "current-line"