### PR TITLE
Change the gcode editor background when the focus changes. 

### DIFF
--- a/lib/python/qtvcp/widgets/gcode_editor.py
+++ b/lib/python/qtvcp/widgets/gcode_editor.py
@@ -634,6 +634,14 @@ class GcodeDisplay(EditorBase, _HalWidgetBase):
             STATUS.connect('interp_idle', lambda w: self.set_line_number(0))
         self.markerDeleteHandle(self.currentHandle)
 
+    def focusOutEvent(self, event):
+        self.setColorBackground(QColor(211, 211, 211))
+        super().focusOutEvent(event)
+
+    def focusInEvent(self, event):
+        self.setColorBackground(QColor(255, 255, 255))
+        super().focusInEvent(event)
+
     def load_program(self, w, filename=None):
         if filename is None:
             filename = self._last_filename


### PR DESCRIPTION
This merge request adds event handling for the focusIn and focusOut events of the gcode editor. If the editor is in focus, it sets the editor's background white. Otherwise, the background is set to lightgrey.