### PR TITLE
Increased single-step test timeout and include time limit in error message.

### DIFF
--- a/tests/single-step/test-ui.py
+++ b/tests/single-step/test-ui.py
@@ -67,7 +67,7 @@ def wait_complete_step():
     This function instead waits for status.task.execState to tell us
     that Task is no longer waiting for Motion in any way.'''
 
-    timeout = 5.0
+    timeout = 15.0
     start = time.time()
 
     # Wait for the command to be acknowledged by Task (FIXME or is it motion?).
@@ -84,7 +84,7 @@ def wait_complete_step():
             return
         time.sleep(0.1)
 
-    raise SystemExit('timeout in wait_complete_step()')
+    raise SystemExit(f'error: timeout in wait_complete_step(), {timeout} seconds were not enough')
 
 
 # Take first three steps (these cause no motion).


### PR DESCRIPTION
This test fail at random times when the build test is running from CI on github. The failure seem to be a simple timeout, because the code has a limited amount of seconds it will wait before giving up. Increased timeout from 5 to 15 seconds.

The change should reduce the chance of random failures during testing, and provide some feedback to those reading the test log as to why it failed.