### PR TITLE
fix: Build: if LinuxCNC is relocated (via --prefix) TCLLIBPATH must be set #3141

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -90,6 +90,13 @@ else
 fi
 export PYTHONPATH
 
+if [ -z "$TCLLIBPATH" ]; then
+    TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk
+else
+    TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk:"$TCLLIBPATH"
+fi
+export TCLLIBPATH
+
 
 MODULE_EXT=@MODEXT@ # module extension, used when insmod'ing
 

--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -90,12 +90,14 @@ else
 fi
 export PYTHONPATH
 
-if [ -z "$TCLLIBPATH" ]; then
-    TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk
-else
-    TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk:"$TCLLIBPATH"
+if test "xyes" != "x@RUN_IN_PLACE@"; then
+    if [ -z "$TCLLIBPATH" ]; then
+         TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk
+    else
+        TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk:"$TCLLIBPATH"
+    fi
+    export TCLLIBPATH
 fi
-export TCLLIBPATH
 
 
 MODULE_EXT=@MODEXT@ # module extension, used when insmod'ing


### PR DESCRIPTION
fix: Build: if LinuxCNC is relocated (via --prefix) TCLLIBPATH must be set #3141

Add to linuxcnc/scripts/linuxcnc.in

if [ -z "$TCLLIBPATH" ]; then
    TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk
else
    TCLLIBPATH=$LINUXCNC_HOME/lib/tcltk:"$TCLLIBPATH"
fi
export TCLLIBPATH