### PR TITLE
fix:  qtvcp uses obsolete(?) env variable EMC2_HOME instead of LINUXCNC_HOME #3151

### DIFF
--- a/lib/python/qtvcp/qt_istat.py
+++ b/lib/python/qtvcp/qt_istat.py
@@ -20,7 +20,7 @@ except:
 
 INIPATH = os.environ.get('INI_FILE_NAME', '/dev/null')
 
-HOME = os.environ.get('EMC2_HOME', '/usr')
+HOME = os.environ.get('LINUXCNC_HOME', '/usr')
 if HOME is not None:
     IMAGEDIR = os.path.join(HOME, "share", "qtvcp", "images")
 else:

--- a/lib/python/qtvcp/qt_pstat.py
+++ b/lib/python/qtvcp/qt_pstat.py
@@ -51,7 +51,7 @@ class _PStat(object):
             self.VISMACHDIR = os.path.join(self.LIBDIR, "qt_vismach")
 
             # share directory moves when using RIP vrs installed
-            home = os.environ.get('EMC2_HOME', '/usr')
+            home = os.environ.get('LINUXCNC_HOME', '/usr')
             if home is not None:
                 self.SHAREDIR = os.path.join(home,"share", "qtvcp")
             self.IMAGEDIR = os.path.join(self.SHAREDIR,  "images")


### PR DESCRIPTION
Solves problem with relocation of LinuxCNC to /opt.