### PR TITLE
Dropped use of depricated python3-setuptools / distutils.

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1684,7 +1684,7 @@ fi
 AC_MSG_RESULT([$PYTHON_TK_VERSION])
 
 AC_MSG_CHECKING(for site-package location)
-SITEPY=`$PYTHON -c 'import distutils.sysconfig; print(distutils.sysconfig.get_python_lib())'`
+SITEPY="$($PYTHON -c 'import sysconfig; s = sysconfig.get_scheme_names(); m=list(set(("deb_system", "rpm_prefix")) & set(s)); print(sysconfig.get_path("platlib", m.__getitem__(0))) if m else print("/usr/lib/python3/dist-packages");')"
 AC_MSG_RESULT($SITEPY)
 
 AC_MSG_CHECKING(for working GLU quadrics)

--- a/src/m4/ax_python.m4
+++ b/src/m4/ax_python.m4
@@ -64,7 +64,7 @@ if test x$ax_python_bin != x; then
      AC_CHECK_LIB(${ax_python_bin}m, main, ax_python_lib=${ax_python_bin}m, ax_python_lib=no)
    fi
    if test x$ax_python_lib != xno; then
-     ax_python_header=`$ax_python_bin -c "from distutils.sysconfig import *; print(get_config_var('CONFINCLUDEPY'))"`
+     ax_python_header=`$ax_python_bin -c "import sysconfig; print(sysconfig.get_path('include'))"`
      if test x$ax_python_header != x; then
        break;
      fi


### PR DESCRIPTION
Make sure sysconfig.get_path("platlib") return correct path on Debian systems, where /usr/lib/ should be used over /usr/local/lib.

Based on e2c10a8ac20c37c231367d3731c79846082b3a53 by Andy Pugh,

Fixes Debian issue #1080668.