### PR TITLE
Make M7, M8 M9 remappable. 

### DIFF
--- a/configs/sim/axis/remap/extend-builtins/extend-builtins.ini
+++ b/configs/sim/axis/remap/extend-builtins/extend-builtins.ini
@@ -67,7 +67,9 @@ REMAP= F   prolog=setfeed_prolog  ngc=setfeed epilog=setfeed_epilog
 REMAP= M0 modalgroup=4 ngc=extend_m0
 REMAP= M1 modalgroup=4 ngc=extend_m1
 REMAP= M60 modalgroup=4 ngc=extend_m60
-
+REMAP = M7  modalgroup=8 argspec=p ngc=extend_m7
+REMAP = M8  modalgroup=8 argspec=p ngc=extend_m8
+REMAP = M9  modalgroup=8 argspec=p ngc=extend_m9
 # this is important - read common_nc_subs/reset_state.ngc
 ON_ABORT_COMMAND= O <reset_state> call
 

--- a/configs/sim/axis/remap/extend-builtins/nc_subroutines/extend_m7.ngc
+++ b/configs/sim/axis/remap/extend-builtins/nc_subroutines/extend_m7.ngc
@@ -1,0 +1,12 @@
+o<extend_m7> sub
+o2 if [#<_task> EQ 1]
+ o1 if [EXISTS [#<P>]]
+  (DEBUG,M7 P-word passed: #<P>)
+ o1 else
+  (DEBUG,M7 No P-word passed)
+ o1 endif
+ m7 (call built-in m7)
+ (DEBUG, extend_m7 done)
+o2 endif
+o<extend_m7> endsub
+m2

--- a/configs/sim/axis/remap/extend-builtins/nc_subroutines/extend_m8.ngc
+++ b/configs/sim/axis/remap/extend-builtins/nc_subroutines/extend_m8.ngc
@@ -1,0 +1,12 @@
+o<extend_m8> sub
+o2 if [#<_task> EQ 1]
+ o1 if [EXISTS [#<P>]]
+  (DEBUG,M8 P-word passed: #<P>)
+ o1 else
+  (DEBUG,M8 No P-word passed)
+ o1 endif
+ m8 (call built-in m8)
+ (DEBUG, extend_m8 done)
+o2 endif
+o<extend_m8> endsub
+m2

--- a/configs/sim/axis/remap/extend-builtins/nc_subroutines/extend_m9.ngc
+++ b/configs/sim/axis/remap/extend-builtins/nc_subroutines/extend_m9.ngc
@@ -1,0 +1,12 @@
+o<extend_m9> sub
+o2 if [#<_task> EQ 1]
+ o1 if [EXISTS [#<P>]]
+  (DEBUG,M9 P-word passed: #<P>)
+ o1 else
+  (DEBUG,M9 No P-word passed)
+ o1 endif
+ m9 (call built-in m9)
+ (DEBUG, extend_m9 done)
+o2 endif
+o<extend_m9> endsub
+m2

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -4068,9 +4068,9 @@ int Interp::convert_m(block_pointer block,       //!< pointer to a block of RS27
       CHP(restore_settings(&_setup, _setup.call_level));
   }
 
-  if (is_user_defined_m_code(block, settings, 8) && ONCE_M(8)) {
-     return convert_remapped_code(block, settings, STEP_M_8, 'm',
-				   block->m_modes[8]);
+  if (is_user_defined_m_code(block, settings, 8) &&
+	  STEP_REMAPPED_IN_BLOCK(block, STEP_M_8) && ONCE_M(8))  {
+      return convert_remapped_code(block, settings, STEP_M_8, 'm', block->m_modes[8]);
   } else if ((block->m_modes[8] == 7) && ONCE_M(8)){
       enqueue_MIST_ON();
       settings->mist = true;

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -42,6 +42,8 @@ bool Interp::is_m_code_remappable(int m_code)
             m_code == 0 ||
             m_code == 1 ||
             m_code == 6 ||
+            m_code == 7 ||
+            m_code == 8 ||
             m_code == 9 ||
             m_code == 60 ||
             m_code == 61 ||

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -693,8 +693,17 @@ int Interp::find_remappings(block_pointer block, setup_pointer settings)
 	block->remappings.insert(STEP_M_7);
 
     // User defined M-Codes in group 8
-    if (is_user_defined_m_code(block, settings, 8))
-	block->remappings.insert(STEP_M_8);
+    if (is_user_defined_m_code(block, settings, 8)) {
+        if (((block->m_modes[8] == 7) && remap_in_progress("M7")) ||
+        ((block->m_modes[8] == 8) && remap_in_progress("M8")) ||
+        ((block->m_modes[8] == 9) && remap_in_progress("M9"))){
+        // recursive behavior
+        CONTROLLING_BLOCK(*settings).builtin_used = true;
+        } else {
+        // non-recursive (ie the built in) behavior
+        block->remappings.insert(STEP_M_8);
+        }
+    }
 
     // User defined M-Codes in group 9
     if (is_user_defined_m_code(block, settings, 9))


### PR DESCRIPTION
Optionally a P word can be passed and the built-in behavior can be called from remap recursively.
This is useful for users who want to setup different types of coolant/mist setups (additional through-tool coolant)

The 'sim/axis/remap/extend-builtins' simulation config has been extended to M7, M8 and M9. 

Note: M9 has been made remappable sometime in the past but calling the built-in 'M9' from inside the remap is currently not possible