### PR TITLE
Gmoccapy duplicated settings

### DIFF
--- a/lib/python/gladevcp/offsetpage.glade
+++ b/lib/python/gladevcp/offsetpage.glade
@@ -37,7 +37,7 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">Tool</col>
+        <col id="0">Tool</col>
         <col id="1">0</col>
         <col id="2">0</col>
         <col id="3">0</col>
@@ -71,7 +71,7 @@
         <col id="14">G5x</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Rot</col>
+        <col id="0">Rot</col>
         <col id="1">0</col>
         <col id="2">0</col>
         <col id="3">0</col>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -2203,12 +2203,11 @@ class gmoccapy(object):
         self.widgets.offsetpage1.set_font("sans 12")
         self.widgets.offsetpage1.set_foreground_color(self._get_RGBA_color("#28D0D9"))
         self.widgets.offsetpage1.selection_mask = ("Tool", "G5x", "Rot")
-        systemlist = ["Tool", "G5x", "Rot", "G92", "G54", "G55", "G56", "G57", "G58", "G59", "G59.1",
-                      "G59.2", "G59.3"]
         names = []
-        for system in systemlist:
+        default_names = self.widgets.offsetpage1.get_names()
+        for system, name in default_names:
             system_name = "system_name_{0}".format(system)
-            name = self.prefs.getpref(system_name, system, str)
+            name = self.prefs.getpref(system_name, name, str)
             names.append([system, name])
         self.widgets.offsetpage1.set_names(names)
 

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -1960,7 +1960,7 @@ class gmoccapy(object):
                 except:
                     pass
         temp = 0
-        theme_name = self.prefs.getpref("Gtk_theme", "Follow System Theme", str)
+        theme_name = self.prefs.getpref("gtk_theme", "Follow System Theme", str)
         for index, theme in enumerate(themes):
             model.append((theme,))
             if theme == theme_name:
@@ -2206,7 +2206,7 @@ class gmoccapy(object):
         names = []
         default_names = self.widgets.offsetpage1.get_names()
         for system, name in default_names:
-            system_name = "system_name_{0}".format(system)
+            system_name = "system_name_{0}".format(system).lower()
             name = self.prefs.getpref(system_name, name, str)
             names.append([system, name])
         self.widgets.offsetpage1.set_names(names)
@@ -2327,7 +2327,7 @@ class gmoccapy(object):
         else:
             names = self.widgets.offsetpage1.get_names()
             for system, name in names:
-                system_name = "system_name_{0}".format(system)
+                system_name = "system_name_{0}".format(system).lower()
                 self.prefs.putpref(system_name, name)
             page.hide()
 
@@ -4408,7 +4408,7 @@ class gmoccapy(object):
         if active is None:
             return
         theme = widget.get_model()[active][0]
-        self.prefs.putpref('Gtk_theme', theme)
+        self.prefs.putpref("gtk_theme", theme)
         if theme == "Follow System Theme":
             theme = self.default_theme
         settings = Gtk.Settings.get_default()


### PR DESCRIPTION
In some cases, especially when switching between 2.9 and 2.10, the gmoccapy preference file gets duplicate entries.
Here a fix.

For more details: https://www.forum.linuxcnc.org/gmoccapy/50371-duplicate-settings-in-pref-file?start=20#314578