### PR TITLE
emcrsh: fix bug with extra reply line for 'get spindle_override'

### DIFF
--- a/src/emc/usr_intf/emcrsh.cc
+++ b/src/emc/usr_intf/emcrsh.cc
@@ -2554,7 +2554,7 @@ static cmdResponseType getSpindleOverride(connectionRecType *context)
             continue;
 
 		  double percent = emcStatus->motion.spindle[n].spindle_scale * 100.0;
-		  dprintf(context->cliSock, "SPINDLE_OVERRIDE %d %f\r\n", n, percent);
+		  OUT("SPINDLE_OVERRIDE %d %f", n, percent);
   }
 
   return rtNoError;


### PR DESCRIPTION
currently 'get spindle_override' command in linuxcncrsh will return an extra line containing the reply from the 'get' command before last:

```
get teleop_enable
TELEOP_ENABLE OFF
get spindle_override
SPINDLE_OVERRIDE 0 49.000000
TELEOP_ENABLE OFF

```

I'm not sure why that happens but using 'OUT' instead of 'dprintf' seems to fix this issue.