### PR TITLE
Make HM2 board pin names const char.

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/hm2_eth.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_eth.c
@@ -100,7 +100,7 @@ int comm_active = 0;
 
 static int comp_id;
 
-static char *hm2_7i96_pin_names[] = {
+static const char *hm2_7i96_pin_names[] = {
     "TB3-01",
     "TB3-02",
     "TB3-03",
@@ -158,7 +158,7 @@ static char *hm2_7i96_pin_names[] = {
     "P1-25/DB25-13",
 };
 
-static char *hm2_7i94_pin_names[] = {
+static const char *hm2_7i94_pin_names[] = {
     "P2-01/DB25-01", /* P2 parallel expansion */
     "P2-02/DB25-14",
     "P2-03/DB25-02",
@@ -204,7 +204,7 @@ static char *hm2_7i94_pin_names[] = {
     "P2-/IOENA"
 };
 
-static char *hm2_7i95_pin_names[] = {
+static const char *hm2_7i95_pin_names[] = {
     "TB3-02/TB3-03", /* Step/Dir/Misc 5V out */
     "TB3-04/TB3-05",
     "TB3-08/TB3-09",
@@ -266,7 +266,7 @@ static char *hm2_7i95_pin_names[] = {
     "P1-25/DB25-13",
 };
 
-static char *hm2_7i97_pin_names[] = {
+static const char *hm2_7i97_pin_names[] = {
     "TB3-04", 		/* Analog out */
     "TB3-08",
     "TB3-12",
@@ -321,7 +321,7 @@ static char *hm2_7i97_pin_names[] = {
     "P1-25/DB25-13",
 };
 
-static char *hm2_Mc04_pin_names[] = {
+static const char *hm2_Mc04_pin_names[] = {
     "Relay2",
     "Relay3",
     "Relay4",
@@ -384,7 +384,7 @@ static char *hm2_Mc04_pin_names[] = {
     "Smart Serial Interface #0, pin rx0 (Input)"
 };
 
-static char *hm2_8cSS_pin_names[] = {
+static const char *hm2_8cSS_pin_names[] = {
     "Not used",
     "Not used",
     "Not used",

--- a/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
@@ -112,7 +112,7 @@ static uint32_t aux_enables;					// Previous state of SPI1 enable
 static hm2_rpspi_t boards[RPSPI_MAX_BOARDS];	// Connected boards
 static int comp_id;				// Upstream assigned component ID
 
-static char *hm2_7c80_pin_names[] = {
+static const char *hm2_7c80_pin_names[] = {
 	"TB07-02/TB07-03",	/* Step/Dir/Misc 5V out */
 	"TB07-04/TB07-05",
 	"TB08-02/TB08-03",
@@ -170,7 +170,7 @@ static char *hm2_7c80_pin_names[] = {
 	"P1-25/DB25-13",
 };
 
-static char *hm2_7c81_pin_names[] = {
+static const char *hm2_7c81_pin_names[] = {
 	"P1-01/DB25-01",
 	"P1-02/DB25-14",
 	"P1-03/DB25-02",

--- a/src/hal/drivers/mesa-hostmot2/hm2_spi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_spi.c
@@ -72,7 +72,7 @@ static hm2_spi_t boards[MAX_BOARDS];
 static int nboards;
 static int comp_id;
 
-static char *hm2_7c80_pin_names[] = {
+static const char *hm2_7c80_pin_names[] = {
 	"TB07-02/TB07-03",	/* Step/Dir/Misc 5V out */
 	"TB07-04/TB07-05",
 	"TB08-02/TB08-03",
@@ -130,7 +130,7 @@ static char *hm2_7c80_pin_names[] = {
 	"P1-25/DB25-13",
 };
 
-static char *hm2_7c81_pin_names[] = {
+static const char *hm2_7c81_pin_names[] = {
 	"P1-01/DB25-01",
 	"P1-02/DB25-14",
 	"P1-03/DB25-02",

--- a/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2-lowlevel.h
@@ -152,7 +152,7 @@ struct hm2_lowlevel_io_struct {
     // will be used as an array of strings, indexed by IO number, where
     // each string is the name of the connector and pin of that IO.
     // For example, on a 7i43, IO 0's "connector pin name" is "P4-01".
-    char **io_connector_pin_names;
+    const char **io_connector_pin_names;
 
     // llio enumeration is the easiest place to count the leds
     int num_leds;


### PR DESCRIPTION
Make HM2 board pin names const char. This is in preparation for a new Raspberry Pi 5 SPI driver. The pin names are purely informational strings and constants.