### PR TITLE
Stat: fix mcodes attribute

### DIFF
--- a/src/emc/rs274ngc/interp_setup.cc
+++ b/src/emc/rs274ngc/interp_setup.cc
@@ -49,7 +49,7 @@ setup::setup() :
     w_origin_offset(0.0),
 
     active_g_codes{},
-    active_m_codes{},
+    active_m_codes{-1,-1,-1,-1,-1,-1,-1,-1,-1,-1},
     active_settings{},
 
     arc_not_allowed(0),

--- a/src/emc/rs274ngc/interp_write.cc
+++ b/src/emc/rs274ngc/interp_write.cc
@@ -312,7 +312,7 @@ int Interp::write_state_tag(block_pointer block,
 	(block == NULL) ? -1 : block->m_modes[4];
 
     state.flags[GM_FLAG_SPINDLE_ON] =
-	!(settings->spindle_turning[0] != CANON_STOPPED);
+	(settings->spindle_turning[0] != CANON_STOPPED);
     state.flags[GM_FLAG_SPINDLE_CW] =
 	(settings->spindle_turning[0] == CANON_CLOCKWISE);
 

--- a/tests/startup-state/test-ui.py
+++ b/tests/startup-state/test-ui.py
@@ -270,7 +270,7 @@ assert(math.fabs(s.linear_units - 0.0393700787402) < 0.0000001)
 #assert(math.fabs(s.max_acceleration - 123.45) < 0.0000001)
 
 assert(math.fabs(s.max_velocity - 45.67) < 0.0000001)
-assert(s.mcodes == (0, -1, 5, -1, 9, -1, 48, -1, 53, 0))
+assert(s.mcodes == (0, -1, 5, -1, 9, -1, 48, -1, 53, -1))
 assert(s.mist == 0)
 assert(s.motion_line == 0)
 assert(s.motion_mode == linuxcnc.TRAJ_MODE_FREE)


### PR DESCRIPTION
- Fixes erroneous zero in last element of the stat.mcodes attribute by initializing the array with -1.
- Fixes broken spindle field in stat.mcodes attribute  

For discussion see:
https://github.com/LinuxCNC/linuxcnc/issues/3186