### PR TITLE
Fix hal warnings

### DIFF
--- a/src/hal/classicladder/classicladder_gtk.c
+++ b/src/hal/classicladder/classicladder_gtk.c
@@ -737,7 +737,7 @@ cairo_t * InitExportSurface( int SurfaceWidth, int SurfaceHeight, char * SvgFile
 
 void ExportSvgOrPngFile( char * FileToCreate, char GoForSvgExport )
 {
-	cairo_t *cr;
+	cairo_t *cr = NULL;
 	int iCurrentLanguage = SectionArray[ InfosGene->CurrentSection ].Language;
 	if ( iCurrentLanguage==SECTION_IN_LADDER )
 	{

--- a/src/hal/classicladder/drawing.c
+++ b/src/hal/classicladder/drawing.c
@@ -52,14 +52,14 @@ int PrintRightMarginNumExpr = 0;
 int PrintRightMarginPosiX;
 int PrintRightMarginWidth;
 
-void CreateVarNameForElement( char * pBuffToWrite, StrElement * pElem, char SymbolsVarsNamesIfAvail )
+void CreateVarNameForElement( char * pBuffToWrite, size_t bufSize, StrElement * pElem, char SymbolsVarsNamesIfAvail )
 {
 	char VarIndexBuffer[20];
 	if ( pElem->IndexedVarType!=-1 )
 	{
 		// buffer for index required as CreateVarName() returns on a static buffer !
 		rtapi_strxcpy( VarIndexBuffer, CreateVarName(pElem->IndexedVarType,pElem->IndexedVarNum,SymbolsVarsNamesIfAvail) );
-		snprintf( pBuffToWrite, sizeof(pBuffToWrite), "%s", CreateVarName(pElem->VarType,pElem->VarNum,SymbolsVarsNamesIfAvail) );
+		snprintf( pBuffToWrite, bufSize, "%s", CreateVarName(pElem->VarType,pElem->VarNum,SymbolsVarsNamesIfAvail) );
 	}
 	else
 	{
@@ -215,11 +215,12 @@ char * DrawExprForCompareOperate( cairo_t * cr, int BaseX, int BaseY, int Width,
 		if ( DrawingOption==DRAW_FOR_PRINT )
 		{
 			// print the expression entirely in the right margin
-			char * pReportNumAndText = malloc( strlen(Text)+10 );
+			size_t sz;
+			char * pReportNumAndText = malloc( sz = strlen(Text)+10 );
 			if ( pReportNumAndText )
 			{
 				int Hgt;
-				snprintf( pReportNumAndText, sizeof(pReportNumAndText), "(*%d) ", PrintRightMarginNumExpr );
+				snprintf( pReportNumAndText, sz, "(*%d) ", PrintRightMarginNumExpr );
 				strcat( pReportNumAndText, Text );
 				Hgt = DrawPangoTextOptions( cr, PrintRightMarginPosiX, PrintRightMarginExprPosiY, PrintRightMarginWidth, 0/*Height*/, pReportNumAndText, FALSE/*CenterAlignment*/ );
 				PrintRightMarginExprPosiY += Hgt;
@@ -744,7 +745,7 @@ cairo_stroke( cr );
 			case ELE_OUTPUT_NOT:
 			case ELE_OUTPUT_SET:
 			case ELE_OUTPUT_RESET:
-				CreateVarNameForElement( BufTxt, &Element, InfosGene->DisplaySymbols );
+				CreateVarNameForElement( BufTxt, sizeof(BufTxt), &Element, InfosGene->DisplaySymbols );
 				DrawPangoText( cr, x, y+HeiDiv4+1, Width, -1, BufTxt );
 				break;
 			case ELE_OUTPUT_JUMP:

--- a/src/hal/classicladder/drawing.h
+++ b/src/hal/classicladder/drawing.h
@@ -17,7 +17,7 @@
 #define DRAW_FOR_TOOLBAR 1
 #define DRAW_FOR_PRINT 2
 
-void CreateVarNameForElement( char * pBuffToWrite, StrElement * pElem, char SymbolsVarsNamesIfAvail );
+void CreateVarNameForElement( char * pBuffToWrite, size_t bufSize, StrElement * pElem, char SymbolsVarsNamesIfAvail );
 char * DisplayArithmExpr(char * Expr, char SymbolsVarsNamesIfAvail);
 void CreateFontPangoLayout( cairo_t *cr, int BlockPxHeight, char DrawingOption );
 int DrawPangoText( cairo_t * cr, int BaseX, int BaseY, int Width, int Height, char * Text );

--- a/src/hal/classicladder/edit.c
+++ b/src/hal/classicladder/edit.c
@@ -145,7 +145,7 @@ void LoadElementProperties(StrElement * Element)
 			case ELE_OUTPUT_SET:
 			case ELE_OUTPUT_RESET:
 				rtapi_strxcpy(TextToWrite,CreateVarName(Element->VarType,Element->VarNum, InfosGene->DisplaySymbols));
-//				CreateVarNameForElement( TextToWrite, Element, InfosGene->DisplaySymbols );
+//				CreateVarNameForElement( TextToWrite, sizeof(TextToWrite), Element, InfosGene->DisplaySymbols );
 				SetProperty(0,_("Variable"),TextToWrite,TRUE);
 				break;
 			case ELE_OUTPUT_JUMP:

--- a/src/hal/classicladder/files_project.c
+++ b/src/hal/classicladder/files_project.c
@@ -230,7 +230,10 @@ char JoinFiles( char * DirAndNameOfProject, char * TmpDirectoryFiles )
 						while( !feof( pParametersFile ) )
 						{
 							char Buff[ 300 ];
-							fgets( Buff, 300, pParametersFile );
+							if( !fgets( Buff, 300, pParametersFile ) )
+							{
+								break;
+							}
 							if (!feof(pParametersFile))
 							{
 								fputs( Buff, pProjectFile );
@@ -271,13 +274,20 @@ char SplitFiles( char * DirAndNameOfProject, char * TmpDirectoryFiles )
 	{
 
 		/* start line of project ?*/
-		fgets( Buff, 300, pProjectFile );
+		if( !fgets( Buff, 300, pProjectFile ) )
+		{
+			fclose( pProjectFile );
+			return FALSE;
+		}
 		if ( strncmp( Buff, "_FILES_CLASSICLADDER", strlen( "_FILES_CLASSICLADDER" ) )==0 )
 		{
 
 			while( !feof( pProjectFile ) )
 			{
-				fgets( Buff, 300, pProjectFile );
+				if( !fgets( Buff, 300, pProjectFile ) )
+				{
+					break;
+				}
 				if ( !feof( pProjectFile ) )
 				{
 					// header line for a file parameter ?
@@ -306,7 +316,11 @@ ParametersFile[ strlen(ParametersFile)-1 ] = '\0';
 								fputs( Buff, pParametersFile );
 								while( !feof( pProjectFile ) && !cEndOfFile )
 								{
-									fgets( Buff, 300, pProjectFile );
+									if ( !fgets( Buff, 300, pProjectFile ) )
+									{
+										cEndOfFile = TRUE;
+										break;
+									}
 									if (strncmp(Buff,"_/FILE-",strlen("_/FILE-")) !=0)
 									{
 										if (!feof(pProjectFile))

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -320,10 +320,11 @@ typedef volatile rtapi_u32 hal_u32_t;
 typedef volatile rtapi_s32 hal_s32_t;
 typedef volatile rtapi_u64 hal_u64_t;
 typedef volatile rtapi_s64 hal_s64_t;
-typedef volatile int hal_port_t;
+typedef int hal_port_t;
 typedef double real_t __attribute__((aligned(8)));
 typedef rtapi_u64 ireal_t __attribute__((aligned(8))); // integral type as wide as real_t / hal_float_t
 
+#define hal_float_nv_t real_t
 #define hal_float_t volatile real_t
        
 /** HAL "data union" structure

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -39,19 +39,19 @@ PyObject *to_python(bool b) {
     return PyBool_FromLong(b);
 }
 
-PyObject *to_python(hal_u32_t u) {
+PyObject *to_python(rtapi_u32 u) {
     return PyLong_FromUnsignedLong(u);
 }
 
-PyObject *to_python(hal_s32_t i) {
+PyObject *to_python(rtapi_s32 i) {
     return PyLong_FromLong(i);
 }
 
-PyObject *to_python(hal_u64_t u) {
+PyObject *to_python(rtapi_u64 u) {
     return PyLong_FromUnsignedLongLong(u);
 }
 
-PyObject *to_python(hal_s64_t i) {
+PyObject *to_python(rtapi_s64 i) {
     return PyLong_FromLongLong(i);
 }
 

--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -579,7 +579,7 @@ bool Hal::isInitialized()
     return mIsInitialized;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisXPosition(bool absolute) const
+hal_float_nv_t Hal::getAxisXPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -588,7 +588,7 @@ hal_float_t Hal::getAxisXPosition(bool absolute) const
     return *memory->in.axisXPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisYPosition(bool absolute) const
+hal_float_nv_t Hal::getAxisYPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -597,7 +597,7 @@ hal_float_t Hal::getAxisYPosition(bool absolute) const
     return *memory->in.axisYPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisZPosition(bool absolute) const
+hal_float_nv_t Hal::getAxisZPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -606,7 +606,7 @@ hal_float_t Hal::getAxisZPosition(bool absolute) const
     return *memory->in.axisZPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisAPosition(bool absolute) const
+hal_float_nv_t Hal::getAxisAPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -615,7 +615,7 @@ hal_float_t Hal::getAxisAPosition(bool absolute) const
     return *memory->in.axisAPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisBPosition(bool absolute) const
+hal_float_nv_t Hal::getAxisBPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -624,7 +624,7 @@ hal_float_t Hal::getAxisBPosition(bool absolute) const
     return *memory->in.axisBPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisCPosition(bool absolute) const
+hal_float_nv_t Hal::getAxisCPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -692,7 +692,7 @@ void Hal::setAxisCActive(bool enabled)
     *mHalCout << "hal   C axis active" << endl;
 }
 // ----------------------------------------------------------------------
-void Hal::setStepSize(const hal_float_t stepSize)
+void Hal::setStepSize(const hal_float_nv_t stepSize)
 {
     *memory->out.axisXJogScale = stepSize;
     *memory->out.axisYJogScale = stepSize;
@@ -848,32 +848,32 @@ void Hal::setFeedMinus(bool enabled)
     setPin(enabled, KeyCodes::Buttons.feed_minus.text);
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getspindleSpeedCmd() const
+hal_float_nv_t Hal::getspindleSpeedCmd() const
 {
     return *memory->in.spindleSpeedCmd;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getspindleSpeedChangeIncrease() const
+hal_float_nv_t Hal::getspindleSpeedChangeIncrease() const
 {
     return *memory->out.spindleDoIncrease;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getspindleSpeedChangeDecrease() const
+hal_float_nv_t Hal::getspindleSpeedChangeDecrease() const
 {
     return *memory->out.spindleDoDecrease;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getSpindleOverrideValue() const
+hal_float_nv_t Hal::getSpindleOverrideValue() const
 {
     return *memory->in.spindleOverrideValue;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getFeedOverrideMaxVel() const
+hal_float_nv_t Hal::getFeedOverrideMaxVel() const
 {
     return *memory->in.feedOverrideMaxVel;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getFeedOverrideValue() const
+hal_float_nv_t Hal::getFeedOverrideValue() const
 {
     return *memory->in.feedOverrideValue;
 }
@@ -913,7 +913,7 @@ void Hal::setFeedValueSelectedLead(bool selected)
     *memory->out.feedValueSelected_lead = selected;
 }
 // ----------------------------------------------------------------------
-void Hal::setFeedOverrideScale(hal_float_t scale)
+void Hal::setFeedOverrideScale(hal_float_nv_t scale)
 {
     *memory->out.feedOverrideScale = scale;
 }

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -373,7 +373,7 @@ public:
 
     //! Sets the new feed rate. The step mode must be set accordingly.
     //! \param feedRate the new feed rate independent of step mode
-    void setStepSize(const hal_float_t feedRate);
+    void setStepSize(const hal_float_nv_t feedRate);
     //! If lead is active.
     void setLead();
     //! Sets the hal state of the respective pin (reset). Usually called in case the reset
@@ -416,13 +416,13 @@ public:
     void setFeedMinus(bool enabled);
     //! Returns the current Max Velocity value.
     //! \sa Hal::In::feedOverrideMaxVel
-    hal_float_t getFeedOverrideMaxVel() const;
+    hal_float_nv_t getFeedOverrideMaxVel() const;
     //! Returns the current feed override value.
     //! \sa Hal::In::feedOverrideValue
     //! \return the current feed override value v: 0 <= v <= 1
-    hal_float_t getFeedOverrideValue() const;
+    hal_float_nv_t getFeedOverrideValue() const;
     //! \xrefitem HalMemory::Out::feedOverrideScale setter
-    void setFeedOverrideScale(hal_float_t scale);
+    void setFeedOverrideScale(hal_float_nv_t scale);
 
     //! Propagates the feed value 0.001 selection state to hal.
     //! \sa Hal::Out::feedValueSelected_2
@@ -455,13 +455,13 @@ public:
 
     //! Returns the spindle speed.
     //! \return the spindle speed in rounds per second
-    hal_float_t getspindleSpeedCmd() const;
-    hal_float_t getspindleSpeedChangeIncrease() const;
-    hal_float_t getspindleSpeedChangeDecrease() const;
+    hal_float_nv_t getspindleSpeedCmd() const;
+    hal_float_nv_t getspindleSpeedChangeIncrease() const;
+    hal_float_nv_t getspindleSpeedChangeDecrease() const;
     //! Returns the current spindle override value.
     //! \sa Hal::In::spindleOverrideValue
     //! \return the current spindle override value v: 0 <= v <= 1
-    hal_float_t getSpindleOverrideValue() const;
+    hal_float_nv_t getSpindleOverrideValue() const;
     //! \sa setSpindleOverridePlus(bool, size_t)
     void setSpindleOverridePlus(bool enabled);
     //! \sa setSpindleOverrideMinus(bool, size_t)
@@ -548,17 +548,17 @@ public:
     //! Returns the axis position.
     //! \param absolute true absolute, false relative
     //! \return the absolute or relative position in machine units
-    hal_float_t getAxisXPosition(bool absolute) const;
+    hal_float_nv_t getAxisXPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisYPosition(bool absolute) const;
+    hal_float_nv_t getAxisYPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisZPosition(bool absolute) const;
+    hal_float_nv_t getAxisZPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisAPosition(bool absolute) const;
+    hal_float_nv_t getAxisAPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisBPosition(bool absolute) const;
+    hal_float_nv_t getAxisBPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisCPosition(bool absolute) const;
+    hal_float_nv_t getAxisCPosition(bool absolute) const;
 
 
 private:

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -308,6 +308,7 @@
 #include "inifile.h"		// iniFind() from libnml
 #endif
 #include <rtapi_string.h>
+*/
 
 /***********************************************************************
 *                  LOCAL FUNCTION DECLARATIONS                         *

--- a/src/libnml/buffer/shmem.cc
+++ b/src/libnml/buffer/shmem.cc
@@ -47,7 +47,7 @@ extern "C" {
 static double last_non_zero_x;
 static double last_x;
 
-static int not_zero(volatile double x)
+static int not_zero(double x)
 {
     last_x = x;
     if (x < -1E-6 && last_x < -1E-6) {


### PR DESCRIPTION
This PR fixes the warnings about using the volatile modifier. Not all instances of volatile are removed. Volatile is only removed from scalar arguments and return values. All other instances remain as they were because volatile has a defined meaning in those contexts (even though not all may be required). All tests (scripts/runtests) pass (except see #3198).

The PR also addresses the warnings in hal/classicladder about wrong snprintf() size argument and failing to check return values of fgets() and write().