### PR TITLE
Update ci.yml - introducing caching of Ubuntu packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
         submodules: true
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/linuxcnc/linuxcnc +refs/tags/*:refs/tags/*
+    - name: Cache APT packages
+      uses: actions/cache@v3
+      with:
+        path: /var/cache/apt
+        key: ${{ runner.os }}-apt-cache-${{ hashFiles('**/Dockerfile') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-cache-
     - name: Build RIP & test
       run: |
         set -x
@@ -52,6 +59,13 @@ jobs:
         submodules: true
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/linuxcnc/linuxcnc +refs/tags/*:refs/tags/*
+    - name: Cache APT packages
+      uses: actions/cache@v3
+      with:
+        path: /var/cache/apt
+        key: ${{ runner.os }}-apt-cache-${{ hashFiles('**/Dockerfile') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-cache-
     - name: Clang build RIP & test
       run: |
         set -x
@@ -78,6 +92,13 @@ jobs:
         submodules: true
         fetch-depth: 0
     - run: git fetch --recurse-submodules=no https://github.com/linuxcnc/linuxcnc +refs/tags/*:refs/tags/*
+    - name: Cache APT packages
+      uses: actions/cache@v3
+      with:
+        path: /var/cache/apt
+        key: ${{ runner.os }}-apt-cache-${{ hashFiles('**/Dockerfile') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-cache-
     - name: Build HTML docmentation
       run: |
         ./scripts/travis-install-build-deps.sh
@@ -106,6 +127,13 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
+    - name: Cache APT packages
+      uses: actions/cache@v3
+      with:
+        path: /var/cache/apt
+        key: ${{ runner.os }}-apt-cache-${{ hashFiles('**/Dockerfile') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-cache-
     - name: Install pre-dependencies
       env:
         DEBIAN_FRONTEND: noninteractive
@@ -187,7 +215,13 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-
+    - name: Cache APT packages
+      uses: actions/cache@v3
+      with:
+        path: /var/cache/apt
+        key: ${{ runner.os }}-apt-cache-${{ hashFiles('**/Dockerfile') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-cache-
     - name: Install pre-dependencies
       env:
         DEBIAN_FRONTEND: noninteractive
@@ -255,6 +289,13 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
+    - name: Cache APT packages
+      uses: actions/cache@v3
+      with:
+        path: /var/cache/apt
+        key: ${{ runner.os }}-apt-cache-${{ hashFiles('**/Dockerfile') }}
+        restore-keys: |
+          ${{ runner.os }}-apt-cache-
     - name: Perform Source Code checks that were successful in the past
       continue-on-error: true
       run: |


### PR DESCRIPTION
I admit not to fully know what I am doing here. What this is meant to do is to avoid all those frequent downloads of the very same Ubuntu packages. This seems to have failed many times, causing the CI to indicate a false positive failure. I have no idea about how close this attempt to have the files in /var/cache/apt indeed cached will work.