### PR TITLE
Add ignore of generated man-page of hm2_spix.9.

### DIFF
--- a/docs/man/.gitignore
+++ b/docs/man/.gitignore
@@ -337,6 +337,7 @@ man9/hm2_eth.9
 man9/hm2_pci.9
 man9/hm2_rpspi.9
 man9/hm2_spi.9
+man9/hm2_spix.9
 man9/homecomp.9
 man9/hostmot2.9
 man9/hypot.9


### PR DESCRIPTION
Adding the new hm2_spix driver in PR #3209 forgot to ignore the generated man-page. This PR fixes that oversight.