### PR TITLE
Fix CI after hm2_spix integration

### DIFF
--- a/docs/man/.gitignore
+++ b/docs/man/.gitignore
@@ -337,6 +337,7 @@ man9/hm2_eth.9
 man9/hm2_pci.9
 man9/hm2_rpspi.9
 man9/hm2_spi.9
+man9/hm2_spix.9
 man9/homecomp.9
 man9/hostmot2.9
 man9/hypot.9

--- a/src/hal/drivers/mesa-hostmot2/eshellf.c
+++ b/src/hal/drivers/mesa-hostmot2/eshellf.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <stdarg.h>
 #include <errno.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Unfortunately, PR #3209 broke CI on the build of bullseye. It was missing an include.

This PR fixes the CI issue and also adds an gitignore entry for the hm2_spix.9 man-page, which is a generated file.