### PR TITLE
Include stdio.h for readline versions that require it.

### DIFF
--- a/tests/halcompile/command_line_flags/flags.c
+++ b/tests/halcompile/command_line_flags/flags.c
@@ -10,6 +10,7 @@
 #error This is intended as a userspace component only.
 #endif
 
+#include <stdio.h>
 #include <readline.h>
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The test in tests/halcompile/command_line_flags is missing the stdio.h include for some version(s) of readline (notably Fedora with readline 8.2).

This PR simply adds the missing include. It does no harm on systems where it is not necessary and fixes the test on systems where it is required.