### PR TITLE
Fix classicladder warnings

### DIFF
--- a/src/hal/classicladder/classicladder_gtk.c
+++ b/src/hal/classicladder/classicladder_gtk.c
@@ -737,7 +737,7 @@ cairo_t * InitExportSurface( int SurfaceWidth, int SurfaceHeight, char * SvgFile
 
 void ExportSvgOrPngFile( char * FileToCreate, char GoForSvgExport )
 {
-	cairo_t *cr;
+	cairo_t *cr = NULL;
 	int iCurrentLanguage = SectionArray[ InfosGene->CurrentSection ].Language;
 	if ( iCurrentLanguage==SECTION_IN_LADDER )
 	{

--- a/src/hal/classicladder/drawing.c
+++ b/src/hal/classicladder/drawing.c
@@ -52,14 +52,14 @@ int PrintRightMarginNumExpr = 0;
 int PrintRightMarginPosiX;
 int PrintRightMarginWidth;
 
-void CreateVarNameForElement( char * pBuffToWrite, StrElement * pElem, char SymbolsVarsNamesIfAvail )
+void CreateVarNameForElement( char * pBuffToWrite, size_t BuffSize, StrElement * pElem, char SymbolsVarsNamesIfAvail )
 {
 	char VarIndexBuffer[20];
 	if ( pElem->IndexedVarType!=-1 )
 	{
 		// buffer for index required as CreateVarName() returns on a static buffer !
 		rtapi_strxcpy( VarIndexBuffer, CreateVarName(pElem->IndexedVarType,pElem->IndexedVarNum,SymbolsVarsNamesIfAvail) );
-		snprintf( pBuffToWrite, sizeof(pBuffToWrite), "%s", CreateVarName(pElem->VarType,pElem->VarNum,SymbolsVarsNamesIfAvail) );
+		snprintf( pBuffToWrite, BuffSize, "%s", CreateVarName(pElem->VarType,pElem->VarNum,SymbolsVarsNamesIfAvail) );
 	}
 	else
 	{
@@ -215,11 +215,12 @@ char * DrawExprForCompareOperate( cairo_t * cr, int BaseX, int BaseY, int Width,
 		if ( DrawingOption==DRAW_FOR_PRINT )
 		{
 			// print the expression entirely in the right margin
-			char * pReportNumAndText = malloc( strlen(Text)+10 );
+			size_t TextSize;
+			char * pReportNumAndText = malloc( TextSize = strlen(Text)+10 );
 			if ( pReportNumAndText )
 			{
 				int Hgt;
-				snprintf( pReportNumAndText, sizeof(pReportNumAndText), "(*%d) ", PrintRightMarginNumExpr );
+				snprintf( pReportNumAndText, TextSize, "(*%d) ", PrintRightMarginNumExpr );
 				strcat( pReportNumAndText, Text );
 				Hgt = DrawPangoTextOptions( cr, PrintRightMarginPosiX, PrintRightMarginExprPosiY, PrintRightMarginWidth, 0/*Height*/, pReportNumAndText, FALSE/*CenterAlignment*/ );
 				PrintRightMarginExprPosiY += Hgt;
@@ -744,7 +745,7 @@ cairo_stroke( cr );
 			case ELE_OUTPUT_NOT:
 			case ELE_OUTPUT_SET:
 			case ELE_OUTPUT_RESET:
-				CreateVarNameForElement( BufTxt, &Element, InfosGene->DisplaySymbols );
+				CreateVarNameForElement( BufTxt, sizeof(BufTxt), &Element, InfosGene->DisplaySymbols );
 				DrawPangoText( cr, x, y+HeiDiv4+1, Width, -1, BufTxt );
 				break;
 			case ELE_OUTPUT_JUMP:

--- a/src/hal/classicladder/drawing.h
+++ b/src/hal/classicladder/drawing.h
@@ -17,7 +17,7 @@
 #define DRAW_FOR_TOOLBAR 1
 #define DRAW_FOR_PRINT 2
 
-void CreateVarNameForElement( char * pBuffToWrite, StrElement * pElem, char SymbolsVarsNamesIfAvail );
+void CreateVarNameForElement( char * pBuffToWrite, size_t BuffSize, StrElement * pElem, char SymbolsVarsNamesIfAvail );
 char * DisplayArithmExpr(char * Expr, char SymbolsVarsNamesIfAvail);
 void CreateFontPangoLayout( cairo_t *cr, int BlockPxHeight, char DrawingOption );
 int DrawPangoText( cairo_t * cr, int BaseX, int BaseY, int Width, int Height, char * Text );

--- a/src/hal/classicladder/edit.c
+++ b/src/hal/classicladder/edit.c
@@ -145,7 +145,7 @@ void LoadElementProperties(StrElement * Element)
 			case ELE_OUTPUT_SET:
 			case ELE_OUTPUT_RESET:
 				rtapi_strxcpy(TextToWrite,CreateVarName(Element->VarType,Element->VarNum, InfosGene->DisplaySymbols));
-//				CreateVarNameForElement( TextToWrite, Element, InfosGene->DisplaySymbols );
+//				CreateVarNameForElement( TextToWrite, sizeof(TextToWrite), Element, InfosGene->DisplaySymbols );
 				SetProperty(0,_("Variable"),TextToWrite,TRUE);
 				break;
 			case ELE_OUTPUT_JUMP:

--- a/src/hal/classicladder/files_project.c
+++ b/src/hal/classicladder/files_project.c
@@ -230,11 +230,11 @@ char JoinFiles( char * DirAndNameOfProject, char * TmpDirectoryFiles )
 						while( !feof( pParametersFile ) )
 						{
 							char Buff[ 300 ];
-							fgets( Buff, 300, pParametersFile );
-							if (!feof(pParametersFile))
+							if (!fgets( Buff, sizeof(Buff), pParametersFile ) )
 							{
-								fputs( Buff, pProjectFile );
+								break;
 							}
+							fputs( Buff, pProjectFile );
 						}
 						fclose( pParametersFile );
 						snprintf(BuffTemp, sizeof(BuffTemp), "_/FILE-%s\n", pEnt->d_name );
@@ -271,13 +271,20 @@ char SplitFiles( char * DirAndNameOfProject, char * TmpDirectoryFiles )
 	{
 
 		/* start line of project ?*/
-		fgets( Buff, 300, pProjectFile );
+		if( !fgets( Buff, sizeof(Buff), pProjectFile ) )
+		{
+			fclose(pProjectFile);
+			return FALSE;
+		}
 		if ( strncmp( Buff, "_FILES_CLASSICLADDER", strlen( "_FILES_CLASSICLADDER" ) )==0 )
 		{
 
 			while( !feof( pProjectFile ) )
 			{
-				fgets( Buff, 300, pProjectFile );
+				if( !fgets( Buff, sizeof(Buff), pProjectFile ) )
+				{
+					break;
+				}
 				if ( !feof( pProjectFile ) )
 				{
 					// header line for a file parameter ?
@@ -306,7 +313,10 @@ ParametersFile[ strlen(ParametersFile)-1 ] = '\0';
 								fputs( Buff, pParametersFile );
 								while( !feof( pProjectFile ) && !cEndOfFile )
 								{
-									fgets( Buff, 300, pProjectFile );
+									if ( !fgets( Buff, sizeof(Buff), pProjectFile ) )
+									{
+										break;
+									}
 									if (strncmp(Buff,"_/FILE-",strlen("_/FILE-")) !=0)
 									{
 										if (!feof(pProjectFile))


### PR DESCRIPTION
There are several warning in the classicladder component. The ones involving string copy operations are quite serious because the used buffer sizes are wrong.

Other warning deal with missing checks on return values of fgets() and write(). The fgets() problem is solved quite easily. Fixing the return value check of write() on a serial port requires some extra code because there may be partial and restartable writes.