### PR TITLE
Fix comment in comment warning

### DIFF
--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -308,6 +308,7 @@
 #include "inifile.h"		// iniFind() from libnml
 #endif
 #include <rtapi_string.h>
+*/
 
 /***********************************************************************
 *                  LOCAL FUNCTION DECLARATIONS                         *


### PR DESCRIPTION
Opening a comment block inside a comment block is problematic. Fix the problem by closing the previous block before the next is opened.