### PR TITLE
Function calls must adhere to their prototypes

### DIFF
--- a/src/hal/classicladder/classicladder_gtk.c
+++ b/src/hal/classicladder/classicladder_gtk.c
@@ -176,7 +176,7 @@ void GetTheSizesForRung( void )
 
 	// size of the page or block changed ?
 	if ( InfosGene->PageHeight!=PageHeightBak || InfosGene->BlockHeight!=BlockHeightBak )
-		UpdateVScrollBar( TRUE/*AutoSelectCurrentRung*/ );
+		UpdateVScrollBar( /*AutoSelectCurrentRung*/ );
 	PageHeightBak = InfosGene->PageHeight;
 	BlockHeightBak = InfosGene->BlockHeight;
 }

--- a/src/hal/classicladder/manager_gtk.c
+++ b/src/hal/classicladder/manager_gtk.c
@@ -69,7 +69,7 @@ void RefreshSectionSelected( )
 	EditorButtonsAccordingSectionType( );
     //XXX search functionality, not implemented in LinuxCNC.
 	//EnableDisableMenusAccordingSectionType( );
-	UpdateVScrollBar( TRUE/*AutoSelectCurrentRung*/ );
+	UpdateVScrollBar( /*AutoSelectCurrentRung*/ );
 }
 
 void ManagerDisplaySections( char ForgetSectionSelected )

--- a/src/hal/classicladder/socket_modbus_master.c
+++ b/src/hal/classicladder/socket_modbus_master.c
@@ -122,7 +122,7 @@ void ConfigSerialModbusMaster( void )
 	int Error = 0;
 	if ( ModbusConfig.ModbusSerialPortNameUsed[ 0 ]!='\0' )
 	{
-		if ( !SerialOpen( ModbusConfig.ModbusSerialPortNameUsed, ModbusConfig.ModbusSerialSpeed ) )
+		if ( !SerialOpen( /*ModbusConfig.ModbusSerialPortNameUsed, ModbusConfig.ModbusSerialSpeed*/ ) )
 		{
 			Error = -1;
                         printf(_("INFO CLASSICLADDER---I/O Modbus master Data bits %i Stop bits %i Parity %i\n"),ModbusConfig.ModbusSerialDataBits,ModbusConfig.ModbusSerialStopBits,ModbusConfig.ModbusSerialParity);


### PR DESCRIPTION
Several function calls added arguments to the function call but the functions in question do not take any arguments.