### PR TITLE
Use consistent silencing of make messages

### DIFF
--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -997,10 +997,11 @@ TARGETS += manpages
 # For more information, see https://github.com/asciidoc/asciidoc/issues/44
 GENERATED_MANPAGES += $(patsubst $(DOC_DIR)/src/man/%.adoc, $(DOC_DIR)/man/%, $(wildcard $(DOC_DIR)/src/man/man?/*.adoc))
 $(DOC_DIR)/man/%: $(DOC_DIR)/src/man/%.adoc
-	@mkdir -p `dirname $@`
-	a2x -v --doctype manpage \
+	$(ECHO) Making manpage $(notdir $@)
+	@mkdir -p $(dir $@)
+	$(Q)a2x --doctype manpage \
 		--format manpage \
-		--destination-dir `dirname $@` \
+		--destination-dir $(dir $@) \
 		--xsltproc-opts="--nonet" \
 		-a mansource=LinuxCNC \
 		-a manmanual='LinuxCNC Documentation' \

--- a/docs/src/man/man1/halui.1.adoc
+++ b/docs/src/man/man1/halui.1.adoc
@@ -168,8 +168,8 @@ contact) connect the physical button to a HAL debounce filter first.
 **halui.mdi-command-**_XX_ bit in::
   *halui* looks for INI variables named [HALUI]MDI_COMMAND, and exports
   a pin for each command it finds. When the pin is driven TRUE, *halui*
-  runs the specified MDI command. _XX_ is a two digit number starting at
-  00. If no [HALUI]MDI_COMMAND variables are set in the INI file, no
+  runs the specified MDI command. _XX_ is a two digit number starting
+  at 00. If no [HALUI]MDI_COMMAND variables are set in the INI file, no
   halui.mdi-command-XX pins will be exported by halui.
 
 === Mist coolant

--- a/docs/src/man/man1/monitor-xhc-hb04.1.adoc
+++ b/docs/src/man/man1/monitor-xhc-hb04.1.adoc
@@ -14,10 +14,9 @@ monitor-xhc-hb04 - monitors the XHC-HB04 pendant and warns of disconnection
 This script runs in the background and will pop up a message when the pendant is disconnected or reconnected.
 
 Usage is optional; if used it is specified with INI file entry:
-```
-[APPLICATIONS]
-APP = monitor-xhc-hb04
-```
+[literal]
+ [APPLICATIONS]
+ APP = monitor-xhc-hb04
 
 == SEE ALSO
 

--- a/docs/src/man/man1/xhc-hb04.1.adoc
+++ b/docs/src/man/man1/xhc-hb04.1.adoc
@@ -287,7 +287,7 @@ pins 3) connect buttons to motion.* pins
 Another script is included to monitor the pendant and report loss of USB connectivity.
 See the README and .txt files in the above directory for usage.
 
-[Note]
+=== Note
 The sim configs use the AXIS GUI but the scripts are available
 with any HAL configuration or GUI. The same scripts can be used to adapt
 the xhc-hb04 to existing configurations provided that the halui, motion,

--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -58,7 +58,7 @@ $(COMP_MANPAGES): ../docs/man/man9/%.9: hal/components/%.comp ../bin/halcompile
 	$(ECHO) Making halcompile manpage $(notdir $@)
 	@mkdir -p $(dir $@)
 	$(Q)../bin/halcompile -U --document -o $@.new $< && preconv -r < $@.new > $@
-	$(RM) $@.new
+	$(Q)$(RM) $@.new
 
 $(COMP_DRIVER_MANPAGES): ../docs/man/man9/%.9: hal/drivers/%.comp ../bin/halcompile
 	$(ECHO) Making halcompile manpage $(notdir $@)


### PR DESCRIPTION
Making man pages is way more verbose than all other jobs. This PR streamlines the a2x call for making man pages to use the same noise limiting procedure. It removes a lot of clutter in the terminal when doing a build.

Additionally, reducing the clutter exposed some formatting warnings which are also fixed. There may be warnings left about "too many manpage names", but this is an internal asciidoc issue.