### PR TITLE
Escaping double quotes must be inside double quotes

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -690,7 +690,7 @@ fe () {
     # Fully expand argument.  Example:
     # ${datadir} -> ${datarootdir} -> ${prefix}/share -> /usr/local
     case "$1" in
-    *\$*) eval fe \""$1"\" ;;
+    *\$*) eval fe "\"$1\"" ;;
     *) echo "$1" ;;
     esac
 }


### PR DESCRIPTION
The src/configure.ac:689 fe function contains double quote escapes that are on the outside of the quoted string instead of inside the string. This PR fixes that. It also solves vim not being able to syntax-highlight after the specific line.