### PR TITLE
Fix volatile warnings

### DIFF
--- a/lib/python/pyhal.py
+++ b/lib/python/pyhal.py
@@ -14,28 +14,28 @@ lib.hal_signal_new.argtypes = [c_char_p, c_int]
 
 lib.hal_link.argtypes = [c_char_p, c_char_p]
 
-lib.hal_port_read.argtypes = [c_int, c_char_p, c_uint]
+lib.hal_port_read.argtypes = [POINTER(c_int), c_char_p, c_uint]
 lib.hal_port_read.restype = c_bool
 
-lib.hal_port_peek.argtypes = [c_int, c_char_p, c_uint]
+lib.hal_port_peek.argtypes = [POINTER(c_int), c_char_p, c_uint]
 lib.hal_port_peek.restype = c_bool
 
-lib.hal_port_peek_commit.argtypes = [c_int, c_char_p, c_uint]
+lib.hal_port_peek_commit.argtypes = [POINTER(c_int), c_char_p, c_uint]
 lib.hal_port_peek.restype = c_bool
 
-lib.hal_port_write.argtypes = [c_int, c_char_p, c_uint]
+lib.hal_port_write.argtypes = [POINTER(c_int), c_char_p, c_uint]
 lib.hal_port_write.restype = c_bool
 
-lib.hal_port_readable.argtypes = [c_int]
+lib.hal_port_readable.argtypes = [POINTER(c_int)]
 lib.hal_port_readable.restype = c_uint
 
-lib.hal_port_writable.argtypes = [c_int]
+lib.hal_port_writable.argtypes = [POINTER(c_int)]
 lib.hal_port_writable.restype = c_uint
 
-lib.hal_port_buffer_size.argtypes = [c_int]
+lib.hal_port_buffer_size.argtypes = [POINTER(c_int)]
 lib.hal_port_buffer_size.restype = c_uint
 
-lib.hal_port_clear.argtypes = [c_int]
+lib.hal_port_clear.argtypes = [POINTER(c_int)]
 
 lib.hal_port_wait_readable.argtypes = [POINTER(POINTER(c_int)), c_uint, c_int]
 lib.hal_port_wait_writable.argtypes = [POINTER(POINTER(c_int)), c_uint, c_int]
@@ -101,7 +101,7 @@ class port(pin):
 
     @property
     def __port(self):
-        return self.data_ptr.contents.contents.value
+        return self.data_ptr.contents
 
     def read(self, count):
         if self.dir != pinDir.IN:

--- a/src/hal/components/raster.comp
+++ b/src/hal/components/raster.comp
@@ -86,7 +86,7 @@ bool float_eq(hal_float_t a, hal_float_t b) {
     return fabs(a-b) < epsilon;
 }
 
-bool read_float(hal_port_t port, hal_float_t* value) {
+bool read_float(const hal_port_t *port, hal_float_t* value) {
     char data[32];
     int available = hal_port_readable(port);
     char* pos;
@@ -110,7 +110,7 @@ bool read_float(hal_port_t port, hal_float_t* value) {
     return true;
 }
 
-bool read_int(hal_port_t port, hal_s32_t* value) {
+bool read_int(const hal_port_t *port, hal_s32_t* value) {
     char data[10];
     long val;
     int available = hal_port_readable(port);
@@ -148,7 +148,7 @@ bool read_int(hal_port_t port, hal_s32_t* value) {
     pixels bpp must be defined in increments of 4.
     a pixel value with all 1 bits is a special value considered "off" for the raster and no power will be output
 */
-bool read_pixel_data(hal_port_t port, int bits_per_pixel, hal_float_t* power) {
+bool read_pixel_data(const hal_port_t *port, int bits_per_pixel, hal_float_t* power) {
     char data[8];
     long value = 0;
     unsigned int off = 0xFFFFFFFF >> (32 - bits_per_pixel);
@@ -190,7 +190,7 @@ FUNCTION(_) {
         state = IDLE;
         fault = 0;
         fault_code = ERROR_NONE;
-        hal_port_clear(program);
+        hal_port_clear(program_ptr);
     } else if (state == FAULT) {
         fault = 1;
     } else if (state == IDLE) {
@@ -202,19 +202,19 @@ FUNCTION(_) {
         //when run is asserted, the port must be full of 1 line of raster data
         if(run) {
 
-            if(!read_float(program, &program_offset)) {
+            if(!read_float(program_ptr, &program_offset)) {
                 state = FAULT;
                 fault_code = ERROR_INVALID_OFFSET;
-            } else if(!read_int(program, &bpp) || (bpp == 0) || (bpp > 32) || ((bpp % 4) != 0)) {
+            } else if(!read_int(program_ptr, &bpp) || (bpp == 0) || (bpp > 32) || ((bpp % 4) != 0)) {
                 state = FAULT;
                 fault_code = ERROR_INVALID_BPP;
-            } else if(!read_float(program, &ppu) || (ppu <= 0.0)) {
+            } else if(!read_float(program_ptr, &ppu) || (ppu <= 0.0)) {
                 state = FAULT;
                 fault_code = ERROR_INVALID_PPU;
-            } else if(!read_int(program, &count) || (count < 2)) {
+            } else if(!read_int(program_ptr, &count) || (count < 2)) {
                 state = FAULT;
                 fault_code = ERROR_INVALID_COUNT;
-            } else if(hal_port_readable(program) != ((bpp / 4) * count)) {
+            } else if(hal_port_readable(program_ptr) != ((bpp / 4) * count)) {
                 state = FAULT;
                 fault_code = ERROR_PROGWRONGSIZE;
             } else {
@@ -227,7 +227,7 @@ FUNCTION(_) {
 
         if(!run) {
             state = IDLE;
-            hal_port_clear(program);
+            hal_port_clear(program_ptr);
         } else {
             enabled = 1;
 
@@ -236,7 +236,7 @@ FUNCTION(_) {
                 current_pixel_index = current_pixel_index+1;
                 previous_pixel_value = current_pixel_value;
 
-                if(!read_pixel_data(program, bpp, &current_pixel_value)) {
+                if(!read_pixel_data(program_ptr, bpp, &current_pixel_value)) {
                     state = FAULT;
                     fault_code = ERROR_BADPIXELDATA;
                     return;

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -866,7 +866,7 @@ extern int hal_set_constructor(int comp_id, constructor make);
         true: count bytes were read into dest
         false: no bytes were read into dest
  */
-extern bool hal_port_read(hal_port_t port, char* dest, unsigned count);
+extern bool hal_port_read(const hal_port_t *port, char* dest, unsigned count);
 
 
 /** hal_port_peek operates the same as hal_port_read but no bytes are consumed
@@ -876,7 +876,7 @@ extern bool hal_port_read(hal_port_t port, char* dest, unsigned count);
         true: count bytes were read into dest
         false: no bytes were read into dest
 */
-extern bool hal_port_peek(hal_port_t port, char* dest, unsigned count);
+extern bool hal_port_peek(const hal_port_t *port, char* dest, unsigned count);
 
 /** hal_port_peek_commit advances the read position in the port buffer
     by count bytes. A hal_port_peek followed by a hal_port_peek_commit
@@ -887,7 +887,7 @@ extern bool hal_port_peek(hal_port_t port, char* dest, unsigned count);
        true: count readable bytes were skipped and are no longer accessible
        false: no bytes wer skipped
 */ 
-extern bool hal_port_peek_commit(hal_port_t port, unsigned count);
+extern bool hal_port_peek_commit(const hal_port_t *port, unsigned count);
 
 /** hal_port_write writes count bytes from src into the port. 
     This function should only be called by the component that owns
@@ -897,28 +897,28 @@ extern bool hal_port_peek_commit(hal_port_t port, unsigned count);
         false: no bytes were written into dest
     
 */
-extern bool hal_port_write(hal_port_t port, const char* src, unsigned count);
+extern bool hal_port_write(const hal_port_t *port, const char* src, unsigned count);
 
 /** hal_port_readable returns the number of bytes available
     for reading from the port.
 */
-extern unsigned hal_port_readable(hal_port_t port);
+extern unsigned hal_port_readable(const hal_port_t *port);
 
 /** hal_port_writable returns the number of bytes that
     can be written into the port
 */
-extern unsigned hal_port_writable(hal_port_t port);
+extern unsigned hal_port_writable(const hal_port_t *port);
 
 /** hal_port_buffer_size returns the total number of bytes
     that a port can buffer
 */
-extern unsigned hal_port_buffer_size(hal_port_t port);
+extern unsigned hal_port_buffer_size(const hal_port_t *port);
 
 /** hal_port_clear emptys a given port of all data
     without consuming any of it.
     hal_port_clear should only be called by a reader
 */
-extern void hal_port_clear(hal_port_t port);
+extern void hal_port_clear(const hal_port_t *port);
 
 
 #ifdef ULAPI

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -483,10 +483,11 @@ extern hal_pin_t *halpr_find_pin_by_sig(hal_sig_t * sig, hal_pin_t * start);
 
 
 /** hal_port_alloc allocates a new empty hal_port having a buffer of size bytes. 
-    returns a negative value on failure or a hal_port_t which can be used with
-    all other hal_port functions.
+    Returns a negative value on failure. On success zero (0) is returned and
+    the newly allocated hal_port_t is returned in the port argument and can be
+    used with all other hal_port functions.
 */
-extern hal_port_t hal_port_alloc(unsigned size);
+extern int hal_port_alloc(unsigned size, hal_port_t *port);
 
 
 

--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -579,7 +579,7 @@ bool Hal::isInitialized()
     return mIsInitialized;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisXPosition(bool absolute) const
+real_t Hal::getAxisXPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -588,7 +588,7 @@ hal_float_t Hal::getAxisXPosition(bool absolute) const
     return *memory->in.axisXPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisYPosition(bool absolute) const
+real_t Hal::getAxisYPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -597,7 +597,7 @@ hal_float_t Hal::getAxisYPosition(bool absolute) const
     return *memory->in.axisYPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisZPosition(bool absolute) const
+real_t Hal::getAxisZPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -606,7 +606,7 @@ hal_float_t Hal::getAxisZPosition(bool absolute) const
     return *memory->in.axisZPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisAPosition(bool absolute) const
+real_t Hal::getAxisAPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -615,7 +615,7 @@ hal_float_t Hal::getAxisAPosition(bool absolute) const
     return *memory->in.axisAPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisBPosition(bool absolute) const
+real_t Hal::getAxisBPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -624,7 +624,7 @@ hal_float_t Hal::getAxisBPosition(bool absolute) const
     return *memory->in.axisBPositionRelative;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getAxisCPosition(bool absolute) const
+real_t Hal::getAxisCPosition(bool absolute) const
 {
     if (absolute)
     {
@@ -692,7 +692,7 @@ void Hal::setAxisCActive(bool enabled)
     *mHalCout << "hal   C axis active" << endl;
 }
 // ----------------------------------------------------------------------
-void Hal::setStepSize(const hal_float_t stepSize)
+void Hal::setStepSize(const real_t stepSize)
 {
     *memory->out.axisXJogScale = stepSize;
     *memory->out.axisYJogScale = stepSize;
@@ -848,32 +848,32 @@ void Hal::setFeedMinus(bool enabled)
     setPin(enabled, KeyCodes::Buttons.feed_minus.text);
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getspindleSpeedCmd() const
+real_t Hal::getspindleSpeedCmd() const
 {
     return *memory->in.spindleSpeedCmd;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getspindleSpeedChangeIncrease() const
+real_t Hal::getspindleSpeedChangeIncrease() const
 {
     return *memory->out.spindleDoIncrease;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getspindleSpeedChangeDecrease() const
+real_t Hal::getspindleSpeedChangeDecrease() const
 {
     return *memory->out.spindleDoDecrease;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getSpindleOverrideValue() const
+real_t Hal::getSpindleOverrideValue() const
 {
     return *memory->in.spindleOverrideValue;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getFeedOverrideMaxVel() const
+real_t Hal::getFeedOverrideMaxVel() const
 {
     return *memory->in.feedOverrideMaxVel;
 }
 // ----------------------------------------------------------------------
-hal_float_t Hal::getFeedOverrideValue() const
+real_t Hal::getFeedOverrideValue() const
 {
     return *memory->in.feedOverrideValue;
 }
@@ -913,7 +913,7 @@ void Hal::setFeedValueSelectedLead(bool selected)
     *memory->out.feedValueSelected_lead = selected;
 }
 // ----------------------------------------------------------------------
-void Hal::setFeedOverrideScale(hal_float_t scale)
+void Hal::setFeedOverrideScale(real_t scale)
 {
     *memory->out.feedOverrideScale = scale;
 }

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -373,7 +373,7 @@ public:
 
     //! Sets the new feed rate. The step mode must be set accordingly.
     //! \param feedRate the new feed rate independent of step mode
-    void setStepSize(const hal_float_t feedRate);
+    void setStepSize(const real_t feedRate);
     //! If lead is active.
     void setLead();
     //! Sets the hal state of the respective pin (reset). Usually called in case the reset
@@ -416,13 +416,13 @@ public:
     void setFeedMinus(bool enabled);
     //! Returns the current Max Velocity value.
     //! \sa Hal::In::feedOverrideMaxVel
-    hal_float_t getFeedOverrideMaxVel() const;
+    real_t getFeedOverrideMaxVel() const;
     //! Returns the current feed override value.
     //! \sa Hal::In::feedOverrideValue
     //! \return the current feed override value v: 0 <= v <= 1
-    hal_float_t getFeedOverrideValue() const;
+    real_t getFeedOverrideValue() const;
     //! \xrefitem HalMemory::Out::feedOverrideScale setter
-    void setFeedOverrideScale(hal_float_t scale);
+    void setFeedOverrideScale(real_t scale);
 
     //! Propagates the feed value 0.001 selection state to hal.
     //! \sa Hal::Out::feedValueSelected_2
@@ -455,13 +455,13 @@ public:
 
     //! Returns the spindle speed.
     //! \return the spindle speed in rounds per second
-    hal_float_t getspindleSpeedCmd() const;
-    hal_float_t getspindleSpeedChangeIncrease() const;
-    hal_float_t getspindleSpeedChangeDecrease() const;
+    real_t getspindleSpeedCmd() const;
+    real_t getspindleSpeedChangeIncrease() const;
+    real_t getspindleSpeedChangeDecrease() const;
     //! Returns the current spindle override value.
     //! \sa Hal::In::spindleOverrideValue
     //! \return the current spindle override value v: 0 <= v <= 1
-    hal_float_t getSpindleOverrideValue() const;
+    real_t getSpindleOverrideValue() const;
     //! \sa setSpindleOverridePlus(bool, size_t)
     void setSpindleOverridePlus(bool enabled);
     //! \sa setSpindleOverrideMinus(bool, size_t)
@@ -548,17 +548,17 @@ public:
     //! Returns the axis position.
     //! \param absolute true absolute, false relative
     //! \return the absolute or relative position in machine units
-    hal_float_t getAxisXPosition(bool absolute) const;
+    real_t getAxisXPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisYPosition(bool absolute) const;
+    real_t getAxisYPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisZPosition(bool absolute) const;
+    real_t getAxisZPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisAPosition(bool absolute) const;
+    real_t getAxisAPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisBPosition(bool absolute) const;
+    real_t getAxisBPosition(bool absolute) const;
     //! \xrefitem getAxisXPosition(bool)
-    hal_float_t getAxisCPosition(bool absolute) const;
+    real_t getAxisCPosition(bool absolute) const;
 
 
 private:

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -723,11 +723,13 @@ static int set_common(hal_type_t type, void *d_ptr, char *value) {
             halcmd_error("value '%s' invalid for PORT\n", value);
             retval = -EINVAL;
         } else {
-            if((*((hal_port_t*)d_ptr) != 0) && (hal_port_buffer_size(*((hal_port_t*)d_ptr)) > 0)) {
-                halcmd_error("port is already allocated with %u bytes.\n", hal_port_buffer_size(*((hal_port_t*)d_ptr)));
+            if((*((hal_port_t*)d_ptr) != 0) && (hal_port_buffer_size(((hal_port_t*)d_ptr)) > 0)) {
+                halcmd_error("port is already allocated with %u bytes.\n", hal_port_buffer_size(((hal_port_t*)d_ptr)));
                 retval = -EINVAL;
         } else {
-            *((hal_port_t*) (d_ptr)) = hal_port_alloc(uval);
+            retval = hal_port_alloc(uval, (hal_port_t *)d_ptr);
+            if(retval)
+                halcmd_error("failed to allocate PORT with size %u\n", uval);
         }
     }
     break;
@@ -2449,7 +2451,7 @@ static const char *data_value(int type, void *valptr)
     value_str = buf;
     break;
     case HAL_PORT:
-	snprintf(buf, 21, "%20u", hal_port_buffer_size(*((hal_port_t*) valptr)));
+	snprintf(buf, 21, "%20u", hal_port_buffer_size((hal_port_t*) valptr));
 	value_str = buf;
 	break;
     default:
@@ -2495,7 +2497,7 @@ static const char *data_value2(int type, void *valptr)
     value_str = buf;
     break;
     case HAL_PORT:
-	snprintf(buf, 14, "%u", hal_port_buffer_size(*((hal_port_t*) valptr)));
+	snprintf(buf, 14, "%u", hal_port_buffer_size((hal_port_t*) valptr));
 	value_str = buf;
 	break;
 


### PR DESCRIPTION
This fixes all the "inappropriate volatile use" compiler warnings as discussed in #3222. But, it does so in a minimal invasive way.

The use of hal_X_t types in pass-by-value arguments and as value-return types is the actual problem. A passed <i>value</i> in a function argument can never ever be volatile. The same goes for return <i>values</i>. The problem can easily be fixed by using pass-by-reference or using the underlying types of the hal_X_t types.

This PR changes the hal port API slightly, changing hal_port_t pass-by-value to pass-by-reference arguments. The xhc-whb04b-06 component is fixed by using the underlying type, changing hal_float_t to real_t.

None of these changes add or remove functionality in any way. Therefore, it does not matter what type of real-time is used.