### PR TITLE
Make switchkins respect external offset during a kinematics switch

### DIFF
--- a/docs/src/motion/switchkins.adoc
+++ b/docs/src/motion/switchkins.adoc
@@ -300,7 +300,7 @@ M-code scripts can be designed as follows:
 The vismach simulation configurations for a puma robot demonstrate
 M-code scripts (M128,M129,M130) for this example use case.
 
-=== Offset considerations
+=== Coordinate system offset considerations
 
 Like INI file limit settings, coordinate system offsets (G92,
 G10L2, G10L20, G43, etc) are generally applicable only for the
@@ -308,6 +308,18 @@ type 0 default startup kinematics type.  When switching
 kinematics types, it may be *important* to either reset all offsets
 prior to switching or update offsets based on system-specific
 requirements.
+
+=== External offset considerations 
+
+External offsets (set to an axis (_L_) via axis.L.eoffset-request) are preserved during 
+kinematics switches. When an offset is active on an axis before the switch
+(visible in axis.L.eoffset), the trajectory planner maintains that same 
+offset after the switch, similar to how it maintains the commanded 
+position from a G-code. This ensures consistent machine behavior regardless
+of the active kinematics.
+
+If maintaining the offset will be an issue due to axis limit changes or other concerns,
+be sure to clear and possibly disable the eoffset before making a kinematics switch
 
 == Simulation configs
 

--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -340,6 +340,7 @@ static void handle_kinematicsSwitch(void) {
                ,anum,beforePose[anum],*pcmd_p[anum],*pcmd_p[anum]-beforePose[anum]);
     }
 #endif
+    axis_apply_ext_offsets_to_carte_pos(-1, pcmd_p);
     tpSetPos(&emcmotInternal->coord_tp, &emcmotStatus->carte_pos_cmd);
 } //handle_kinematicsSwitch()
 


### PR DESCRIPTION
Currently, when an external offset is present on an axis and the kinematics are switched, there is unexpected behavior where the commanded position stays the same, as well as the commanded offset, but the axis position is changed to account for the offset. 

This is unexpected because usually external offsets are kept separate from the axis position, but when the kinematics 
are switched, this is no longer the case. 

This results in the motion planner trying to move the axis back down to the commanded position from Gcode, but also trying to add back the commanded external offset. 

This causes strange oscillation depending on the external offset A/V ratio and the magnitude of the offset. 

This change makes the motion planner keep the same separation between external offset and commanded position as is seen in the rest of the code. 


Fixes #3207 
 
