### PR TITLE
Fix typos in configs/sim/axis directory

### DIFF
--- a/configs/sim/axis/plasma/plasmac2/migrate.py
+++ b/configs/sim/axis/plasma/plasmac2/migrate.py
@@ -151,7 +151,7 @@ class Migrate(Tk):
         title = _('Directory Name')
         msg1 = _('The new directory name will be')
         msg2 = _('If you change it to the same name as the QtPlasmaC config')
-        msg3 = _('then the QtPlasmaC config directory wil be renamed to:')
+        msg3 = _('then the QtPlasmaC config directory will be renamed to:')
         msg4 = _('Accept it or change it then accept')
         reply = Dialog(self, title, f"{msg1}: {newBase}\n\n{msg2}\n{msg3}\n{base}_qtplasmac\n\n{msg4}\n", buttons=2, entry=newBase).show()
         if reply == base:

--- a/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/README
+++ b/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/README
@@ -2,7 +2,7 @@ This is a simulation configuration for a 6 axis machine with one table rotary an
 
 This simulation also includes a python remap of Gcodes for tilted workplane (TWP) functionality.
 Both the kinematic and the twp remap support nutation of the secondary rotary joints (ie A or B ) form 0 to 90°. 
-Hence this also works for the 'usual' orthogonal spindle rotary-tilt type machines by seting the nutation angle to 90°.
+Hence this also works for the 'usual' orthogonal spindle rotary-tilt type machines by setting the nutation angle to 90°.
 
 Implemented TWP functionality:
 G68.2 : defines twp using euler-angles, pitch-roll-yaw, 2-vectors, 3 points, optionally with offset in XYZ and rotation in XY

--- a/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/python/remap.py
+++ b/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/python/remap.py
@@ -70,7 +70,7 @@ else:
     log.info('Joint letter for secondary is %s with MIN/MAX Limits: %s,%s', joint_letter_secondary, secondary_min_limit, secondary_max_limit)
 
 
-## CONECTIONS TO THE KINEMATIC COMPONENT
+## CONNECTIONS TO THE KINEMATIC COMPONENT
 # get the name of the kinematic component (this seems to ingest also the next line)
 kins_comp = (config['KINS']['KINEMATICS']).partition('\n')[0]
 # name of the hal pin that represents the nutation-angle
@@ -82,7 +82,7 @@ kins_primary_rotation = kins_comp + '_kins.primary-angle'
 # name of the hal pin that represents the secondary joint orientation angle
 kins_secondary_rotation = kins_comp + '_kins.secondary-angle'
 
-## CONECTIONS TO THE HELPER COMPONENT 
+## CONNECTIONS TO THE HELPER COMPONENT 
 twp_comp = 'twp-helper-comp.'
 twp_is_defined = twp_comp + 'twp-is-defined' 
 twp_is_active = twp_comp + 'twp-is-active' 
@@ -137,7 +137,7 @@ def kins_tool_transformation(theta_1, theta_2, pre_rot, matrix_in, direction='fw
         Rp = Ry(theta_1)
     elif joint_letter_primary == 'C':
         Rp = Rz(theta_1)
-    # add fourth colums on the right
+    # add fourth column on the right
     Rp = np.hstack((Rp, [[0],[0],[0]]))
     # expand to 4x4 array and make into a matrix
     row_4 = [0,0,0,1]
@@ -152,7 +152,7 @@ def kins_tool_transformation(theta_1, theta_2, pre_rot, matrix_in, direction='fw
         Rs = Ry(theta_2)
     elif joint_letter_secondary == 'C':
         Rs = Rz(theta_2)
-    # add fourth colums on the right
+    # add fourth column on the right
     Rs = np.hstack((Rs, [[0],[0],[0]]))
     # expand to 4x4 array and make into a matrix
     row_4 = [0,0,0,1]
@@ -243,7 +243,7 @@ def kins_calc_tool_rot_c_for_horizontal_x(self, theta_1, theta_2):
     return tc
 
 
-# calulates the secondary joint position for a given tool-vector
+# calculates the secondary joint position for a given tool-vector
 # secondary being the joint closest to the tool
 # Note: this uses functions derived from the custom kinematic
 def kins_calc_secondary(self, tool_z_req):
@@ -283,7 +283,7 @@ def kins_calc_secondary(self, tool_z_req):
     return [theta_2 , -theta_2]
 
 
-# calulates the primary joint position for a given tool-vector
+# calculates the primary joint position for a given tool-vector
 # Note: this uses functions derived from the custom kinematic
 def kins_calc_primary(self, tool_z_req, theta_2_list):
     global joint_letter_primary, joint_letter_secondary
@@ -379,7 +379,7 @@ def kins_calc_jnt_angles(self, tool_z_req):
             # rotate an identity matrix using the custom tool kinematic model and the (theta_1, theta_2)
             matrix_in = np.asmatrix(np.identity(4))
             t_out = kins_tool_transformation(theta_1_pair[i], theta_2_pair[j], 0, matrix_in,'inv')
-            # the resulting tool-z vector for this pair of (theta_1, theta_2) is found in the third collumn
+            # the resulting tool-z vector for this pair of (theta_1, theta_2) is found in the third column
             tool_z_would_be = np.array([t_out[0,2], t_out[1,2], t_out[2,2]])
             log.debug('tool_z_would_be: %s', tool_z_would_be)
             # calculate the difference of the respective elements
@@ -499,7 +499,7 @@ def calc_angle_pairs_and_distances(self, possible_prim_sec_angle_pairs):
 # For orient_mode=(1,2): If no move can be found within joint limits we return None
 def calc_optimal_joint_move(self, possible_prim_sec_angle_pairs):
     global orient_mode
-    # this retruns a list with all moves ((prim_move, sec_move),(prim_dist, sec_dist)) that
+    # this returns a list with all moves ((prim_move, sec_move),(prim_dist, sec_dist)) that
     # will result in correct tool orientation, stay within the rotary axis limits and respect the 
     # orient_mode if set by the operator
     valid_joint_moves_and_distances = calc_angle_pairs_and_distances(self, possible_prim_sec_angle_pairs)
@@ -511,7 +511,7 @@ def calc_optimal_joint_move(self, possible_prim_sec_angle_pairs):
         if orient_mode == 0 and fabs(dists[0]) < fabs(dist): # shortest move requested
             (theta_1, theta_2) = trgt_angles            
             dist = dists[0]
-        elif orient_mode == 1 and fabs(dists[0]) < fabs(dist) and dists[0] >= 0: # positve primary rotation only
+        elif orient_mode == 1 and fabs(dists[0]) < fabs(dist) and dists[0] >= 0: # positive primary rotation only
             (theta_1, theta_2) = trgt_angles            
             dist = dists[0]
         elif orient_mode == 2 and fabs(dists[0]) < fabs(dist) and dists[0] <= 0: # negative primary rotation only
@@ -535,7 +535,7 @@ def kins_calc_pre_rot(self, theta_1, theta_2, tool_x_req, tool_z_requested):
     # using the given joint angles and pre-rotation zero
     matrix_in = np.asmatrix(np.identity(4))
     t_out = kins_tool_transformation(theta_1, theta_2, 0, matrix_in,'inv')
-    # the tool-x vector for the given machine joint rotations is found directly in the first collumn
+    # the tool-x vector for the given machine joint rotations is found directly in the first column
     tool_x_is = [t_out[0,0], t_out[1,0], t_out[2,0]]
     log.debug("tool-x after machine rotation would be: %s", tool_x_is)
     # we calculate the angular difference between the two vectors so we can 'pre-rotate'
@@ -567,7 +567,7 @@ def kins_calc_pre_rot(self, theta_1, theta_2, tool_x_req, tool_z_requested):
             # using the given joint angles and pre-rotation angle in the list
             matrix_in = np.asmatrix(np.identity(4))
             t_out = kins_tool_transformation(theta_1, theta_2, pre_rot, matrix_in,'inv')
-            # the tool-x vector for the given primary and secondary rotations is found directly in the first collumn
+            # the tool-x vector for the given primary and secondary rotations is found directly in the first column
             tool_x_would_be = [t_out[0,0], t_out[1,0], t_out[2,0]]
             log.debug('tool_x_would_be: %s', tool_x_would_be)
             # calculate the difference of the respective elements
@@ -811,7 +811,7 @@ def g53x_core(self):
         # calculate all possible pairs of (primary, secondary) angles so our tool-z vector matches the requested tool-z
         # angles are returned in [-pi,pi]
         possible_prim_sec_angle_pairs = kins_calc_jnt_angles(self, tool_z_requested)
-    # An excepton will occur if the requested tool orientation cannot be achieved wtih the kinematic at hand 
+    # An excepton will occur if the requested tool orientation cannot be achieved with the kinematic at hand 
     except Exception as error:
         log.error('G53.x: Calculation failed, %s', error)
         possible_prim_sec_angle_pairs = []

--- a/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/python/twp-helper-comp.py
+++ b/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/python/twp-helper-comp.py
@@ -49,7 +49,7 @@ s = linuxcnc.stat()
 
 try:
     while 1:
-        # puplish twp-status
+        # publish twp-status
         if h['twp-status'] == 1:
             h['twp-is-defined'] = 1
             h['twp-is-active']  = 0

--- a/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/remap_subs/g69remap.ngc
+++ b/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/remap_subs/g69remap.ngc
@@ -3,7 +3,7 @@
 o<g69remap>sub
 M66 L0 E0       ; force sync, stop read ahead
 M469            ; call the python G69_core code
-M68 E3 Q0       ; switch to identiy kins            
+M68 E3 Q0       ; switch to identity kins            
 M68 E2 Q0       ; reset twp-state to 'undefined' (0) 
 G54             ; switch to G54            
 M66 L0 E0       ; force sync, stop read ahead

--- a/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/vismach/xyzacb-trsrn-gui.py
+++ b/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/vismach/xyzacb-trsrn-gui.py
@@ -124,7 +124,7 @@ class HalSpindleHousingZ(CylinderZ):
     def coords(self):
         r = 140
         length = c.pivot_z + 200
-        # start the spindle housing at hight 100 above the spindle nose
+        # start the spindle housing at height 100 above the spindle nose
         return length, r, 100, r
 
 # used to create the spindle rotary as set by the variable 'pivot_y'
@@ -147,7 +147,7 @@ class HalPivotZ(CylinderZ):
     def coords(self):
         r = 2
         length = c.pivot_z
-        # start the spindle housing at hight 100 above the spindle nose
+        # start the spindle housing at height 100 above the spindle nose
         return length, 1, 0, r
 
 # used to create an indicator for the variable 'pivot_y'

--- a/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/vismach/xyzbca-trsrn-gui.py
+++ b/configs/sim/axis/vismach/5axis/table-rotary_spindle-rotary-nutating/vismach/xyzbca-trsrn-gui.py
@@ -123,7 +123,7 @@ class HalSpindleHousingZ(CylinderZ):
     def coords(self):
         r = 140
         length = c.pivot_z + 200
-        # start the spindle housing at hight 100 above the spindle nose
+        # start the spindle housing at height 100 above the spindle nose
         return length, r, 100, r
 
 # used to create the spindle rotary as set by the variable 'pivot_x'
@@ -146,7 +146,7 @@ class HalPivotZ(CylinderZ):
     def coords(self):
         r = 2
         length = c.pivot_z
-        # start the spindle housing at hight 100 above the spindle nose
+        # start the spindle housing at height 100 above the spindle nose
         return length, 1, 0, r
 
 # used to create an indicator for the variable 'pivot_x'


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,*.pot,*.svg,*.ts,*.changes_es,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es,./src/hal/classicladder" -L abd,alle,ans,apoints,atleast,ba,breal,bu,bulle,busses,checke,childs,collet,comando,commutated,componentes,currenty,dashs,doubleclick,dout,dum,etxt,extint,faktor,finis,fo,fpr,halp,ihs,indx,ine,inout,inport,ist,leadin,momento,mot,nce,nome,oder,ontext,ot,parm,parms,propertys,realy,rin,ro,seh,sems,ser,serie,splitted,smoe,tabl,te,tey,tre,trough,ue,ure,usin,varn,vell,wille,wont,wonte`