### PR TITLE
Fix typos in Docs directory

### DIFF
--- a/docs/src/code/code-notes.adoc
+++ b/docs/src/code/code-notes.adoc
@@ -1082,7 +1082,7 @@ called by the NML read/write functions when the NML formatter is called --
 the pointer to the formatter will have been declared in the NML
 constructor at some point. By virtue of the linked lists NML creates,
 it is able to select cms pointer that is passed to the formatter and
-therefor which buffer is to be used.
+therefore which buffer is to be used.
 
 == Adding custom NML commands
 

--- a/docs/src/gui/qtvcp-code-snippets.adoc
+++ b/docs/src/gui/qtvcp-code-snippets.adoc
@@ -1023,7 +1023,7 @@ You must parse and define what is accepted and what to do with it.
 == Gcode to read qt preferences
 Here is how to create an Oword program to read a qtdragon preference file entry and add it as a gcode parameter +
 Calling this oword will update the param 'toolToLoad' +
-This uses 'Python hot comment' to comunicate with the embeded python instance. +
+This uses 'Python hot comment' to communicate with the embedded python instance. +
 See the Remap section of the Documents for a description.
 
 [source,{ngc}]

--- a/docs/src/gui/qtvcp-vismach.adoc
+++ b/docs/src/gui/qtvcp-vismach.adoc
@@ -133,12 +133,12 @@ c.newpin("joint1", hal.HAL_FLOAT, hal.HAL_IN)
 c.ready()
 ----
 
-You can choose this differents in the function that take these entries:
+You can select between the two options in the functions that take these entries:
 
   `hal_comp`;; The _HAL component Object_ or None. +
     In QtVCP if you are reading _system pins_ directly, then the component argument is set to `None`. +
   `hal_pin`;; The _name of the BIT HAL IN pin_ that will change the color. +
-    if hal_comp is 'None' then this must be the full name of a system pin other wise this is the pin name excluding the component name
+    if hal_comp is 'None' then this must be the full name of a system pin otherwise this is the pin name excluding the component name
 
 [[sec:qtvcp:vismach:parts]]
 == Creating Parts

--- a/docs/src/man/man9/kins.9.adoc
+++ b/docs/src/man/man9/kins.9.adoc
@@ -253,7 +253,7 @@ See matrixkins(9) man page for detailed instructions.
 === maxkins - 5-axis kinematics example
 
 Kinematics for Chris Radek's tabletop 5 axis mill named 'max' with
-tilting head (B axis) and horizintal rotary mounted to the table (C axis).
+tilting head (B axis) and horizontal rotary mounted to the table (C axis).
 Provides UVW motion in the rotated coordinate system.
 The source file, maxkins.c, may be a useful starting point for other 5-axis systems.
 

--- a/docs/src/motion/external-offsets.adoc
+++ b/docs/src/motion/external-offsets.adoc
@@ -322,7 +322,7 @@ are not acknowledged while a program is running.
 The opa.ini configuration uses the INI component eoffset_per_angle
 (*$ man eoffset_per_angle*) to demonstrate an XZC machine with functional
 offsets computed from the C coordinate (angle) and applied to
-the transvers (X) coordinate.  Offset computations are based on
+the transverse (X) coordinate.  Offset computations are based on
 a specified reference radius typically set by a program (or MDI)
 M68 command to control a *motion.analog-out-NN* pin.
 

--- a/docs/src/plasma/qtplasmac.adoc
+++ b/docs/src/plasma/qtplasmac.adoc
@@ -2499,7 +2499,7 @@ The following two custom layouts are used for soft key support:
 
 image::images/qtplasmac_numpad.png[caption="", title="Number keypad - used for the CONVERSATIONAL Tab and the PARAMETERS Tab",width=240,align="center"]
 
-image::images/qtplasmac_keypad.png[caption="", title="Alpha-numeric keypad - used for G-code editing and file management.",width=700,align="center"]
+image::images/qtplasmac_keypad.png[caption="", title="Alphanumeric keypad - used for G-code editing and file management.",width=700,align="center"]
 
 If the virtual keyboard has been repositioned and on the next opening of a virtual keyboard it is not visible, then clicking twice on the onboard icon in the system tray will reposition the virtual keyboard so the move handle is visible.
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,*.pot,*.svg,*.ts,*.changes_es,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es,./src/hal/classicladder" -L abd,alle,ans,apoints,atleast,ba,breal,bu,bulle,busses,checke,childs,collet,comando,commutated,componentes,currenty,dashs,doubleclick,dout,dum,etxt,extint,faktor,finis,fo,fpr,halp,ihs,indx,ine,inout,inport,ist,leadin,momento,mot,nce,nome,oder,ontext,ot,parm,parms,propertys,realy,rin,ro,seh,sems,ser,serie,splitted,smoe,tabl,te,tey,tre,trough,ue,ure,usin,varn,vell,wille,wont,wonte`