### PR TITLE
G70: format Q-number as int

### DIFF
--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -1050,7 +1050,7 @@ int Interp::convert_g7x(int mode,
     std::complex<double> start(z,x);
 
     auto exit_call_level=settings->call_level;
-    CHP(read((std::string("O")+std::to_string(block->q_number)+" CALL").c_str()));
+    CHP(read((std::string("O")+std::to_string(static_cast<int>(block->q_number))+" CALL").c_str()));
     for(;;) {
 	if(block->o_name!=0)
 	    CHP(convert_control_functions(block, settings));


### PR DESCRIPTION
std::to_string is locale dependant (except for int overloads), q_number is a double and can end up being formatted in a way O<num> CALL doesn't like, depending on locale settings. Cast to int (which is used elsewhere to store o-numbers) to avoid that. Should probably be unsigned.
 
fixes #3245 