### PR TITLE
Fix typos in src/hal directory

### DIFF
--- a/src/hal/components/panelui.c
+++ b/src/hal/components/panelui.c
@@ -219,11 +219,11 @@ int main(int argc, char **argv)
                      "pyui.update_funct =  pyui.master.keyboard.update\n"
                      "pyui.periodic_funct =  pyui.master.keyboard.periodic\n");
     if (vdbg == 1){
-        PyRun_SimpleString("pyui.intilize = pyui.instance.build(2)\n");
+        PyRun_SimpleString("pyui.instance.build(2)\n");
     }else if (dbg == 1){
-        PyRun_SimpleString("pyui.intilize = pyui.instance.build(1)\n");
+        PyRun_SimpleString("pyui.instance.build(1)\n");
     }else{
-        PyRun_SimpleString("pyui.intilize = pyui.instance.build(0)\n");
+        PyRun_SimpleString("pyui.instance.build(0)\n");
     }
     pModule = PyImport_ImportModule("pyui");
 

--- a/src/hal/components/plasmac.comp
+++ b/src/hal/components/plasmac.comp
@@ -55,7 +55,7 @@ pin in  bit     cut_recovery                "recover from cut error";
 pin in  float   cut_volts                   "cut voltage (volts)";
 pin in  bit     cutting_start               "start a new cut, connect to spindle.0.on";
 pin in  bit     debug_print                 "if true will print state changes as a debug aid";
-pin in  bit     dry_run                     "perfom a dry run without probing";
+pin in  bit     dry_run                     "perform a dry run without probing";
 pin in  bit     external_estop              "external E-stop input";
 pin in  float   feed_override               "feed override value from GUI (connect to halui.feed-override.value)";
 pin in  float   feed_reduction              "reduce adaptive feed to this percentage (connect to motion.analog-out-03)";

--- a/src/hal/components/toggle2nist.comp
+++ b/src/hal/components/toggle2nist.comp
@@ -70,7 +70,7 @@ FUNCTION(_)  {
             state = 0;
             debounce_cntr = 0;
         }
-    } else if ((!is_on && off) || (is_on && on)) { /* reset ouputs once device has switched*/
+    } else if ((!is_on && off) || (is_on && on)) { /* reset outputs once device has switched*/
         on = 0;
         off = 0;
         debounce_cntr = 0;

--- a/src/hal/components/xyzacb_trsrn.comp
+++ b/src/hal/components/xyzacb_trsrn.comp
@@ -23,7 +23,7 @@ static struct haldata {
   // Example pin pointers:
   hal_u32_t *in;
   hal_u32_t *out;
-  // thise should be parameters really but we want to be able to
+  // these should be parameters really but we want to be able to
   // change them for demonstration purposes
   hal_float_t *y_pivot;
   hal_float_t *z_pivot;

--- a/src/hal/components/xyzbca_trsrn.comp
+++ b/src/hal/components/xyzbca_trsrn.comp
@@ -23,7 +23,7 @@ static struct haldata {
   // Example pin pointers:
   hal_u32_t *in;
   hal_u32_t *out;
-  // thise should be parameters really but we want to be able to
+  // these should be parameters really but we want to be able to
   // change them for demonstration purposes
   hal_float_t *x_pivot;
   hal_float_t *z_pivot;

--- a/src/hal/drivers/mesa-hostmot2/rp1dev.h
+++ b/src/hal/drivers/mesa-hostmot2/rp1dev.h
@@ -26,7 +26,7 @@
  * - https://datasheets.raspberrypi.com/rp1/rp1-peripherals.pdf
  *
  * *** Note:
- * Lots of RP1 stuff is not used by the driver and is ommitted in the
+ * Lots of RP1 stuff is not used by the driver and is omitted in the
  * defines in this header file.
  */
 
@@ -373,7 +373,7 @@ typedef struct __dw_ssi_t {
 #define DW_SSI_IMR_MSTIM_BIT	5	/* multi-master contention interrupt mask */
 #define DW_SSI_IMR_RXFIM_BIT	4	/* receive fifo full interrupt mask */
 #define DW_SSI_IMR_RXOIM_BIT	3	/* receive fifi overflow interrupt mask */
-#define DW_SSI_IMR_RXUIM_BIT	2	/* receive fifo underfow interrupt mask */
+#define DW_SSI_IMR_RXUIM_BIT	2	/* receive fifo underflow interrupt mask */
 #define DW_SSI_IMR_TXOIM_BIT	1	/* transmit fifo overflow interrupt mask */
 #define DW_SSI_IMR_TXEIM_BIT	0	/* transmit fifo empty interrupt mask */
 #define DW_SSI_IMR_MSTIM		RP1BIT(DW_SSI_IMR_MSTIM_BIT)
@@ -386,7 +386,7 @@ typedef struct __dw_ssi_t {
 #define DW_SSI_ISR_MSTIS_BIT	5	/* multi-master contention interrupt status */
 #define DW_SSI_ISR_RXFIS_BIT	4	/* receive fifo full interrupt status */
 #define DW_SSI_ISR_RXOIS_BIT	3	/* receive fifi overflow interrupt status */
-#define DW_SSI_ISR_RXUIS_BIT	2	/* receive fifo underfow interrupt status */
+#define DW_SSI_ISR_RXUIS_BIT	2	/* receive fifo underflow interrupt status */
 #define DW_SSI_ISR_TXOIS_BIT	1	/* transmit fifo overflow interrupt status */
 #define DW_SSI_ISR_TXEIS_BIT	0	/* transmit fifo empty interrupt status */
 #define DW_SSI_ISR_MSTIS		RP1BIT(DW_SSI_ISR_MSTIS_BIT)
@@ -399,7 +399,7 @@ typedef struct __dw_ssi_t {
 #define DW_SSI_RISR_MSTIR_BIT	5	/* multi-master contention interrupt raw status */
 #define DW_SSI_RISR_RXFIR_BIT	4	/* receive fifo full interrupt raw status */
 #define DW_SSI_RISR_RXOIR_BIT	3	/* receive fifi overflow interrupt raw status */
-#define DW_SSI_RISR_RXUIR_BIT	2	/* receive fifo underfow interrupt raw status */
+#define DW_SSI_RISR_RXUIR_BIT	2	/* receive fifo underflow interrupt raw status */
 #define DW_SSI_RISR_TXOIR_BIT	1	/* transmit fifo overflow interrupt raw status */
 #define DW_SSI_RISR_TXEIR_BIT	0	/* transmit fifo empty interrupt raw status */
 #define DW_SSI_RISR_MSTIR		RP1BIT(DW_SSI_RISR_MSTIR_BIT)

--- a/src/hal/drivers/mesa-hostmot2/spix_rpi5.c
+++ b/src/hal/drivers/mesa-hostmot2/spix_rpi5.c
@@ -124,7 +124,7 @@ typedef struct __spisave_t {
 static spisave_t spi0save;	// Settings before our setup
 static spisave_t spi1save;
 static int has_spi_module;	// Set to non-zero when the kernel modules dw_spi and dw_spi_mmio are loaded
-static int driver_enabled;	// Set to non-zero ehen rpi5_setup() is successfully called
+static int driver_enabled;	// Set to non-zero when rpi5_setup() is successfully called
 static int port_probe_mask;	// Which ports are requested
 
 static void *peripheralmem = MAP_FAILED;	// mmap'ed peripheral memory

--- a/src/hal/user_comps/vismach/melfagui.py
+++ b/src/hal/user_comps/vismach/melfagui.py
@@ -114,7 +114,7 @@ link3 = HalRotate([link3],c,"joint2",1,0,1,0)
 link2 = Color([0.9,0.9,0.9,1],[link2])
 # combine the upper-arm-assembly to the shoulder = shoulder-assembly
 link2 = Collection([link3, link2])
-# translate the shoulder-assembly so joint1 rotaton is in the origin
+# translate the shoulder-assembly so joint1 rotation is in the origin
 link2 = Translate([link2], 85,0,111)
 # create HAL-link for Joint1 "Waist rotation"
 link2 = HalRotate([link2],c,"joint1",1,0,0,1)


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,*.pot,*.svg,*.ts,*.changes_es,./.git/logs,./share,./docs/man/es,./configs/attic,*_fr.*,*_es.*,README_es,./src/hal/classicladder" -L abd,alle,ans,apoints,atleast,ba,breal,bu,bulle,busses,checke,childs,collet,comando,commutated,componentes,currenty,dashs,doubleclick,dout,dum,etxt,extint,faktor,finis,fo,fpr,halp,ihs,indx,ine,inout,inport,ist,leadin,momento,mot,nce,nome,oder,ontext,ot,parm,parms,propertys,realy,rin,ro,seh,sems,ser,serie,splitted,smoe,tabl,te,tey,tre,trough,ue,ure,usin,varn,vell,wille,wont,wonte`


Quick question: I found these source typos  
https://github.com/LinuxCNC/linuxcnc/blob/c903ccd7e34ccb178bf301a16753094e9e451908/src/hal/components/panelui.c#L222-L226
(`intilize->initialize`) but didn't include them. Please advise.