### PR TITLE
Necessary include for gettimeofday() in debian:sid.

### DIFF
--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -40,7 +40,7 @@
   */
 
 
-
+#include <sys/time.h>
 
 #include <Python.h>
 #include <structmember.h>


### PR DESCRIPTION
The CI build for "package-arch debian:sid" started failing in src/emc/rs274ngc/gcodemodule.cc:854 in a call to gettimeofday(). A previous implicit include of sys/time.h apparently been (re)moved.

This PR includes sys/time.h so the CI build functions again.