### PR TITLE
Fix last 4 volatile warnings

### DIFF
--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -39,19 +39,19 @@ PyObject *to_python(bool b) {
     return PyBool_FromLong(b);
 }
 
-PyObject *to_python(hal_u32_t u) {
+PyObject *to_python(rtapi_u32 u) {
     return PyLong_FromUnsignedLong(u);
 }
 
-PyObject *to_python(hal_s32_t i) {
+PyObject *to_python(rtapi_s32 i) {
     return PyLong_FromLong(i);
 }
 
-PyObject *to_python(hal_u64_t u) {
+PyObject *to_python(rtapi_u64 u) {
     return PyLong_FromUnsignedLongLong(u);
 }
 
-PyObject *to_python(hal_s64_t i) {
+PyObject *to_python(rtapi_s64 i) {
     return PyLong_FromLongLong(i);
 }
 


### PR DESCRIPTION
There are a couple of volatile argument warnings not covered by #3240.
These are now also fixed using the underlying type. Funnily enough, two of the six functions already did so from the start (to_python(bool) and to_python(double)). This PR just brings them in line with each other and fixes the warnings.