### PR TITLE
Fix Py_UnbufferedStdioFlag deprecation warning

### DIFF
--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -326,8 +326,9 @@ PythonPlugin::PythonPlugin(struct _inittab *inittab) :
         }
       }
   }
-  Py_UnbufferedStdioFlag = 1;
-  Py_Initialize();
+  config.buffered_stdio = 0;
+  Py_InitializeFromConfig(&config);
+  PyConfig_Clear(&config);
   initialize();
 }
 


### PR DESCRIPTION
The use of Py_UnbufferedStdioFlag has been deprecated in python 3.12 (current debian:sid and other distros) and will be removed in 3.14. This PR fixes the warning (see also: #3203) and also fixes additional problems with the PyConfig code.

@rene-dev: The python documentation states that you need to use Py_InitializeFromConfig() when you change the PyConfig and you need to release the configuration with PyConfig_Clear() (see: https://docs.python.org/3.12/c-api/init_config.html#initialization-with-pyconfig).

Note: the merging #2487 to fix a previous deprecation warning introducing use of PyConfig caused all python versions lower than 3.8 to fail or anything older than Bullseye (see https://wiki.debian.org/Python). Therefore, no CPP conditional are placed around the code to support older distributions.

