### PR TITLE
Fix ignored qualifiers

### DIFF
--- a/src/emc/motion/axis.c
+++ b/src/emc/motion/axis.c
@@ -457,7 +457,7 @@ void axis_apply_ext_offsets_to_carte_pos(int extfactor, double *pcmd_p[])
     }
 }
 
-hal_bit_t axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bool all_homed)
+bool axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bool all_homed)
 {
     static int first_pass = 1;
     int n;

--- a/src/emc/motion/axis.h
+++ b/src/emc/motion/axis.h
@@ -14,7 +14,7 @@ void axis_initialize_external_offsets(void);
 int axis_init_hal_io(int mot_comp_id);
 
 void axis_handle_jogwheels(bool motion_teleop_flag, bool motion_enable_flag, bool homing_is_active);
-hal_bit_t axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bool all_homed);
+bool axis_plan_external_offsets(double servo_period, bool motion_enable_flag, bool all_homed);
 void axis_check_constraints(double pos[], int failing_axes[]);
 
 void axis_jog_cont(int axis_num, double vel, long servo_period);

--- a/src/emc/nml_intf/canon_position.cc
+++ b/src/emc/nml_intf/canon_position.cc
@@ -165,7 +165,7 @@ const CANON_POSITION CANON_POSITION::operator-(const EmcPose &o) const {
     return result;
 }
 
-const double CANON_POSITION::max() const{
+double CANON_POSITION::max() const{
     double res = x;
     res = fmax(res, this->y);
     res = fmax(res, this->z);

--- a/src/emc/nml_intf/canon_position.hh
+++ b/src/emc/nml_intf/canon_position.hh
@@ -58,7 +58,7 @@ struct CANON_POSITION {
 
     const CANON_POSITION abs() const;
     const CANON_POSITION absdiff(const CANON_POSITION &o) const;
-    const double max() const;
+    double max() const;
 
     const EmcPose toEmcPose() const;
 

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -87,7 +87,7 @@ bool from_python(PyObject *o, hal_u32_t *u) {
 
     l = PyLong_AsLongLong(tmp);
     if(PyErr_Occurred()) goto fail;
-    if(l < 0 || l != (hal_u32_t)l) {
+    if(l < 0 || l != (rtapi_u32)l) {
         PyErr_Format(PyExc_OverflowError, "Value %lld out of range", l);
         goto fail;
     }
@@ -108,7 +108,7 @@ bool from_python(PyObject *o, hal_s32_t *i) {
 
     l = PyLong_AsLongLong(tmp);
     if(PyErr_Occurred()) goto fail;
-    if(l != (hal_s32_t)l) {
+    if(l != (rtapi_s32)l) {
         PyErr_Format(PyExc_OverflowError, "Value %lld out of range", l);
         goto fail;
     }
@@ -129,7 +129,7 @@ bool from_python(PyObject *o, hal_u64_t *u) {
 
     l = PyLong_AsLongLong(tmp);
     if(PyErr_Occurred()) goto fail;
-    if(l < 0 || l != (hal_u64_t)l) {
+    if(l < 0 || l != (rtapi_u64)l) {
         PyErr_Format(PyExc_OverflowError, "Value %lld out of range", l);
         goto fail;
     }
@@ -150,7 +150,7 @@ bool from_python(PyObject *o, hal_s64_t *i) {
 
     l = PyLong_AsLongLong(tmp);
     if(PyErr_Occurred()) goto fail;
-    if(l != (hal_s64_t)l) {
+    if(l != (rtapi_s64)l) {
         PyErr_Format(PyExc_OverflowError, "Value %lld out of range", l);
         goto fail;
     }

--- a/src/hal/user_comps/xhc-whb04b-6/usb.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/usb.cc
@@ -135,7 +135,7 @@ uint16_t Usb::getUsbProductId() const
     return usbProductId;
 }
 // ----------------------------------------------------------------------
-const bool Usb::isDeviceOpen() const
+bool Usb::isDeviceOpen() const
 {
     return deviceHandle != nullptr;
 }

--- a/src/hal/user_comps/xhc-whb04b-6/usb.h
+++ b/src/hal/user_comps/xhc-whb04b-6/usb.h
@@ -280,7 +280,7 @@ public:
     ~Usb();
     uint16_t getUsbVendorId() const;
     uint16_t getUsbProductId() const;
-    const bool isDeviceOpen() const;
+    bool isDeviceOpen() const;
     libusb_context** getContextReference();
     libusb_context* getContext();
     void setContext(libusb_context* context);

--- a/src/libnml/inifile/inifile.cc
+++ b/src/libnml/inifile/inifile.cc
@@ -601,14 +601,14 @@ iniFind(FILE *fp, const char *tag, const char *section)
     return(f.Find(tag, section).value_or(nullptr));
 }
 
-extern "C" const int
+extern "C" int
 iniFindInt(FILE *fp, const char *tag, const char *section, int *result)
 {
     IniFile f(false, fp);
     return(f.Find(result, tag, section));
 }
 
-extern "C" const int
+extern "C" int
 iniFindDouble(FILE *fp, const char *tag, const char *section, double *result)
 {
     IniFile f(false, fp);

--- a/src/libnml/inifile/inifile.h
+++ b/src/libnml/inifile/inifile.h
@@ -26,8 +26,8 @@ extern "C"
 #endif
 
 extern const char *iniFind(FILE *fp, const char *tag, const char *section);
-extern const int iniFindInt(FILE *fp, const char *tag, const char *section, int *result);
-extern const int iniFindDouble(FILE *fp, const char *tag, const char *section, double *result);
+extern int iniFindInt(FILE *fp, const char *tag, const char *section, int *result);
+extern int iniFindDouble(FILE *fp, const char *tag, const char *section, double *result);
 extern int TildeExpansion(const char *file, char *path, size_t size);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Running the compile with <code>-Wignored-qualifiers</code> results in more warnings that indicate wrong types being used. This PR fixes two cases:
* ignored volatile qualifier on cast
* ignored const or volatile return qualifier

Returning const or volatile _values_ is inappropriate, just like casting a _value_ to volatile is inappropriate. The hal_X_t types are replaced with the underlying type and the const on return values is removed.

BTW, yes, I'm trying to eliminate <i>all</i> warnings from the compile.