### PR TITLE
Fix implicitly-declared 'constexpr...' warnings

### DIFF
--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -1342,10 +1342,11 @@ class EMC_TOOL_STAT_MSG:public RCS_STAT_MSG {
 class EMC_TOOL_STAT:public EMC_TOOL_STAT_MSG {
   public:
     EMC_TOOL_STAT();
+    EMC_TOOL_STAT(const EMC_TOOL_STAT &) = delete; // No copy constructor
 
     // For internal NML/CMS use only.
     void update(CMS * cms);
-    EMC_TOOL_STAT operator =(EMC_TOOL_STAT s);	// need this for [] members
+    EMC_TOOL_STAT& operator =(const EMC_TOOL_STAT &s);	// need this for [] members
 
     int pocketPrepped;		// idx ready for loading from
     int toolInSpindle;		// tool loaded, 0 is no tool

--- a/src/emc/nml_intf/emcops.cc
+++ b/src/emc/nml_intf/emcops.cc
@@ -196,7 +196,7 @@ EMC_COOLANT_STAT::EMC_COOLANT_STAT():EMC_COOLANT_STAT_MSG(EMC_COOLANT_STAT_TYPE,
 }
 
 // overload = , since class has array elements
-EMC_TOOL_STAT EMC_TOOL_STAT::operator =(EMC_TOOL_STAT s)
+EMC_TOOL_STAT& EMC_TOOL_STAT::operator =(const EMC_TOOL_STAT& s)
 {
     pocketPrepped = s.pocketPrepped; // idx
     toolInSpindle = s.toolInSpindle; // toolno
@@ -221,7 +221,7 @@ EMC_TOOL_STAT EMC_TOOL_STAT::operator =(EMC_TOOL_STAT s)
     toolTableCurrent = tdata;
 #endif //}
 
-    return s;
+    return *this;
 }
 
 EMC_STAT::EMC_STAT():EMC_STAT_MSG(EMC_STAT_TYPE, sizeof(EMC_STAT))

--- a/src/libnml/posemath/posemath.h
+++ b/src/libnml/posemath/posemath.h
@@ -95,7 +95,17 @@
 #define PM_REF
 #endif
 
+#if __cplusplus < 201103L
+/*
+ * Not required in C++11 and beyond. It will generate a warning:
+ *    "implicitly-declared 'constexpr ...' is deprecated [-Wdeprecated-copy]"
+ * If, somehow, somewhere, it is required, then you probably must implement
+ * both copy-constructor, destructor and operator= override (rule of three).
+ * Otherwise, if you do not have anything special in the members, then the
+ * compiler will do a good job at doing the right thing for you.
+ */
 #define INCLUDE_POSEMATH_COPY_CONSTRUCTORS
+#endif
 
 /* forward declarations-- conversion ctors will need these */
 


### PR DESCRIPTION
A couple of warnings are detected when adding <code>-Wdeprecated-copy</code>. Defining a copy-constructor in C++11 and beyond requires you to overload the operator= too, just as you probably need a destructor (rule-of-three).

This PR fixes the warnings for posemath by simply disabling the appropriate define.

The EMC_TOOL_STAT class had a strange operator= override, making a copy and then returning another copy. This has been fixed in the PR to use standard const reference as argument and returning the new object. It also blocks any use of the copy-constructor to be sure to use the right assignment code.