### PR TITLE
Gmoccapy 3.4.9 - several bugfixes for 2.9

### DIFF
--- a/lib/python/gladevcp/offsetpage.glade
+++ b/lib/python/gladevcp/offsetpage.glade
@@ -37,7 +37,7 @@
     </columns>
     <data>
       <row>
-        <col id="0" translatable="yes">Tool</col>
+        <col id="0">Tool</col>
         <col id="1">0</col>
         <col id="2">0</col>
         <col id="3">0</col>
@@ -71,7 +71,7 @@
         <col id="14">G5x</col>
       </row>
       <row>
-        <col id="0" translatable="yes">Rot</col>
+        <col id="0">Rot</col>
         <col id="1">0</col>
         <col id="2">0</col>
         <col id="3">0</col>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.glade
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.glade
@@ -799,14 +799,14 @@
                     <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkPaned" id="hbox2">
+                      <object class="GtkBox" id="hbox2">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="wide-handle">True</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkBox" id="vbox14">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
+                            <property name="margin-end">3</property>
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkNotebook" id="ntb_preview">
@@ -1238,8 +1238,9 @@
                             </child>
                           </object>
                           <packing>
-                            <property name="resize">True</property>
-                            <property name="shrink">True</property>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
@@ -1783,8 +1784,9 @@
                             </child>
                           </object>
                           <packing>
-                            <property name="resize">False</property>
-                            <property name="shrink">False</property>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                       </object>

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -3985,7 +3985,10 @@ class gmoccapy(object):
             widget.set_image(self.widgets.img_spindle_forward_on)
             self._set_spindle("forward")
         else:
-            self.widgets.rbt_forward.set_image(self.widgets.img_spindle_forward)
+            widget.set_image(self.widgets.img_spindle_forward)
+        # Toggling the sensitive property is important here! See the commit description.
+        widget.set_sensitive(not widget.get_sensitive())
+        widget.set_sensitive(not widget.get_sensitive())
 
     def on_rbt_reverse_clicked(self, widget, data=None):
         if widget.get_active():
@@ -3993,13 +3996,19 @@ class gmoccapy(object):
             self._set_spindle("reverse")
         else:
             widget.set_image(self.widgets.img_spindle_reverse)
+        # Toggling the sensitive property is important here! See the commit description.
+        widget.set_sensitive(not widget.get_sensitive())
+        widget.set_sensitive(not widget.get_sensitive())
 
     def on_rbt_stop_clicked(self, widget, data=None):
         if widget.get_active():
             widget.set_image(self.widgets.img_spindle_stop_on)
             self._set_spindle("stop")
         else:
-            self.widgets.rbt_stop.set_image(self.widgets.img_spindle_stop)
+            widget.set_image(self.widgets.img_spindle_stop)
+        # Toggling the sensitive property is important here! See the commit description.
+        widget.set_sensitive(not widget.get_sensitive())
+        widget.set_sensitive(not widget.get_sensitive())
 
     def _set_spindle(self, command):
         # if we are in estop state, we will have to leave here, otherwise
@@ -4012,18 +4021,6 @@ class gmoccapy(object):
         # be set to the commanded value due to the next code part
         if self.stat.task_mode != linuxcnc.MODE_MANUAL:
             if self.stat.interp_state == linuxcnc.INTERP_READING or self.stat.interp_state == linuxcnc.INTERP_WAITING:
-                if self.stat.spindle[0]['direction'] > 0:
-                    self.widgets.rbt_forward.set_sensitive(False)
-                    self.widgets.rbt_reverse.set_sensitive(True)
-                    self.widgets.rbt_stop.set_sensitive(True)
-                elif self.stat.spindle[0]['direction'] < 0:
-                    self.widgets.rbt_forward.set_sensitive(True)
-                    self.widgets.rbt_reverse.set_sensitive(False)
-                    self.widgets.rbt_stop.set_sensitive(True)
-                else:
-                    self.widgets.rbt_forward.set_sensitive(True)
-                    self.widgets.rbt_reverse.set_sensitive(True)
-                    self.widgets.rbt_stop.set_sensitive(False)
                 return
 
         rpm = self._check_spindle_range()

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -1960,7 +1960,7 @@ class gmoccapy(object):
                 except:
                     pass
         temp = 0
-        theme_name = self.prefs.getpref("Gtk_theme", "Follow System Theme", str)
+        theme_name = self.prefs.getpref("gtk_theme", "Follow System Theme", str)
         for index, theme in enumerate(themes):
             model.append((theme,))
             if theme == theme_name:
@@ -2206,7 +2206,7 @@ class gmoccapy(object):
         names = []
         default_names = self.widgets.offsetpage1.get_names()
         for system, name in default_names:
-            system_name = "system_name_{0}".format(system)
+            system_name = "system_name_{0}".format(system).lower()
             name = self.prefs.getpref(system_name, name, str)
             names.append([system, name])
         self.widgets.offsetpage1.set_names(names)
@@ -2327,7 +2327,7 @@ class gmoccapy(object):
         else:
             names = self.widgets.offsetpage1.get_names()
             for system, name in names:
-                system_name = "system_name_{0}".format(system)
+                system_name = "system_name_{0}".format(system).lower()
                 self.prefs.putpref(system_name, name)
             page.hide()
 
@@ -4405,7 +4405,7 @@ class gmoccapy(object):
         if active is None:
             return
         theme = widget.get_model()[active][0]
-        self.prefs.putpref('Gtk_theme', theme)
+        self.prefs.putpref("gtk_theme", theme)
         if theme == "Follow System Theme":
             theme = self.default_theme
         settings = Gtk.Settings.get_default()

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -2203,12 +2203,11 @@ class gmoccapy(object):
         self.widgets.offsetpage1.set_font("sans 12")
         self.widgets.offsetpage1.set_foreground_color(self._get_RGBA_color("#28D0D9"))
         self.widgets.offsetpage1.selection_mask = ("Tool", "G5x", "Rot")
-        systemlist = ["Tool", "G5x", "Rot", "G92", "G54", "G55", "G56", "G57", "G58", "G59", "G59.1",
-                      "G59.2", "G59.3"]
         names = []
-        for system in systemlist:
+        default_names = self.widgets.offsetpage1.get_names()
+        for system, name in default_names:
             system_name = "system_name_{0}".format(system)
-            name = self.prefs.getpref(system_name, system, str)
+            name = self.prefs.getpref(system_name, name, str)
             names.append([system, name])
         self.widgets.offsetpage1.set_names(names)
 

--- a/src/emc/usr_intf/gmoccapy/gmoccapy.py
+++ b/src/emc/usr_intf/gmoccapy/gmoccapy.py
@@ -76,7 +76,7 @@ sys.excepthook = excepthook
 
 # constants
 #         # gmoccapy  #"
-_RELEASE = " 3.4.8"
+_RELEASE = " 3.4.9"
 _INCH = 0                         # imperial units are active
 _MM = 1                           # metric units are active
 

--- a/src/emc/usr_intf/gmoccapy/release_notes.txt
+++ b/src/emc/usr_intf/gmoccapy/release_notes.txt
@@ -1,3 +1,8 @@
+ver 3.4.9
+- Fix problems with duplicated entries in the preferences file
+- Remove Gtk.Paned for upper main area (introduced in 3.4.0)
+- Fix wrong states of spindle button images after program abort
+
 ver 3.4.8
  - Remove some deprecation warnings (#3130)
  - Migrate to GtKSourceview 4 (#3083)


### PR DESCRIPTION
This fixes some annoying bugs in the current 2.9 release:
- Fix problems with duplicated entries in the preferences file (#3181)
- Remove Gtk.Paned for upper main area because this prevents one to lick the DRO axes letters on touch screens (https://www.forum.linuxcnc.org/gmoccapy/51526-unwanted-actions-with-a-touch-screen)
- Fix wrong states of spindle button images after program abort
