### PR TITLE
Fix transposed arguments in call to calloc()

### DIFF
--- a/src/hal/user_comps/xhc-hb04.cc
+++ b/src/hal/user_comps/xhc-hb04.cc
@@ -515,7 +515,7 @@ static void quit(int sig)
 static int hal_pin_simu(char *pin_name, void **ptr, int s)
 {
 	printf("Creating pin: %s\n", pin_name);
-	*ptr = calloc(s, 1);
+	*ptr = calloc(1, s);
 	return 0;
 }
 
@@ -585,7 +585,7 @@ static void hal_setup()
 		}
 	}
 	else {
-		xhc.hal = (xhc_hal_t *)calloc(sizeof(xhc_hal_t), 1);
+		xhc.hal = (xhc_hal_t *)calloc(1, sizeof(xhc_hal_t));
 	}
 
     r = 0;

--- a/src/libnml/os_intf/_shm.c
+++ b/src/libnml/os_intf/_shm.c
@@ -189,7 +189,7 @@ shm_t *rcs_shm_open(key_t key, size_t size, int oflag, /* int mode */ ...)
 	shmflg |= IPC_CREAT;
     }
 
-    shm = (shm_t *) calloc(sizeof(shm_t), 1);
+    shm = (shm_t *) calloc(1, sizeof(shm_t));
     if (NULL == shm) {
 	rcs_print_error("rcs_shm_open: calloc failed\n");
 	return NULL;


### PR DESCRIPTION
A call to calloc() uses the first argument as number of elements and the second as the size of an element. It is an often made mistake to exchange the arguments, even though the result is effectively the same, it is wrong and results in a warning.

This PR fixes the instances of transposed arguments.