### PR TITLE
Keyword static must come first in declaration

### DIFF
--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -308,7 +308,7 @@ static         int  uuid_mem_id = 0;
 int rtapi_init(const char *modname)
 {
     static uuid_data_t* uuid_data   = 0;
-    const static   int  uuid_id     = 0;
+    static const   int  uuid_id     = 0;
 
     static char* uuid_shmem_base = 0;
     int retval,id;


### PR DESCRIPTION
This PR fixes old style declaration. Modern C requires the static keyword to be the first.