### PR TITLE
Add format length limit to prevent format-truncation warning

### DIFF
--- a/src/emc/usr_intf/emclcd.cc
+++ b/src/emc/usr_intf/emclcd.cc
@@ -491,7 +491,7 @@ static int createWidgets()
   int i;
 
   for (i=0; i<WIDGET_COUNT; i++) {
-    snprintf(sockStr, sizeof(sockStr), "widget_add %s %s %s\n", widgets[i].screenName,
+    snprintf(sockStr, sizeof(sockStr), "widget_add %.20s %s %s\n", widgets[i].screenName,
       widgets[i].widgetName, typeStrs[widgets[i].type]);
     sockSendStr(sockfd, sockStr);
     switch (widgets[i].type) {


### PR DESCRIPTION
A spurious format truncation warning appears when extra warnings are enabled (using g++ 14.2.1). This might be a false positive, but is easily fixed by limiting the expansion size. All the names have a maximum length of 20 characters so limiting the expansion to that length should be fine.