### PR TITLE
Using std::move is redundant

### DIFF
--- a/src/emc/rs274ngc/interpmodule.cc
+++ b/src/emc/rs274ngc/interpmodule.cc
@@ -115,7 +115,7 @@ static bp::object errorStack(Interp &interp)
 
     for (int i = 0; i < settings->stack_index; i++)
 	msgs.append(bp::object( (const char *) settings->stack[i]));
-    return std::move(msgs);
+    return msgs;
 }
 
 static bp::object wrap_find_tool_pocket(Interp &interp, int toolno)


### PR DESCRIPTION
Using std:move on a (convertible) return value is redundant. The warning was exposed using g++ with -Wredundant-move and fixed in this PR.

(Note: this issue was addressed in C++ Core Issue 1579 ten years ago for C++14 and we are requiring C++17 or later. Both gcc and clang implement the resolution.)