### PR TITLE
Fix signed/unsigned comparison mismatches

### DIFF
--- a/src/emc/usr_intf/axis/extensions/togl.c
+++ b/src/emc/usr_intf/axis/extensions/togl.c
@@ -154,7 +154,7 @@ static LRESULT (CALLBACK *tkWinChildProc)(HWND hwnd, UINT message,
 
 /* The constant DUMMY_WINDOW is used to signal window creation 
    failure from the Togl_CreateWindow() */
-#define DUMMY_WINDOW -1
+#define DUMMY_WINDOW ((Window)-1)
 
 #define ALL_EVENTS_MASK 	\
    (KeyPressMask |		\

--- a/src/emc/usr_intf/sockets.c
+++ b/src/emc/usr_intf/sockets.c
@@ -138,7 +138,7 @@ int sockPrintf(int fd, const char *format, .../*args*/ )
     rcs_print_error("sock_printf: vsnprintf failed\n");
     return -1;
     }
-  if (size > sizeof(buf)) {
+  if (size > (int)sizeof(buf)) {
     rcs_print_error("sock_printf: vsnprintf truncated message\n");
     }
   return sockSendString(fd, buf);
@@ -182,7 +182,7 @@ int sockRecvString(int fd, char *dest, size_t maxlen)
     recvBytes++;
 
     // stop at max. bytes allowed, at NUL or at LF
-    if (recvBytes == maxlen || *ptr == '\0' || *ptr == '\n') {
+    if (recvBytes == (int)maxlen || *ptr == '\0' || *ptr == '\n') {
       *ptr = '\0';
       break;
       }
@@ -193,7 +193,7 @@ int sockRecvString(int fd, char *dest, size_t maxlen)
   if (recvBytes == 1 && dest[0] == '\0')
     return 0;
 
-  if (recvBytes < maxlen - 1)
+  if (recvBytes < (int)maxlen - 1)
     dest[recvBytes] = '\0';
 
   return recvBytes;
@@ -202,7 +202,7 @@ int sockRecvString(int fd, char *dest, size_t maxlen)
 // Send/receive raw data
 int sockSend(int fd, const void *src, size_t size)
 {
-  int offset = 0;
+  size_t offset = 0;
 
   if (!src) return -1;
 
@@ -210,9 +210,9 @@ int sockSend(int fd, const void *src, size_t size)
     // write isn't guaranteed to send the entire string at once,
     // so we have to sent it in a loop like this
 #ifndef WINSOCK2
-    int sent = write(fd, ((const char *) src) + offset, size - offset);
+    ssize_t sent = write(fd, ((const char *) src) + offset, size - offset);
 #else
-    int sent = send(fd, ((const char *) src) + offset, size - offset, 0);
+    ssize_t sent = send(fd, ((const char *) src) + offset, size - offset, 0);
 #endif
     if (sent == -1) {
       if (errno != EAGAIN) {
@@ -226,7 +226,7 @@ int sockSend(int fd, const void *src, size_t size)
     offset += sent;
     } // while
 
-  return offset;
+  return (int)offset;
 }
 
 int sockRecv(int fd, void *dest, size_t maxlen)
@@ -317,7 +317,7 @@ int sockPrintfError(int fd, const char *format, .../*args*/ )
     rcs_print_error("sock_printf_error: vsnprintf failed\n");
     return -1;
     }
-  if (size >= sizeof(buf) - (sizeof(huh)-1)) {
+  if (size >= (int)(sizeof(buf) - (sizeof(huh)-1))) {
     rcs_print_error("sock_printf_error: vsnprintf truncated message\n");
     }
 

--- a/src/hal/classicladder/socket_modbus_master.c
+++ b/src/hal/classicladder/socket_modbus_master.c
@@ -60,8 +60,8 @@
 HANDLE ThreadHandleClient = NULL;
 DWORD ThreadIdClient;
 #else
-#define SOCK_FD unsigned int
-#define SOCK_INVALID -1
+#define SOCK_FD int
+#define SOCK_INVALID (-1)
 pthread_t thread_socket_client;
 #endif
 

--- a/src/hal/classicladder/socket_server.c
+++ b/src/hal/classicladder/socket_server.c
@@ -56,8 +56,8 @@
 HANDLE ThreadHandle = NULL;
 DWORD ThreadId;
 #else
-#define SOCK_FD unsigned int
-#define SOCK_INVALID -1
+#define SOCK_FD int
+#define SOCK_INVALID (-1)
 pthread_t thread_socket_server;
 #endif
 

--- a/src/hal/hal.h
+++ b/src/hal/hal.h
@@ -959,7 +959,7 @@ typedef struct {
 
 #define HAL_STREAM_MAX_PINS (21)
 /** create and attach a stream */
-extern int hal_stream_create(hal_stream_t *stream, int comp, int key, int depth, const char *typestring);
+extern int hal_stream_create(hal_stream_t *stream, int comp, int key, unsigned depth, const char *typestring);
 /** detach and destroy an open stream */
 extern void hal_stream_destroy(hal_stream_t *stream);
 
@@ -976,7 +976,7 @@ extern hal_type_t hal_stream_element_type(hal_stream_t *stream, int idx);
 extern int hal_stream_read(hal_stream_t *stream, union hal_stream_data *buf, unsigned *sampleno);
 extern bool hal_stream_readable(hal_stream_t *stream);
 extern int hal_stream_depth(hal_stream_t *stream);
-extern int hal_stream_maxdepth(hal_stream_t *stream);
+extern unsigned hal_stream_maxdepth(hal_stream_t *stream);
 extern int hal_stream_num_underruns(hal_stream_t *stream);
 extern int hal_stream_num_overruns(hal_stream_t *stream);
 #ifdef ULAPI

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -4111,7 +4111,7 @@ int halpr_parse_types(hal_type_t type[HAL_STREAM_MAX_PINS], const char *cfg)
     return n;
 }
 
-int hal_stream_create(hal_stream_t *stream, int comp, int key, int depth, const char *typestring)
+int hal_stream_create(hal_stream_t *stream, int comp, int key, unsigned depth, const char *typestring)
 {
     int result = 0;
     hal_type_t type[HAL_STREAM_MAX_PINS];
@@ -4144,13 +4144,13 @@ extern void hal_stream_destroy(hal_stream_t *stream)
     hal_stream_detach(stream);
 }
 
-static int hal_stream_advance(hal_stream_t *stream, int n) {
+static unsigned hal_stream_advance(hal_stream_t *stream, unsigned n) {
     n = n + 1;
     if(n >= stream->fifo->depth) n = 0;
     return n;
 }
 
-static int hal_stream_newin(hal_stream_t *stream) {
+static unsigned hal_stream_newin(hal_stream_t *stream) {
     return hal_stream_advance(stream, stream->fifo->in);
 }
 
@@ -4170,7 +4170,7 @@ int hal_stream_depth(hal_stream_t *stream) {
     return result;
 }
 
-int hal_stream_maxdepth(hal_stream_t *stream) {
+unsigned hal_stream_maxdepth(hal_stream_t *stream) {
     return stream->fifo->depth;
 }
 
@@ -4280,7 +4280,7 @@ int hal_stream_attach(hal_stream_t *stream, int comp_id, int key, const char *ty
         }
     }
     /* now use data in fifo structure to calculate proper shmem size */
-    int depth = fifo->depth;
+    unsigned depth = fifo->depth;
     int pin_count = fifo->num_pins;
     size_t size = sizeof(struct hal_stream_shm) + sizeof(union hal_stream_data) * depth * (1+pin_count);
     /* close shmem, re-open with proper size */

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -493,11 +493,11 @@ extern int hal_port_alloc(unsigned size, hal_port_t *port);
 
 #define HAL_STREAM_MAGIC_NUM		0x4649464F
 struct hal_stream_shm {
-    unsigned int magic;
-    volatile unsigned int in;
-    volatile unsigned int out;
+    unsigned magic;
+    volatile unsigned in;
+    volatile unsigned out;
     unsigned this_sample;
-    int depth;
+    unsigned depth;
     int num_pins;
     unsigned long num_overruns, num_underruns;
     hal_type_t type[HAL_STREAM_MAX_PINS];

--- a/src/hal/user_comps/gs2_vfd.c
+++ b/src/hal/user_comps/gs2_vfd.c
@@ -168,7 +168,8 @@ static void quit(int sig) {
 static int comm_delay = 0; // JET delay counter for at-speed
 
 int match_string(char *string, char **matches) {
-    int len, which, match;
+    size_t len;
+    int which, match;
     which=0;
     match=-1;
     if ((matches==NULL) || (string==NULL)) return -1;

--- a/src/hal/user_comps/huanyang-vfd/hy_vfd.c
+++ b/src/hal/user_comps/huanyang-vfd/hy_vfd.c
@@ -179,7 +179,8 @@ static char *ratestrings[] = {"110", "300", "600", "1200", "2400", "4800", "9600
 static char *stopstrings[] = {"1", "2", NULL};
 
 int match_string(char *string, char **matches) {
-	int len, which, match;
+	size_t len;
+	int which, match;
 	which=0;
 	match=-1;
 	if ((matches==NULL) || (string==NULL)) return -1;

--- a/src/hal/user_comps/hy_gt_vfd.c
+++ b/src/hal/user_comps/hy_gt_vfd.c
@@ -122,7 +122,8 @@ static void quit(int sig) {
 
 
 int match_string(char *string, char **matches) {
-    int len, which, match;
+    size_t len;
+    int which, match;
     which=0;
     match=-1;
     if ((matches==NULL) || (string==NULL)) return -1;

--- a/src/hal/user_comps/mb2hal/mb2hal_init.c
+++ b/src/hal/user_comps/mb2hal/mb2hal_init.c
@@ -354,7 +354,7 @@ retCode parse_transaction_section(const int mb_tx_num)
                 break;
             }
         }
-        int max = gbl.version<1001?mbtx_01_READ_COILS:mbtxMAX;
+        mb_tx_fnct max = gbl.version<1001?mbtx_01_READ_COILS:mbtxMAX;
         if (this_mb_tx->mb_tx_fnct <= mbtxERR || this_mb_tx->mb_tx_fnct >= max) {
             ERR(gbl.init_dbg, "[%s] [%s] [%s] out of range", section, tag, tmpstr);
             return retERR;

--- a/src/hal/user_comps/sendkeys.c
+++ b/src/hal/user_comps/sendkeys.c
@@ -271,7 +271,7 @@ int main(int argc, char* argv[]) {
             }
             if (*hal->keycode != param->oldcode) {
                 /* Key press, report the event, send key release, and report again*/
-                if ((*hal->keycode & 0x3F) > param->num_events) continue;
+                if ((int)(*hal->keycode & 0x3F) > param->num_events) continue;
                 if (hal->event[*hal->keycode & 0x3F] == 0) continue;
                 if ((*hal->keycode & 0xC0) == 0xC0){ // keydown
                     emit(param->fd, EV_KEY, hal->event[*hal->keycode & 0x3F], 1);

--- a/src/hal/user_comps/shuttle.c
+++ b/src/hal/user_comps/shuttle.c
@@ -217,7 +217,7 @@ struct shuttle *check_for_shuttle(char *dev_filename) {
         goto fail1;
     }
 
-    for (int i = 0; i < sizeof(contour_dev)/sizeof(contour_dev_t); i ++) {
+    for (unsigned i = 0; i < sizeof(contour_dev)/sizeof(contour_dev_t); i ++) {
         if (devinfo.vendor != contour_dev[i].vendor_id) {
             continue;
         }

--- a/src/hal/user_comps/svd-ps_vfd.c
+++ b/src/hal/user_comps/svd-ps_vfd.c
@@ -114,7 +114,8 @@ static void quit(int sig) {
 
 
 int match_string(char *string, char **matches) {
-    int len, which, match;
+    size_t len;
+    int which, match;
     which=0;
     match=-1;
     if ((matches==NULL) || (string==NULL)) return -1;

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -748,7 +748,7 @@ static int replace_vars(char *source_str, char *dest_str, int max_chars, char **
 		if (*sp=='(') {		/* look for a parenthesized var */
 		    varP=++sp;
 		    next_delim=strcspn(varP, ")");
-		    if (next_delim >= strlen(varP))	/* error - no matching parens */
+		    if (next_delim >= (int)strlen(varP))	/* error - no matching parens */
 			return -1;
 		    sp++;
 		} else next_delim = strspn(varP, words);
@@ -773,7 +773,7 @@ static int replace_vars(char *source_str, char *dest_str, int max_chars, char **
 	    case '[':
 		secP = sp;
 		next_delim = strcspn(secP, "]");
-		if (next_delim >= strlen(secP))	/* error - no matching square bracket */
+		if (next_delim >= (int)strlen(secP))	/* error - no matching square bracket */
 		    return -3;
 		if (next_delim > 127)		/* section name too long */
 		    return -7;
@@ -784,7 +784,7 @@ static int replace_vars(char *source_str, char *dest_str, int max_chars, char **
 		if (*sp=='(') {		/* look for a parenthesized var */
 		    varP=++sp;
 		    next_delim=strcspn(varP, ")");
-		    if (next_delim > strlen(varP))	/* error - no matching parens */
+		    if (next_delim > (int)strlen(varP))	/* error - no matching parens */
 			return -1;
 		    sp++;
 		} else next_delim = strspn(varP, words);

--- a/src/hal/utils/halcmd_completion.c
+++ b/src/hal/utils/halcmd_completion.c
@@ -136,7 +136,7 @@ static int writer_match(hal_pin_dir_t dir, int writers) {
 
 static void check_match_type_pin(const char *name) {
     int next = hal_data->pin_list_ptr;
-    int sz = strcspn(name, " \t");
+    size_t sz = strcspn(name, " \t");
 
     while(next) {
         hal_pin_t *pin = SHMPTR(next);
@@ -151,7 +151,7 @@ static void check_match_type_pin(const char *name) {
 
 static void check_match_type_signal(const char *name) {
     int next = hal_data->sig_list_ptr;
-    int sz = strcspn(name, " \t");
+    size_t sz = strcspn(name, " \t");
 
     while(next) {
         hal_sig_t *sig = SHMPTR(next);

--- a/src/hal/utils/meter.c
+++ b/src/hal/utils/meter.c
@@ -177,10 +177,10 @@ int main(int argc, gchar * argv[])
             n++;
             if ( argc > n ){
                 rtapi_strxcpy(buf,argv[n]);
-                for (i=0; i< strlen(argv[n]); i++) {
+                for (i=0; i< (int)strlen(argv[n]); i++) {
                     if (isdigit(buf[i]) == 0) { break; } 
                 }
-                if (strlen(argv[n]) == i){
+                if ((int)strlen(argv[n]) == i){
                     width =  atoi(argv[n]);
                     n++;
                 }

--- a/src/hal/utils/scope.c
+++ b/src/hal/utils/scope.c
@@ -413,14 +413,10 @@ void capture_complete(void)
 
 static void init_usr_control_struct(void *shmem)
 {
-    char *cp;
     int n, skip;
 
     /* first clear entire user struct to all zeros */
-    cp = (char *) ctrl_usr;
-    for (n = 0; n < sizeof(scope_usr_control_t); n++) {
-	cp[n] = 0;
-    }
+    memset(ctrl_usr, 0, sizeof(scope_usr_control_t));
 
     /* save pointer to shared control structure */
     ctrl_shm = shmem;

--- a/src/module_helper/module_helper.c
+++ b/src/module_helper/module_helper.c
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
     }
 
     res = snprintf(buf, sizeof(buf), "/usr/realtime-%s/modules", u.release);
-    if(res < 0 || res >= sizeof(buf))
+    if(res < 0 || res >= (int)sizeof(buf))
     {
         perror("snprintf");
         return 1;

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -29,7 +29,7 @@
 
 #include <rtapi_errno.h>
 #include <rtapi_mutex.h>
-static int msg_level = RTAPI_MSG_ERR;	/* message printing level */
+static msg_level_t msg_level = RTAPI_MSG_ERR;	/* message printing level */
 
 #include <sys/ipc.h>		/* IPC_* */
 #include <sys/shm.h>		/* shmget() */
@@ -275,7 +275,7 @@ int rtapi_vsnprintf(char *buffer, unsigned long int size, const char *fmt,
 }
 
 int rtapi_set_msg_level(int level) {
-    msg_level = level;
+    msg_level = (msg_level_t)level;
     return 0;
 }
 


### PR DESCRIPTION
Many places had unclear distinction between signed and unsigned types. This results in comparisons that are potentially wrong. This PR fixes all problems identifies when compiling with -Wsign-compare.

Where possible, types were changes to match the actual code. Only few places required explicit casting. The code was not functionally changed, although some places could use a caring hand. But that is for another PR.