### PR TITLE
Fix missing field initializers

### DIFF
--- a/src/emc/kinematics/lineardeltakins.cc
+++ b/src/emc/kinematics/lineardeltakins.cc
@@ -34,7 +34,7 @@ static object forward(double j0, double j1, double j2)
 static object inverse(double x, double y, double z)
 {
     double joints[9];
-    EmcPose pos = {{x,y,z}};
+    EmcPose pos = {{x,y,z}, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     int result = kinematics_inverse(&pos, joints);
     if(result == 0)
         return make_tuple(joints[0], joints[1], joints[2]);

--- a/src/emc/kinematics/rotarydeltakins.cc
+++ b/src/emc/kinematics/rotarydeltakins.cc
@@ -33,7 +33,7 @@ static object forward(double j0, double j1, double j2)
 static object inverse(double x, double y, double z)
 {
     double joints[9];
-    EmcPose pos = {{x,y,z}};
+    EmcPose pos = {{x,y,z}, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     int result = kinematics_inverse(&pos, joints);
     if(result == 0)
         return make_tuple(joints[0], joints[1], joints[2]);

--- a/src/emc/kinematics/ugenserkins.c
+++ b/src/emc/kinematics/ugenserkins.c
@@ -32,8 +32,8 @@ int main(int argc, char *argv[])
     char buffer[BUFFERLEN];
     int inverse = 1;
     int jacobian = 0;
-    EmcPose pos = { {0.0, 0.0, 0.0}, 0.0, 0.0, 0.0 };
-    EmcPose vel = { {0.0, 0.0, 0.0}, 0.0, 0.0, 0.0 }; // will need this for
+    EmcPose pos = { {0.0, 0.0, 0.0}, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+    EmcPose vel = { {0.0, 0.0, 0.0}, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 }; // will need this for
                                                       // jacobian
     double joints[6] = { 0.0 };
     double jointvels[6] = { 0.0 };

--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -89,35 +89,35 @@ static PyObject *LineCode_mcodes(LineCode *l) {
 }
 
 static PyGetSetDef LineCodeGetSet[] = {
-    {(char*)"gcodes", (getter)LineCode_gcodes},
-    {(char*)"mcodes", (getter)LineCode_mcodes},
-    {NULL, NULL},
+    {(char*)"gcodes", (getter)LineCode_gcodes, NULL, NULL, NULL},
+    {(char*)"mcodes", (getter)LineCode_mcodes, NULL, NULL, NULL},
+    {},
 };
 
 static PyMemberDef LineCodeMembers[] = {
-    {(char*)"sequence_number", T_INT, offsetof(LineCode, gcodes[0]), READONLY},
+    {(char*)"sequence_number", T_INT, offsetof(LineCode, gcodes[0]), READONLY, NULL},
 
-    {(char*)"feed_rate", T_DOUBLE, offsetof(LineCode, settings[1]), READONLY},
-    {(char*)"speed", T_DOUBLE, offsetof(LineCode, settings[2]), READONLY},
-    {(char*)"motion_mode", T_INT, offsetof(LineCode, gcodes[1]), READONLY},
-    {(char*)"block", T_INT, offsetof(LineCode, gcodes[2]), READONLY},
-    {(char*)"plane", T_INT, offsetof(LineCode, gcodes[3]), READONLY},
-    {(char*)"cutter_side", T_INT, offsetof(LineCode, gcodes[4]), READONLY},
-    {(char*)"units", T_INT, offsetof(LineCode, gcodes[5]), READONLY},
-    {(char*)"distance_mode", T_INT, offsetof(LineCode, gcodes[6]), READONLY},
-    {(char*)"feed_mode", T_INT, offsetof(LineCode, gcodes[7]), READONLY},
-    {(char*)"origin", T_INT, offsetof(LineCode, gcodes[8]), READONLY},
-    {(char*)"tool_length_offset", T_INT, offsetof(LineCode, gcodes[9]), READONLY},
-    {(char*)"retract_mode", T_INT, offsetof(LineCode, gcodes[10]), READONLY},
-    {(char*)"path_mode", T_INT, offsetof(LineCode, gcodes[11]), READONLY},
+    {(char*)"feed_rate", T_DOUBLE, offsetof(LineCode, settings[1]), READONLY, NULL},
+    {(char*)"speed", T_DOUBLE, offsetof(LineCode, settings[2]), READONLY, NULL},
+    {(char*)"motion_mode", T_INT, offsetof(LineCode, gcodes[1]), READONLY, NULL},
+    {(char*)"block", T_INT, offsetof(LineCode, gcodes[2]), READONLY, NULL},
+    {(char*)"plane", T_INT, offsetof(LineCode, gcodes[3]), READONLY, NULL},
+    {(char*)"cutter_side", T_INT, offsetof(LineCode, gcodes[4]), READONLY, NULL},
+    {(char*)"units", T_INT, offsetof(LineCode, gcodes[5]), READONLY, NULL},
+    {(char*)"distance_mode", T_INT, offsetof(LineCode, gcodes[6]), READONLY, NULL},
+    {(char*)"feed_mode", T_INT, offsetof(LineCode, gcodes[7]), READONLY, NULL},
+    {(char*)"origin", T_INT, offsetof(LineCode, gcodes[8]), READONLY, NULL},
+    {(char*)"tool_length_offset", T_INT, offsetof(LineCode, gcodes[9]), READONLY, NULL},
+    {(char*)"retract_mode", T_INT, offsetof(LineCode, gcodes[10]), READONLY, NULL},
+    {(char*)"path_mode", T_INT, offsetof(LineCode, gcodes[11]), READONLY, NULL},
 
-    {(char*)"stopping", T_INT, offsetof(LineCode, mcodes[1]), READONLY},
-    {(char*)"spindle", T_INT, offsetof(LineCode, mcodes[2]), READONLY},
-    {(char*)"toolchange", T_INT, offsetof(LineCode, mcodes[3]), READONLY},
-    {(char*)"mist", T_INT, offsetof(LineCode, mcodes[4]), READONLY},
-    {(char*)"flood", T_INT, offsetof(LineCode, mcodes[5]), READONLY},
-    {(char*)"overrides", T_INT, offsetof(LineCode, mcodes[6]), READONLY},
-    {NULL}
+    {(char*)"stopping", T_INT, offsetof(LineCode, mcodes[1]), READONLY, NULL},
+    {(char*)"spindle", T_INT, offsetof(LineCode, mcodes[2]), READONLY, NULL},
+    {(char*)"toolchange", T_INT, offsetof(LineCode, mcodes[3]), READONLY, NULL},
+    {(char*)"mist", T_INT, offsetof(LineCode, mcodes[4]), READONLY, NULL},
+    {(char*)"flood", T_INT, offsetof(LineCode, mcodes[5]), READONLY, NULL},
+    {(char*)"overrides", T_INT, offsetof(LineCode, mcodes[6]), READONLY, NULL},
+    {}
 };
 
 static PyTypeObject LineCodeType = {
@@ -162,6 +162,20 @@ static PyTypeObject LineCodeType = {
     PyType_GenericNew,      /*tp_new*/
     0,                      /*tp_free*/
     0,                      /*tp_is_gc*/
+    0,                      /*tp_bases*/
+    0,                      /*tp_mro*/
+    0,                      /*tp_cache*/
+    0,                      /*tp_subclasses*/
+    0,                      /*tp_weaklink*/
+    0,                      /*tp_del*/
+    0,                      /*tp_version_tag*/
+    0,                      /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                      /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                      /*tp_watched*/
+#endif
+#endif
 };
 
 static PyObject *callback;
@@ -649,7 +663,7 @@ void GET_EXTERNAL_PARAMETER_FILE_NAME(char *name, int max_size) {
 }
 CANON_UNITS GET_EXTERNAL_LENGTH_UNIT_TYPE() { return CANON_UNITS_INCHES; }
 CANON_TOOL_TABLE GET_EXTERNAL_TOOL_TABLE(int pocket) {
-    CANON_TOOL_TABLE tdata = {-1,-1,{{0,0,0},0,0,0,0,0,0},0,0,0,0};
+    CANON_TOOL_TABLE tdata = {-1,-1,{{0,0,0},0,0,0,0,0,0},0,0,0,0,{}};
     if(interp_error) return tdata;
     PyObject *result =
         callmethod(callback, "get_tool", "i", pocket);
@@ -1168,7 +1182,7 @@ static PyMethodDef gcode_methods[] = {
         "Calculate information about extents of gcode"},
     {"arc_to_segments", (PyCFunction)rs274_arc_to_segments, METH_VARARGS,
         "Convert an arc to straight segments"},
-    {NULL}
+    {}
 };
 
 static struct PyModuleDef gcode_moduledef = {
@@ -1176,7 +1190,11 @@ static struct PyModuleDef gcode_moduledef = {
     "gcode",                                  /* m_name    */
     "Interface to EMC rs274ngc interpreter",  /* m_doc     */
     -1,                                       /* m_size    */
-    gcode_methods                             /* m_methods */
+    gcode_methods,                            /* m_methods */
+    NULL,                                     /* m_slots   */
+    NULL,                                     /* m_traverse*/
+    NULL,                                     /* m_clear   */
+    NULL,                                     /* m_free    */
 };
 
 PyMODINIT_FUNC PyInit_gcode(void);

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -3315,7 +3315,7 @@ int main(int argc, char *argv[])
     }
 
     // create EMC2_TMP_DIR if it's not existing, yet
-    struct stat s = {0};
+    struct stat s;
     if (stat(EMC2_TMP_DIR, &s) != 0) {
         if(mkdir(EMC2_TMP_DIR, 0700) != 0) {
 		rcs_print_error("mkdir(%s): %s", EMC2_TMP_DIR, strerror(errno));

--- a/src/emc/usr_intf/axis/extensions/_toglmodule.c
+++ b/src/emc/usr_intf/axis/extensions/_toglmodule.c
@@ -69,11 +69,15 @@ PyMethodDef togl_methods[] = {
 };
 
 static struct PyModuleDef togl_moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_togl",
-    "togl extension for Tkinter",
-    -1,
-    togl_methods
+    PyModuleDef_HEAD_INIT, /* m_base */
+    "_togl",               /* m_name */
+    "togl extension for Tkinter", /* m_doc */
+    -1,                    /* m_size */
+    togl_methods,          /* m_methods */
+    NULL,                  /* m_slots */
+    NULL,                  /* m_traverse */
+    NULL,                  /* m_clear */
+    NULL,                  /* m_free */
 };
 
 PyMODINIT_FUNC PyInit__togl(void);

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -155,7 +155,7 @@ static PyMethodDef Ini_methods[] = {
     {"findall", (PyCFunction)Ini_findall, METH_VARARGS,
         "Find value in inifile as a list.  This uses the ConfigParser-style "
         "(section,option) order, not the linuxcnc order."},
-    {NULL}
+    {}
 };
 
 static PyTypeObject Ini_Type = {
@@ -200,6 +200,20 @@ static PyTypeObject Ini_Type = {
     PyType_GenericNew,      /*tp_new*/
     0,                      /*tp_free*/
     0,                      /*tp_is_gc*/
+    0,                      /*tp_bases*/
+    0,                      /*tp_mro*/
+    0,                      /*tp_cache*/
+    0,                      /*tp_subclasses*/
+    0,                      /*tp_weaklink*/
+    0,                      /*tp_del*/
+    0,                      /*tp_version_tag*/
+    0,                      /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                      /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                      /*tp_watched*/
+#endif
+#endif
 };
 
 #define EMC_COMMAND_TIMEOUT 5.0  // how long to wait until timeout
@@ -395,18 +409,18 @@ static PyMethodDef Stat_methods[] = {
          "   returns dict for toolnumber parameters (pocket,offsets,etc)\n"
          "   ValueError Exception if toolnumber not available"
     },
-    {NULL}
+    {}
 };
 
 #define O(x) offsetof(pyStatChannel,status.x)
 static PyMemberDef Stat_members[] = {
 // stat
-    {(char*)"echo_serial_number", T_INT, O(echo_serial_number), READONLY},
-    {(char*)"echo_serial_number", T_INT, O(echo_serial_number), READONLY},
-    {(char*)"state", T_INT, O(status), READONLY},
+    {(char*)"echo_serial_number", T_INT, O(echo_serial_number), READONLY, NULL},
+    {(char*)"echo_serial_number", T_INT, O(echo_serial_number), READONLY, NULL},
+    {(char*)"state", T_INT, O(status), READONLY, NULL},
 
 // task
-    {(char*)"task_mode", T_INT, O(task.mode), READONLY},
+    {(char*)"task_mode", T_INT, O(task.mode), READONLY, NULL},
     {(char*)"task_state", T_INT, O(task.state), READONLY,
         "Current Task state.  Possible values:\n"
         "    STATE_ESTOP: E-Stop is active.\n"
@@ -414,61 +428,61 @@ static PyMemberDef Stat_members[] = {
         "    STATE_OFF: Same as STATE_ESTOP_RESET, this one is not used.\n"
         "    STATE_ON: Machine is out of E-Stop and is powered on.\n"
     },
-    {(char*)"exec_state", T_INT, O(task.execState), READONLY},
-    {(char*)"interp_state", T_INT, O(task.interpState), READONLY},
-    {(char*)"call_level", T_INT, O(task.callLevel), READONLY},
-    {(char*)"read_line", T_INT, O(task.readLine), READONLY},
-    {(char*)"motion_line", T_INT, O(task.motionLine), READONLY},
-    {(char*)"current_line", T_INT, O(task.currentLine), READONLY},
-    {(char*)"file", T_STRING_INPLACE, O(task.file), READONLY},
-    {(char*)"command", T_STRING_INPLACE, O(task.command), READONLY},
-    {(char*)"program_units", T_INT, O(task.programUnits), READONLY},
-    {(char*)"interpreter_errcode", T_INT, O(task.interpreter_errcode), READONLY},
-    {(char*)"optional_stop", T_BOOL, O(task.optional_stop_state), READONLY},
-    {(char*)"block_delete", T_BOOL, O(task.block_delete_state), READONLY},
-    {(char*)"task_paused", T_INT, O(task.task_paused), READONLY},
-    {(char*)"input_timeout", T_BOOL, O(task.input_timeout), READONLY},
-    {(char*)"rotation_xy", T_DOUBLE, O(task.rotation_xy), READONLY},
-    {(char*)"ini_filename", T_STRING_INPLACE, O(task.ini_filename), READONLY},
-    {(char*)"delay_left", T_DOUBLE, O(task.delayLeft), READONLY},
+    {(char*)"exec_state", T_INT, O(task.execState), READONLY, NULL},
+    {(char*)"interp_state", T_INT, O(task.interpState), READONLY, NULL},
+    {(char*)"call_level", T_INT, O(task.callLevel), READONLY, NULL},
+    {(char*)"read_line", T_INT, O(task.readLine), READONLY, NULL},
+    {(char*)"motion_line", T_INT, O(task.motionLine), READONLY, NULL},
+    {(char*)"current_line", T_INT, O(task.currentLine), READONLY, NULL},
+    {(char*)"file", T_STRING_INPLACE, O(task.file), READONLY, NULL},
+    {(char*)"command", T_STRING_INPLACE, O(task.command), READONLY, NULL},
+    {(char*)"program_units", T_INT, O(task.programUnits), READONLY, NULL},
+    {(char*)"interpreter_errcode", T_INT, O(task.interpreter_errcode), READONLY, NULL},
+    {(char*)"optional_stop", T_BOOL, O(task.optional_stop_state), READONLY, NULL},
+    {(char*)"block_delete", T_BOOL, O(task.block_delete_state), READONLY, NULL},
+    {(char*)"task_paused", T_INT, O(task.task_paused), READONLY, NULL},
+    {(char*)"input_timeout", T_BOOL, O(task.input_timeout), READONLY, NULL},
+    {(char*)"rotation_xy", T_DOUBLE, O(task.rotation_xy), READONLY, NULL},
+    {(char*)"ini_filename", T_STRING_INPLACE, O(task.ini_filename), READONLY, NULL},
+    {(char*)"delay_left", T_DOUBLE, O(task.delayLeft), READONLY, NULL},
     {(char*)"queued_mdi_commands", T_INT, O(task.queuedMDIcommands), READONLY, (char*)"Number of MDI commands queued waiting to run." },
 
 //   EMC_TRAJ_STAT traj
-    {(char*)"linear_units", T_DOUBLE, O(motion.traj.linearUnits), READONLY},
-    {(char*)"angular_units", T_DOUBLE, O(motion.traj.angularUnits), READONLY},
-    {(char*)"cycle_time", T_DOUBLE, O(motion.traj.cycleTime), READONLY},
-    {(char*)"joints", T_INT, O(motion.traj.joints), READONLY},
-    {(char*)"spindles", T_INT, O(motion.traj.spindles), READONLY},
-    {(char*)"axis_mask", T_INT, O(motion.traj.axis_mask), READONLY},
+    {(char*)"linear_units", T_DOUBLE, O(motion.traj.linearUnits), READONLY, NULL},
+    {(char*)"angular_units", T_DOUBLE, O(motion.traj.angularUnits), READONLY, NULL},
+    {(char*)"cycle_time", T_DOUBLE, O(motion.traj.cycleTime), READONLY, NULL},
+    {(char*)"joints", T_INT, O(motion.traj.joints), READONLY, NULL},
+    {(char*)"spindles", T_INT, O(motion.traj.spindles), READONLY, NULL},
+    {(char*)"axis_mask", T_INT, O(motion.traj.axis_mask), READONLY, NULL},
     {(char*)"motion_mode", T_INT, O(motion.traj.mode), READONLY, (char*)"The current mode of the Motion controller.  One of TRAJ_MODE_FREE,\n"
         "TRAJ_MODE_COORD, or TRAJ_MODE_TELEOP." },
-    {(char*)"enabled", T_BOOL, O(motion.traj.enabled), READONLY},
-    {(char*)"inpos", T_BOOL, O(motion.traj.inpos), READONLY},
-    {(char*)"queue", T_INT, O(motion.traj.queue), READONLY},
-    {(char*)"active_queue", T_INT, O(motion.traj.activeQueue), READONLY},
-    {(char*)"queue_full", T_BOOL, O(motion.traj.queueFull), READONLY},
-    {(char*)"motion_id", T_INT, O(motion.traj.id), READONLY},
-    {(char*)"paused", T_BOOL, O(motion.traj.paused), READONLY},
-    {(char*)"feedrate", T_DOUBLE, O(motion.traj.scale), READONLY},
-    {(char*)"rapidrate", T_DOUBLE, O(motion.traj.rapid_scale), READONLY},
-    {(char*)"velocity", T_DOUBLE, O(motion.traj.velocity), READONLY},
-    {(char*)"acceleration", T_DOUBLE, O(motion.traj.acceleration), READONLY},
-    {(char*)"max_velocity", T_DOUBLE, O(motion.traj.maxVelocity), READONLY},
-    {(char*)"max_acceleration", T_DOUBLE, O(motion.traj.maxAcceleration), READONLY},
-    {(char*)"probe_tripped", T_BOOL, O(motion.traj.probe_tripped), READONLY},
-    {(char*)"probing", T_BOOL, O(motion.traj.probing), READONLY},
-    {(char*)"probe_val", T_INT, O(motion.traj.probeval), READONLY},
-    {(char*)"kinematics_type", T_INT, O(motion.traj.kinematics_type), READONLY},
+    {(char*)"enabled", T_BOOL, O(motion.traj.enabled), READONLY, NULL},
+    {(char*)"inpos", T_BOOL, O(motion.traj.inpos), READONLY, NULL},
+    {(char*)"queue", T_INT, O(motion.traj.queue), READONLY, NULL},
+    {(char*)"active_queue", T_INT, O(motion.traj.activeQueue), READONLY, NULL},
+    {(char*)"queue_full", T_BOOL, O(motion.traj.queueFull), READONLY, NULL},
+    {(char*)"motion_id", T_INT, O(motion.traj.id), READONLY, NULL},
+    {(char*)"paused", T_BOOL, O(motion.traj.paused), READONLY, NULL},
+    {(char*)"feedrate", T_DOUBLE, O(motion.traj.scale), READONLY, NULL},
+    {(char*)"rapidrate", T_DOUBLE, O(motion.traj.rapid_scale), READONLY, NULL},
+    {(char*)"velocity", T_DOUBLE, O(motion.traj.velocity), READONLY, NULL},
+    {(char*)"acceleration", T_DOUBLE, O(motion.traj.acceleration), READONLY, NULL},
+    {(char*)"max_velocity", T_DOUBLE, O(motion.traj.maxVelocity), READONLY, NULL},
+    {(char*)"max_acceleration", T_DOUBLE, O(motion.traj.maxAcceleration), READONLY, NULL},
+    {(char*)"probe_tripped", T_BOOL, O(motion.traj.probe_tripped), READONLY, NULL},
+    {(char*)"probing", T_BOOL, O(motion.traj.probing), READONLY, NULL},
+    {(char*)"probe_val", T_INT, O(motion.traj.probeval), READONLY, NULL},
+    {(char*)"kinematics_type", T_INT, O(motion.traj.kinematics_type), READONLY, NULL},
     {(char*)"motion_type", T_INT, O(motion.traj.motion_type), READONLY, (char*)"The type of the currently executing motion (one of MOTION_TYPE_TRAVERSE,\n"
         "MOTION_TYPE_FEED, MOTION_TYPE_ARC, MOTION_TYPE_TOOLCHANGE,\n"
         "MOTION_TYPE_PROBING, or MOTION_TYPE_INDEXROTARY), or 0 if no motion is\n"
         "currently taking place."},
-    {(char*)"distance_to_go", T_DOUBLE, O(motion.traj.distance_to_go), READONLY},
-    {(char*)"current_vel", T_DOUBLE, O(motion.traj.current_vel), READONLY},
-    {(char*)"feed_override_enabled", T_BOOL, O(motion.traj.feed_override_enabled), READONLY},
-    {(char*)"adaptive_feed_enabled", T_BOOL, O(motion.traj.adaptive_feed_enabled), READONLY},
-    {(char*)"feed_hold_enabled", T_BOOL, O(motion.traj.feed_hold_enabled), READONLY},
-    {(char*)"num_extrajoints", T_INT, O(motion.numExtraJoints), READONLY},
+    {(char*)"distance_to_go", T_DOUBLE, O(motion.traj.distance_to_go), READONLY, NULL},
+    {(char*)"current_vel", T_DOUBLE, O(motion.traj.current_vel), READONLY, NULL},
+    {(char*)"feed_override_enabled", T_BOOL, O(motion.traj.feed_override_enabled), READONLY, NULL},
+    {(char*)"adaptive_feed_enabled", T_BOOL, O(motion.traj.adaptive_feed_enabled), READONLY, NULL},
+    {(char*)"feed_hold_enabled", T_BOOL, O(motion.traj.feed_hold_enabled), READONLY, NULL},
+    {(char*)"num_extrajoints", T_INT, O(motion.numExtraJoints), READONLY, NULL},
 
 
 // EMC_SPINDLE_STAT motion.spindle
@@ -491,14 +505,14 @@ static PyMemberDef Stat_members[] = {
     },
 
 // EMC_COOLANT_STAT io.cooland
-    {(char*)"mist", T_INT, O(io.coolant.mist), READONLY},
-    {(char*)"flood", T_INT, O(io.coolant.flood), READONLY},
+    {(char*)"mist", T_INT, O(io.coolant.mist), READONLY, NULL},
+    {(char*)"flood", T_INT, O(io.coolant.flood), READONLY, NULL},
 
 // EMC_AUX_STAT     io.aux
-    {(char*)"estop", T_INT, O(io.aux.estop), READONLY},
+    {(char*)"estop", T_INT, O(io.aux.estop), READONLY, NULL},
 
-    {(char*)"debug", T_INT, O(debug), READONLY},
-    {NULL}
+    {(char*)"debug", T_INT, O(debug), READONLY, NULL},
+    {}
 };
 
 static PyObject *int_array(int *arr, int sz) {
@@ -721,21 +735,21 @@ static PyObject *Stat_spindle(pyStatChannel *s) {
 }
 
 static PyStructSequence_Field tool_fields[] = {
-    {(char*)"id", },
-    {(char*)"xoffset", },
-    {(char*)"yoffset", },
-    {(char*)"zoffset", },
-    {(char*)"aoffset", },
-    {(char*)"boffset", },
-    {(char*)"coffset", },
-    {(char*)"uoffset", },
-    {(char*)"voffset", },
-    {(char*)"woffset", },
-    {(char*)"diameter", },
-    {(char*)"frontangle", },
-    {(char*)"backangle", },
-    {(char*)"orientation", },
-    {0,},
+    {(char*)"id", NULL},
+    {(char*)"xoffset", NULL},
+    {(char*)"yoffset", NULL},
+    {(char*)"zoffset", NULL},
+    {(char*)"aoffset", NULL},
+    {(char*)"boffset", NULL},
+    {(char*)"coffset", NULL},
+    {(char*)"uoffset", NULL},
+    {(char*)"voffset", NULL},
+    {(char*)"woffset", NULL},
+    {(char*)"diameter", NULL},
+    {(char*)"frontangle", NULL},
+    {(char*)"backangle", NULL},
+    {(char*)"orientation", NULL},
+    {},
 };
 
 static PyStructSequence_Desc tool_result_desc = {
@@ -788,39 +802,39 @@ static PyObject *Stat_tool_table(pyStatChannel *s) {
 }
 
 static PyGetSetDef Stat_getsetlist[] = {
-    {(char*)"actual_position", (getter)Stat_actual},
-    {(char*)"ain", (getter)Stat_ain},
-    {(char*)"aout", (getter)Stat_aout},
-    {(char*)"joint", (getter)Stat_joint},
-    {(char*)"axis", (getter)Stat_axis},
-    {(char*)"spindle", (getter)Stat_spindle},
-    {(char*)"din", (getter)Stat_din},
-    {(char*)"dout", (getter)Stat_dout},
-    {(char*)"gcodes", (getter)Stat_activegcodes},
+    {(char*)"actual_position", (getter)Stat_actual, NULL, NULL, NULL},
+    {(char*)"ain", (getter)Stat_ain, NULL, NULL, NULL},
+    {(char*)"aout", (getter)Stat_aout, NULL, NULL, NULL},
+    {(char*)"joint", (getter)Stat_joint, NULL, NULL, NULL},
+    {(char*)"axis", (getter)Stat_axis, NULL, NULL, NULL},
+    {(char*)"spindle", (getter)Stat_spindle, NULL, NULL, NULL},
+    {(char*)"din", (getter)Stat_din, NULL, NULL, NULL},
+    {(char*)"dout", (getter)Stat_dout, NULL, NULL, NULL},
+    {(char*)"gcodes", (getter)Stat_activegcodes, NULL, NULL, NULL},
     {(char*)"homed", (getter)Stat_homed, (setter)NULL,
-        (char*)"An array of integers indicating the 'homed' status of each joint (0 or 1)."
+        (char*)"An array of integers indicating the 'homed' status of each joint (0 or 1).", NULL
     },
-    {(char*)"limit", (getter)Stat_limit},
-    {(char*)"mcodes", (getter)Stat_activemcodes},
-    {(char*)"misc_error", (getter)Stat_misc_error},
-    {(char*)"g5x_offset", (getter)Stat_g5x_offset},
-    {(char*)"g5x_index", (getter)Stat_g5x_index},
-    {(char*)"g92_offset", (getter)Stat_g92_offset},
-    {(char*)"position", (getter)Stat_position},
-    {(char*)"dtg", (getter)Stat_dtg},
-    {(char*)"joint_position", (getter)Stat_joint_position},
-    {(char*)"joint_actual_position", (getter)Stat_joint_actual},
-    {(char*)"probed_position", (getter)Stat_probed},
+    {(char*)"limit", (getter)Stat_limit, NULL, NULL, NULL},
+    {(char*)"mcodes", (getter)Stat_activemcodes, NULL, NULL, NULL},
+    {(char*)"misc_error", (getter)Stat_misc_error, NULL, NULL, NULL},
+    {(char*)"g5x_offset", (getter)Stat_g5x_offset, NULL, NULL, NULL},
+    {(char*)"g5x_index", (getter)Stat_g5x_index, NULL, NULL, NULL},
+    {(char*)"g92_offset", (getter)Stat_g92_offset, NULL, NULL, NULL},
+    {(char*)"position", (getter)Stat_position, NULL, NULL, NULL},
+    {(char*)"dtg", (getter)Stat_dtg, NULL, NULL, NULL},
+    {(char*)"joint_position", (getter)Stat_joint_position, NULL, NULL, NULL},
+    {(char*)"joint_actual_position", (getter)Stat_joint_actual, NULL, NULL, NULL},
+    {(char*)"probed_position", (getter)Stat_probed, NULL, NULL, NULL},
     {(char*)"settings", (getter)Stat_activesettings, (setter)NULL,
         (char*)"This is an array containing the Interp active settings: sequence number,\n"
-        "feed rate, spindle speed, and G64 blend and naive CAM tolerances."
+        "feed rate, spindle speed, and G64 blend and naive CAM tolerances.", NULL
     },
-    {(char*)"tool_offset", (getter)Stat_tool_offset},
+    {(char*)"tool_offset", (getter)Stat_tool_offset, NULL, NULL, NULL},
     {(char*)"tool_table", (getter)Stat_tool_table, (setter)NULL,
         (char*)"The tooltable, expressed as a list of tools.  Each tool is a dict with the\n"
-        "tool id (tool number), diameter, offsets, etc."
+        "tool id (tool number), diameter, offsets, etc.", NULL
     },
-    {NULL}
+    {}
 };
 
 static PyTypeObject Stat_Type = {
@@ -865,6 +879,20 @@ static PyTypeObject Stat_Type = {
     PyType_GenericNew,      /*tp_new*/
     0,                      /*tp_free*/
     0,                      /*tp_is_gc*/
+    0,                      /*tp_bases*/
+    0,                      /*tp_mro*/
+    0,                      /*tp_cache*/
+    0,                      /*tp_subclasses*/
+    0,                      /*tp_weaklink*/
+    0,                      /*tp_del*/
+    0,                      /*tp_version_tag*/
+    0,                      /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                      /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                      /*tp_watched*/
+#endif
+#endif
 };
 
 static int Command_init(pyCommandChannel *self, PyObject *a, PyObject *k) {
@@ -1533,15 +1561,15 @@ static PyObject *display_msg(pyCommandChannel *s,  PyObject *args ) {
 }
 
 static PyMemberDef Command_members[] = {
-    {(char*)"serial", T_INT, offsetof(pyCommandChannel, serial), READONLY},
-    {NULL}
+    {(char*)"serial", T_INT, offsetof(pyCommandChannel, serial), READONLY, NULL},
+    {}
 };
 
 static PyMethodDef Command_methods[] = {
-    {"debug", (PyCFunction)debug, METH_VARARGS},
-    {"teleop_enable", (PyCFunction)teleop, METH_VARARGS},
-    {"traj_mode", (PyCFunction)set_traj_mode, METH_VARARGS},
-    {"wait_complete", (PyCFunction)wait_complete, METH_VARARGS},
+    {"debug", (PyCFunction)debug, METH_VARARGS, NULL},
+    {"teleop_enable", (PyCFunction)teleop, METH_VARARGS, NULL},
+    {"traj_mode", (PyCFunction)set_traj_mode, METH_VARARGS, NULL},
+    {"wait_complete", (PyCFunction)wait_complete, METH_VARARGS, NULL},
     {"state", (PyCFunction)state, METH_VARARGS,
         "state(NEW_STATE) - Set the machine E-Stop & Power-On state.\n"
         "Possible values for `NEW_STATE` are:\n"
@@ -1550,26 +1578,26 @@ static PyMethodDef Command_methods[] = {
         "    STATE_ON: Power on (only works from STATE_ESTOP_RESET state).\n"
         "    STATE_OFF: Power off (only works from STATE_ON state).\n"
     },
-    {"mdi", (PyCFunction)mdi, METH_VARARGS},
-    {"mode", (PyCFunction)mode, METH_VARARGS},
-    {"feedrate", (PyCFunction)feedrate, METH_VARARGS},
-    {"rapidrate", (PyCFunction)rapidrate, METH_VARARGS},
-    {"maxvel", (PyCFunction)maxvel, METH_VARARGS},
-    {"spindleoverride", (PyCFunction)spindleoverride, METH_VARARGS},
-    {"spindle", (PyCFunction)spindle, METH_VARARGS},
-    {"tool_offset", (PyCFunction)tool_offset, METH_VARARGS},
-    {"mist", (PyCFunction)mist, METH_VARARGS},
-    {"flood", (PyCFunction)flood, METH_VARARGS},
-    {"brake", (PyCFunction)brake, METH_VARARGS},
-    {"load_tool_table", (PyCFunction)load_tool_table, METH_NOARGS},
-    {"abort", (PyCFunction)emcabort, METH_NOARGS},
-    {"task_plan_synch", (PyCFunction)task_plan_synch, METH_NOARGS},
-    {"override_limits", (PyCFunction)override_limits, METH_NOARGS},
+    {"mdi", (PyCFunction)mdi, METH_VARARGS, NULL},
+    {"mode", (PyCFunction)mode, METH_VARARGS, NULL},
+    {"feedrate", (PyCFunction)feedrate, METH_VARARGS, NULL},
+    {"rapidrate", (PyCFunction)rapidrate, METH_VARARGS, NULL},
+    {"maxvel", (PyCFunction)maxvel, METH_VARARGS, NULL},
+    {"spindleoverride", (PyCFunction)spindleoverride, METH_VARARGS, NULL},
+    {"spindle", (PyCFunction)spindle, METH_VARARGS, NULL},
+    {"tool_offset", (PyCFunction)tool_offset, METH_VARARGS, NULL},
+    {"mist", (PyCFunction)mist, METH_VARARGS, NULL},
+    {"flood", (PyCFunction)flood, METH_VARARGS, NULL},
+    {"brake", (PyCFunction)brake, METH_VARARGS, NULL},
+    {"load_tool_table", (PyCFunction)load_tool_table, METH_NOARGS, NULL},
+    {"abort", (PyCFunction)emcabort, METH_NOARGS, NULL},
+    {"task_plan_synch", (PyCFunction)task_plan_synch, METH_NOARGS, NULL},
+    {"override_limits", (PyCFunction)override_limits, METH_NOARGS, NULL},
     {"home", (PyCFunction)home, METH_VARARGS,
         "home(JOINT) - Home the specified joint.\n"
         "JOINT can be a valid joint number (0-9), or -1 to home all joints.\n"
     },
-    {"unhome", (PyCFunction)unhome, METH_VARARGS},
+    {"unhome", (PyCFunction)unhome, METH_VARARGS, NULL},
     {"jog", (PyCFunction)jog, METH_VARARGS,
         "jog(JOG_CONTINUOUS, joint_flag, index, speed)\n"
         "jog(JOG_INCREMENT, joint_flag, index, speed, increment)\n"
@@ -1582,23 +1610,23 @@ static PyMethodDef Command_methods[] = {
         "    speed: jog speed\n"
         "    increment: distance to jog\n"
     },
-    {"reset_interpreter", (PyCFunction)reset_interpreter, METH_NOARGS},
-    {"program_open", (PyCFunction)program_open, METH_VARARGS},
-    {"auto", (PyCFunction)emcauto, METH_VARARGS},
-    {"set_optional_stop", (PyCFunction)optional_stop, METH_VARARGS},
-    {"set_block_delete", (PyCFunction)block_delete, METH_VARARGS},
-    {"set_min_limit", (PyCFunction)set_min_limit, METH_VARARGS},
-    {"set_max_limit", (PyCFunction)set_max_limit, METH_VARARGS},
-    {"set_feed_override", (PyCFunction)set_feed_override, METH_VARARGS},
-    {"set_spindle_override", (PyCFunction)set_spindle_override, METH_VARARGS},
-    {"set_feed_hold", (PyCFunction)set_feed_hold, METH_VARARGS},
-    {"set_adaptive_feed", (PyCFunction)set_adaptive_feed, METH_VARARGS},
-    {"set_digital_output", (PyCFunction)set_digital_output, METH_VARARGS},
-    {"set_analog_output", (PyCFunction)set_analog_output, METH_VARARGS},
+    {"reset_interpreter", (PyCFunction)reset_interpreter, METH_NOARGS, NULL},
+    {"program_open", (PyCFunction)program_open, METH_VARARGS, NULL},
+    {"auto", (PyCFunction)emcauto, METH_VARARGS, NULL},
+    {"set_optional_stop", (PyCFunction)optional_stop, METH_VARARGS, NULL},
+    {"set_block_delete", (PyCFunction)block_delete, METH_VARARGS, NULL},
+    {"set_min_limit", (PyCFunction)set_min_limit, METH_VARARGS, NULL},
+    {"set_max_limit", (PyCFunction)set_max_limit, METH_VARARGS, NULL},
+    {"set_feed_override", (PyCFunction)set_feed_override, METH_VARARGS, NULL},
+    {"set_spindle_override", (PyCFunction)set_spindle_override, METH_VARARGS, NULL},
+    {"set_feed_hold", (PyCFunction)set_feed_hold, METH_VARARGS, NULL},
+    {"set_adaptive_feed", (PyCFunction)set_adaptive_feed, METH_VARARGS, NULL},
+    {"set_digital_output", (PyCFunction)set_digital_output, METH_VARARGS, NULL},
+    {"set_analog_output", (PyCFunction)set_analog_output, METH_VARARGS, NULL},
     {"error_msg", (PyCFunction)error_msg, METH_VARARGS, "Send operator error message"},
     {"text_msg", (PyCFunction)text_msg, METH_VARARGS, "Send operator text message"},
     {"display_msg", (PyCFunction)display_msg, METH_VARARGS, "Send operator display message"},
-    {NULL}
+    {}
 };
 
 static PyTypeObject Command_Type = {
@@ -1643,6 +1671,20 @@ static PyTypeObject Command_Type = {
     PyType_GenericNew,      /*tp_new*/
     0,                      /*tp_free*/
     0,                      /*tp_is_gc*/
+    0,                      /*tp_bases*/
+    0,                      /*tp_mro*/
+    0,                      /*tp_cache*/
+    0,                      /*tp_subclasses*/
+    0,                      /*tp_weaklink*/
+    0,                      /*tp_del*/
+    0,                      /*tp_version_tag*/
+    0,                      /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                      /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                      /*tp_watched*/
+#endif
+#endif
 };
 
 static int Error_init(pyErrorChannel *self, PyObject *a, PyObject *k) {
@@ -1706,7 +1748,7 @@ static void Error_dealloc(PyObject *self) {
 
 static PyMethodDef Error_methods[] = {
     {"poll", (PyCFunction)Error_poll, METH_NOARGS, "Poll for errors"},
-    {NULL}
+    {}
 };
 
 static PyTypeObject Error_Type = {
@@ -1751,6 +1793,20 @@ static PyTypeObject Error_Type = {
     PyType_GenericNew,      /*tp_new*/
     0,                      /*tp_free*/
     0,                      /*tp_is_gc*/
+    0,                      /*tp_bases*/
+    0,                      /*tp_mro*/
+    0,                      /*tp_cache*/
+    0,                      /*tp_subclasses*/
+    0,                      /*tp_weaklink*/
+    0,                      /*tp_del*/
+    0,                      /*tp_version_tag*/
+    0,                      /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                      /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                      /*tp_watched*/
+#endif
+#endif
 };
 
 #define AXIS_MASK_A 0x08
@@ -2402,8 +2458,8 @@ static PyObject *Logger_last(pyPositionLogger *s, PyObject *o) {
 }
 
 static PyMemberDef Logger_members[] = {
-    {(char*)"npts", T_INT, offsetof(pyPositionLogger, npts), READONLY},
-    {0, 0, 0, 0},
+    {(char*)"npts", T_INT, offsetof(pyPositionLogger, npts), READONLY, NULL},
+    {},
 };
 
 static PyMethodDef Logger_methods[] = {
@@ -2423,7 +2479,7 @@ static PyMethodDef Logger_methods[] = {
         "get the plotting colors"},
     {"last", (PyCFunction)Logger_last, METH_VARARGS,
         "Return the most recent point on the plot or None"},
-    {NULL, NULL, 0, NULL},
+    {},
 };
 
 static PyTypeObject PositionLoggerType = {
@@ -2468,6 +2524,20 @@ static PyTypeObject PositionLoggerType = {
     PyType_GenericNew,      /*tp_new*/
     0,                      /*tp_free*/
     0,                      /*tp_is_gc*/
+    0,                      /*tp_bases*/
+    0,                      /*tp_mro*/
+    0,                      /*tp_cache*/
+    0,                      /*tp_subclasses*/
+    0,                      /*tp_weaklink*/
+    0,                      /*tp_del*/
+    0,                      /*tp_version_tag*/
+    0,                      /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                      /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                      /*tp_watched*/
+#endif
+#endif
 };
 
 static PyMethodDef emc_methods[] = {
@@ -2478,7 +2548,7 @@ METH(line9, "Draw a single line in the 'rs274.glcanon' format; assumes glBegin(G
 METH(vertex9, "Get the 3d location for a 9d point"),
 METH(gui_rot_offsets, "Set x,y,z offsets for A,B,C rotations"),
 METH(gui_respect_offsets, "Enable rotations about g5x,g92 offsets"),
-    {NULL}
+    {}
 #undef METH
 };
 
@@ -2491,11 +2561,15 @@ METH(gui_respect_offsets, "Enable rotations about g5x,g92 offsets"),
 #define ENUMX(x,e) PyModule_AddIntConstant(m, x + const_cast<char*>(#e), e)
 
 static struct PyModuleDef linuxcnc_moduledef = {
-    PyModuleDef_HEAD_INIT,  /* m_base */
-    "linuxcnc",     /* m_name */
-    "Interface to LinuxCNC",    /* m_doc */
-    -1,     /* m_size */
-    emc_methods     /* m_methods */
+    PyModuleDef_HEAD_INIT, /* m_base */
+    "linuxcnc",            /* m_name */
+    "Interface to LinuxCNC", /* m_doc */
+    -1,                    /* m_size */
+    emc_methods,           /* m_methods */
+    NULL,                  /* m_slots */
+    NULL,                  /* m_travese */
+    NULL,                  /* m_clear */
+    NULL,                  /* m_free */
 };
 
 PyMODINIT_FUNC PyInit_linuxcnc(void);

--- a/src/emc/usr_intf/axis/extensions/togl.c
+++ b/src/emc/usr_intf/axis/extensions/togl.c
@@ -351,7 +351,7 @@ static Tk_ConfigSpec configSpecs[] = {
 
 #ifndef NO_TK_CURSOR
     { TK_CONFIG_ACTIVE_CURSOR, "-cursor", "cursor", "Cursor",
-     "", Tk_Offset(struct Togl, Cursor), TK_CONFIG_NULL_OK },
+     "", Tk_Offset(struct Togl, Cursor), TK_CONFIG_NULL_OK, NULL },
 #endif
 
     {TK_CONFIG_INT, "-time", "time", "Time",

--- a/src/hal/classicladder/menu_and_toolbar_gtk.c
+++ b/src/hal/classicladder/menu_and_toolbar_gtk.c
@@ -40,7 +40,7 @@
 GtkUIManager * uiManager;
 
 static GtkActionEntry ActionEntriesArray[ ] =
-{	{ "FileMenuAction", NULL, N_("File") },
+{	{ "FileMenuAction", NULL, N_("File"), NULL, NULL, NULL },
 	{ "NewAction", GTK_STOCK_NEW, N_("New"), NULL, N_("Create a new project"), G_CALLBACK( DoActionConfirmNewProject ) },
 	{ "LoadAction", GTK_STOCK_OPEN, N_("Load"), NULL, N_("Load an existing project"), G_CALLBACK( DoActionLoadProject ) },
 	{ "SaveAction", GTK_STOCK_SAVE, N_("Save"), NULL, N_("Save current project"), G_CALLBACK( DoActionSave ) },
@@ -53,14 +53,14 @@ static GtkActionEntry ActionEntriesArray[ ] =
 	{ "PrintAction", GTK_STOCK_PRINT, N_("Print"), "<Control>P", N_("Print current section"), G_CALLBACK( PrintGtk ) },
 	{ "QuitAction", GTK_STOCK_QUIT, N_("Quit"), NULL, NULL, G_CALLBACK( ConfirmQuit ) },
 
-	{ "ViewMenuAction", NULL, N_("View") },
+	{ "ViewMenuAction", NULL, N_("View"), NULL, NULL, NULL },
 
-	{ "PLCAction", NULL, N_("PLC") },
+	{ "PLCAction", NULL, N_("PLC"), NULL, NULL, NULL },
 	{ "RunStopAction", GTK_STOCK_EXECUTE, N_("Run logic"), NULL, N_("Start/stop logic"), G_CALLBACK( DoFlipFlopRunStop ) },
 	{ "ResetAction", GTK_STOCK_REFRESH, N_("Reset logic"), NULL, N_("Reset logic"), G_CALLBACK( DoActionResetAndConfirmIfRunning ) },
 	{ "ConfigurationAction", GTK_STOCK_PREFERENCES, N_("Configuration"), NULL, N_("Configuration (sizes, i/o, ...)"), G_CALLBACK( OpenConfigWindowGtk ) },
 
-	{ "HelpMenuAction", NULL, N_("Help") },
+	{ "HelpMenuAction", NULL, N_("Help"), NULL, NULL, NULL },
 	{ "AboutAction", GTK_STOCK_ABOUT, N_("About"), "F1", NULL, G_CALLBACK( DoActionAboutClassicLadder ) },
 };
 static GtkToggleActionEntry ToggleActionEntriesArray[ ] =

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -639,7 +639,7 @@ static PyMethodDef hal_methods[] = {
         "Call hal_ready"},
     {"unready", pyhal_unready, METH_NOARGS,
         "Call hal_unready"},
-    {NULL},
+    {},
 };
 
 static PyMappingMethods halobject_map = {
@@ -690,6 +690,20 @@ PyTypeObject halobject_type = {
     PyType_GenericNew,         /*tp_new*/
     0,                         /*tp_free*/
     0,                         /*tp_is_gc*/
+    0,                         /*tp_bases*/
+    0,                         /*tp_mro*/
+    0,                         /*tp_cache*/
+    0,                         /*tp_subclasses*/
+    0,                         /*tp_weaklink*/
+    0,                         /*tp_del*/
+    0,                         /*tp_version_tag*/
+    0,                         /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                         /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                         /*tp_watched*/
+#endif
+#endif
 };
 
 static const char * pin_type2name(hal_type_t type) {
@@ -793,7 +807,7 @@ static PyMethodDef halpin_methods[] = {
     {"get_dir", pyhal_pin_get_dir, METH_NOARGS, "Get item direction"},
     {"get_name", pyhal_pin_get_name, METH_NOARGS, "Get item name"},
     {"is_pin", pyhal_pin_is_pin, METH_NOARGS, "If item is pin or param"},
-    {NULL},
+    {},
 };
 
 static
@@ -838,6 +852,20 @@ PyTypeObject halpin_type = {
     PyType_GenericNew,         /*tp_new*/
     0,                         /*tp_free*/
     0,                         /*tp_is_gc*/
+    0,                         /*tp_bases*/
+    0,                         /*tp_mro*/
+    0,                         /*tp_cache*/
+    0,                         /*tp_subclasses*/
+    0,                         /*tp_weaklink*/
+    0,                         /*tp_del*/
+    0,                         /*tp_version_tag*/
+    0,                         /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                         /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                         /*tp_watched*/
+#endif
+#endif
 };
 
 static PyObject * pyhal_pin_new(halitem * pin, const char * name) {
@@ -1584,7 +1612,7 @@ static PyMethodDef shm_methods[] = {
 	"Get a writable buffer object for the shared memory segment"},
     {"setsize", shm_setsize, METH_VARARGS,
 	"Set the size of the shared memory segment"},
-    {NULL},
+    {},
 };
 
 static
@@ -1629,6 +1657,20 @@ PyTypeObject shm_type = {
     PyType_GenericNew,         /*tp_new*/
     0,                         /*tp_free*/
     0,                         /*tp_is_gc*/
+    0,                         /*tp_bases*/
+    0,                         /*tp_mro*/
+    0,                         /*tp_cache*/
+    0,                         /*tp_subclasses*/
+    0,                         /*tp_weaklink*/
+    0,                         /*tp_del*/
+    0,                         /*tp_version_tag*/
+    0,                         /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                         /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                         /*tp_watched*/
+#endif
+#endif
 };
 
 struct streamobj {
@@ -1760,8 +1802,8 @@ PyObject *stream_write(PyObject *_self, PyObject *args) {
 }
 
 static PyMethodDef stream_methods[] = {
-    {"read", stream_read, METH_NOARGS},
-    {"write", stream_write, METH_VARARGS},
+    {"read", stream_read, METH_NOARGS, NULL},
+    {"write", stream_write, METH_VARARGS, NULL},
     {}
 };
 
@@ -1864,6 +1906,20 @@ PyTypeObject stream_type = {
     PyType_GenericNew,         /*tp_new*/
     0,                         /*tp_free*/
     0,                         /*tp_is_gc*/
+    0,                         /*tp_bases*/
+    0,                         /*tp_mro*/
+    0,                         /*tp_cache*/
+    0,                         /*tp_subclasses*/
+    0,                         /*tp_weaklink*/
+    0,                         /*tp_del*/
+    0,                         /*tp_version_tag*/
+    0,                         /*tp_finalize*/
+#if PY_VERSION_HEX >= 0x030800f0	// 3.8
+    0,                         /*tp_vectorcall*/
+#if PY_VERSION_HEX >= 0x030c00f0	// 3.12
+    0,                         /*tp_watched*/
+#endif
+#endif
 };
 
 
@@ -1898,7 +1954,7 @@ PyMethodDef module_methods[] = {
 	".get_info_signals(): Get a list of dicts for all the signals; {NAME:, VALUE:}"},
     {"get_info_params", get_info_params, METH_VARARGS,
 	".get_info_params(): Get a list of dicts for all the parameters; {NAME:, VALUE:}"},
-    {NULL},
+    {},
 };
 
 const char *module_doc = "Interface to emc2's hal\n"
@@ -1930,9 +1986,13 @@ const char *module_doc = "Interface to emc2's hal\n"
 static struct PyModuleDef hal_moduledef = {
     PyModuleDef_HEAD_INIT,  /* m_base */
     "_hal",                 /* m_name */
-    module_doc,                   /* m_doc */
+    module_doc,             /* m_doc */
     -1,                     /* m_size */
-    module_methods            /* m_methods */
+    module_methods,         /* m_methods */
+    NULL,                   /* m_slots */
+    NULL,                   /* m_traverse */
+    NULL,                   /* m_clear */
+    NULL,                   /* m_free */
 };
 
 PyMODINIT_FUNC PyInit__hal(void);

--- a/src/rtapi/uspace_common.h
+++ b/src/rtapi/uspace_common.h
@@ -55,7 +55,7 @@ typedef struct {
 
 #define SHMEM_MAGIC   25453	/* random numbers used as signatures */
 
-static rtapi_shmem_handle shmem_array[MAX_SHM] = {{0},};
+static rtapi_shmem_handle shmem_array[MAX_SHM];
 
 int rtapi_shmem_new(int key, int module_id, unsigned long int size)
 {


### PR DESCRIPTION
Many initialization were incomplete, only partially filling all the fields. However, compiling with -Wmissing-field-initializers (part of -Wextra) will result in many, many warnings.

This PR fixes these warnings by adjusting the initialization to include all necessary fields.