### PR TITLE
Add missing backslash

### DIFF
--- a/tests/motion-logger/basic/test-ui.py
+++ b/tests/motion-logger/basic/test-ui.py
@@ -64,7 +64,7 @@ end_log('builtin-startup')
 for ngc in glob.glob('*.ngc'):
     if ngc == 'reset.ngc': continue
 
-    m = re.match('(.*)\.ngc', ngc)
+    m = re.match('(.*)\\.ngc', ngc)
     basename = m.group(1)
 
     c.program_open('reset.ngc')

--- a/tests/trajectory-planner/circular-arcs/run_all_tests.py
+++ b/tests/trajectory-planner/circular-arcs/run_all_tests.py
@@ -98,7 +98,7 @@ sleep(1)
 e.set_mode(linuxcnc.MODE_AUTO)
 sleep(1)
 for f in test_files:
-    if re.search('\.ngc$',f) is not None:
+    if re.search('\\.ngc$',f) is not None:
         print("Loading program {0}".format(f))
         e.set_mode(linuxcnc.MODE_AUTO)
         sleep(1)


### PR DESCRIPTION
Another Python SyntaxWarning about invalid escapes was encountered while doing a <code>make pycheck</code>. This PR fixes these instances.