### PR TITLE
Fix assigned but unused variables

### DIFF
--- a/src/emc/tooldata/tooldata_db.cc
+++ b/src/emc/tooldata/tooldata_db.cc
@@ -208,7 +208,7 @@ int tooldata_db_getall() {
         int nonran_start_idx = 1;
         tooldata_add_init(nonran_start_idx);
     }
-    int ct=1;
+    //int ct=1;
     while (1) {
         char reply[CANON_TOOL_ENTRY_LEN];
         if (read_reply(reply,sizeof(reply)) <0) {
@@ -223,7 +223,7 @@ int tooldata_db_getall() {
         }
 
         int foundidx = tooldata_read_entry(reply);
-        ct++;
+        //ct++;
         if (foundidx < 0) {
             fprintf(stderr,"!!!tooldata_db_getall %s\n",reply);
             return -1;

--- a/src/hal/components/filter_kalman.comp
+++ b/src/hal/components/filter_kalman.comp
@@ -71,11 +71,11 @@ typedef hal_float_t D; // to Keep code synchronized with C++ based TrivialKalman
 
 // Based on: https://github.com/dwrobel/TrivialKalmanFilter/blob/master/src/TrivialKalmanFilter.h
 // Assumes simplified model
-static const D k    = 1;
+//static const D k  = 1;
 static const D Bk   = 0;
 static const D uk   = 0;
 static const D Fk   = 1;
-static const D T    = 1;
+//static const D T  = 1;
 static const D Fk_T = 1; // pow(Fk, T);
 static const D Hk   = 1;
 static const D Hk_T = 1; // pow(Hk, T);

--- a/src/hal/user_comps/xhc-hb04.cc
+++ b/src/hal/user_comps/xhc-hb04.cc
@@ -567,7 +567,7 @@ int _hal_pin_bit_newf(hal_pin_dir_t dir, hal_bit_t ** data_ptr_addr, int comp_id
     }
 }
 
-static void hal_setup()
+static int hal_setup()
 {
 	int r, i;
 
@@ -661,7 +661,7 @@ static void hal_setup()
     r |= _hal_pin_bit_newf(HAL_OUT, &(xhc.hal->jog_plus_a), hal_comp_id, "%s.jog.plus-a", modname);
     r |= _hal_pin_bit_newf(HAL_OUT, &(xhc.hal->jog_minus_a), hal_comp_id, "%s.jog.minus-a", modname);
 
-	return;
+	return r;
 }
 
 int read_ini_file(char *filename)
@@ -768,7 +768,10 @@ int main (int argc,char **argv)
     }
     stepsize_last_idx  =  idx - 1;
 
-	hal_setup();
+	if(hal_setup()) {
+		fprintf(stderr, "%s: ERROR: hal pin creation failed\n", modname);
+		exit(EXIT_FAILURE);
+	}
 
     signal(SIGINT, quit);
 	signal(SIGTERM, quit);

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -724,7 +724,7 @@ static int strlimcpy(char **dest, char *src, int srclen, int *destspace) {
 */
 static int replace_vars(char *source_str, char *dest_str, int max_chars, char **detail)
 {
-    int retval = 0, loopcount=0;
+    int retval = 0;
     int next_delim, remaining, buf_space;
     char *replacement, sec[128], var[128];
     static char info[256];
@@ -736,7 +736,6 @@ static int replace_vars(char *source_str, char *dest_str, int max_chars, char **
     *dest_str='\0';			/* return null string if input is null string */
     buf_space = max_chars-1;		/* leave space for terminating null */
     while ((remaining = strlen(sp)) > 0) {
-	loopcount++;
 	next_delim=strcspn(sp, "$[");
 	if (strlimcpy(&dp, sp, next_delim, &buf_space) < 0)
 	    return -6;


### PR DESCRIPTION
This PR removes variables that are set but not used (clang warnings). Some are only commented out if it makes sense in the context of those variables.
One case in src/hal/user_comps/xhc-hb04.cc now actually uses the value because it is a collection of possible errors and is passed on to report any error.