### PR TITLE
Fix clang warning "private field '...' is not used"

### DIFF
--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -68,6 +68,7 @@ Hal::Hal(Profiles::HalRequestProfile halRequestProfile) :
     mStepMode(HandwheelStepmodes::Mode::MPG),
     mHalRequestProfile(halRequestProfile)
 {
+    (void)mStepMode;
 }
 // ----------------------------------------------------------------------
 Hal::~Hal()

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.cc
@@ -543,6 +543,7 @@ FeedRotaryButton::FeedRotaryButton(const KeyCode& keyCode,
     mStepSize(0),
     mEventListener(listener)
 {
+    (void)mEventListener;
 }
 // ----------------------------------------------------------------------
 FeedRotaryButton::~FeedRotaryButton()
@@ -647,6 +648,7 @@ AxisRotaryButton::AxisRotaryButton(const KeyCode& keyCode, KeyEventListener* lis
     RotaryButton(keyCode),
     mEventListener(listener)
 {
+    (void)mEventListener;
 }
 // ----------------------------------------------------------------------
 AxisRotaryButton::~AxisRotaryButton()
@@ -681,6 +683,7 @@ Handwheel::Handwheel(const FeedRotaryButton& feedButton, KeyEventListener* liste
     mWheelCout(&std::cout),
     mPrefix("pndnt ")
 {
+    (void)mFeedButton;
 }
 // ----------------------------------------------------------------------
 Handwheel::~Handwheel()
@@ -753,6 +756,7 @@ ButtonsState::ButtonsState(KeyEventListener* listener, const ButtonsState* previ
     mPreviousState(previousState),
     mEventListener(listener)
 {
+    (void)mPreviousState;
 }
 // ----------------------------------------------------------------------
 ButtonsState::~ButtonsState()

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.h
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.h
@@ -588,8 +588,8 @@ private:
     bool         mIsLeadModeFeed = false;
     bool         mIsStepMode_5_10 = false;
 
-    float mScale;
-    float mMaxVelocity;
+    // float mScale;
+    // float mMaxVelocity;
 
     const char  * mPrefix;
     std::ostream  mDevNull{nullptr};

--- a/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.cc
@@ -292,6 +292,7 @@ XhcWhb04b6Component::XhcWhb04b6Component() :
     packageReceivedEventReceiver(*this),
     mPendant(mHal, mUsb.getOutputPackageData())
 {
+    (void)packageReceivedEventReceiver;
     setSimulationMode(true);
     enableVerbosePendant(false);
     enableVerboseRx(false);


### PR DESCRIPTION
There are several cases in the hal/user_comps/xhc-whb04b-6 pendent code where private member variables are completely unused or initialized and then never used. They generate a warning in clang.

This PR comments out unused private class members where never addressed. The private class members initialized but unused afterwards are declared (void) in the respective constructor.

The other option would be to delete those members completely. However, I cannot tell whether that would have other side effects and is therefore not the path chosen.