### PR TITLE
Fix clang vla problems

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -3652,18 +3652,20 @@ int Interp::restore_settings(setup_pointer settings,
     if (!cmd.empty()) {
 	// the sequence can be multiline, separated by nl
 	// so split and execute each line
-        char buf[cmd.size() + 1];
-        strncpy(buf, cmd.c_str(), sizeof(buf));
-	char *last = buf;
-	char *s;
-	while ((s = strtok_r(last, "\n", &last)) != NULL) {
+	char *buf = new char[cmd.size() + 1];
+	strcpy(buf, cmd.c_str());
+	char *stateptr = NULL;
+	char *s = strtok_r(buf, "\n", &stateptr);
+	while (s != NULL) {
 	    int status = execute(s);
 	    if (status != INTERP_OK) {
 		char currentError[LINELEN+1];
 		rtapi_strxcpy(currentError,getSavedError());
 		CHKS(status, _("M7x: restore_settings failed executing: '%s': %s"), s, currentError);
 	    }
+	    s = strtok_r(NULL, "\n", &stateptr);
 	}
+	delete[] buf;
 	write_g_codes((block_pointer) NULL, settings);
 	write_m_codes((block_pointer) NULL, settings);
 	write_settings(settings);
@@ -3721,11 +3723,11 @@ int Interp::restore_from_tag(StateTag const &tag)
     if (!cmd.empty()) {
         // the sequence can be multiline, separated by nl
         // so split and execute each line
-        char buf[cmd.size() + 1];
-        strncpy(buf, cmd.c_str(), sizeof(buf));
-        char *last = buf;
-        char *s;
-        while ((s = strtok_r(last, "\n", &last)) != NULL) {
+        char *buf = new char[cmd.size() + 1];
+        strcpy(buf, cmd.c_str());
+        char *stateptr = NULL;
+        char *s = strtok_r(buf, "\n", &stateptr);
+        while (s != NULL) {
             int status = execute(s);
             if (status != INTERP_OK) {
                 char currentError[LINELEN+1];
@@ -3733,7 +3735,9 @@ int Interp::restore_from_tag(StateTag const &tag)
                 CHKS(status, _("Failed to restore interp state on abort "
 			       "'%s': %s"), s, currentError);
             }
+            s = strtok_r(NULL, "\n", &stateptr);
         }
+        delete[] buf;
         write_g_codes((block_pointer) NULL, &_setup);
         write_m_codes((block_pointer) NULL, &_setup);
         write_settings(&_setup);

--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -3652,10 +3652,9 @@ int Interp::restore_settings(setup_pointer settings,
     if (!cmd.empty()) {
 	// the sequence can be multiline, separated by nl
 	// so split and execute each line
-	char *buf = new char[cmd.size() + 1];
-	strcpy(buf, cmd.c_str());
+	std::string cpy = cmd;
 	char *stateptr = NULL;
-	char *s = strtok_r(buf, "\n", &stateptr);
+	char *s = strtok_r(cpy.data(), "\n", &stateptr);
 	while (s != NULL) {
 	    int status = execute(s);
 	    if (status != INTERP_OK) {
@@ -3665,7 +3664,6 @@ int Interp::restore_settings(setup_pointer settings,
 	    }
 	    s = strtok_r(NULL, "\n", &stateptr);
 	}
-	delete[] buf;
 	write_g_codes((block_pointer) NULL, settings);
 	write_m_codes((block_pointer) NULL, settings);
 	write_settings(settings);
@@ -3723,10 +3721,9 @@ int Interp::restore_from_tag(StateTag const &tag)
     if (!cmd.empty()) {
         // the sequence can be multiline, separated by nl
         // so split and execute each line
-        char *buf = new char[cmd.size() + 1];
-        strcpy(buf, cmd.c_str());
+        std::string cpy = cmd;
         char *stateptr = NULL;
-        char *s = strtok_r(buf, "\n", &stateptr);
+        char *s = strtok_r(cpy.data(), "\n", &stateptr);
         while (s != NULL) {
             int status = execute(s);
             if (status != INTERP_OK) {
@@ -3737,7 +3734,6 @@ int Interp::restore_from_tag(StateTag const &tag)
             }
             s = strtok_r(NULL, "\n", &stateptr);
         }
-        delete[] buf;
         write_g_codes((block_pointer) NULL, &_setup);
         write_m_codes((block_pointer) NULL, &_setup);
         write_settings(&_setup);

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -56,7 +56,7 @@
 #include <errno.h>
 #include <time.h>
 #include <fnmatch.h>
-
+#include <vector>
 
 static int unloadrt_comp(char *mod_name);
 static void print_comp_info(char **patterns);
@@ -2605,8 +2605,8 @@ static void save_comps(FILE *dst)
         return;
 	}
 
-    hal_comp_t **comps = new hal_comp_t*[ncomps];
-    hal_comp_t **compptr = comps;
+    std::vector<hal_comp_t *> comps(ncomps, nullptr);
+    hal_comp_t **compptr = comps.data();
     next = hal_data->comp_list_ptr;
     while(next != 0)  {
 	comp = SHMPTR(next);
@@ -2628,9 +2628,6 @@ static void save_comps(FILE *dst)
                 (char *)SHMPTR(comp->insmod_args));
         }
     }
-
-    delete[] comps;
-
 #if 0  /* newinst deferred to version 2.2 */
     next = hal_data->comp_list_ptr;
     while (next != 0) {

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -2599,7 +2599,14 @@ static void save_comps(FILE *dst)
 	next = comp->next_ptr;
     }
 
-    hal_comp_t *comps[ncomps], **compptr = comps;
+    if(!ncomps) {
+        // No components found, bail
+        rtapi_mutex_give(&(hal_data->mutex));
+        return;
+	}
+
+    hal_comp_t **comps = new hal_comp_t*[ncomps];
+    hal_comp_t **compptr = comps;
     next = hal_data->comp_list_ptr;
     while(next != 0)  {
 	comp = SHMPTR(next);
@@ -2621,6 +2628,9 @@ static void save_comps(FILE *dst)
                 (char *)SHMPTR(comp->insmod_args));
         }
     }
+
+    delete[] comps;
+
 #if 0  /* newinst deferred to version 2.2 */
     next = hal_data->comp_list_ptr;
     while (next != 0) {

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -346,14 +346,25 @@ static int read_number(int fd) {
 
 static string read_string(int fd) {
     int len = read_number(fd);
-    char buf[len];
-    if(read(fd, buf, len) != len) throw ReadError();
-    return string(buf, len);
+    if(len < 0)
+        throw ReadError();
+    if(!len)
+        return string();
+    char *buf = new char[len];
+    if(read(fd, buf, len) != len) {
+        delete[] buf;
+        throw ReadError();
+    }
+    string str(buf, len);
+    delete[] buf;
+    return str;
 }
 
 static vector<string> read_strings(int fd) {
     vector<string> result;
     int count = read_number(fd);
+    if(count < 0)
+        return result;
     for(int i=0; i<count; i++) {
         result.push_back(read_string(fd));
     }

--- a/src/rtapi/uspace_rtapi_app.cc
+++ b/src/rtapi/uspace_rtapi_app.cc
@@ -350,13 +350,9 @@ static string read_string(int fd) {
         throw ReadError();
     if(!len)
         return string();
-    char *buf = new char[len];
-    if(read(fd, buf, len) != len) {
-        delete[] buf;
+    string str(len, 0);
+    if(read(fd, str.data(), len) != len)
         throw ReadError();
-    }
-    string str(buf, len);
-    delete[] buf;
     return str;
 }
 


### PR DESCRIPTION
Variable length arrays (vla) are a feature of C and are not in the C++ standard. Both gcc and clang have fixes for this, but they remain non-standard and result in a warning in clang.

This PR removes the use of vla and replaces it with new[]/delete[]. This is all non-RT code, so that is no problem. In the process it uncovered some subtle and less subtle problems in the code:
* strtok_r() reused the state pointer as string argument. This is very inappropriate because the state pointer is an opaque libc internal state. You should never depend that. The code is modified to use documented strtok_r() procedures.
* Several instances did not check the vla size for being zero or negative. Both cases are not handled well in vla's. The code is modified to test for negative or zero lengths and acts accordingly.
