### PR TITLE
Fix clang minmax coercion

### DIFF
--- a/src/hal/components/Submakefile
+++ b/src/hal/components/Submakefile
@@ -109,119 +109,116 @@ TARGETS += ../bin/panelui
 
 hal/components/conv_float_s32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh float s32 "" -2147483647-1 2147483647 < $< > $@
+	$(Q)sh hal/components/mkconv.sh float s32 < $< > $@
 
 hal/components/conv_float_u32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh float u32 "" 0 2147483647 < $< > $@
+	$(Q)sh hal/components/mkconv.sh float u32 < $< > $@
 
 hal/components/conv_float_s64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh float s64 "" -9223372036854775807u-1 9223372036854775807u < $< > $@
+	$(Q)sh hal/components/mkconv.sh float s64 < $< > $@
 
-# Clang error out when using 18446744073709551616u, reduce range by
-# one as a workaround:
-#  error: integer literal is too large to be represented in any integer type
 hal/components/conv_float_u64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh float u64 "" 0 18446744073709551615u < $< > $@
+	$(Q)sh hal/components/mkconv.sh float u64 < $< > $@
 
 hal/components/conv_bit_s32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh bit s32 // < $< > $@
+	$(Q)sh hal/components/mkconv.sh bit s32 < $< > $@
 
 hal/components/conv_bit_u32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh bit u32 // < $< > $@
+	$(Q)sh hal/components/mkconv.sh bit u32 < $< > $@
 
 hal/components/conv_bit_s64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh bit s64 // < $< > $@
+	$(Q)sh hal/components/mkconv.sh bit s64 < $< > $@
 
 hal/components/conv_bit_u64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh bit u64 // < $< > $@
+	$(Q)sh hal/components/mkconv.sh bit u64 < $< > $@
 
 hal/components/conv_bit_float.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh bit float // < $< > $@
+	$(Q)sh hal/components/mkconv.sh bit float < $< > $@
 
 hal/components/conv_s32_float.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s32 float // < $< > $@
+	$(Q)sh hal/components/mkconv.sh s32 float < $< > $@
 
 hal/components/conv_s32_bit.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s32 bit "" 0 1 < $< > $@
+	$(Q)sh hal/components/mkconv.sh s32 bit < $< > $@
 
 hal/components/conv_s32_u32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s32 u32 "" 0 0 < $< > $@
+	$(Q)sh hal/components/mkconv.sh s32 u32 < $< > $@
 
 hal/components/conv_s32_u64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s32 u64 "" -1 0 < $< > $@
+	$(Q)sh hal/components/mkconv.sh s32 u64 < $< > $@
 
 hal/components/conv_s32_s64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s32 s64 "" < $< > $@
+	$(Q)sh hal/components/mkconv.sh s32 s64 < $< > $@
 
 hal/components/conv_u32_float.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u32 float // < $< > $@
+	$(Q)sh hal/components/mkconv.sh u32 float < $< > $@
 
 hal/components/conv_u32_bit.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u32 bit "" -1 1 < $< > $@
+	$(Q)sh hal/components/mkconv.sh u32 bit < $< > $@
 
 hal/components/conv_u32_s32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u32 s32 "" -1 2147483647 < $< > $@
+	$(Q)sh hal/components/mkconv.sh u32 s32 < $< > $@
 
 hal/components/conv_u32_u64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u32 u64 "" < $< > $@
+	$(Q)sh hal/components/mkconv.sh u32 u64 < $< > $@
 
 hal/components/conv_u32_s64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u32 s64 "" < $< > $@
+	$(Q)sh hal/components/mkconv.sh u32 s64 < $< > $@
 
 hal/components/conv_s64_float.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s64 float // < $< > $@
+	$(Q)sh hal/components/mkconv.sh s64 float < $< > $@
 
 hal/components/conv_s64_bit.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s64 bit "" 0 1 < $< > $@
+	$(Q)sh hal/components/mkconv.sh s64 bit < $< > $@
 
 hal/components/conv_s64_u32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s64 u32 "" -1 2147483647 < $< > $@
+	$(Q)sh hal/components/mkconv.sh s64 u32 < $< > $@
 
 hal/components/conv_s64_s32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s64 s32 "" -2147483647-1 2147483647 < $< > $@
+	$(Q)sh hal/components/mkconv.sh s64 s32 < $< > $@
 
 hal/components/conv_s64_u64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh s64 u64 "" -1 9223372036854775807u < $< > $@
+	$(Q)sh hal/components/mkconv.sh s64 u64 < $< > $@
 
 hal/components/conv_u64_float.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u64 float // < $< > $@
+	$(Q)sh hal/components/mkconv.sh u64 float < $< > $@
 
 hal/components/conv_u64_bit.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u64 bit "" 0 1 < $< > $@
+	$(Q)sh hal/components/mkconv.sh u64 bit < $< > $@
 
 hal/components/conv_u64_u32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u64 u32 "" -1 4294967295 < $< > $@
+	$(Q)sh hal/components/mkconv.sh u64 u32 < $< > $@
 
 hal/components/conv_u64_s32.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u64 s32 "" -2147483647-1 2147483647 < $< > $@
+	$(Q)sh hal/components/mkconv.sh u64 s32 < $< > $@
 
 hal/components/conv_u64_s64.comp: hal/components/conv.comp.in hal/components/mkconv.sh hal/components/Submakefile
 	$(ECHO) converting conv for $(notdir $@)
-	$(Q)sh hal/components/mkconv.sh u64 s64 "" -1 9223372036854775808u < $< > $@
+	$(Q)sh hal/components/mkconv.sh u64 s64 < $< > $@

--- a/src/hal/components/conv.comp.in
+++ b/src/hal/components/conv.comp.in
@@ -1,25 +1,27 @@
 component conv_@IN@_@OUT@ "Convert a value from @IN@ to @OUT@";
-pin in @IN@ in_;
+pin in @IN@ in;
 pin out @OUT@ out;
-@CC@ pin out bit out_of_range "TRUE when 'in' is not in the range of @OUT@";
-@CC@ param rw bit clamp """If TRUE, then clamp to the range of @OUT@.  If FALSE, then allow the value to "wrap around".""";
+@CC@pin out bit out_of_range "TRUE when 'in' is not in the range of @OUT@";
+@CC@param rw bit clamp """If TRUE, then clamp to the range of @OUT@.  If FALSE, then allow the value to "wrap around".""";
 function _ @FP@ "Update 'out' based on 'in'";
 license "GPL";
 author "Jeff Epler";
 
 ;;
+#include <stdint.h>
 FUNCTION(_) {
-    hal_@IN@_t in = in_;
-@CC@    if(clamp) {
-#if @MAX@ != 0
-@CC@	if(in > @MAX@) { out = @MAX@; out_of_range = 1; return; }
+	@TYPI@ val = in;
+@CC@	if(clamp) {
+#if @MAXEN@ == 0
+@CC@		if(val > (@TYPI@)@MAX@) { out = @MAX@; out_of_range = 1; return; }
 #endif
-#if @MIN@ != -1
-@CC@	if(in < @MIN@) { out = @MIN@; out_of_range = 1; return; }
+#if @MINEN@ == 0
+@CC@		if(val < (@TYPI@)@MIN@) { out = @MIN@; out_of_range = 1; return; }
 #endif
-@CC@	out = in; out_of_range = 0;
-@CC@    } else {
-	out = in;
-@CC@	if(out != in) out_of_range = 1;
-@CC@    }
+@CC@		out = (@TYPO@)val;
+@CC@		out_of_range = 0;
+@CC@	} else {
+		out = (@TYPO@)val;
+@CC@		if((@TYPI@)out != val) out_of_range = 1;
+@CC@	}
 }

--- a/src/hal/components/mkconv.sh
+++ b/src/hal/components/mkconv.sh
@@ -1,3 +1,107 @@
 #!/bin/bash
-if [ "$1" = "float" -o "$2" = "float" ]; then F=""; else F="nofp"; fi
-sed -e "s,@IN@,$1,g; s,@OUT@,$2,g; s,@CC@,$3,g; s,@MIN@,${4-0},g; s,@MAX@,${5-0},g; s,@FP@,$F,g;"
+
+if [ $# -lt 2 ]; then
+	echo "Too few arguments to $(basename "$0")." >&2
+	echo "Usage: $(basename "$0") <from_type> <to_type>." >&2
+	exit 1
+fi
+
+# Convert the hal type into the underlying type
+utype() {
+	case "$1" in
+	"bit")	echo "bool" ;;
+	"s32")	echo "rtapi_s32" ;;
+	"u32")	echo "rtapi_u32" ;;
+	"s64")	echo "rtapi_s64" ;;
+	"u64")	echo "rtapi_u64" ;;
+	"float") echo "real_t" ;;
+	*)	echo "This_Will_Generate_An_Error" ;;
+	esac
+}
+
+# Return the maximum value supported by a type
+maxval() {
+	case "$1" in
+	"bit")	echo "1" ;;
+	"s32")	echo "INT32_MAX" ;;
+	"u32")	echo "UINT32_MAX" ;;
+	"s64")	echo "INT64_MAX" ;;
+	"u64")	echo "UINT64_MAX" ;;
+	"float") echo "Never_Used" ;;
+	*)	echo "This_Will_Generate_An_Error" ;;
+	esac
+}
+
+# Return the minimum value supported by a type
+minval() {
+	case "$1" in
+	"bit")	echo "0" ;;
+	"s32")	echo "INT32_MIN" ;;
+	"u32")	echo "0" ;;
+	"s64")	echo "INT64_MIN" ;;
+	"u64")	echo "0" ;;
+	"float") echo "Never_Used" ;;
+	*)	echo "This_Will_Generate_An_Error" ;;
+	esac
+}
+
+#
+# Conversions
+# xxx = unsupported conversion
+# o   = no bounds checks or clamp needed
+#  +  = max side bound needed
+#   - = min side bound needed
+# (table: vertical=from ($1); horizontal=to ($2))
+#     | flt | u32 | s32 | u64 | s64 | bit
+# ----+-----+-----+-----+-----+-----+-----
+# flt | xxx |  +- |  +- |  +- |  +- | xxx
+# u32 | o   | xxx |  +  | o   | o   |  +
+# s32 | o   |   - | xxx |   - | o   |  +-
+# u64 | o   |  +  |  +  | xxx |  +  |  +
+# s64 | o   |  +- |  +- |   - | xxx |  +-
+# bit | o   | o   | o   | o   | o   | xxx
+#
+# Boolean implementation of the above table:
+#     | flt | u32 | s32 | u64 | s64 | bit
+# ----+-----+-----+-----+-----+-----+-----
+# flt | o+- |  +- |  +- |  +- |  +- | x+-
+# u32 | o   | xxx |  +  | o   | o   |  +
+# s32 | o   |   - | x+x |   - | o   |  +-
+# u64 | o   |  +  |  +  | x+x |  +  |  +
+# s64 | o   |  +- |  +- |   - | xx- |  +-
+# bit | o   | o   | o   | o   | o   | o+x
+#
+
+# Enable (val > MAX) test
+MAXEN="s,@MAXEN@,$([[ \
+		"$1" == "float" || \
+		"$2" == "bit" || \
+		( "$2" == "s32" && "$1" != "bit" ) || \
+		( "$1" == "u64" && "$2" != "float" ) || \
+		( "$1" == "s64" && "$2" == "u32" ) \
+	]]; echo $?),g"
+
+# Enable (val < MIN) test
+MINEN="s,@MINEN@,$([[ \
+		"$1" == "float" || \
+		( "$1" == "s64" && "$2" != "float" ) || \
+		( "$1" == "s32" && ( "$2" == "u32" || "$2" == "u64" || "$2" == "bit" ) ) \
+	]]; echo $?),g"
+
+# Disable clamp code
+CC="s,@CC@,$([[ \
+		"$2" == "float" || \
+		"$1" == "bit" || \
+		( "$1" == "u32" && ( "$2" == "u64" || "$2" == "s64" ) ) || \
+		( "$1" == "s32" && "$2" == "s64" ) \
+	]] && echo "//"),g"
+
+FP="s,@FP@,$([[ "$1" == "float" || "$2" == "float" ]] || echo "nofp"),g"
+IN="s,@IN@,$1,g"
+OUT="s,@OUT@,$2,g"
+MIN="s,@MIN@,$(minval "$2"),g"
+MAX="s,@MAX@,$(maxval "$2"),g"
+TYPI="s,@TYPI@,$(utype "$1"),g"
+TYPO="s,@TYPO@,$(utype "$2"),g"
+
+exec sed -e "$IN; $OUT; $CC; $MIN; $MAX; $FP; $TYPI; $TYPO; $MINEN; $MAXEN;"


### PR DESCRIPTION
This PR fixes the clang warnings about values not fitting the type and implicit conversion.

The previous solution to generating the type conversion components used the C preprocessor with very large literal int and uint values, passed to the script, to determine whether some code should be enabled or not. This is prone to error as the preprocessor may not handle types the same way as the actual language. This results in errors and warnings.

All conversions are a matrix of possible combinations that have predetermined outcome how they should be handled. The minimum and maximum values for the target types are defined in the C language and are the authoritative values:  <code>0</code>, <code>1</code>, <code>INT{32,64}_{MIN,MAX}</code> and <code>UINT{32,64}_MAX</code>.

The PR changes the build to use a programmed approach to determine which parts of the component template are used and how they are activated. The preprocessor is no longer used with large values but only simple true/false conditions. Template generation invocation no longer requires the min/max values to be passed as they are determined by the script using C defined symbolic values. Finally, the conversion components use the underlying type for caching the value, which may be properly optimized by the compiler and values are cast to their targets.