### PR TITLE
Fix most of the incompatible function cast warnings

### DIFF
--- a/src/emc/rs274ngc/gcodemodule.cc
+++ b/src/emc/rs274ngc/gcodemodule.cc
@@ -81,10 +81,10 @@ typedef struct {
     int mcodes[ACTIVE_M_CODES];
 } LineCode;
 
-static PyObject *LineCode_gcodes(LineCode *l) {
+static PyObject *LineCode_gcodes(LineCode *l, void *) {
     return int_array(l->gcodes, ACTIVE_G_CODES);
 }
-static PyObject *LineCode_mcodes(LineCode *l) {
+static PyObject *LineCode_mcodes(LineCode *l, void *) {
     return int_array(l->mcodes, ACTIVE_M_CODES);
 }
 

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -545,35 +545,35 @@ static PyObject *pose(const EmcPose &p) {
     return res;
 }
 
-static PyObject *Stat_g5x_index(pyStatChannel *s) {
+static PyObject *Stat_g5x_index(pyStatChannel *s, void *) {
     return PyLong_FromLong(s->status.task.g5x_index);
 }
 
-static PyObject *Stat_g5x_offset(pyStatChannel *s) {
+static PyObject *Stat_g5x_offset(pyStatChannel *s, void *) {
     return pose(s->status.task.g5x_offset);
 }
 
-static PyObject *Stat_g92_offset(pyStatChannel *s) {
+static PyObject *Stat_g92_offset(pyStatChannel *s, void *) {
     return pose(s->status.task.g92_offset);
 }
 
-static PyObject *Stat_tool_offset(pyStatChannel *s) {
+static PyObject *Stat_tool_offset(pyStatChannel *s, void *) {
     return pose(s->status.task.toolOffset);
 }
 
-static PyObject *Stat_position(pyStatChannel *s) {
+static PyObject *Stat_position(pyStatChannel *s, void *) {
     return pose(s->status.motion.traj.position);
 }
 
-static PyObject *Stat_dtg(pyStatChannel *s) {
+static PyObject *Stat_dtg(pyStatChannel *s, void *) {
     return pose(s->status.motion.traj.dtg);
 }
 
-static PyObject *Stat_actual(pyStatChannel *s) {
+static PyObject *Stat_actual(pyStatChannel *s, void *) {
     return pose(s->status.motion.traj.actualPosition);
 }
 
-static PyObject *Stat_joint_position(pyStatChannel *s) {
+static PyObject *Stat_joint_position(pyStatChannel *s, void *) {
     PyObject *res = PyTuple_New(EMCMOT_MAX_JOINTS);
     for(int i=0; i<EMCMOT_MAX_JOINTS; i++) {
         PyTuple_SetItem(res, i,
@@ -582,7 +582,7 @@ static PyObject *Stat_joint_position(pyStatChannel *s) {
     return res;
 }
 
-static PyObject *Stat_joint_actual(pyStatChannel *s) {
+static PyObject *Stat_joint_actual(pyStatChannel *s, void *) {
     PyObject *res = PyTuple_New(EMCMOT_MAX_JOINTS);
     for(int i=0; i<EMCMOT_MAX_JOINTS; i++) {
         PyTuple_SetItem(res, i,
@@ -591,31 +591,31 @@ static PyObject *Stat_joint_actual(pyStatChannel *s) {
     return res;
 }
 
-static PyObject *Stat_probed(pyStatChannel *s) {
+static PyObject *Stat_probed(pyStatChannel *s, void *) {
     return pose(s->status.motion.traj.probedPosition);
 }
 
-static PyObject *Stat_activegcodes(pyStatChannel *s) {
+static PyObject *Stat_activegcodes(pyStatChannel *s, void *) {
     return int_array(s->status.task.activeGCodes, ACTIVE_G_CODES);
 }
 
-static PyObject *Stat_activemcodes(pyStatChannel *s) {
+static PyObject *Stat_activemcodes(pyStatChannel *s, void *) {
     return int_array(s->status.task.activeMCodes, ACTIVE_M_CODES);
 }
 
-static PyObject *Stat_activesettings(pyStatChannel *s) {
+static PyObject *Stat_activesettings(pyStatChannel *s, void *) {
    return double_array(s->status.task.activeSettings, ACTIVE_SETTINGS);
 }
 
-static PyObject *Stat_din(pyStatChannel *s) {
+static PyObject *Stat_din(pyStatChannel *s, void *) {
     return int_array(s->status.motion.synch_di, EMCMOT_MAX_AIO);
 }
 
-static PyObject *Stat_dout(pyStatChannel *s) {
+static PyObject *Stat_dout(pyStatChannel *s, void *) {
     return int_array(s->status.motion.synch_do, EMCMOT_MAX_AIO);
 }
 
-static PyObject *Stat_limit(pyStatChannel *s) {
+static PyObject *Stat_limit(pyStatChannel *s, void *) {
     PyObject *res = PyTuple_New(EMCMOT_MAX_JOINTS);
     for(int i = 0; i < EMCMOT_MAX_JOINTS; i++) {
         int v = 0;
@@ -628,7 +628,7 @@ static PyObject *Stat_limit(pyStatChannel *s) {
     return res;
 }
 
-static PyObject *Stat_homed(pyStatChannel *s) {
+static PyObject *Stat_homed(pyStatChannel *s, void *) {
     PyObject *res = PyTuple_New(EMCMOT_MAX_JOINTS);
     for(int i = 0; i < EMCMOT_MAX_JOINTS; i++) {
         PyTuple_SET_ITEM(res, i, PyLong_FromLong(s->status.motion.joint[i].homed));
@@ -636,15 +636,15 @@ static PyObject *Stat_homed(pyStatChannel *s) {
     return res;
 }
 
-static PyObject *Stat_ain(pyStatChannel *s) {
+static PyObject *Stat_ain(pyStatChannel *s, void *) {
     return double_array(s->status.motion.analog_input, EMCMOT_MAX_AIO);
 }
 
-static PyObject *Stat_aout(pyStatChannel *s) {
+static PyObject *Stat_aout(pyStatChannel *s, void *) {
     return double_array(s->status.motion.analog_output, EMCMOT_MAX_AIO);
 }
 
-static PyObject *Stat_misc_error(pyStatChannel *s){
+static PyObject *Stat_misc_error(pyStatChannel *s, void *){
   return int_array(s->status.motion.misc_error, EMCMOT_MAX_MISC_ERROR);
 }
 
@@ -679,7 +679,7 @@ static PyObject *Stat_joint_one(pyStatChannel *s, int jointno) {
 #undef F
 #undef F2
 
-static PyObject *Stat_joint(pyStatChannel *s) {
+static PyObject *Stat_joint(pyStatChannel *s, void *) {
     PyObject *res = PyTuple_New(EMCMOT_MAX_JOINTS);
     for(int i=0; i<EMCMOT_MAX_JOINTS; i++) {
         PyTuple_SetItem(res, i, Stat_joint_one(s, i));
@@ -700,7 +700,7 @@ static PyObject *Stat_axis_one(pyStatChannel *s, int axisno) {
 #undef F
 #undef F2
 
-static PyObject *Stat_axis(pyStatChannel *s) {
+static PyObject *Stat_axis(pyStatChannel *s, void *) {
     PyObject *res = PyTuple_New(EMCMOT_MAX_AXIS);
     for(int i=0; i<EMCMOT_MAX_AXIS; i++) {
         PyTuple_SetItem(res, i, Stat_axis_one(s, i));
@@ -726,7 +726,7 @@ static PyObject *Stat_spindle_one(pyStatChannel *s, int spindleno) {
 #undef F
 #undef F2
 
-static PyObject *Stat_spindle(pyStatChannel *s) {
+static PyObject *Stat_spindle(pyStatChannel *s, void *) {
     PyObject *res = PyTuple_New(EMCMOT_MAX_SPINDLES);
     for(int i=0; i<EMCMOT_MAX_SPINDLES; i++) {
         PyTuple_SetItem(res, i, Stat_spindle_one(s, i));
@@ -761,7 +761,7 @@ static PyStructSequence_Desc tool_result_desc = {
 
 static PyTypeObject ToolResultType;
 
-static PyObject *Stat_tool_table(pyStatChannel *s) {
+static PyObject *Stat_tool_table(pyStatChannel *s, void *) {
     PyObject *res;
     int j = 0;
 
@@ -966,7 +966,7 @@ static PyObject *mode(pyCommandChannel *s, PyObject *o) {
     return Py_None;
 }
 
-static PyObject *task_plan_synch(pyCommandChannel *s) {
+static PyObject *task_plan_synch(pyCommandChannel *s, PyObject *) {
     EMC_TASK_PLAN_SYNCH synch;
     emcSendCommand(s, synch);
     Py_INCREF(Py_None);
@@ -1312,7 +1312,9 @@ static PyObject *program_open(pyCommandChannel *s, PyObject *o) {
             PyErr_Format(PyExc_OSError, "fseek(%s) error: %s", file, strerror(errno));
             return PyErr_SetFromErrno(PyExc_OSError);
         }
-        if((m.remote_filesize = ftell(fd)) < 0) {
+        long ftpos = ftell(fd);
+        m.remote_filesize = ftpos;
+        if(ftpos < 0) {
             fclose(fd);
             PyErr_Format(PyExc_OSError, "ftell(%s) error: %s", file, strerror(errno));
             return PyErr_SetFromErrno(PyExc_OSError);
@@ -1701,7 +1703,7 @@ static int Error_init(pyErrorChannel *self, PyObject *a, PyObject *k) {
     return 0;
 }
 
-static PyObject* Error_poll(pyErrorChannel *s) {
+static PyObject* Error_poll(pyErrorChannel *s, PyObject *) {
     if(!s->c->valid()) {
         PyErr_Format( error, "Error buffer invalid" );
         return NULL;
@@ -2186,7 +2188,7 @@ static void UNLOCK() { pthread_mutex_unlock(&mutex); }
 static int Logger_init(pyPositionLogger *self, PyObject *a, PyObject *k) {
     char *geometry;
     struct color *c = self->colors;
-    self->p = (logger_point*)malloc(0);
+    self->p = (logger_point*)malloc(sizeof(self->p[0])); // Will be realloc'ed
     self->npts = self->mpts = 0;
     self->exit = self->clear = 0;
     self->changed = 1;
@@ -2242,7 +2244,7 @@ static PyObject *Logger_set_colors(pyPositionLogger *s, PyObject *a) {
     return Py_None;
 }
 
-static PyObject *Logger_get_colors(pyPositionLogger *s) {
+static PyObject *Logger_get_colors(pyPositionLogger *s, PyObject *) {
     struct color *c = s->colors;
     PyObject *result = NULL;
         result = Py_BuildValue("(BBBB)(BBBB)(BBBB)(BBBB)(BBBB)(BBBB)",

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -959,7 +959,9 @@ int sendProgramOpen(char *program)
             rcs_print_error("fseek(%s) error: %s\n", program, strerror(errno));
             return -1;
         }
-        if((msg.remote_filesize = ftell(fd)) < 0) {
+        long ftpos = ftell(fd);
+        msg.remote_filesize = ftpos;
+        if(ftpos < 0) {
             fclose(fd);
             rcs_print_error("ftell(%s) error: %s\n", program, strerror(errno));
             return -1;

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -124,13 +124,13 @@ fail:
 
 bool from_python(PyObject *o, hal_u64_t *u) {
     PyObject *tmp = 0;
-    unsigned long long l;
+    long long l;
     tmp = PyLong_Check(o) ? o : PyNumber_Long(o);
     if(!tmp) goto fail;
 
     l = PyLong_AsLongLong(tmp);
     if(PyErr_Occurred()) goto fail;
-    if(l < 0 || l != (rtapi_u64)l) {
+    if(l < 0 || l >= (long long)UINT64_MAX) {
         PyErr_Format(PyExc_OverflowError, "Value %lld out of range", l);
         goto fail;
     }

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -130,7 +130,7 @@ bool from_python(PyObject *o, hal_u64_t *u) {
 
     l = PyLong_AsLongLong(tmp);
     if(PyErr_Occurred()) goto fail;
-    if(l < 0 || l >= (long long)UINT64_MAX) {
+    if(l < 0) {
         PyErr_Format(PyExc_OverflowError, "Value %lld out of range", l);
         goto fail;
     }

--- a/src/hal/utils/halcmd.c
+++ b/src/hal/utils/halcmd.c
@@ -132,47 +132,47 @@ void halcmd_shutdown(void) {
    command.
 */
 
-#define FUNCT(x) ((halcmd_func_t)x)
+#define FUNCT(x,t) { ./**/t = x }
 
 struct halcmd_command halcmd_commands[] = {
-    {"addf",    FUNCT(do_addf_cmd),    A_TWO | A_PLUS },
-    {"alias",   FUNCT(do_alias_cmd),   A_THREE },
-    {"delf",    FUNCT(do_delf_cmd),    A_TWO | A_OPTIONAL },
-    {"delsig",  FUNCT(do_delsig_cmd),  A_ONE },
-    {"debug",   FUNCT(do_set_debug_cmd),A_ONE },
-    {"echo",    FUNCT(do_echo_cmd),    A_ZERO },
-    {"getp",    FUNCT(do_getp_cmd),    A_ONE },
-    {"gets",    FUNCT(do_gets_cmd),    A_ONE },
-    {"print",   FUNCT(do_print_cmd),   A_ONE | A_OPTIONAL},
-    {"ptype",   FUNCT(do_ptype_cmd),   A_ONE },
-    {"stype",   FUNCT(do_stype_cmd),   A_ONE },
-    {"help",    FUNCT(do_help_cmd),    A_ONE | A_OPTIONAL },
-    {"linkpp",  FUNCT(do_linkpp_cmd),  A_TWO | A_REMOVE_ARROWS },
-    {"linkps",  FUNCT(do_linkps_cmd),  A_TWO | A_REMOVE_ARROWS },
-    {"linksp",  FUNCT(do_linksp_cmd),  A_TWO | A_REMOVE_ARROWS },
-    {"list",    FUNCT(do_list_cmd),    A_ONE | A_PLUS },
-    {"loadrt",  FUNCT(do_loadrt_cmd),  A_ONE | A_PLUS },
-    {"loadusr", FUNCT(do_loadusr_cmd), A_PLUS | A_TILDE },
-    {"lock",    FUNCT(do_lock_cmd),    A_ONE | A_OPTIONAL },
-    {"net",     FUNCT(do_net_cmd),     A_ONE | A_PLUS | A_REMOVE_ARROWS },
-    {"newsig",  FUNCT(do_newsig_cmd),  A_TWO },
-    {"save",    FUNCT(do_save_cmd),    A_TWO | A_OPTIONAL | A_TILDE },
-    {"setexact_for_test_suite_only", FUNCT(do_setexact_cmd), A_ZERO },
-    {"setp",    FUNCT(do_setp_cmd),    A_TWO },
-    {"sets",    FUNCT(do_sets_cmd),    A_TWO },
-    {"show",    FUNCT(do_show_cmd),    A_ONE | A_OPTIONAL | A_PLUS},
-    {"source",  FUNCT(do_source_cmd),  A_ONE | A_TILDE },
-    {"start",   FUNCT(do_start_cmd),   A_ZERO},
-    {"status",  FUNCT(do_status_cmd),  A_ONE | A_OPTIONAL },
-    {"stop",    FUNCT(do_stop_cmd),    A_ZERO},
-    {"unalias", FUNCT(do_unalias_cmd), A_TWO },
-    {"unecho",  FUNCT(do_unecho_cmd),  A_ZERO },
-    {"unlinkp", FUNCT(do_unlinkp_cmd), A_ONE },
-    {"unload",  FUNCT(do_unload_cmd),  A_ONE },
-    {"unloadrt", FUNCT(do_unloadrt_cmd), A_ONE },
-    {"unloadusr", FUNCT(do_unloadusr_cmd), A_ONE },
-    {"unlock",  FUNCT(do_unlock_cmd),  A_ONE | A_OPTIONAL },
-    {"waitusr", FUNCT(do_waitusr_cmd), A_ONE },
+    {"addf",    FUNCT(do_addf_cmd, cp_cp_cpp), A_TWO | A_PLUS },
+    {"alias",   FUNCT(do_alias_cmd, cp_cp_cp), A_THREE },
+    {"delf",    FUNCT(do_delf_cmd, cp_cp),     A_TWO | A_OPTIONAL },
+    {"delsig",  FUNCT(do_delsig_cmd, cp),      A_ONE },
+    {"debug",   FUNCT(do_set_debug_cmd, cp),   A_ONE },
+    {"echo",    FUNCT(do_echo_cmd, v),         A_ZERO },
+    {"getp",    FUNCT(do_getp_cmd, cp),        A_ONE },
+    {"gets",    FUNCT(do_gets_cmd, cp),        A_ONE },
+    {"print",   FUNCT(do_print_cmd, cp),       A_ONE | A_OPTIONAL},
+    {"ptype",   FUNCT(do_ptype_cmd, cp),       A_ONE },
+    {"stype",   FUNCT(do_stype_cmd, cp),       A_ONE },
+    {"help",    FUNCT(do_help_cmd, cp),        A_ONE | A_OPTIONAL },
+    {"linkpp",  FUNCT(do_linkpp_cmd, cp_cp),   A_TWO | A_REMOVE_ARROWS },
+    {"linkps",  FUNCT(do_linkps_cmd, cp_cp),   A_TWO | A_REMOVE_ARROWS },
+    {"linksp",  FUNCT(do_linksp_cmd, cp_cp),   A_TWO | A_REMOVE_ARROWS },
+    {"list",    FUNCT(do_list_cmd, cp_cpp),    A_ONE | A_PLUS },
+    {"loadrt",  FUNCT(do_loadrt_cmd, cp_cpp),  A_ONE | A_PLUS },
+    {"loadusr", FUNCT(do_loadusr_cmd, ccpp),   A_PLUS | A_TILDE },
+    {"lock",    FUNCT(do_lock_cmd, cp),        A_ONE | A_OPTIONAL },
+    {"net",     FUNCT(do_net_cmd, cp_cpp),     A_ONE | A_PLUS | A_REMOVE_ARROWS },
+    {"newsig",  FUNCT(do_newsig_cmd, cp_cp),   A_TWO },
+    {"save",    FUNCT(do_save_cmd, ccp_cp),    A_TWO | A_OPTIONAL | A_TILDE },
+    {"setexact_for_test_suite_only", FUNCT(do_setexact_cmd, v), A_ZERO },
+    {"setp",    FUNCT(do_setp_cmd, cp_cp),     A_TWO },
+    {"sets",    FUNCT(do_sets_cmd, cp_cp),     A_TWO },
+    {"show",    FUNCT(do_show_cmd, cp_cpp),    A_ONE | A_OPTIONAL | A_PLUS},
+    {"source",  FUNCT(do_source_cmd, cp),      A_ONE | A_TILDE },
+    {"start",   FUNCT(do_start_cmd, v),        A_ZERO},
+    {"status",  FUNCT(do_status_cmd, cp),      A_ONE | A_OPTIONAL },
+    {"stop",    FUNCT(do_stop_cmd, v),         A_ZERO},
+    {"unalias", FUNCT(do_unalias_cmd, cp_cp),  A_TWO },
+    {"unecho",  FUNCT(do_unecho_cmd, v),       A_ZERO },
+    {"unlinkp", FUNCT(do_unlinkp_cmd, cp),     A_ONE },
+    {"unload",  FUNCT(do_unload_cmd, cp),      A_ONE },
+    {"unloadrt", FUNCT(do_unloadrt_cmd, cp),   A_ONE },
+    {"unloadusr", FUNCT(do_unloadusr_cmd, cp), A_ONE },
+    {"unlock",  FUNCT(do_unlock_cmd, cp),      A_ONE | A_OPTIONAL },
+    {"waitusr", FUNCT(do_waitusr_cmd, cp),     A_ONE },
 };
 int halcmd_ncommands = (sizeof(halcmd_commands) / sizeof(halcmd_commands[0]));
 
@@ -375,57 +375,37 @@ static int parse_cmd1(char **argv) {
 	if(!strcmp(command->name, "echo")) {echo_mode = 1;}
 	if(!strcmp(command->name, "unecho")) {echo_mode = 0;}
 	switch(nargs | is_plus) {
-	case A_ZERO: {
-	    result = command->func();
+	case A_ZERO:
+	    result = command->func.v();
 	    break;
-	}
 
-	case A_PLUS: {
-	    int(*f)(char **args) = (int(*)(char**))command->func;
-	    result = f(REST(1));
+	case A_PLUS:
+	    result = command->func.cpp(REST(1));
 	    break;
-	}
 
-	case A_ONE: {
-	    int(*f)(char *arg) = (int(*)(char*))command->func;
-	    result = f(ARG(1));
+	case A_ONE:
+	    result = command->func.cp(ARG(1));
 	    break;
-	}
 
-	case A_ONE | A_PLUS: {
-	    int(*f)(char *arg, char **rest) =
-                (int(*)(char*,char**))command->func;
-	    result = f(ARG(1), REST(2));
+	case A_ONE | A_PLUS:
+	    result = command->func.cp_cpp(ARG(1), REST(2));
 	    break;
-	}
 
-	case A_TWO: {
-	    int(*f)(char *arg, char *arg2) =
-                (int(*)(char*,char*))command->func;
-	    result = f(ARG(1), ARG(2));
+	case A_TWO:
+	    result = command->func.cp_cp(ARG(1), ARG(2));
 	    break;
-	}
 
-	case A_TWO | A_PLUS: {
-	    int(*f)(char *arg, char *arg2, char **rest) =
-                (int(*)(char*,char*,char**))command->func;
-	    result = f(ARG(1), ARG(2), REST(3));
+	case A_TWO | A_PLUS:
+	    result = command->func.cp_cp_cpp(ARG(1), ARG(2), REST(3));
 	    break;
-	}
 
-	case A_THREE: {
-	    int(*f)(char *arg, char *arg2, char *arg3) =
-                (int(*)(char*,char*,char*))command->func;
-	    result = f(ARG(1), ARG(2), ARG(3));
+	case A_THREE:
+	    result = command->func.cp_cp_cp(ARG(1), ARG(2), ARG(3));
 	    break;
-	}
 
-	case A_THREE | A_PLUS: {
-	    int(*f)(char *arg, char *arg2, char *arg3, char **rest) =
-                (int(*)(char*,char*,char*,char**))command->func;
-	    result = f(ARG(1), ARG(2), ARG(3), REST(4));
+	case A_THREE | A_PLUS:
+	    result = command->func.cp_cp_cp_cpp(ARG(1), ARG(2), ARG(3), REST(4));
 	    break;
-	}
 
 	default:
 	    halcmd_error("BUG: unchandled case: command=%s type=0x%x",

--- a/src/hal/utils/halcmd.h
+++ b/src/hal/utils/halcmd.h
@@ -76,8 +76,30 @@ enum halcmd_argtype {
     A_TILDE = 0x800,         /* tilde-expand all arguments */
 };
 
-typedef int(*halcmd_func_t)(void);
 
+typedef int(*halcmd_func_v_t)(void);
+typedef int(*halcmd_func_cp_t)(char *);
+typedef int(*halcmd_func_cpp_t)(char **);
+typedef int(*halcmd_func_ccpp_t)(const char **);
+typedef int(*halcmd_func_cp_cp_t)(char *, char *);
+typedef int(*halcmd_func_ccp_cp_t)(const char *, char *);
+typedef int(*halcmd_func_cp_cpp_t)(char *, char **);
+typedef int(*halcmd_func_cp_cp_cp_t)(char *, char *, char *);
+typedef int(*halcmd_func_cp_cp_cpp_t)(char *, char *, char **);
+typedef int(*halcmd_func_cp_cp_cp_cpp_t)(char *, char *, char *, char **);
+
+typedef union {
+	halcmd_func_v_t		v;
+	halcmd_func_cp_t	cp;
+	halcmd_func_cpp_t	cpp;
+	halcmd_func_ccpp_t	ccpp;
+	halcmd_func_cp_cp_t	cp_cp;
+	halcmd_func_ccp_cp_t	ccp_cp;
+	halcmd_func_cp_cpp_t	cp_cpp;
+	halcmd_func_cp_cp_cp_t	cp_cp_cp;
+	halcmd_func_cp_cp_cpp_t	cp_cp_cpp;
+	halcmd_func_cp_cp_cp_cpp_t cp_cp_cp_cpp;
+} halcmd_func_t;
 
 struct halcmd_command {
     const char *name;


### PR DESCRIPTION
This PR takes care of nearly all warnings from <code>-Wcast-function-type</code>. A few were left to be examined closer.

Part of these warnings were caused by using functions missing an unused parameter, which could be added without changing functionality. The other set were because of initializing function pointers with different prototypes in one and the same struct field. Here the field's type is changed to a union to encompass all the function prototypes used. Dereferencing this union also reduced the amount of casting needed to call the functions.

Additionally, a non-portable call to malloc(0), allocating zero bytes, was replaced to allocate one element instead. The code flow reallocs this later.

Finally, the PR fixes a few signed to unsigned conversion with subsequent compare to less than zero. Unsigned comparison to less than zero makes no sense, but the values come from function return values that can be negative on error, which was tested for.