### PR TITLE
Fix cast function type warnings and base class constructor call

### DIFF
--- a/src/emc/rs274ngc/interp_array_types.hh
+++ b/src/emc/rs274ngc/interp_array_types.hh
@@ -26,9 +26,15 @@
 namespace pp = pyplusplus::containers::static_sized;
 
 typedef pp::array_1_t<double, EMCMOT_MAX_SPINDLES> spindle_speed_array, (*spindle_speed_w)(Interp &);
-typedef pp::array_1_t< int, ACTIVE_G_CODES> active_g_codes_array, (*active_g_codes_w)( Interp & );
-typedef pp::array_1_t< int, ACTIVE_M_CODES> active_m_codes_array, (*active_m_codes_w)( Interp & );
-typedef pp::array_1_t< double, ACTIVE_SETTINGS> active_settings_array, (*active_settings_w)( Interp & );
+typedef pp::array_1_t< int, ACTIVE_G_CODES> active_g_codes_array,
+    (*active_g_codes_w)( Interp & ),
+    (*active_g_codes_w_ctx)( context & );
+typedef pp::array_1_t< int, ACTIVE_M_CODES> active_m_codes_array,
+    (*active_m_codes_w)( Interp & ),
+    (*active_m_codes_w_ctx)( context & );
+typedef pp::array_1_t< double, ACTIVE_SETTINGS> active_settings_array,
+    (*active_settings_w)( Interp & ),
+    (*active_settings_w_ctx)( context & );
 typedef pp::array_1_t< block, MAX_NESTED_REMAPS> blocks_array, (*blocks_w)( Interp & );
 
 typedef pp::array_1_t< double, interp_param_global::RS274NGC_MAX_PARAMETERS > parameters_array, (*parameters_w)( Interp & );

--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -641,7 +641,7 @@ private:
 
 public:
     g7x() = default;
-    g7x(g7x const &other) {
+    g7x(g7x const &other) : std::list<std::unique_ptr<segment>>() {
 	delta=other.delta;
 	escape=other.escape;
 	flip_state=other.flip_state;

--- a/src/emc/rs274ngc/pyinterp1.cc
+++ b/src/emc/rs274ngc/pyinterp1.cc
@@ -68,13 +68,13 @@ void export_Internals()
 		       bp::make_function( saved_params_w(&saved_params_wrapper),
 					  bp::with_custodian_and_ward_postcall< 0, 1 >()))
 	.add_property( "saved_g_codes",
-		       bp::make_function( active_g_codes_w(&saved_g_codes_wrapper),
+		       bp::make_function( active_g_codes_w_ctx(&saved_g_codes_wrapper),
 					  bp::with_custodian_and_ward_postcall< 0, 1 >()))
 	.add_property( "saved_m_codes",
-		       bp::make_function( active_m_codes_w(&saved_m_codes_wrapper),
+		       bp::make_function( active_m_codes_w_ctx(&saved_m_codes_wrapper),
 					  bp::with_custodian_and_ward_postcall< 0, 1 >()))
 	.add_property( "saved_settings",
-		       bp::make_function( active_settings_w(&saved_settings_wrapper),
+		       bp::make_function( active_settings_w_ctx(&saved_settings_wrapper),
 					  bp::with_custodian_and_ward_postcall< 0, 1 >()))
 	.def_readwrite("context_status", &context::context_status)
 	.def_readwrite("named_params",  &context::named_params)


### PR DESCRIPTION
This PR solves the last of the function type cast warnings. These were caused by reusing a typedef of a function with wrong parameter types. The solution was to add the proper typedefs and use them. This does not change anything at the (binary) compiled code level because both typedef versions use a single pass-by-reference parameter and have the same return type.
BTW, the line-breaks are added to be consistent with the same format used a few lines down in the file (not seen in the diff).

Also fixed is a missing base-class constructor call in the copy constructor of the g7x class. The constructor call is silently added by the compiler when missing as it does not need any parameters to pass on. The data contained in the base-class is copied in the derived class copy-constructor. The proper way is to make base-class construction explicit, removing the warning it otherwise would generate.