### PR TITLE
Remove the kludge and fix the race between task and motion

### DIFF
--- a/src/emc/motion-logger/motion-logger.c
+++ b/src/emc/motion-logger/motion-logger.c
@@ -96,9 +96,6 @@ static int init_comm_buffers(void) {
 	return -1;
     }
 
-    /* zero shared memory before doing anything else. */
-    memset(emcmotStruct, 0, sizeof(emcmot_struct_t));
-
     /* we'll reference emcmotStruct directly */
     c = &emcmotStruct->command;
     emcmotStatus = &emcmotStruct->status;

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -826,9 +826,6 @@ static int init_comm_buffers(void)
 	return -1;
     }
 
-    /* zero shared memory before doing anything else. */
-    memset(emcmotStruct, 0, sizeof(emcmot_struct_t));
-
     /* we'll reference emcmotStruct directly */
     emcmotCommand = &emcmotStruct->command;
     emcmotStatus = &emcmotStruct->status;
@@ -839,9 +836,16 @@ static int init_comm_buffers(void)
     /* init error struct */
     emcmotErrorInit(emcmotError);
 
-    /* init command struct */
-    emcmotCommand->command = 0;
-    emcmotCommand->commandNum = 0;
+    /*
+     * DO NOT init the command struct!
+     * This is a reader process and the writer (f.ex. milltask) may already
+     * have written a command in there before we get attached to shared memory.
+     * We might (actually will) lose a command if we write to the command
+     * structure.
+     *
+     * emcmotCommand->command = 0;
+     * emcmotCommand->commandNum = 0;
+     */
 
     /* init status struct */
     emcmotStatus->head = 0;

--- a/src/emc/motion/usrmotintf.cc
+++ b/src/emc/motion/usrmotintf.cc
@@ -89,6 +89,7 @@ int usrmotWriteEmcmotCommand(emcmot_command_t * c)
         rcs_print("USRMOT: ERROR: can't connect to shared memory\n");
 	return EMCMOT_COMM_ERROR_CONNECT;
     }
+
     /* copy entire command structure to shared memory */
     rtapi_mutex_get(&emcmotStruct->command_mutex);
     *emcmotCommand = *c;
@@ -110,17 +111,8 @@ int usrmotWriteEmcmotCommand(emcmot_command_t * c)
 	    }
 	}
 	esleep(25e-6);
-	/* KLUDGE: while waiting on motion to be ready, */
-	/* this particular command requires a re-copy to update for some reason */
-	/* otherwise it times out and "fails" task */
-	if (c->command == EMCMOT_SET_NUM_JOINTS) {
-		/* re-copy entire command structure to shared memory */
-		rtapi_mutex_get(&emcmotStruct->command_mutex);
-		*emcmotCommand = *c;
-		rtapi_mutex_give(&emcmotStruct->command_mutex);
-	}
     }
-    rcs_print("USRMOT: ERROR: command %u timeout\n", c->command);
+    rcs_print("USRMOT: ERROR: command %u timeout (seq: %d)\n", c->command, commandNum);
     return EMCMOT_COMM_ERROR_TIMEOUT;
 }
 
@@ -143,7 +135,9 @@ int usrmotReadEmcmotStatus(emcmot_status_t * s)
 	    return EMCMOT_COMM_OK;
 	}
 	/* inc counter and try again, max three times */
+	esleep(1e-6);	// Don't busy-loop
     } while ( ++split_read_count < 3 );
+    rcs_print("%s: Split read timeout\n", __FUNCTION__);
     return EMCMOT_COMM_SPLIT_READ_TIMEOUT;
 }
 
@@ -166,8 +160,9 @@ int usrmotReadEmcmotConfig(emcmot_config_t * s)
 	    return EMCMOT_COMM_OK;
 	}
 	/* inc counter and try again, max three times */
+	esleep(1e-6);	// Don't busy-loop
     } while ( ++split_read_count < 3 );
-printf("ReadEmcmotConfig COMM_SPLIT_READ_TIMEOUT\n" );
+    rcs_print("%s: Split read timeout\n", __FUNCTION__);
     return EMCMOT_COMM_SPLIT_READ_TIMEOUT;
 }
 
@@ -190,8 +185,9 @@ int usrmotReadEmcmotInternal(emcmot_internal_t * s)
 	    return EMCMOT_COMM_OK;
 	}
 	/* inc counter and try again, max three times */
+	esleep(1e-6);	// Don't busy-loop
     } while ( ++split_read_count < 3 );
-printf("ReadEmcmotInternal COMM_SPLIT_READ_TIMEOUT\n" );
+    rcs_print("%s: Split read timeout\n", __FUNCTION__);
     return EMCMOT_COMM_SPLIT_READ_TIMEOUT;
 }
 

--- a/src/emc/motion/usrmotintf.cc
+++ b/src/emc/motion/usrmotintf.cc
@@ -127,6 +127,7 @@ int usrmotReadEmcmotStatus(emcmot_status_t * s)
     }
     split_read_count = 0;
     do {
+	if(split_read_count > 0) esleep(1e-6);	// Don't busy-loop and give time to process
 	/* copy status struct from shmem to local memory */
 	memcpy(s, emcmotStatus, sizeof(emcmot_status_t));
 	/* got it, now check head-tail matche */
@@ -135,7 +136,6 @@ int usrmotReadEmcmotStatus(emcmot_status_t * s)
 	    return EMCMOT_COMM_OK;
 	}
 	/* inc counter and try again, max three times */
-	esleep(1e-6);	// Don't busy-loop
     } while ( ++split_read_count < 3 );
     rcs_print("%s: Split read timeout\n", __FUNCTION__);
     return EMCMOT_COMM_SPLIT_READ_TIMEOUT;
@@ -152,6 +152,7 @@ int usrmotReadEmcmotConfig(emcmot_config_t * s)
     }
     split_read_count = 0;
     do {
+	if(split_read_count > 0) esleep(1e-6);	// Don't busy-loop and give time to process
 	/* copy config struct from shmem to local memory */
 	memcpy(s, emcmotConfig, sizeof(emcmot_config_t));
 	/* got it, now check head-tail matches */
@@ -160,7 +161,6 @@ int usrmotReadEmcmotConfig(emcmot_config_t * s)
 	    return EMCMOT_COMM_OK;
 	}
 	/* inc counter and try again, max three times */
-	esleep(1e-6);	// Don't busy-loop
     } while ( ++split_read_count < 3 );
     rcs_print("%s: Split read timeout\n", __FUNCTION__);
     return EMCMOT_COMM_SPLIT_READ_TIMEOUT;
@@ -177,6 +177,7 @@ int usrmotReadEmcmotInternal(emcmot_internal_t * s)
     }
     split_read_count = 0;
     do {
+	if(split_read_count > 0) esleep(1e-6);	// Don't busy-loop and give time to process
 	/* copy debug struct from shmem to local memory */
 	memcpy(s, emcmotInternal, sizeof(emcmot_internal_t));
 	/* got it, now check head-tail matches */
@@ -185,7 +186,6 @@ int usrmotReadEmcmotInternal(emcmot_internal_t * s)
 	    return EMCMOT_COMM_OK;
 	}
 	/* inc counter and try again, max three times */
-	esleep(1e-6);	// Don't busy-loop
     } while ( ++split_read_count < 3 );
     rcs_print("%s: Split read timeout\n", __FUNCTION__);
     return EMCMOT_COMM_SPLIT_READ_TIMEOUT;


### PR DESCRIPTION
This PR addresses the problem that shows itself at startup with these two messages:
```
 USRMOT: ERROR: command 30 timeout
 emcMotionInit: emcTrajInit failed
```

Commit https://github.com/LinuxCNC/linuxcnc/commit/9a45ed94f75f2cef5cef29fd92d859d7ab0662a9 added a kludge to re-copy the command in case of timeout in a specific command. However, it is a kludge and it turns out that it was always the _first_ command that timed out. That clearly indicated a race/overwrite situation.

The problem exists between task and motion, usually milltask and motmod, but also motion-logger is affected. The race is an overwrite scenario with following sequence:
1. the writer, milltask, copies a command into shared memory command structure
2. the reader, motmod or motion-logger, attaches to shared memory and clears the shared memory overwriting the command structure
3. the writer never sees its command completing.

The timeout happens consistently because the milltask process starts before the motmod thread (though it is not guaranteed which process attaches first and writes the memory). The solution is obvious. The reader must not write to the command structure during initialization because there may already be a command in there.

This PR removes the kludge and removes the initialization of the command structure in the readers. The initial value of shared memory (when created) is always zero, so that works out fine if the reader attaches before the writer. The reader may set status and other structures to its liking, but the command structure is left alone.

Additionally, a micro-sleep is added in the split read functions (<code>usrmotReadEmcmotStatus()</code>, <code>usrmotReadEmcmotConfig()</code> and <code>usrmotReadEmcmotInternal()</code>). These were running a too tight loop with three retries. A tight loop is over in a matter of nanoseconds and will most likely timeout. Adding a minute sleep forces a reschedule and possible yield, giving the other side time to actually catch up. The micro sleep is no problem because the routines are only called from non-realtime.