### PR TITLE
Remove an awkward ternary without middle value

### DIFF
--- a/src/emc/sai/driver.cc
+++ b/src/emc/sai/driver.cc
@@ -560,7 +560,6 @@ int main (int argc, char ** argv)
   print_stack = OFF;
   tool_flag = 0;
   SET_PARAMETER_FILE_NAME(default_name);
-  _outfile = stdout; /* may be reset below */
   go_flag = 0;
 
 #ifdef TOOL_NML //{

--- a/src/emc/sai/saicanon.cc
+++ b/src/emc/sai/saicanon.cc
@@ -50,7 +50,7 @@ StandaloneInterpInternals _sai = StandaloneInterpInternals();
 char               _parameter_file_name[PARAMETER_FILE_NAME_LENGTH];
 
 /* where to print */
-FILE * _outfile=nullptr;      /* where to print, set in main */
+FILE * _outfile = stdout;      /* where to print, set in main */
 static bool fo_enable=true, so_enable=true;
 
 /************************************************************************/
@@ -79,11 +79,6 @@ void print_nc_line_number()
   int k;
   int m;
 
-  if(!_outfile)
-    {
-      _outfile = stdout;
-    }
-
   pinterp->line_text(text, 256);
   for (k = 0;
        ((k < 256) &&
@@ -107,7 +102,6 @@ void print_nc_line_number()
 
 #define PRINT(control, ...) do \
 { \
-    _outfile = _outfile ?: stdout; \
     fprintf(_outfile,  "%5d ", _sai._line_number++); \
     print_nc_line_number(); \
     fprintf(_outfile, control, ##__VA_ARGS__); \


### PR DESCRIPTION
This PR solves use of the :? ternary operator where the middle value is missing. This is discouraged and not needed. The use case was repeatedly testing something that was assigned long before.