### PR TITLE
Fix rtai warnings

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -200,7 +200,7 @@ AC_ARG_ENABLE(toolnml,
 
 #at this point if RTS is empty, we need to find RT ourselves
 AC_MSG_CHECKING([for rtai-config])
-if test -z "$RTDIR"; then
+if test -z "$RTS"; then
   DIRS="/usr/realtime-`uname -r` /usr/realtime /usr/realtime* /usr /usr/src/rtai*"
 else
   DIRS="$RTS"

--- a/src/emc/motion/command.c
+++ b/src/emc/motion/command.c
@@ -369,6 +369,7 @@ STATIC int is_feed_type(int motion_type)
         return 1;
     default:
         rtapi_print_msg(RTAPI_MSG_ERR, "Internal error: unhandled motion type %d\n", motion_type);
+        /* Fallthrough */
     case EMC_MOTION_TYPE_TOOLCHANGE:
     case EMC_MOTION_TYPE_TRAVERSE:
     case EMC_MOTION_TYPE_INDEXROTARY:

--- a/src/emc/motion/homing.c
+++ b/src/emc/motion/homing.c
@@ -350,7 +350,7 @@ static void do_homing_sequence(void)
             }
         }
         sequence_is_set = 1;
-        //drop through----drop through----drop through----drop through
+        /* Fallthrough */
 
     case HOME_SEQUENCE_DO_ONE_SEQUENCE:
         // Expect multiple joints with home_state==HOME_START
@@ -378,8 +378,7 @@ static void do_homing_sequence(void)
             }
         }
         sequence_state = HOME_SEQUENCE_START;
-
-        //drop through----drop through----drop through----drop through
+        /* Fallthrough */
 
     case HOME_SEQUENCE_START:
         // Request to home all joints or a single sequence
@@ -430,7 +429,7 @@ static void do_homing_sequence(void)
         }
         /* tell the world we're on the job */
         homing_active = 1;
-        //drop through----drop through----drop through----drop through
+        /* Fallthrough */
 
     case HOME_SEQUENCE_START_JOINTS:
         seen = 0;

--- a/src/emc/tp/tc.c
+++ b/src/emc/tp/tc.c
@@ -41,6 +41,7 @@ double tcGetMaxTargetVel(TC_STRUCT const * const tc,
 
         case TC_SYNC_VELOCITY: //Fallthrough
             max_scale = 1.0;
+            /* Fallthrough */
         case TC_SYNC_POSITION:
             // Assume no spindle override during blend target
         default:

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -2524,7 +2524,7 @@ STATIC void tpUpdateRigidTapState(TP_STRUCT const * const tp,
         case RIGIDTAP_START:
             old_spindlepos = new_spindlepos;
             tc->coords.rigidtap.state = TAPPING;
-            // Deliberate fallthrough
+            /* Fallthrough */
         case TAPPING:
             tc_debug_print("TAPPING\n");
             if (tc->progress >= tc->coords.rigidtap.reversal_target) {

--- a/src/hal/components/carousel.comp
+++ b/src/hal/components/carousel.comp
@@ -357,6 +357,7 @@ FUNCTION(_){
         }
         state = DIR_CHOOSE;
         ready = 0;
+        /* Fallthrough */
     case DIR_CHOOSE: // choose direction
         if (mod_pocket < 1 || mod_pocket > inst_pockets) {
             state = WAITING;
@@ -403,6 +404,7 @@ FUNCTION(_){
             motor_dir = 1;
         }
         state = MOVE;
+        /* Fallthrough */
     case MOVE: // moving
         if ((current_position != mod_pocket) && enable){
             deb = debounce;
@@ -493,6 +495,7 @@ FUNCTION(_){
         counts_target += scale * inst_pockets;
         old_index = 1; // ensure 0->1 cycle of home sensor
         state = HOME_WAIT;
+        /* Fallthrough */
     case HOME_WAIT: ;// waiting for index & pulse
         int ind = 0;
         if (inst_code == 'C'){

--- a/src/hal/components/lcd.c
+++ b/src/hal/components/lcd.c
@@ -347,6 +347,7 @@ static void write_one(lcd_inst_t *inst){
                     inst->f_ptr++;
                     inst->buff[0] = '\\';
                     inst->buff[1] = 0;
+                    /* Fallthrough */
                     
                 default: //check for hex
                     c2 = inst->pages[*inst->page_num].fmt[++inst->f_ptr];
@@ -376,6 +377,7 @@ static void write_one(lcd_inst_t *inst){
                 inst->f_ptr++;
                 return;
             }
+            /* Fallthrough */
         default:
             *inst->out = inst->pages[*inst->page_num].fmt[inst->f_ptr++];
     }
@@ -427,6 +429,7 @@ static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp){
                     fill = '0';
                     break;
                 }
+                /* Fallthrough */
             case '1':
             case '2':
             case '3':
@@ -463,8 +466,10 @@ static int parse_fmt(char *in, int *ptr, char *out, void *val, char dp){
             case 'x':
             case 'X':
                 base = 16;
+                /* Fallthrough */
             case 'o':
                 if (base == 10) base = 8;
+                /* Fallthrough */
             case 'u':
                 if (out == NULL || val == NULL) return 'u';
             {

--- a/src/hal/components/mesa_pktgyro_test.comp
+++ b/src/hal/components/mesa_pktgyro_test.comp
@@ -69,9 +69,14 @@ static hostmot2_t* hm2=NULL;
 
 
 FUNCTION(receive){
-	rtapi_u16 max_frame_length = 20;
-	rtapi_u8 num_frames = 20;
-	unsigned char Replyd3[num_frames*max_frame_length];
+#define MAX_FRAME_LENGTH 20
+#define NUM_FRAMES 20
+	rtapi_u16 max_frame_length = MAX_FRAME_LENGTH;
+	rtapi_u8 num_frames = NUM_FRAMES;
+	unsigned char Replyd3[NUM_FRAMES*MAX_FRAME_LENGTH];
+#undef MAX_FRAME_LENGTH
+#undef NUM_FRAMES
+
 	rtapi_u16 frame_sizes3[20];
 	rxbytes=hm2_pktuart_read(name, Replyd3, &num_frames, &max_frame_length, frame_sizes3);
 	rtapi_print_msg(RTAPI_MSG_INFO, "PktUART receive: got %d bytes, %d frames\n", rxbytes, num_frames);
@@ -170,12 +175,16 @@ EXTRA_SETUP(){ // the names parameters are passed in 'prefix'.
 	  Anyway as long as the array size we pass to hm2_pktuart_read
 	  is big enough, we can read everything which is in the Rx buffer.
 	*/
-	rtapi_u16 max_frame_length = 58*2;
-	rtapi_u8 num_frames = 20;
+#define MAX_FRAME_LENGTH (58*2)
+#define NUM_FRAMES 20
+	rtapi_u16 max_frame_length = MAX_FRAME_LENGTH;
+	rtapi_u8 num_frames = NUM_FRAMES;
 
 	// If Rx buffer <= 1024 bytes, than 2*58*20 bytes of read1 array are enough
-	unsigned char read1[num_frames*max_frame_length];
-	rtapi_u16 read1_sizes[num_frames];
+	unsigned char read1[NUM_FRAMES*MAX_FRAME_LENGTH];
+	rtapi_u16 read1_sizes[NUM_FRAMES];
+#undef MAX_FRAME_LENGTH
+#undef NUM_FRAMES
 
 	// read out as many frames as possible
 	retval=hm2_pktuart_read(name, read1, &num_frames, &max_frame_length, read1_sizes);
@@ -229,7 +238,7 @@ EXTRA_SETUP(){ // the names parameters are passed in 'prefix'.
 	and receive 16 ACK datagrams as replies.
 	*/
 
-	unsigned char disable16[11*16] ={
+	static unsigned char disable16[11*16] ={
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19,
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19,
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19,
@@ -250,7 +259,7 @@ EXTRA_SETUP(){ // the names parameters are passed in 'prefix'.
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19,
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19
 	};
-	rtapi_u16 disable_size16[16]={11,11,11,11, 11,11,11,11, 11,11,11,11, 11,11,11,11};
+	static rtapi_u16 disable_size16[16]={11,11,11,11, 11,11,11,11, 11,11,11,11, 11,11,11,11};
 	num_frames = 16;
 	retval=hm2_pktuart_send(name, disable16, &num_frames, disable_size16);
 	rtapi_print_msg(RTAPI_MSG_INFO, "%s sent: bytes %d, frames %u\n", name, retval, num_frames);

--- a/src/hal/drivers/hal_motenc.c
+++ b/src/hal/drivers/hal_motenc.c
@@ -701,7 +701,6 @@ static int
 Device_ExportMiscPinsParametersFunctions(Device *this, int componentId, int boardId)
 {
     int					halError;
-    char				name[HAL_NAME_LEN + 1];
 
     // Export Pins.
     halError = hal_pin_bit_newf(HAL_OUT, &(this->misc.pEstopIn), componentId,

--- a/src/hal/drivers/mesa-hostmot2/abs_encoder.c
+++ b/src/hal/drivers/mesa-hostmot2/abs_encoder.c
@@ -86,7 +86,7 @@ int hm2_absenc_register_tram(hostmot2_t *hm2){
             r += hm2_register_tram_read_region(hm2, chan->rw_addr[2],
                     sizeof(rtapi_u32),
                     &chan->read[2]);
-                    /* no break */
+            /* Fallthrough */
         case HM2_GTAG_SSI:
             r += hm2_register_tram_read_region(hm2, chan->rw_addr[1],
                     sizeof(rtapi_u32),

--- a/src/hal/drivers/mesa-hostmot2/sserial.c
+++ b/src/hal/drivers/mesa-hostmot2/sserial.c
@@ -1499,6 +1499,7 @@ fail1:
             inst->r_index = 0;
             inst->g_index = 0;
             *inst->state2 = 1;
+            /* Fallthrough */
         case 1:
             if (inst->num_remotes == 0) return 0;
             r = &(inst->remotes[inst->r_index]);
@@ -1538,6 +1539,7 @@ fail1:
                                 // ( double significand - variable type significand)
                                 default:
                                 HM2_ERR("Non IEEE float type parameter of length %i\n", g->DataLength);
+                                /* Fallthrough */
                                 case 8:
                                     shift = (52 -  4); break; // 1.3.4 minifloat, if we ever add them
                                 case 16:
@@ -1985,7 +1987,7 @@ int hm2_sserial_read_pins(hm2_sserial_remote_t *chan){
                     break;
                 }
                 buff = buff_store;
-                /* no break */
+                /* Fallthrough */
             case LBP_ENCODER:
             {
                 int bitlength;

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -1137,7 +1137,7 @@ int do_loadrt_cmd(char *mod_name, char *args[])
     argv[m++] = NULL;
     retval = do_loadusr_cmd(argv);
 #else
-    static char *rtmod_dir = EMC2_RTLIB_DIR;
+    static const char *rtmod_dir = EMC2_RTLIB_DIR;
     struct stat stat_buf;
     char mod_path[MAX_CMD_LEN+1];
 
@@ -1157,7 +1157,7 @@ int do_loadrt_cmd(char *mod_name, char *args[])
         if (r < 0) {
             halcmd_error("error making module path for %s/%s%s\n", rtmod_dir, mod_name, MODULE_EXT);
             return -1;
-        } else if (r >= sizeof(mod_path)) {
+        } else if (r >= (int)sizeof(mod_path)) {
             // truncation!
             halcmd_error("module path too long (max %lu) for %s/%s%s\n", (unsigned long)sizeof(mod_path)-1, rtmod_dir, mod_name, MODULE_EXT);
             return -1;

--- a/src/libnml/posemath/posemath.h
+++ b/src/libnml/posemath/posemath.h
@@ -696,7 +696,7 @@ extern "C" {
 //#define pmSq(x) ((x)*(x))
 
 int pmClose(double a, double b, double eps); 
-inline double pmSq(double x) { return x*x; }
+__attribute__((always_inline)) static inline double pmSq(double x) { return x*x; }
 
 #ifdef TO_DEG
 #undef TO_DEG

--- a/src/rtapi/rtapi_vsnprintf.h
+++ b/src/rtapi/rtapi_vsnprintf.h
@@ -424,6 +424,7 @@ int rtapi_vsnprintf(char *buf, unsigned long size, const char *fmt, va_list args
 	    break;
 	case 'X':
 	    flags |= LARGE;
+	    /* Fallthrough */
 	case 'x':
 	    base = 16;
 	    break;


### PR DESCRIPTION
Many warnings not caught in uspace compilation but appear with rtai have been fixed in this PR.

The implicit fall through warnings are removed by making it explicit using the standard <code>/* Fallthrough */</code> marker, which is understood by the compiler. A variable length array warning was not actually using variable length arrays.

There are some warnings left that will be fixed in a later PR. These are about the stackframe size (larger than 2048). Maybe it could/should be enlarged?

BTW, it also fixes properly inlining the pmSq() function.