### PR TITLE
Fix pragmas

### DIFF
--- a/src/emc/usr_intf/axis/extensions/_toglmodule.c
+++ b/src/emc/usr_intf/axis/extensions/_toglmodule.c
@@ -65,7 +65,7 @@ PyObject *install(PyObject *s, PyObject *arg) {
 
 PyMethodDef togl_methods[] = {
     {"install", (PyCFunction)install, METH_O, "install togl in a tkinter application"},
-    {NULL}
+    {}
 };
 
 static struct PyModuleDef togl_moduledef = {

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -1829,9 +1829,6 @@ PyObject *stream_element_types(PyObject *_self, void *unused) {
     return self->pyelt;
 }
 
-// "deprecated conversion from string constant to 'char *'" occurs due to
-// missing const-qualifications in Python headers
-#pragma GCC diagnostic ignored "-Wwrite-strings"
 static PyMemberDef stream_members[] = {
     {"sampleno", T_UINT, offsetof(streamobj, sampleno), READONLY,
         "The number of the last successfully read sample"},
@@ -1848,7 +1845,6 @@ static PyGetSetDef stream_getset[] = {
     {"num_overruns", stream_getter<int>, NULL, NULL, VFC(hal_stream_num_overruns)},
     {}
 };
-#pragma GCC diagnostic warning "-Wwrite-strings"
 
 static void pystream_delete(PyObject *_self) {
     streamobj *self = reinterpret_cast<streamobj*>(_self);

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -17,7 +17,8 @@
    02111-1307 USA.
  */
 
-#pragma once
+#ifndef __XHC_WHB04B_6_HAL_H
+#define __XHC_WHB04B_6_HAL_H
 
 // local includes
 #include "pendant-types.h"
@@ -642,3 +643,4 @@ private:
     bool requestMode(bool isRisingEdge, hal_bit_t* requestPin, hal_bit_t* modeFeedbackPin);
 };
 }
+#endif

--- a/src/hal/user_comps/xhc-whb04b-6/pendant-types.h
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant-types.h
@@ -17,7 +17,8 @@
    02111-1307 USA.
  */
 
-#pragma once
+#ifndef __XHC_WHB04B_6_PENDANT_TYPES_H
+#define __XHC_WHB04B_6_PENDANT_TYPES_H
 
 // system includes
 #include <stdint.h>
@@ -85,3 +86,4 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const HandWheelCounters& data);
 }
+#endif

--- a/src/hal/user_comps/xhc-whb04b-6/pendant.h
+++ b/src/hal/user_comps/xhc-whb04b-6/pendant.h
@@ -17,7 +17,8 @@
    02111-1307 USA.
  */
 
-#pragma once
+#ifndef __XHC_WHB04B_6_PENDANT_H
+#define __XHC_WHB04B_6_PENDANT_H
 
 // local includes
 #include "pendant-types.h"
@@ -611,3 +612,4 @@ private:
 // ----------------------------------------------------------------------
 std::ostream& operator<<(std::ostream& os, const Pendant& data);
 }
+#endif

--- a/src/hal/user_comps/xhc-whb04b-6/usb.h
+++ b/src/hal/user_comps/xhc-whb04b-6/usb.h
@@ -17,7 +17,8 @@
    02111-1307 USA.
  */
 
-#pragma once
+#ifndef __XHC_WHB04B_6_USB_H
+#define __XHC_WHB04B_6_USB_H
 
 // system includes
 #include <stdint.h>
@@ -336,3 +337,4 @@ std::ostream& operator<<(std::ostream& os, const UsbOutPackageData& data);
 std::ostream& operator<<(std::ostream& os, const UsbOutPackageBlockFields& block);
 std::ostream& operator<<(std::ostream& os, const UsbOutPackageBlocks& blocks);
 }
+#endif

--- a/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.h
+++ b/src/hal/user_comps/xhc-whb04b-6/xhc-whb04b6.h
@@ -17,7 +17,8 @@
    02111-1307 USA.
  */
 
-#pragma once
+#ifndef __XHC_WHB04B_6_XHC_WHB04B6_H
+#define __XHC_WHB04B_6_XHC_WHB04B6_H
 
 // system includes
 #include <stdint.h>
@@ -110,3 +111,4 @@ private:
     void printHexdump(const UsbInPackage& inPackage);
 };
 }
+#endif

--- a/src/libnml/buffer/tcpmem.cc
+++ b/src/libnml/buffer/tcpmem.cc
@@ -12,11 +12,6 @@
 * Last change: 
 ********************************************************************/
 
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 4)))
-#pragma GCC optimize "-fno-strict-aliasing"
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
There are several pragmas in use that either do nothing or must be discouraged.

* Using <code>#pragma once</code> is not guaranteed to work (because of links). This is changed to standard include guards.
* The writable strings warning exclusion was only for older python versions. It was fixed in python 3.7 and LCNC only supports 3.8+.
* The strict aliasing warning does not trigger and is no longer required.

Finally a missed missing initialization was fixed.