### PR TITLE
Compound assignment with LHS volatile is deprecated

### DIFF
--- a/src/hal/user_comps/xhc-hb04.cc
+++ b/src/hal/user_comps/xhc-hb04.cc
@@ -303,34 +303,34 @@ void linuxcnc_simu(xhc_t *xhc)
 		int delta_int = *(hal->jog_counts) - last_jog_counts;
 		float delta = delta_int * *(hal->jog_scale);
 		if (*(hal->jog_enable_x)) {
-			*(hal->x_mc) += delta;
-			*(hal->x_wc) += delta;
+			*(hal->x_mc) = *(hal->x_mc) + delta;
+			*(hal->x_wc) = *(hal->x_wc) + delta;
 		}
 
 		if (*(hal->jog_enable_y)) {
-			*(hal->y_mc) += delta;
-			*(hal->y_wc) += delta;
+			*(hal->y_mc) = *(hal->y_mc) + delta;
+			*(hal->y_wc) = *(hal->y_wc) + delta;
 		}
 
 		if (*(hal->jog_enable_z)) {
-			*(hal->z_mc) += delta;
-			*(hal->z_wc) += delta;
+			*(hal->z_mc) = *(hal->z_mc) + delta;
+			*(hal->z_wc) = *(hal->z_wc) + delta;
 		}
 
 		if (*(hal->jog_enable_a)) {
-			*(hal->a_mc) += delta;
-			*(hal->a_wc) += delta;
+			*(hal->a_mc) = *(hal->a_mc) + delta;
+			*(hal->a_wc) = *(hal->a_wc) + delta;
 		}
 
 		if (*(hal->jog_enable_spindle)) {
-			*(hal->spindle_override) += delta_int * 0.01;
+			*(hal->spindle_override) = *(hal->spindle_override) + delta_int * 0.01;
 			if (*(hal->spindle_override) > 1) *(hal->spindle_override) = 1;
 			if (*(hal->spindle_override) < 0) *(hal->spindle_override) = 0;
 			*(hal->spindle_rps) = 25000.0/60.0 * *(hal->spindle_override);
 		}
 
 		if (*(hal->jog_enable_feedrate)) {
-			*(hal->feedrate_override) += delta_int * 0.01;
+			*(hal->feedrate_override) = *(hal->feedrate_override) + delta_int * 0.01;
 			if (*(hal->feedrate_override) > 1) *(hal->feedrate_override) = 1;
 			if (*(hal->feedrate_override) < 0) *(hal->feedrate_override) = 0;
 			*(hal->feedrate) = 3000.0/60.0 * *(hal->feedrate_override);
@@ -431,7 +431,7 @@ void cb_response_in(struct libusb_transfer *transfer)
 		xhc.button_code = in_buf[1];
 		xhc.axis = (xhc_axis_t)in_buf[3];
 
-		*(xhc.hal->jog_counts) += ((signed char)in_buf[4]);
+		*(xhc.hal->jog_counts) = *(xhc.hal->jog_counts) + ((signed char)in_buf[4]);
 		*(xhc.hal->jog_counts_neg) = - *(xhc.hal->jog_counts);
 		*(xhc.hal->jog_enable_off) = (xhc.axis == axis_off);
 		*(xhc.hal->jog_enable_x) = (xhc.axis == axis_x);


### PR DESCRIPTION
This is (probably) the last set of volatile warnings to be fixed.

Compound assignment, like in <code>a += b</code>, where <code>a</code> is volatile is deprecated. It is a complex read-modify-write operation, which should be done using atomic operations, but that requires bigger changes. Just not using the compound assignment is good for now.