### PR TITLE
Fix more rtai warnings

### DIFF
--- a/docs/man/.gitignore
+++ b/docs/man/.gitignore
@@ -390,9 +390,12 @@ man9/oneshot.9
 man9/opto_ac5.9
 man9/or2.9
 man9/orient.9
+man9/pcl720.9
 man9/pentakins.9
 man9/pid.9
 man9/plasmac.9
+man9/pluto_servo.9
+man9/pluto_step.9
 man9/pumakins.9
 man9/pwmgen.9
 man9/raster.9

--- a/src/emc/kinematics/genserfuncs.c
+++ b/src/emc/kinematics/genserfuncs.c
@@ -44,6 +44,14 @@
 #include "rtapi.h"
 #endif
 
+// Only gcc/g++ supports the #pragma
+#if __GNUC__ && !defined(__clang__)
+// The matrix and vector storage is just big.
+// genser_kin_jac_inv() is 2112
+// genserKinematicsInverse() is 2576
+  #pragma GCC diagnostic warning "-Wframe-larger-than=2600"
+#endif
+
 static struct haldata {
     hal_u32_t     *max_iterations;
     hal_u32_t     *last_iterations;

--- a/src/emc/motion/stashf_wrap.h
+++ b/src/emc/motion/stashf_wrap.h
@@ -30,8 +30,20 @@ const char *fmt, *efmt;
     while((efmt = strchr(fmt, '%'))) {
         int modifier_l;
         int code = get_code(&efmt, &modifier_l);
+	// A format should be a "few" characters long, like "+999.999lf".
+	// However, it is never sure how long they are. An artificial limit
+	// must be imposed unless we use variable length arrays (VLAs) or use
+	// dynamic memory. VLAs are not really allowed in kernel and are the
+	// reason for this comment. Using dynamic memory is slow and must be
+	// discouraged here.
+	// A limit to 63+1 characters seems fair. If the format is larger than
+	// the limit, then the print will not be right, but it doesn't crash
+	// either. The next round will skip properly because 'efmt' points to
+	// after the format.
+        char block[63 + 1];
         int fmt_len = efmt - fmt;
-        char block[fmt_len + 1];
+	if(fmt_len >= sizeof(block))
+		fmt_len = sizeof(block) - 1;
         memcpy(block, fmt, fmt_len);
         block[fmt_len] = 0;
 

--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -55,6 +55,12 @@
 #include "hal.h"
 #endif // }
 
+// Only gcc/g++ supports the #pragma
+#if __GNUC__ && !defined(__clang__)
+// tpHandleBlendArc() is 2512
+  #pragma GCC diagnostic warning "-Wframe-larger-than=2600"
+#endif
+
 static emcmot_status_t *emcmotStatus;
 static emcmot_config_t *emcmotConfig;
 

--- a/src/hal/components/mesa_pktgyro_test.comp
+++ b/src/hal/components/mesa_pktgyro_test.comp
@@ -106,6 +106,11 @@ FUNCTION(receive){
 
 
 }
+// Only gcc/g++ supports the #pragma
+#if __GNUC__ && !defined(__clang__)
+// EXTRA_SETUP() is 2400
+#pragma GCC diagnostic warning "-Wframe-larger-than=2500"
+#endif
 
 EXTRA_SETUP(){ // the names parameters are passed in 'prefix'.
 	if (prefix[0] == 'm'){ // should be the 'm' of hm2_....
@@ -238,7 +243,7 @@ EXTRA_SETUP(){ // the names parameters are passed in 'prefix'.
 	and receive 16 ACK datagrams as replies.
 	*/
 
-	static unsigned char disable16[11*16] ={
+	static const unsigned char disable16[11*16] ={
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19,
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19,
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19,
@@ -259,7 +264,7 @@ EXTRA_SETUP(){ // the names parameters are passed in 'prefix'.
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19,
 	0x75, 0x65, 0x0C,0x05,  0x05,0x11, 0x01,0x01, 0x00, 0x03, 0x19
 	};
-	static rtapi_u16 disable_size16[16]={11,11,11,11, 11,11,11,11, 11,11,11,11, 11,11,11,11};
+	static const rtapi_u16 disable_size16[16]={11,11,11,11, 11,11,11,11, 11,11,11,11, 11,11,11,11};
 	num_frames = 16;
 	retval=hm2_pktuart_send(name, disable16, &num_frames, disable_size16);
 	rtapi_print_msg(RTAPI_MSG_INFO, "%s sent: bytes %d, frames %u\n", name, retval, num_frames);

--- a/src/hal/drivers/mesa-hostmot2/hostmot2-serial.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2-serial.h
@@ -31,7 +31,7 @@ int hm2_pktuart_setup(char *name, int bitrate, rtapi_s32 tx_mode, rtapi_s32 rx_m
 int hm2_pktuart_setup_rx(char *name, unsigned int bitrate, unsigned int filter_hz, unsigned int parity, int frame_delay, bool rx_enable, bool rx_mask);
 int hm2_pktuart_setup_tx(char *name, unsigned int bitrate, unsigned int parity, int frame_delay, bool drive_enable, bool drive_auto, int enable_delay);
 void hm2_pktuart_reset(char *name);
-int hm2_pktuart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 frame_sizes[]);
+int hm2_pktuart_send(char *name, const unsigned char data[], rtapi_u8 *num_frames, const rtapi_u16 frame_sizes[]);
 int hm2_pktuart_read(char *name, unsigned char data[],  rtapi_u8 *num_frames, rtapi_u16 *max_frame_length, rtapi_u16 frame_sizes[]);
 int hm2_pktuart_queue_get_frame_sizes(char *name, rtapi_u32 fsizes[]);
 int hm2_pktuart_queue_read_data(char *name, rtapi_u32 *data, int bytes);

--- a/src/hal/drivers/mesa-hostmot2/hostmot2.h
+++ b/src/hal/drivers/mesa-hostmot2/hostmot2.h
@@ -1974,7 +1974,7 @@ int hm2_pktuart_setup(char *name, unsigned int bitrate, rtapi_s32 tx_mode, rtapi
 int hm2_pktuart_setup_rx(char *name, unsigned int bitrate, unsigned int filter_hz, unsigned int parity, int frame_delay, bool rx_enable, bool rx_mask);
 int hm2_pktuart_setup_tx(char *name, unsigned int bitrate, unsigned int parity, int frame_delay, bool drive_enable, bool drive_auto, int enable_delay);
 void hm2_pktuart_reset(char *name);
-int hm2_pktuart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 frame_sizes[]);
+int hm2_pktuart_send(char *name, const unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 const frame_sizes[]);
 int hm2_pktuart_read(char *name, unsigned char data[],  rtapi_u8 *num_frames, rtapi_u16 *max_frame_length, rtapi_u16 frame_sizes[]);
 
 //

--- a/src/hal/drivers/mesa-hostmot2/pktuart.c
+++ b/src/hal/drivers/mesa-hostmot2/pktuart.c
@@ -428,7 +428,7 @@ int hm2_pktuart_setup(char *name, unsigned int bitrate, rtapi_s32 tx_mode, rtapi
 
 
 EXPORT_SYMBOL_GPL(hm2_pktuart_send);
-int hm2_pktuart_send(char *name,  unsigned char data[], rtapi_u8 *num_frames, rtapi_u16 frame_sizes[])
+int hm2_pktuart_send(char *name, const unsigned char data[], rtapi_u8 *num_frames, const rtapi_u16 frame_sizes[])
 {
     hostmot2_t *hm2;
     rtapi_u32 buff;

--- a/src/hal/drivers/mesa-hostmot2/sserial.c
+++ b/src/hal/drivers/mesa-hostmot2/sserial.c
@@ -386,7 +386,7 @@ int hm2_sserial_get_param_value(hostmot2_t *hm2,
             break; // Hard to imagine an encoder not in Process data
         case LBP_FLOAT:
             {
-                char buf[g->DataLength/8];
+                char buf[HM2_SSERIAL_MAX_DATALENGTH/8];
                 r = hm2_sserial_get_bytes(hm2, chan, &buf[0], g->ParmAddr, g->DataLength/8);
                 if (g->DataLength == sizeof(float) * 8) {
                     float temp;

--- a/src/hal/drivers/mesa-hostmot2/sserial.h
+++ b/src/hal/drivers/mesa-hostmot2/sserial.h
@@ -25,6 +25,7 @@
 #define HM2_SSERIAL_TYPE_8I20               0x30324938  // '8i20' as 4 ascii
 #define HM2_SSERIAL_TYPE_7I64               0x34364937  // '7i64' All newer cards self-declare
 #define HM2_SSERIAL_MAX_STRING_LENGTH       48
+#define HM2_SSERIAL_MAX_DATALENGTH          (255+1)     // unsigned char max value plus one for buffer sizing
 #define HM2_SSERIAL_MAX_PORTS               8           // only used in pins.c
 #define HM2_SSERIAL_NUMREGS                 7           // 224 bits of data per channel in sserialb
 


### PR DESCRIPTION
The last RTAI warnings should be covered by this PR.

The variable array issues are resolved:
* hostmot2 sserial uses an unsigned char as length indicator so that the total length never can exceed 256/8 words. That limit is now set statically.
* a printf format can usually not be very large (like %999.999lf). A small but very much large enough format buffer of static size is now used and an overflow guard is in place.

The frame size warnings cannot be solved by code changes. These are mainly caused by matrices and vectors in kinematics that are just big. A pragma is used to guard just above the current level.

Some function parameters arereally  const data pointer, but were not declared as such. This prohibits data from being static read only. Now they are.

Note: there are many more instances where the code would benefit from using const where appropriate. Another project, another time.