### PR TITLE
tests-hardening: addressing shellcheck errors in our tests

### DIFF
--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -25,19 +25,19 @@ CPPCHKCC="$CPPCHKOPT $CCSTD"
 CPPCHKCX="$CPPCHKOPT $CXSTD"
 
 # Do this from the source directory
-cd "$(dirname "$0")/../src"
+cd "$(dirname "$0")/../src" || (echo "E: Could not return to source directory" ; exit 1 )
 
 docheck() {
     files=$(find "$1" -maxdepth 1 \( -name "*.c" -o -name "*.h" \) )
-    [ ! -z "$files" ] && cppcheck -I"$1" $CPPCHKCC $files
+    [ -n "$files" ] && cppcheck -I"$1" "$CPPCHKCC" "$files"
 
     files=$(find "$1" -maxdepth 1 \( -name "*.cc" -o -name "*.hh" \) )
-    [ ! -z "$files" ] && cppcheck -I"$1" $CPPCHKCX $files
+    [ -n "$files" ] && cppcheck -I"$1" "$CPPCHKCX" "$files"
 }
 
 # *** HAL files ***
 echo "I (1/4): checking HAL folders with both C and C++ code"
-for d in $(find hal/ -type d -not -name "*__pycache__")
+find hal/ -type d -not -name "*__pycache__" | while read -r d
 do
     # Don't care about examples
     case "$d" in hal/user_comps/mb2hal/examples*) continue;; esac
@@ -48,7 +48,7 @@ done
 
 # *** EMC files ***
 echo "I (2/4): checking EMC folders with both C and C++ code"
-for d in $(find emc/ -type d -not -name "*__pycache__")
+find emc/ -type d -not -name "*__pycache__" | while read -r d 
 do
     # Will give Tcl problems
     case "$d" in emc/usr_intf/axis/extensions*) continue;; esac
@@ -59,7 +59,7 @@ done
 
 # *** NML files ***
 echo "I (3/4): checking LIBNML folders with both C and C++ code"
-for d in $(find libnml/ -type d -not -name "*__pycache__")
+find libnml/ -type d -not -name "*__pycache__" | while read -r d
 do
     echo "I (3/4): checking $d"
     docheck "$d"
@@ -67,7 +67,7 @@ done
 
 # *** RTAPI files ***
 echo "I (4/4): checking RTAPI folders with both C and C++ code"
-for d in $(find rtapi/ -type d -not -name "*__pycache__")
+find rtapi/ -type d -not -name "*__pycache__" | while read -r d
 do
     echo "I (4/4): checking $d"
     docheck "$d"

--- a/scripts/get-deb-component-from-git
+++ b/scripts/get-deb-component-from-git
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-if [ ! -z "$EMC2_HOME" ]; then
-    source $EMC2_HOME/scripts/githelper.sh
+if [ -n "$EMC2_HOME" ]; then
+    source "$EMC2_HOME"/scripts/githelper.sh
 else
-    source $(git rev-parse --show-toplevel)/scripts/githelper.sh
+    source "$(git rev-parse --show-toplevel)"/scripts/githelper.sh
 fi
 
-githelper $1
+githelper "$1"
 
-echo $DEB_COMPONENT
+echo "$DEB_COMPONENT"
 

--- a/scripts/get-version-from-git
+++ b/scripts/get-version-from-git
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [ ! -z "$EMC2_HOME" ]; then
-    source $EMC2_HOME/scripts/githelper.sh
+if [ -n "$EMC2_HOME" ]; then
+    source "$EMC2_HOME"/scripts/githelper.sh
 else
-    source $(git rev-parse --show-toplevel)/scripts/githelper.sh
+    source "$(git rev-parse --show-toplevel)"/scripts/githelper.sh
 fi
 
 githelper $1

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -1,3 +1,5 @@
+#!/bin/false
+#shellcheck disable=SC1008 
 #
 # This is a bash shell fragment, intended to be sourced by scripts that
 # want to work with git in the emc2 repo.
@@ -28,63 +30,71 @@ function githelper() {
     case $GIT_BRANCH in
         master)
             GIT_TAG_GLOB="v2.10.*"
+            # shellcheck disable=SC2034
             DEB_COMPONENT="master"
             ;;
         # release branches have names matching "number.number", which is awkward to express as a glob
         [0-9].[0-9] | [0-9].[0-9][0-9] | [0-9].[0-9][0-9][0-9] | [0-9][0-9].[0-9] | [0-9][0-9].[0-9][0-9] | [0-9][0-9].[0-9][0-9][0-9])
             GIT_TAG_GLOB="v${GIT_BRANCH}.*"
+            # shellcheck disable=SC2034
             DEB_COMPONENT=$GIT_BRANCH
             ;;
         v2.5_branch)
             GIT_TAG_GLOB="v2.5*"
+            # shellcheck disable=SC2034
             DEB_COMPONENT="v2.5_branch"
             ;;
         v2.4_branch)
             GIT_TAG_GLOB="v2.4*"
+            # shellcheck disable=SC2034
             DEB_COMPONENT="v2.4_branch"
             ;;
         *)
             GIT_TAG_GLOB="*"
+            # shellcheck disable=SC2034
             DEB_COMPONENT="scratch"
             ;;
     esac
 
 
     # use the gnupg keyring from our git repo to verify signatures on the release tags
-    export GNUPGHOME=$(git rev-parse --show-toplevel)/gnupg
+    export GNUPGHOME
+    GNUPGHOME=$(git rev-parse --show-toplevel)/gnupg
 
     NEWEST_SIGNED_TAG_UTIME=-1
     NEWEST_UNSIGNED_TAG_UTIME=-1
     for TAG in $(git tag -l "$GIT_TAG_GLOB"); do
-        if ! git cat-file tag $TAG > /dev/null 2> /dev/null; then
+        if ! git cat-file tag "$TAG" > /dev/null 2> /dev/null; then
             continue
         fi
 
-        TAG_UTIME=$(git cat-file tag $TAG | grep tagger | awk '{print $(NF-1)-$NF*36}')
+        TAG_UTIME=$(git cat-file tag "$TAG" | grep tagger | awk '{print $(NF-1)-$NF*36}')
 
         if git tag -v "$TAG" > /dev/null 2> /dev/null; then
             # it's a valid signed tag
-            if [ $TAG_UTIME -gt $NEWEST_SIGNED_TAG_UTIME ]; then
-                NEWEST_SIGNED_TAG=$TAG
-                NEWEST_SIGNED_TAG_UTIME=$TAG_UTIME
+            if [ "$TAG_UTIME" -gt "$NEWEST_SIGNED_TAG_UTIME" ]; then
+                NEWEST_SIGNED_TAG="$TAG"
+                NEWEST_SIGNED_TAG_UTIME="$TAG_UTIME"
             fi
         else
             # unsigned tag
-            if [ $TAG_UTIME -gt $NEWEST_UNSIGNED_TAG_UTIME ]; then
-                NEWEST_UNSIGNED_TAG=$TAG
-                NEWEST_UNSIGNED_TAG_UTIME=$TAG_UTIME
+            if [ "$TAG_UTIME" -gt "$NEWEST_UNSIGNED_TAG_UTIME" ]; then
+                NEWEST_UNSIGNED_TAG="$TAG"
+                NEWEST_UNSIGNED_TAG_UTIME="$TAG_UTIME"
             fi
         fi
 
     done
 
-    if [ $NEWEST_SIGNED_TAG_UTIME -gt -1 ]; then
+    if [ "$NEWEST_SIGNED_TAG_UTIME" -gt -1 ]; then
+        # shellcheck disable=SC2034
         GIT_TAG="$NEWEST_SIGNED_TAG"
         return
     fi
 
-    if [ $NEWEST_UNSIGNED_TAG_UTIME -gt -1 ]; then
+    if [ "$NEWEST_UNSIGNED_TAG_UTIME" -gt -1 ]; then
         echo "no signed tags found, falling back to unsigned tags" > /dev/null 1>&2
+        # shellcheck disable=SC2034
         GIT_TAG="$NEWEST_UNSIGNED_TAG"
         return
     fi

--- a/scripts/gladevcp_demo
+++ b/scripts/gladevcp_demo
@@ -23,7 +23,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-prog=$(basename $0)
+prog=$(basename "$0")
 
 function usage () {
   cat <<EOF
@@ -57,7 +57,7 @@ EOF
 REALTIME=$(linuxcnc_var REALTIME)
 $REALTIME status >/dev/null
 status=$?
-if [ $status = 0 ] ; then
+if [ "$status" = 0 ] ; then
   msg="$prog: Realtime is already active"
   echo "$msg"
   popup "$msg"
@@ -71,10 +71,10 @@ case $# in
   *) ARGS="$@";;
 esac
 
-if [ ! -z "$debug" ] ; then
-  echo debug=$debug
-  echo REALTIME=$REALTIME
-  echo ARGS="$ARGS"
+if [ -n "$debug" ] ; then
+  echo "debug=$debug"
+  echo "REALTIME=$REALTIME"
+  echo "ARGS=$ARGS"
 pwd
 fi
 

--- a/scripts/hal_demo
+++ b/scripts/hal_demo
@@ -18,7 +18,7 @@
 #    
 # Copyright (c) 2004-2009 All rights reserved.
 #*******************************************************************/
-if [ ! $1 ] ; then
+if [ -z "$1" ] ; then
     echo "Usage:  scripts/hal_demo <demo_name>"
     echo "Run from the emc2 directory only"
     # print the list of demos
@@ -28,7 +28,7 @@ fi
 #
 # the first demo isn't a real demo - it simply lists all the demos
 #
-if [ $1 = list ] ; then
+if [ "$1" = list ] ; then
     echo "Available demos are:"
     echo "  list - prints this list"
     echo "  load - loads hal core modules"
@@ -44,7 +44,7 @@ fi
 #
 # here is the "load" command
 #
-if [ $1 = load ] ; then
+if [ "$1" = load ] ; then
     # load the rtos and rtapi
     if ! scripts/realtime start ; then
         exit -1
@@ -56,7 +56,7 @@ fi
 #
 # here is the "unload" command
 #
-if [ $1 = unload ] ; then
+if [ "$1" = unload ] ; then
     # unload any left-over modules
     bin/halcmd unloadrt all
     # unload the rtos and rtapi
@@ -72,7 +72,7 @@ fi
 # make sure the rtapi core is loaded
 #
 HAL_LIB_STR=`/sbin/lsmod | awk '{print $1}' | grep -x hal_lib `
-if [ ! "$HAL_LIB_STR" ] ; then
+if [ -z "$HAL_LIB_STR" ] ; then
     echo "All of the demos require the RTAPI and HAL_LIB modules"
     echo "to be loaded.  Use 'hal_demo load' to load them."
     exit -1
@@ -81,7 +81,7 @@ fi
 # The first demo: "parport1" simply tests the parallel port
 # this one is a step by step, tutorial/intro to HAL concepts
 #
-if [ $1 = parport1 ] ; then
+if [ "$1" = parport1 ] ; then
     echo "(Comments that are part of the demo are in parenthesis.)"
     echo "(This demo echos its commands to the screen so you can"
     echo " see what each step does.  Echoed commands start with '$')"
@@ -288,7 +288,7 @@ fi
 # using siggen as a signal source.
 # this one is also a step by step tutorial
 #
-if [ $1 = scope ] ; then
+if [ "$1" = scope ] ; then
     echo "The first part of this demo is identical to the siggen"
     echo "demo.  Hit enter to get started"
     read
@@ -400,5 +400,5 @@ fi
 #
 echo "Sorry, there is no demo called '$1'"
 scripts/hal_demo
-exit -1
+exit 1
 

--- a/scripts/latency-test
+++ b/scripts/latency-test
@@ -1,12 +1,13 @@
 #!/bin/bash
-SCRIPT_LOCATION=$(dirname $(readlink -f $0));
-if [ -f $SCRIPT_LOCATION/rip-environment ] && [ -z "$EMC2_HOME" ]; then
-    . $SCRIPT_LOCATION/rip-environment
+
+SCRIPT_LOCATION=$(dirname "$(readlink -f "$0")");
+if [ -f "$SCRIPT_LOCATION"/rip-environment ] && [ -z "$EMC2_HOME" ]; then
+    . "$SCRIPT_LOCATION"/rip-environment
 fi
 
-T=`mktemp -d`
+T=$(mktemp -d)
 trap 'cd /; [ -d $T ] && rm -rf $T' SIGINT SIGTERM EXIT
-cd $T
+cd "$T" || (echo "E: Cannot change directory to 'T'"; exit 1)
 node=$(uname -n)
 machine=$(uname  -m)
 date=$(date +%d%b%Y)
@@ -23,15 +24,15 @@ parse_time () {
     *us|*µs) icalc "1000*${1%us}" ;;
     *ms) icalc "1000*1000*${1%ms}" ;;
     *s)  icalc "1000*1000*1000*${1%s}" ;;
-    *)   if [ $1 -lt 1000 ]; then icalc "1000*$1"; else icalc "$1"; fi ;;
+    *)   if [ "$1" -lt 1000 ]; then icalc "1000*$1"; else icalc "$1"; fi ;;
     esac
 }
 
 human_time () {
     if [ "$1" -eq 0 ]; then echo "-"
-    elif [ "$1" -ge 1000000000 ]; then echo "$(calc $1/1000/1000/1000)s"
-    elif [ "$1" -ge 1000000 ]; then echo "$(calc $1/1000/1000)ms"
-    elif [ "$1" -ge 1000 ]; then echo "$(calc $1/1000)µs"
+    elif [ "$1" -ge 1000000000 ]; then echo "$(calc "$1"/1000/1000/1000)s"
+    elif [ "$1" -ge 1000000 ]; then echo "$(calc "$1"/1000/1000)ms"
+    elif [ "$1" -ge 1000 ]; then echo "$(calc "$1"/1000)µs"
     else echo "$1ns"
     fi
 }
@@ -48,7 +49,7 @@ usage () {
     echo "       latency-test 50000 1000000"
     echo ""
     echo "Defaults:     base-period=${BASE}nS servo-period=${SERVO}nS"
-    echo "Equivalently: base-period=$(human_time $BASE) servo-period=$(human_time $SERVO)"
+    echo "Equivalently: base-period=$(human_time "$BASE") servo-period=$(human_time "$SERVO")"
     echo ""
     echo "Times may be specified with suffix \"s\", \"ms\", \"us\" \"µs\", or \"ns\""
     echo "Times without a suffix and less than 1000 are taken to be in us;"
@@ -62,26 +63,26 @@ usage () {
     exit 1
 }
 
-BASE=$(parse_time 25us); SERVO=$(parse_time 1ms)
+BASE="$(parse_time 25us)"; SERVO="$(parse_time 1ms)"
 
-case $1 in
+case "$1" in
   -h|--help) usage;;
 esac
 
 case $# in
 0) ;;
-1) BASE=0; SERVO=$(parse_time $1) ;;
-2) BASE=$(parse_time $1); SERVO=$(parse_time $2) ;;
+1) BASE=0; SERVO="$(parse_time "$1")" ;;
+2) BASE="$(parse_time "$1")"; SERVO="$(parse_time "$2")" ;;
 *) usage;;
 esac
 
-if [ "$BASE" -gt "$SERVO" ]; then TEMP=$BASE; BASE=$SERVO; SERVO=$TEMP; fi
+if [ "$BASE" -gt "$SERVO" ]; then TEMP="$BASE"; BASE="$SERVO"; SERVO="$TEMP"; fi
 if [ "$BASE" -eq "$SERVO" ]; then BASE=0; fi
 
-BASE_HUMAN=$(human_time $BASE)
-SERVO_HUMAN=$(human_time $SERVO)
+BASE_HUMAN="$(human_time "$BASE")"
+SERVO_HUMAN="$(human_time "$SERVO")"
 
-if [ $BASE -eq 0 ]; then
+if [ "$BASE" -eq 0 ]; then
 cat > lat.hal <<EOF
 loadrt threads name1=slow period1=$SERVO
 loadrt timedelta count=1
@@ -143,7 +144,7 @@ While the test is running, you should "abuse" the computer. Move windows around 
 <tablerow/><label text="Servo thread ($SERVO_HUMAN):"/><s32 halpin="sl"/><s32 halpin="sj" font="Helvetica 12 bold"/><s32 halpin="st"/>
 EOF
 
-if [ $BASE -ne 0 ]; then
+if [ "$BASE" -ne 0 ]; then
 cat >> lat.xml <<EOF
 <tablerow/><label text="Base thread ($BASE_HUMAN):"/><s32 halpin="bl"/><s32 halpin="bj" font="Helvetica 12 bold"/><s32 halpin="bt"/>
 EOF
@@ -157,7 +158,7 @@ cat >> lat.xml <<EOF
 </pyvcp>
 EOF
 
-if [ $BASE -eq 0 ]; then
+if [ "$BASE" -eq 0 ]; then
     SIGNALS="halcmd gets sj"
 else
     SIGNALS="halcmd gets sj; halcmd gets bj"
@@ -165,9 +166,9 @@ fi
 
 cat > latexit.sh <<EOF
 L=\$(($SIGNALS
-    if [ -f $HOME/.latency ]; then cat $HOME/.latency; fi
+    if [ -f "$HOME"/.latency ]; then cat "$HOME"/.latency; fi
     ) | sort -n | tail -1)
-echo \$L > $HOME/.latency
+echo \$L > "$HOME"/.latency
 EOF
 
 halrun lat.hal

--- a/scripts/make-docs-pdf-index
+++ b/scripts/make-docs-pdf-index
@@ -9,9 +9,9 @@ set -e
 # --show-toplevel` because when building from dsc we don't have a
 # git repo.
 TOPLEVEL=${PWD}/..
-cd ${TOPLEVEL}/docs
+cd "${TOPLEVEL}"/docs
 
-TITLE="LinuxCNC PDF docs ($(cat ${TOPLEVEL}/VERSION))"
+TITLE="LinuxCNC PDF docs ($(cat "${TOPLEVEL}"/VERSION))"
 
 rm -f index.html
 

--- a/scripts/man2adoc-migrate
+++ b/scripts/man2adoc-migrate
@@ -4,33 +4,33 @@
 
 # Convert all non-link manual pages to adoc
 for m in docs/man/man?/*; do
-    test -L $m && continue
-    n=$(echo $m |sed s%docs/man%docs/src/man%).adoc
-    if [ -e "$n" ] || [ -e "$n".in ] || grep -q '^.so' $m; then
-	echo "Not converting $m due to roff include or existing adoc version"
+    test -L "$m" && continue
+    n=$(echo "$m" |sed s%docs/man%docs/src/man%).adoc
+    if [ -e "$n" ] || [ -e "$n".in ] || grep -q '^.so' "$m"; then
+	echo "E: Not converting '$m' due to roff include or existing adoc version"
     else
-	echo "Converting $m to $n"
-        pandoc -f man -t asciidoc $m -o $n
-        git add $n
-        git rm --quiet $m
+	echo "I: Converting '$m' to '$n'"
+        pandoc -f man -t asciidoc "$m" -o "$n"
+        git add "$n"
+        git rm --quiet "$m"
     fi
 done
 
 # Make sure they can be converted back to manpage format
 for n in docs/src/man/man?/*.adoc; do
     #echo "Making sure $n got required header"
-    b=$(basename $n .adoc)
-    name=$(echo $b|cut -d. -f1)
-    s=$(echo $b|cut -d. -f2)
-    if ! head -1 $n | grep -q "= $name ($s)" ||
+    b=$(basename "$n" .adoc)
+    name=$(echo "$b"|cut -d. -f1)
+    s=$(echo "$b"|cut -d. -f2)
+    if ! head -1 "$n" | grep -q "= $name ($s)" ||
 	    ! "/usr/bin/asciidoc" --backend docbook \
               -a "a2x-format=manpage" --doctype manpage \
               --attribute "mansource=LinuxCNC" \
               --attribute "manmanual=LinuxCNC Documentation" \
               --verbose \
-              --out-file x.man $m
+              --out-file x.man "$m"
     then
-        (echo "= $name($s)"; echo; cat $n) > $n.new && mv $n.new $n
-        git add $n
+        (echo "= $name($s)"; echo; cat "$n") > "$n".new && mv "$n".new "$n"
+        git add "$n"
     fi
 done

--- a/scripts/pyvcp_demo
+++ b/scripts/pyvcp_demo
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-prog=$(basename $0)
+prog=$(basename "$0")
 
 function usage () {
   cat <<EOF
@@ -52,7 +52,7 @@ EOF
 REALTIME=$(linuxcnc_var REALTIME)
 $REALTIME status >/dev/null
 status=$?
-if [ $status = 0 ] ; then
+if [ "$status" = 0 ] ; then
   msg="$prog: Realtime is already active"
   echo "$msg"
   popup "$msg"
@@ -74,16 +74,16 @@ case $# in
     *) usage;;
 esac
 
-if [ ! -z "$debug" ] ; then
-  echo debug=$debug
-  echo REALTIME=$REALTIME
-  echo XMLFILE=$XMLFILE
-  echo HALFILE=$HALFILE
-  echo COMPNAME=$COMPNAME
+if [ -n "$debug" ] ; then
+  echo "debug=$debug"
+  echo "REALTIME=$REALTIME"
+  echo "XMLFILE=$XMLFILE"
+  echo "HALFILE=$HALFILE"
+  echo "COMPNAME=$COMPNAME"
 fi
 
-cd $(dirname "$XMLFILE") ;# to allow relative includes
-pyvcp -c $COMPNAME $XMLFILE &
+cd "$(dirname "$XMLFILE")" || (echo "E: Could not change directory to '$(dirname "$XMLFILE")'"; exit 1);# to allow relative includes
+pyvcp -c "$COMPNAME" "$XMLFILE" &
 pyvcpjob=$!
 ct=0
 # wait for pins to be created before creating signals
@@ -91,37 +91,38 @@ while true ; do
    halcmd show|grep "${COMPNAME}.*ready" >/dev/null 2>&1
    status=$?
    sleep 1
-   if [ $status == 0 ] ; then
+   if [ "$status" == 0 ] ; then
       #echo "ready after ct=$ct"
       break
    fi
-   if [ $ct -ge 10 ] ; then
+   if [ "$ct" -ge 10 ] ; then
       echo "$0: hal-pyvcp startup failed"
       exit 1
    fi
-   ct=$(($ct+1))
+   ct=$((ct+1))
 done
 
-cd $(dirname "$HALFILE") ;# so HALFILE can source relative files
+cd "$(dirname "$HALFILE")" || (echo "E: Could not change directory to '$(dirname "$HALFILE")'"; exit 1) ;# so HALFILE can source relative files
 
 halmsg=/tmp/pyvcp_demo_halcmd.err
+# Always write to the $halmsg file, first empty the file (the >| overrides 'noclobber')
 >|$halmsg
-halcmd -f $HALFILE >$halmsg 2>&1
+halcmd -f "$HALFILE" > "$halmsg" 2>&1
 halstatus=$?
-if [ $halstatus != 0 ] ; then
+if [ "$halstatus" != 0 ] ; then
   IFS=$'\n' # split lines
   newmsg=
   # put extra blank line between lines of output
   for line in $(cat $halmsg) ; do
-newmsg="$newmsg
+    newmsg="$newmsg
 $line
 "
   done
   popup "$newmsg"
-  kill $pyvcpjob
+  kill "$pyvcpjob"
   halrun -U
   exit 1
 fi
-wait $pyvcpjob
+wait "$pyvcpjob"
 halrun -U
 exit 0

--- a/scripts/swish
+++ b/scripts/swish
@@ -11,11 +11,11 @@ fi
 
 case "$0" in
 	*/*) MYDIR="${0%/*}" ;;
-	*) MYDIR="`type -path $0`"; MYDIR="${MYDIR%/*}"
+	*) MYDIR="$(type -path "$0")"; MYDIR="${MYDIR%/*}"
 esac
 
-SRCDIR=$(cd "$MYDIR/../src"; pwd)
-SWISHINDEX="$SRCDIR/.swishindex"
+SRCDIR=$(cd "$MYDIR/../src" && pwd || exit 1)
+SWISHINDEX="$SRCDIR"/.swishindex
 
 function makerelative () {
 python -c '
@@ -73,27 +73,27 @@ do
 	h|?)	usage ;;
 	esac
 done
-shift $(($OPTIND-1))
+shift $((OPTIND-1))
 
 if [ "$FORCEREBUILD" -o ! -f "$SWISHINDEX" ]
 then
-	make -C "$SRCDIR" swish || exit $?
-	if [ $# -eq 0 ]; then exit 0; fi
+	make -C "$SRCDIR" swish || exit "$?"
+	if [ "$#" -eq 0 ]; then exit 0; fi
 fi
 
 PAT="$1"; shift
-if [ $# -eq 0 ]; then
+if [ "$#" -eq 0 ]; then
 	REGEXP="${PAT%%\*}"
 else
 	REGEXP="$1"
 fi
 
-if ! [ -z "$FILEFILTER" ]; then
-	swish-e -f $SWISHINDEX -H0 -x '<swishdocpath>\0' -w "$PAT" \
+if [ -n "$FILEFILTER" ]; then
+	swish-e -f "$SWISHINDEX" -H0 -x '<swishdocpath>\0' -w "$PAT" \
 		| $FILEFILTER | makerelative \
 		| xargs -0 grep -E -Hnis -e "$REGEXP"
 else
-	swish-e -f $SWISHINDEX -H0 -x '<swishdocpath>\0' -w "$PAT" \
+	swish-e -f "$SWISHINDEX" -H0 -x '<swishdocpath>\0' -w "$PAT" \
 		| makerelative \
 		| xargs -0 grep -E -Hnis -e "$REGEXP"
 fi

--- a/scripts/version-is-release
+++ b/scripts/version-is-release
@@ -8,20 +8,20 @@
 # that is signed by the release manager's key.
 #
 
-if [ ! -z "$EMC2_HOME" ]; then
-    source $EMC2_HOME/scripts/githelper.sh
+if [ -n "$EMC2_HOME" ]; then
+    source "$EMC2_HOME"/scripts/githelper.sh
 else
-    source $(git rev-parse --show-toplevel)/scripts/githelper.sh
+    source "$(git rev-parse --show-toplevel)"/scripts/githelper.sh
 fi
 
-githelper $1
+githelper "$1"
 if [ -z "$GIT_TAG" ]; then
     # no signed tags found
     echo "no"
     exit 1
 fi
 
-TAGGED_REV=$(git rev-parse $GIT_TAG^{commit})
+TAGGED_REV=$(git rev-parse "$GIT_TAG"^{commit})
 HEAD_REV=$(git rev-parse HEAD)
 
 if [ "$TAGGED_REV" == "$HEAD_REV" ]; then

--- a/tests/build/header-sanity/test.sh
+++ b/tests/build/header-sanity/test.sh
@@ -1,21 +1,28 @@
 #!/bin/sh
 set -xe 
 CPPFLAGS=$(pkg-config --silence-errors --cflags libtirpc)
-for i in $HEADERS/*.h; do
+
+for i in "$HEADERS"/*.h
+do
     case $i in
     */rtapi_app.h) continue ;;
     esac
+    # shellcheck disable=SC2086
     gcc ${CPPFLAGS} -DULAPI -I$HEADERS -E -x c $i > /dev/null
 done
-for i in $HEADERS/*.h $HEADERS/*.hh; do
-    case $i in
+
+for i in "$HEADERS"/*.h "$HEADERS"/*.hh
+do
+    case "$i" in
     */rtapi_app.h) continue ;;
     */interp_internal.hh) continue ;;
     esac
+    # shellcheck disable=SC2086
     if g++ ${CPPFLAGS} -std=c++11 -S -o /dev/null -xcxx /dev/null > /dev/null 2>&1; then
         ELEVEN=-std=c++11
     else
         ELEVEN=-std=c++0x
     fi
-    g++ ${CPPFLAGS} $ELEVEN -DULAPI -I$HEADERS -E -x c++ $i > /dev/null
+    # shellcheck disable=SC2086
+    g++ ${CPPFLAGS} $ELEVEN -DULAPI -I$HEADERS -E -x c++ "$i" > /dev/null
 done

--- a/tests/ccomp/lathe-comp/test.sh
+++ b/tests/ccomp/lathe-comp/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -t test.tbl -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/ccomp/mill-g90g91g92/test.sh
+++ b/tests/ccomp/mill-g90g91g92/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -t test.tbl -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/ccomp/mill-line-arc-entry/test.sh
+++ b/tests/ccomp/mill-line-arc-entry/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -t test.tbl -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/ccomp/mill-zchanges/test.sh
+++ b/tests/ccomp/mill-zchanges/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -t test.tbl -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/classicladder/estop/test.sh
+++ b/tests/classicladder/estop/test.sh
@@ -7,4 +7,4 @@
 if [ "libeatmydata.so" = "$LD_PRELOAD" ] ; then
     unset LD_PRELOAD
 fi
-exec linuxcnc $(dirname $0)/classicladder-estop.ini
+exec linuxcnc "$(dirname "$0")"/classicladder-estop.ini

--- a/tests/halcompile/names/test.sh
+++ b/tests/halcompile/names/test.sh
@@ -3,11 +3,12 @@ set -x
 
 # this one must succeed
 rm -f names_match.c
-halcompile names_match.comp
-if [ $? -ne 0 ]; then
+
+if ! halcompile names_match.comp; then
     echo 'halcompile failed to process names_match.comp'
     exit 1
 fi
+
 if [ ! -f names_match.c ]; then
     echo 'halcompile failed to produce names_match.c'
     exit 1
@@ -15,11 +16,12 @@ fi
 
 # this one must fail
 rm -f names_dont_match.c
-halcompile names_dont_match.comp
-if [ $? -eq 0 ]; then
+
+if halcompile names_dont_match.comp; then
     echo 'halcompile erroneously accepted names_dont_match.comp'
     exit 1
 fi
+
 if [ -f names_dont_match.c ]; then
     echo 'halcompile erroneously produced names_dont_match.c'
     exit 1

--- a/tests/hm2-idrom/test.sh
+++ b/tests/hm2-idrom/test.sh
@@ -19,11 +19,11 @@ Error[14]="hm2/hm2_test\.0: IDROM IOPorts is 0 but llio num_ioport_connectors is
 result=0
 
 TEST_PATTERN=0
-while [ ! -z "${Error[$TEST_PATTERN]}" ]; do
+while [ -n "${Error[$TEST_PATTERN]}" ]; do
     export TEST_PATTERN
     halrun -f broken-load-test.hal >halrun-stdout 2>halrun-stderr
     ./check-dmesg.py "${Error[$TEST_PATTERN]}" || exit $?
-    TEST_PATTERN=$(($TEST_PATTERN+1))
+    TEST_PATTERN=$((TEST_PATTERN+1))
 done
 
 exit $result

--- a/tests/interp/cam-nisley/test.sh
+++ b/tests/interp/cam-nisley/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -t test.tbl -g cam.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/crazy-paths/test.sh
+++ b/tests/interp/crazy-paths/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/do-while-break/test.sh
+++ b/tests/interp/do-while-break/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/exists/test.sh
+++ b/tests/interp/exists/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/flowsnake/test.sh
+++ b/tests/interp/flowsnake/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g flowsnake.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/fractional-linenumbers/test.sh
+++ b/tests/interp/fractional-linenumbers/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g10/g10-l1-l10/test.sh
+++ b/tests/interp/g10/g10-l1-l10/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc -t test.tbl | awk '{$1=""; print}' | sed 's/-0\.0000/0.0000/g'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g10/g10-l11/test.sh
+++ b/tests/interp/g10/g10-l11/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc -t test.tbl | awk '{$1=""; print}' | sed 's/-0\.0000/0.0000/g'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g10/g10-l2-while-active/test.sh
+++ b/tests/interp/g10/g10-l2-while-active/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g10/g10-l20-while-active/test.sh
+++ b/tests/interp/g10/g10-l20-while-active/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}' | sed 's/-0\.0000/0.0000/g'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g10/g10-with-g92/test.sh
+++ b/tests/interp/g10/g10-with-g92/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc -t test.tbl | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g33.1/test.sh
+++ b/tests/interp/g33.1/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g33.1.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g6164/test.sh
+++ b/tests/interp/g6164/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g71-endless-loop/test.sh
+++ b/tests/interp/g71-endless-loop/test.sh
@@ -10,14 +10,14 @@ pid=$!
 
 # Give it 10 seconds to complete
 count=10
-while [ 0 -lt $count ] && kill -0 $pid > /dev/null 2>&1 ; do
+while [ 0 -lt "$count" ] && kill -0 "$pid" > /dev/null 2>&1 ; do
     sleep 1
-    count=$(($count - 1))
+    count=$((count - 1))
 done
 
-if kill -0 $pid > /dev/null 2>&1; then
-    kill -9 $pid
-    echo "error: g71-endless-loop.ngc program seem to be stuck, killing"
+if kill -0 "$pid" > /dev/null 2>&1; then
+    kill -9 "$pid"
+    echo "E: g71-endless-loop.ngc program seem to be stuck, killing"
     exit 1
 fi
 

--- a/tests/interp/g71-with-g70/test.sh
+++ b/tests/interp/g71-with-g70/test.sh
@@ -7,13 +7,13 @@ pid=$!
 
 # Give it 5 seconds to complete
 count=5
-while [ 0 -lt $count ] && kill -0 $pid > /dev/null 2>&1 ; do
+while [ 0 -lt "$count" ] && kill -0 "$pid" > /dev/null 2>&1 ; do
     sleep 1
-    count=$(($count - 1))
+    count=$((count - 1))
 done
 
-if kill -0 $pid > /dev/null 2>&1; then
-    kill -9 $pid
+if kill -0 "$pid" > /dev/null 2>&1; then
+    kill -9 "$pid"
     echo "error: g71_and_g70.ngc program seem to be stuck, killing"
     exit 1
 fi

--- a/tests/interp/g72-facing/test.sh
+++ b/tests/interp/g72-facing/test.sh
@@ -8,14 +8,14 @@ pid=$!
 
 # Give it 10 seconds to complete
 count=10
-while [ 0 -lt $count ] && kill -0 $pid > /dev/null 2>&1 ; do
+while [ 0 -lt "$count" ] && kill -0 "$pid" > /dev/null 2>&1 ; do
     sleep 1
-    count=$(($count - 1))
+    count=$((count - 1))
 done
 
-if kill -0 $pid > /dev/null 2>&1; then
-    kill -9 $pid
-    echo "error: g71-iterations-present.ngc program seem to be stuck, killing"
+if kill -0 "$pid" > /dev/null 2>&1; then
+    kill -9 "$pid"
+    echo "E: g71-iterations-present.ngc program seem to be stuck, killing"
     exit 1
 fi
 

--- a/tests/interp/g72-missing-iteration/test.sh
+++ b/tests/interp/g72-missing-iteration/test.sh
@@ -10,14 +10,14 @@ pid=$!
 
 # Give it 10 seconds to complete
 count=10
-while [ 0 -lt $count ] && kill -0 $pid > /dev/null 2>&1 ; do
+while [ 0 -lt "$count" ] && kill -0 "$pid" > /dev/null 2>&1 ; do
     sleep 1
     count=$((count - 1))
 done
 
-if kill -0 $pid > /dev/null 2>&1; then
-    kill -9 $pid
-    echo "error: g71-iterations-missing.ngc program seem to be stuck, killing"
+if kill -0 "$pid" > /dev/null 2>&1; then
+    kill -9 "$pid"
+    echo "E: g71-iterations-missing.ngc program seem to be stuck, killing"
     exit 1
 fi
 

--- a/tests/interp/g76/test.sh
+++ b/tests/interp/g76/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -t test.tbl -g g76only.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g81/g17/g98/test.sh
+++ b/tests/interp/g81/g17/g98/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g17-g98-g81.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g81/g17/g99/test.sh
+++ b/tests/interp/g81/g17/g99/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g17-g99-g81.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g81/g18/g98/test.sh
+++ b/tests/interp/g81/g18/g98/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g18-g98-g81.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g81/g18/g99/test.sh
+++ b/tests/interp/g81/g18/g99/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g18-g99-g81.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g81/g19/g98/test.sh
+++ b/tests/interp/g81/g19/g98/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g19-g98-g81.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g81/g19/g99/test.sh
+++ b/tests/interp/g81/g19/g99/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g19-g99-g81.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g84/g17/g98/test.sh
+++ b/tests/interp/g84/g17/g98/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g17-g98-g84.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g84/g17/g99/test.sh
+++ b/tests/interp/g84/g17/g99/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g17-g99-g84.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g84/g18/g98/test.sh
+++ b/tests/interp/g84/g18/g98/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g18-g98-g84.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g84/g18/g99/test.sh
+++ b/tests/interp/g84/g18/g99/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g18-g99-g84.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g84/g19/g98/test.sh
+++ b/tests/interp/g84/g19/g98/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g19-g98-g84.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/g84/g19/g99/test.sh
+++ b/tests/interp/g84/g19/g99/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g19-g99-g84.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/iniparam-failassign/test.sh
+++ b/tests/interp/iniparam-failassign/test.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 export PYTHONUNBUFFERED=1
-rs274 -i test.ini  -g test.ngc 2>&1
-
-# expected to fail
-if [ $? -ne 0 ]; then
+if ! rs274 -i test.ini  -g test.ngc 2>&1
+then
+    # expected to fail
     exit 0
 fi
-
 exit 1

--- a/tests/interp/inside-corners/test.sh
+++ b/tests/interp/inside-corners/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/inverse-time-with-comp/test.sh
+++ b/tests/interp/inverse-time-with-comp/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g inverse.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/m19/test.sh
+++ b/tests/interp/m19/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -n 0 -i test.ini -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/m98m99/01-basics/test.sh
+++ b/tests/interp/m98m99/01-basics/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/m98m99/02-variables/test.sh
+++ b/tests/interp/m98m99/02-variables/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/m98m99/03-error-M98-no-P-word/test.sh
+++ b/tests/interp/m98m99/03-error-M98-no-P-word/test.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
-rs274  -g test.ngc 2>&1
-
-# expected to fail
-if [ $? -ne 0 ]; then
+if ! rs274  -g test.ngc 2>&1
+then
+    # expected to fail
     exit 0
 fi
-
 exit 1

--- a/tests/interp/m98m99/05-M98-loops/test.sh
+++ b/tests/interp/m98m99/05-M98-loops/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/m98m99/07-nested-subs/test.sh
+++ b/tests/interp/m98m99/07-nested-subs/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/m98m99/08-sub-follows-main/test.sh
+++ b/tests/interp/m98m99/08-sub-follows-main/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/m98m99/10-M98-P001/test.sh
+++ b/tests/interp/m98m99/10-M98-P001/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/m98m99/11-main-program-oword/test.sh
+++ b/tests/interp/m98m99/11-main-program-oword/test.sh
@@ -18,8 +18,8 @@ ILLEGAL_TESTS="
 #
 for t in $LEGAL_TESTS; do
     echo "Legal test ${t}:"
-    rs274 -g test-legal-${t}.ngc | awk '{$1=""; print}'
-    res=${PIPESTATUS[0]}
+    rs274 -g "test-legal-${t}.ngc" | awk '{$1=""; print}'
+    res="${PIPESTATUS[0]}"
     if test "$res" = 0; then
 	echo "Success: Test '${t}' exited ${res}" >&2
     else
@@ -33,8 +33,8 @@ done
 for t in $ILLEGAL_TESTS; do
     echo "Illegal test ${t}:"
     res=-1
-    rs274 -g test-illegal-${t}.ngc | awk '{$1=""; print}'
-    res=${PIPESTATUS[0]}
+    rs274 -g "test-illegal-${t}.ngc" | awk '{$1=""; print}'
+    res="${PIPESTATUS[0]}"
     if test "$res" = 0; then
 	echo "Error: Illegal test '${t}' exited ${res}" >&2
 	exit "$res"

--- a/tests/interp/m98m99/12-M99-endless-main-program/test.sh
+++ b/tests/interp/m98m99/12-M99-endless-main-program/test.sh
@@ -7,4 +7,4 @@ linuxcnc -r motion-logger.ini
 
 # Run test file in stand-alone interpreter:  should run program once
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/magic_comments/param_format_printing/test.sh
+++ b/tests/interp/magic_comments/param_format_printing/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/namedparam-bug424/test.sh
+++ b/tests/interp/namedparam-bug424/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/oword-bug315-p2/test.sh
+++ b/tests/interp/oword-bug315-p2/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/oword-bug315/test.sh
+++ b/tests/interp/oword-bug315/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/oword-unwind/test.sh
+++ b/tests/interp/oword-unwind/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -n 0 -i test.ini -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/plug/absolute/test.sh
+++ b/tests/interp/plug/absolute/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -p "${LIBDIR}"/linuxcnc/canterp.so -g canon | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/plug/filename/test.sh
+++ b/tests/interp/plug/filename/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -p canterp.so -g canon | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/plug/relative/test.sh
+++ b/tests/interp/plug/relative/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -p ./canterp.so -g canon | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/return-value/test.sh
+++ b/tests/interp/return-value/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/rotation/abs-pts/test.sh
+++ b/tests/interp/rotation/abs-pts/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc -t test.tbl | awk '/MESSAGE/ {$1=""; print}' | sed 's/-0\.0000/0.0000/g'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/rotation/g28/test.sh
+++ b/tests/interp/rotation/g28/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g28.ngc | sed 's/-0\.0000/0.0000/g'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/rotation/g53/test.sh
+++ b/tests/interp/rotation/g53/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g g53.ngc | sed 's/-0\.0000/0.0000/g'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/interp/subs-follow-main/test.sh
+++ b/tests/interp/subs-follow-main/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/linuxcncrsh-tcp/test.sh
+++ b/tests/linuxcncrsh-tcp/test.sh
@@ -12,42 +12,42 @@ linuxcnc -r linuxcncrsh-test.ini &
 
 # let linuxcnc come up
 TOGO=80
-while [  $TOGO -gt 0 ]; do
+while [ "$TOGO" -gt 0 ]; do
     echo trying to connect to linuxcncrsh TOGO=$TOGO
     if nc -z localhost 5007; then
         break
     fi
     sleep 0.25
-    TOGO=$(($TOGO - 1))
+    TOGO=$((TOGO - 1))
 done
-if [  $TOGO -eq 0 ]; then
-    echo connection to linuxcncrsh timed out
+if [  "$TOGO" -eq 0 ]; then
+    echo "connection to linuxcncrsh timed out"
     exit 1
 fi
 
 
 (
-    echo hello EMC mt 1.0
-    echo set enable EMCTOO
+    echo "hello EMC mt 1.0"
+    echo "set enable EMCTOO"
 
     # ask linuxcncrsh to not read the next command until it's done running
     # the current one
-    echo set set_wait done
+    echo "set set_wait done"
 
-    echo set mode manual
-    echo set estop off
-    echo set machine on
+    echo "set mode manual"
+    echo "set estop off"
+    echo "set machine on"
 
-    echo set mode mdi
-    echo set mdi m100 p-1 q-2
+    echo "set mode mdi"
+    echo "set mdi m100 p-1 q-2"
     sleep 1
 
     # here comes a big blob
     dd bs=4096 if=lots-of-gcode
 
-    echo set mdi m100 p-3 q-4
+    echo "set mdi m100 p-3 q-4"
 
-    echo shutdown
+    echo "shutdown"
 ) | nc localhost 5007
 
 

--- a/tests/lowlevel/mutex/test.sh
+++ b/tests/lowlevel/mutex/test.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2086
 gcc -O -I${HEADERS} test.c -o test -DULAPI -std=gnu99 -pthread || exit 1
 ./test; exitval=$?
 rm -f test

--- a/tests/m70-m73/m70m72-restore.0/test.sh
+++ b/tests/m70-m73/m70m72-restore.0/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/m70-m73/m73-flood-mist-restore.0/test.sh
+++ b/tests/m70-m73/m73-flood-mist-restore.0/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/m70-m73/m73autorestore.0/test.sh
+++ b/tests/m70-m73/m73autorestore.0/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/mdi-queue/oword-queue-buster/test.sh
+++ b/tests/mdi-queue/oword-queue-buster/test.sh
@@ -28,9 +28,9 @@ while [  $TOGO -gt 0 ]; do
         break
     fi
     sleep 0.25
-    TOGO=$(($TOGO - 1))
+    TOGO=$((TOGO - 1))
 done
-if [  $TOGO -eq 0 ]; then
+if [ "$TOGO" -eq 0 ]; then
     echo "E: connection to linuxcncrsh timed out"
     exit 1
 fi
@@ -42,12 +42,13 @@ NUM_MDIS=1
 NUM_MDIS_LEFT=$NUM_MDIS
 TOOL=1
 for i in $(seq 0 1000); do
-    NUM_MDIS_LEFT=$(($NUM_MDIS_LEFT - 1))
+    NUM_MDIS_LEFT=$((NUM_MDIS_LEFT - 1))
     if [ $NUM_MDIS_LEFT -eq 0 ]; then
         echo "set mdi o<queue-buster> call [$TOOL]" >> lots-of-gcode
+        # shellcheck disable=SC2129
         echo "P is 12345.000000" >> expected-gcode-output
-        echo "P is $((-1 * $TOOL)).000000" >> expected-gcode-output
-        echo "P is 54321.000000"  >> expected-gcode-output
+        echo "P is $((-1 * TOOL)).000000" >> expected-gcode-output
+        echo "P is 54321.000000" >> expected-gcode-output
 
         if [ $TOOL -eq 1 ]; then
             TOOL=2
@@ -55,8 +56,8 @@ for i in $(seq 0 1000); do
             TOOL=1
         fi
 
-        NUM_MDIS=$(($NUM_MDIS + 1))
-        if [ $NUM_MDIS -gt 10 ]; then
+        NUM_MDIS=$((NUM_MDIS + 1))
+        if [ "$NUM_MDIS" -gt 10 ]; then
             NUM_MDIS=1
         fi
 
@@ -68,27 +69,27 @@ done
 echo "P is -200.000000" >> expected-gcode-output
 
 (
-    echo hello EMC mt 1.0
-    echo set enable EMCTOO
+    echo "hello EMC mt 1.0"
+    echo "set enable EMCTOO"
 
-    echo set mode manual
-    echo set estop off
-    echo set machine on
+    echo "set mode manual"
+    echo "set estop off"
+    echo "set machine on"
 
-    echo set mode auto
-    echo set open dummy.ngc
+    echo "set mode auto"
+    echo "set open dummy.ngc"
 
-    echo set mode mdi
-    echo set mdi m100 p-100
-    echo set wait done
+    echo "set mode mdi"
+    echo "set mdi m100 p-100"
+    echo "set wait done"
 
     # here comes a big blob
     dd bs=4096 if=lots-of-gcode
 
-    echo set mdi m100 p-200
-    echo set wait done
+    echo "set mdi m100 p-200"
+    echo "set wait done"
 
-    echo shutdown
+    echo "shutdown"
 ) | nc localhost 5007
 
 

--- a/tests/mdi-queue/simple-queue-buster/test.sh
+++ b/tests/mdi-queue/simple-queue-buster/test.sh
@@ -28,7 +28,7 @@ while [  $TOGO -gt 0 ]; do
         break
     fi
     sleep 0.25
-    TOGO=$(($TOGO - 1))
+    TOGO=$((TOGO - 1))
 done
 if [  $TOGO -eq 0 ]; then
     echo connection to linuxcncrsh timed out
@@ -42,8 +42,8 @@ NUM_MDIS=1
 NUM_MDIS_LEFT=$NUM_MDIS
 TOOL=1
 for i in $(seq 0 1000); do
-    NUM_MDIS_LEFT=$(($NUM_MDIS_LEFT - 1))
-    if [ $NUM_MDIS_LEFT -eq 0 ]; then
+    NUM_MDIS_LEFT=$((NUM_MDIS_LEFT - 1))
+    if [ "$NUM_MDIS_LEFT" -eq 0 ]; then
         echo "set mdi t$TOOL m6" >> lots-of-gcode
         if [ $TOOL -eq 1 ]; then
             TOOL=2
@@ -51,8 +51,8 @@ for i in $(seq 0 1000); do
             TOOL=1
         fi
 
-        NUM_MDIS=$(($NUM_MDIS + 1))
-        if [ $NUM_MDIS -gt 10 ]; then
+        NUM_MDIS=$((NUM_MDIS + 1))
+        if [ "$NUM_MDIS" -gt 10 ]; then
             NUM_MDIS=1
         fi
 
@@ -64,28 +64,28 @@ done
 echo "P is -2.000000" >> expected-gcode-output
 
 (
-    echo hello EMC mt 1.0
-    echo set enable EMCTOO
+    echo "hello EMC mt 1.0"
+    echo "set enable EMCTOO"
 
     # ask linuxcncrsh to not read the next command until it's done running
     # the current one
-    #echo set set_wait done
+    #echo "set set_wait done"
 
-    echo set mode manual
-    echo set estop off
-    echo set machine on
+    echo "set mode manual"
+    echo "set estop off"
+    echo "set machine on"
 
-    echo set mode mdi
-    echo set mdi m100 p-1
-    echo set wait done
+    echo "set mode mdi"
+    echo "set mdi m100 p-1"
+    echo "set wait done"
 
     # here comes a big blob
     dd bs=4096 if=lots-of-gcode
 
-    echo set mdi m100 p-2
-    echo set wait done
+    echo "set mdi m100 p-2"
+    echo "set wait done"
 
-    echo shutdown
+    echo "shutdown"
 ) | nc localhost 5007
 
 

--- a/tests/mdi-while-queuebuster-waitflag/test.sh
+++ b/tests/mdi-while-queuebuster-waitflag/test.sh
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 
-for i in `seq 20`; do
+# shellcheck disable=SC2034
+for i in $(seq 20)
+do
     linuxcnc -r test.ini
     if grep -q '^[^+].*Segmentation fault' stderr; then
-	exit 1
+        exit 1
     fi
 done

--- a/tests/module-loading/shared-test.sh
+++ b/tests/module-loading/shared-test.sh
@@ -3,13 +3,14 @@
 halrun setup.hal > hal-output 2>&1
 RESULT=$?
 
-NUM_PINS=$(cat hal-output | grep -E $(cat PIN_NAME_REGEX) | wc -l)
+# grep -c counts number of matches
+NUM_PINS=$(grep -E -c "$(cat PIN_NAME_REGEX)" hal-output)
 
-if [ $RESULT -ne $(cat RESULT) ]; then
+if [ "$RESULT" -ne "$(cat RESULT)" ]; then
     exit 1
 fi
 
-if [ "$NUM_PINS" -ne $(cat NUM_PINS) ]; then
+if [ "$NUM_PINS" -ne "$(cat NUM_PINS)" ]; then
     exit 1
 fi
 

--- a/tests/motion/g0/test.sh
+++ b/tests/motion/g0/test.sh
@@ -7,15 +7,15 @@ wait_for_pin() {
     pin="$1"
     value="$2"
     maxwait=10 # seconds
-    while [ 0 -lt $maxwait ] \
-      && [ "$value" != "$(halcmd -s show pin $pin | awk '{print $4}')" ]; do
+    while [ 0 -lt "$maxwait" ] \
+      && [ "$value" != "$(halcmd -s show pin "$pin" | awk '{print $4}')" ]; do
         sleep 1
-	maxwait=$(($maxwait -1))
+	maxwait=$((maxwait - 1))
     done
-    if [ 0 -eq $maxwait ] ; then
-	echo "error: waiting for pin $pin timed out"
-	kill $linuxcncpid
-	kill $samplerpid
+    if [ 0 -eq "$maxwait" ] ; then
+	echo "error: waiting for pin '$pin' timed out"
+	kill "$linuxcncpid"
+	kill "$samplerpid"
 	exit 1
     fi
 }
@@ -25,47 +25,47 @@ linuxcncpid=$!
 
 # let linuxcnc come up
 TOGO=80
-while [  $TOGO -gt 0 ]; do
-    echo trying to connect to linuxcncrsh TOGO=$TOGO
+while [ "$TOGO" -gt 0 ]; do
+    echo "I: trying to connect to linuxcncrsh TOGO=$TOGO"
     if nc -z localhost 5007; then
         break
     fi
     sleep 0.25
-    TOGO=$(($TOGO - 1))
+    TOGO=$((TOGO - 1))
 done
-if [  $TOGO -eq 0 ]; then
-    echo connection to linuxcncrsh timed out
+if [ "$TOGO" -eq 0 ]; then
+    echo "E: connection to linuxcncrsh timed out"
     exit 1
 fi
 
 wait_for_pin motion.in-position TRUE
 
-echo starting to capture data
+echo "I: starting to capture data"
 halsampler -t >| result.halsamples &
 samplerpid=$!
 
 (
-    echo hello EMC mt 1.0
-    echo set enable EMCTOO
+    echo "hello EMC mt 1.0"
+    echo "set enable EMCTOO"
 
-    echo set estop off
-    echo set machine on
+    echo "set estop off"
+    echo "set machine on"
 
-    echo set mode mdi
+    echo "set mode mdi"
     dist=1
-    echo set mdi g0x$dist
+    echo "set mdi g0x$dist"
 
     # Wait for movement to complete
     wait_for_pin joint.0.pos-fb $dist
     wait_for_pin joint.0.in-position TRUE
     wait_for_pin joint.1.in-position TRUE
 
-    echo shutdown
+    echo "shutdown"
 ) | nc localhost 5007
 
 kill $samplerpid
 wait $samplerpid
-echo finished capturing data
+echo "I: finished capturing data"
 
 # wait for linuxcnc to finish
 wait $linuxcncpid

--- a/tests/overrun/test.sh
+++ b/tests/overrun/test.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-TMPDIR=`mktemp -d /tmp/overrun.XXXXXX`
-trap "rm -rf $TMPDIR" 0 1 2 3 9 15
+TMPDIR=$(mktemp -d /tmp/overrun.XXXXXX)
+trap "rm -rf '$TMPDIR'" 0 1 2 3 15
+# not trapping 9 since it cannot be trapped
 
-TEST_HAL=$TMPDIR/test.hal
-echo loadusr -w echo overrun > $TMPDIR/test.hal
+TEST_HAL="$TMPDIR"/test.hal
+echo loadusr -w echo overrun > "$TMPDIR"/test.hal
 
-! $RUNTESTS $TMPDIR 2>&1
+! $RUNTESTS "$TMPDIR" 2>&1

--- a/tests/oword/sub.0/test.sh
+++ b/tests/oword/sub.0/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/oword/while.0/test.sh
+++ b/tests/oword/while.0/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/remap/duplicate-o-word/test.sh
+++ b/tests/remap/duplicate-o-word/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export INI_FILE_NAME=test.ini
-rs274 -i $INI_FILE_NAME -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+rs274 -i "$INI_FILE_NAME" -g test.ngc | awk '{$1=""; print}'
+exit "${PIPESTATUS[0]}"

--- a/tests/remap/fail/args.0/test.sh
+++ b/tests/remap/fail/args.0/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -i test.ini -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/remap/fail/args.1/test.sh
+++ b/tests/remap/fail/args.1/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -i test.ini -n 0 -g test.ngc 2>&1
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/remap/fail/args.2/test.sh
+++ b/tests/remap/fail/args.2/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -i test.ini -n 0 -g test.ngc 2>&1
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/remap/fail/body-ngc/test.sh
+++ b/tests/remap/fail/body-ngc/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -i test.ini -n 0 -g test.ngc 2>&1
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/remap/m30-interaction/test.sh
+++ b/tests/remap/m30-interaction/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -i test.ini -g test.ngc 2>&1 | sed 's/^ *[0-9]* //'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/remap/nested-remaps-oword/test.sh
+++ b/tests/remap/nested-remaps-oword/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 rs274 -i test.ini -g test.ngc 2>&1 | sed 's/^ *[0-9]* //'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"
 

--- a/tests/remap/posargs.0/test.sh
+++ b/tests/remap/posargs.0/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rs274 -i test.ini -n 0 -g test.ngc| awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/remap/remap-reentry/test.sh
+++ b/tests/remap/remap-reentry/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 rs274 -g -i test.ini test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/remap/sequencing/test.sh
+++ b/tests/remap/sequencing/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export INI_FILE_NAME=test.ini
 rs274 -i $INI_FILE_NAME -g test.ngc | awk '{$1=""; print}'
-exit ${PIPESTATUS[0]}
+exit "${PIPESTATUS[0]}"

--- a/tests/t0/shared-test.sh
+++ b/tests/t0/shared-test.sh
@@ -25,7 +25,7 @@ while [  $TOGO -gt 0 ]; do
         break
     fi
     sleep 0.25
-    TOGO=$(($TOGO - 1))
+    TOGO=$((TOGO - 1))
 done
 if [  $TOGO -eq 0 ]; then
     echo connection to linuxcncrsh timed out

--- a/tests/toolchanger/toolno-pocket-differ/shared-test.sh
+++ b/tests/toolchanger/toolno-pocket-differ/shared-test.sh
@@ -19,13 +19,13 @@ linuxcnc -r sim.ini &
 
 # let linuxcnc come up
 TOGO=80
-while [  $TOGO -gt 0 ]; do
+while [ "$TOGO" -gt 0 ]; do
     echo trying to connect to linuxcncrsh TOGO=$TOGO
     if nc -z localhost 5007; then
         break
     fi
     sleep 0.25
-    TOGO=$(($TOGO - 1))
+    TOGO=$((TOGO - 1))
 done
 if [  $TOGO -eq 0 ]; then
     echo connection to linuxcncrsh timed out
@@ -37,123 +37,118 @@ fi
     function introspect() {
         SEQUENCE_NUMBER=$1
         echo "set mdi m100 P6 Q$SEQUENCE_NUMBER"  # sequence number
-        echo 'set mdi m100 P0 Q#5420'             # X
-        echo 'set mdi m100 P1 Q#5421'             # Y
-        echo 'set mdi m100 P2 Q#5422'             # Z
-        echo 'set mdi m100 P3 Q#5400'             # toolno
-        echo 'set mdi m100 P4 Q#5403'             # TLO z
-        echo 'set mdi m100 P5'                    # blank line
+        echo "set mdi m100 P0 Q#5420"             # X
+        echo "set mdi m100 P1 Q#5421"             # Y
+        echo "set mdi m100 P2 Q#5422"             # Z
+        echo "set mdi m100 P3 Q#5400"             # toolno
+        echo "set mdi m100 P4 Q#5403"             # TLO z
+        echo "set mdi m100 P5"                    # blank line
     }
 
-    echo hello EMC mt 1.0
-    echo set enable EMCTOO
+    echo "hello EMC mt 1.0"
+    echo "set enable EMCTOO"
 
-    echo set estop off
-    echo set machine on
-    echo set mode mdi
+    echo "set estop off"
+    echo "set machine on"
+    echo "set mode mdi"
 
     introspect 0
 
-    echo set mdi t1 m6
+    echo "set mdi t1 m6"
     introspect 1
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 2
 
-    echo set mdi g10 l10 p1 z.1
+    echo "set mdi g10 l10 p1 z.1"
     introspect 3
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 4
 
-    echo set mdi g10 l10 p10 z.15
+    echo "set mdi g10 l10 p10 z.15"
     introspect 5
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 6
 
-    echo set mdi g10 l10 p99999 z.2
+    echo "set mdi g10 l10 p99999 z.2"
     introspect 7
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 8
 
-
-    echo set mdi t10 m6
+    echo "set mdi t10 m6"
     introspect 9
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 10
 
-    echo set mdi g10 l10 p1 z.103
+    echo "set mdi g10 l10 p1 z.103"
     introspect 11
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 12
 
-    echo set mdi g10 l10 p10 z.1035
+    echo "set mdi g10 l10 p10 z.1035"
     introspect 13
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 14
 
-    echo set mdi g10 l10 p99999 z.104
+    echo "set mdi g10 l10 p99999 z.104"
     introspect 15
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 16
 
-
-    echo set mdi t99999 m6
+    echo "set mdi t99999 m6"
     introspect 17
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 18
 
-    echo set mdi g10 l10 p1 z.3
+    echo "set mdi g10 l10 p1 z.3"
     introspect 19
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 20
 
-    echo set mdi g10 l10 p10 z.35
+    echo "set mdi g10 l10 p10 z.35"
     introspect 21
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 22
 
-    echo set mdi g10 l10 p99999 z.4
+    echo "set mdi g10 l10 p99999 z.4"
     introspect 23
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 24
 
-
-    echo set mdi t1 m6
+    echo "set mdi t1 m6"
     introspect 25
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 26
 
-
-    echo set mdi t10 m6
+    echo "set mdi t10 m6"
     introspect 27
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 28
 
-
-    echo set mdi t99999 m6
+    echo "set mdi t99999 m6"
     introspect 29
 
-    echo set mdi g43
+    echo "set mdi g43"
     introspect 30
 
 
     # wait for linuxcnc to finish
-    echo set wait done
+    echo "set wait done"
 
-    echo shutdown
+    echo "shutdown"
 ) | nc localhost 5007
 
 

--- a/tests/tooledit/test.sh
+++ b/tests/tooledit/test.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+
 # test if floating point numbers are formatted correctly
 
 if ! command -v xvfb-run &> /dev/null; then
-    echo "xvfb-run could not be found, we assume everything works" > /dev/stderr
+    echo "W: xvfb-run could not be found, we assume everything works" > /dev/stderr
     cat expected
     exit 0
 fi
@@ -11,20 +12,20 @@ fi
 #create temporary files so we don't write into write access problems
 infile=$(mktemp)
 outfile=$(mktemp)
-cat test.tbl > $infile
+cat test.tbl > "$infile"
 
 # run the test
-xvfb-run ${LINUXCNC_EMCSH/wish/tclsh} test.tcl $infile $outfile 2> tclerror.log;
+xvfb-run "${LINUXCNC_EMCSH/wish/tclsh}" test.tcl "$infile" "$outfile" 2> tclerror.log
 
-if [ $(cat tclerror.log | wc -l) -ne 0 ]; then
+if [ "$(wc -l tclerror.log)" -ne 0 ]; then
     cat tclerror.log
     exit 1
 fi
 
 # write the resulting tool table to stdout so the test framework can evaluate it
-cat $outfile
+cat "$outfile"
 
 # remove the temporary files
-rm $infile $outfile $outfile".bak"
+rm "$infile" "$outfile" "$outfile.bak"
 
 exit 0

--- a/tests/trajectory-planner/circular-arcs/test-lengths.sh
+++ b/tests/trajectory-planner/circular-arcs/test-lengths.sh
@@ -2,8 +2,8 @@
 set -o monitor
 ./build-debug.sh
 cp position.blank position.txt
-linuxcnc $1 > test.log &
-./machine_setup.py $2
+linuxcnc "$1" > test.log &
+./machine_setup.py "$2"
 fg
 ./save_lengths.sh test.log
 #if [ -a length_data.log ] 

--- a/tests/trajectory-planner/circular-arcs/test-optimization.sh
+++ b/tests/trajectory-planner/circular-arcs/test-optimization.sh
@@ -13,4 +13,4 @@ linuxcnc -r circular_arcs.ini > test.log &
 ./machine_setup.py "$1" && say_done
 fg
 ./save_activate.sh test.log
-exit $1
+exit "$1"

--- a/tests/trajectory-planner/circular-arcs/util/save_vel.sh
+++ b/tests/trajectory-planner/circular-arcs/util/save_vel.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o nounset                              # Treat unset variables as an error
 
-if [ -a $1 ] 
+if [ -a "$1" ] 
 then
-    awk '/tc state/ {print $5,$8,$11}' $1 > vel_data.log
+    awk '/tc state/ {print $5,$8,$11}' "$1" > vel_data.log
 fi


### PR DESCRIPTION
These changes shall prepare LinuxCNC's test routines to accept blanks in file names.