### PR TITLE
Fix test scripts

### DIFF
--- a/tests/halcompile/serial-out-of-tree/checkresult
+++ b/tests/halcompile/serial-out-of-tree/checkresult
@@ -1,2 +1,2 @@
 #!/bin/sh
-[ -e "`dirname "$1"`/mesa_uart.so" -o "`dirname "$1"`/mesa_uart.ko" ]
+[ -e "$(dirname "$1")/mesa_uart_test.so" ] || [ -e "$(dirname "$1")/mesa_uart_test.ko" ]

--- a/tests/trajectory-planner/circular-arcs/test-optimization.sh
+++ b/tests/trajectory-planner/circular-arcs/test-optimization.sh
@@ -13,4 +13,3 @@ linuxcnc -r circular_arcs.ini > test.log &
 ./machine_setup.py "$1" && say_done
 fg
 ./save_activate.sh test.log
-exit $1


### PR DESCRIPTION
This PR addresses wrong tests performed in test scripts.
One tests checked the wrong file-name and the other tests used an exit with a file as argument.