### PR TITLE
Fix shellcheck problems in test scripts

### DIFF
--- a/tests/halcompile/names/test.sh
+++ b/tests/halcompile/names/test.sh
@@ -3,8 +3,7 @@ set -x
 
 # this one must succeed
 rm -f names_match.c
-halcompile names_match.comp
-if [ $? -ne 0 ]; then
+if ! halcompile names_match.comp; then
     echo 'halcompile failed to process names_match.comp'
     exit 1
 fi
@@ -15,8 +14,7 @@ fi
 
 # this one must fail
 rm -f names_dont_match.c
-halcompile names_dont_match.comp
-if [ $? -eq 0 ]; then
+if halcompile names_dont_match.comp; then
     echo 'halcompile erroneously accepted names_dont_match.comp'
     exit 1
 fi

--- a/tests/halcompile/personalities_mod/checkresult
+++ b/tests/halcompile/personalities_mod/checkresult
@@ -1,10 +1,10 @@
 #!/bin/bash
-cd $(dirname $1)
+cd "$(dirname "$1")" || exit
 RETVAL=0
 for EXPECTED in *.expected ; do
-    BASE=$(basename $EXPECTED .expected)
+    BASE=$(basename "$EXPECTED" .expected)
     RESULT=$BASE.result
-    diff -u $EXPECTED $RESULT
+    diff -u "$EXPECTED" "$RESULT"
     if [ $? -ne 0 ]; then
         RETVAL=1
     fi

--- a/tests/halcompile/relative-header-user/checkresult
+++ b/tests/halcompile/relative-header-user/checkresult
@@ -1,2 +1,2 @@
 #!/bin/sh
-[ -e "`dirname "$1"`/relative_header" ]
+[ -e "$(dirname "$1")/relative_header" ]

--- a/tests/halcompile/relative-header/checkresult
+++ b/tests/halcompile/relative-header/checkresult
@@ -1,2 +1,2 @@
 #!/bin/sh
-[ -e "`dirname "$1"`/relative_header.so" -o "`dirname "$1"`/relative_header.ko" ]
+[ -e "$(dirname "$1")/relative_header.so" ] || [ -e "$(dirname "$1")/relative_header.ko" ]

--- a/tests/halcompile/userspace-count-names/checkresult
+++ b/tests/halcompile/userspace-count-names/checkresult
@@ -1,10 +1,10 @@
 #!/bin/sh
-cd $(dirname $1)
+cd "$(dirname "$1")" || { echo "E: Could not change directory to '$(dirname "$1")'"; exit 1; }
 RETVAL=0
 for EXPECTED in *.expected ; do
-    BASE=$(basename $EXPECTED .expected)
+    BASE=$(basename "$EXPECTED" .expected)
     RESULT=$BASE.result
-    diff -u $EXPECTED $RESULT
+    diff -u "$EXPECTED" "$RESULT"
     if [ $? -ne 0 ]; then
         RETVAL=1
     fi

--- a/tests/hm2-idrom/test.sh
+++ b/tests/hm2-idrom/test.sh
@@ -19,11 +19,11 @@ Error[14]="hm2/hm2_test\.0: IDROM IOPorts is 0 but llio num_ioport_connectors is
 result=0
 
 TEST_PATTERN=0
-while [ ! -z "${Error[$TEST_PATTERN]}" ]; do
+while [ -n "${Error[$TEST_PATTERN]}" ]; do
     export TEST_PATTERN
     halrun -f broken-load-test.hal >halrun-stdout 2>halrun-stderr
     ./check-dmesg.py "${Error[$TEST_PATTERN]}" || exit $?
-    TEST_PATTERN=$(($TEST_PATTERN+1))
+    TEST_PATTERN=$((TEST_PATTERN + 1))
 done
 
 exit $result

--- a/tests/interp/g71-endless-loop/test.sh
+++ b/tests/interp/g71-endless-loop/test.sh
@@ -12,12 +12,12 @@ pid=$!
 count=10
 while [ 0 -lt $count ] && kill -0 $pid > /dev/null 2>&1 ; do
     sleep 1
-    count=$(($count - 1))
+    count=$((count - 1))
 done
 
 if kill -0 $pid > /dev/null 2>&1; then
     kill -9 $pid
-    echo "error: g71-endless-loop.ngc program seem to be stuck, killing"
+    echo "E: g71-endless-loop.ngc program seem to be stuck, killing"
     exit 1
 fi
 

--- a/tests/interp/g71-with-g70/test.sh
+++ b/tests/interp/g71-with-g70/test.sh
@@ -9,12 +9,12 @@ pid=$!
 count=5
 while [ 0 -lt $count ] && kill -0 $pid > /dev/null 2>&1 ; do
     sleep 1
-    count=$(($count - 1))
+    count=$((count - 1))
 done
 
 if kill -0 $pid > /dev/null 2>&1; then
     kill -9 $pid
-    echo "error: g71_and_g70.ngc program seem to be stuck, killing"
+    echo "E: g71_and_g70.ngc program seem to be stuck, killing"
     exit 1
 fi
 

--- a/tests/interp/g72-facing/test.sh
+++ b/tests/interp/g72-facing/test.sh
@@ -10,12 +10,12 @@ pid=$!
 count=10
 while [ 0 -lt $count ] && kill -0 $pid > /dev/null 2>&1 ; do
     sleep 1
-    count=$(($count - 1))
+    count=$((count - 1))
 done
 
 if kill -0 $pid > /dev/null 2>&1; then
     kill -9 $pid
-    echo "error: g71-iterations-present.ngc program seem to be stuck, killing"
+    echo "E: g71-iterations-present.ngc program seem to be stuck, killing"
     exit 1
 fi
 

--- a/tests/interp/g72-missing-iteration/test.sh
+++ b/tests/interp/g72-missing-iteration/test.sh
@@ -17,7 +17,7 @@ done
 
 if kill -0 $pid > /dev/null 2>&1; then
     kill -9 $pid
-    echo "error: g71-iterations-missing.ngc program seem to be stuck, killing"
+    echo "E: g71-iterations-missing.ngc program seem to be stuck, killing"
     exit 1
 fi
 

--- a/tests/interp/iniparam-failassign/test.sh
+++ b/tests/interp/iniparam-failassign/test.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 export PYTHONUNBUFFERED=1
-rs274 -i test.ini  -g test.ngc 2>&1
-
-# expected to fail
-if [ $? -ne 0 ]; then
+if ! rs274 -i test.ini -g test.ngc 2>&1; then
+    # expected to fail
     exit 0
 fi
 

--- a/tests/interp/m98m99/03-error-M98-no-P-word/test.sh
+++ b/tests/interp/m98m99/03-error-M98-no-P-word/test.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-rs274  -g test.ngc 2>&1
-
-# expected to fail
-if [ $? -ne 0 ]; then
+if ! rs274 -g test.ngc 2>&1; then
+    # expected to fail
     exit 0
 fi
 

--- a/tests/interp/m98m99/12-M99-endless-main-program/checkresult
+++ b/tests/interp/m98m99/12-M99-endless-main-program/checkresult
@@ -1,3 +1,3 @@
 #!/bin/sh
-cd $(dirname $1)
+cd "$(dirname "$1")" || { echo "E: Could not change directory to '$(dirname "$1")'"; exit 1; }
 diff -u expected.motion-logger out.motion-logger

--- a/tests/interp/oword-mdi-sub-update/checkresult
+++ b/tests/interp/oword-mdi-sub-update/checkresult
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-TEST_DIR=$(dirname $1)
-cd $TEST_DIR
+TEST_DIR=$(dirname "$1")
+cd "$TEST_DIR"
 
 # Avoid false negatives:  This string should be present
 grep -q 'test RAN' result

--- a/tests/linuxcncrsh-tcp/checkresult
+++ b/tests/linuxcncrsh-tcp/checkresult
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_DIR=$(dirname $1)
-cd $TEST_DIR
+TEST_DIR=$(dirname "$1")
+cd "$TEST_DIR" || { echo "E: Could not change directory to '$TEST_DIR'"; exit 1; }
 
 diff -u expected-gcode-output gcode-output

--- a/tests/linuxcncrsh/checkresult
+++ b/tests/linuxcncrsh/checkresult
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-TEST_DIR=$(dirname $1)
-cd $TEST_DIR
+TEST_DIR=$(dirname "$1")
+cd "$TEST_DIR" || { echo "E: Could not change directory to '$TEST_DIR'"; exit 1; }
 
 # show deviation from expected output
 diff -uwB expected-gcode-output gcode-output || exit 1

--- a/tests/linuxcncrsh/test.sh
+++ b/tests/linuxcncrsh/test.sh
@@ -15,7 +15,7 @@ linuxcnc -r linuxcncrsh-test.ini &
 # let linuxcnc come up
 TOGO=80
 while [  $TOGO -gt 0 ]; do
-    echo trying to connect to linuxcncrsh TOGO=$TOGO
+    echo "trying to connect to linuxcncrsh TOGO=$TOGO"
     if nc -z localhost 5007; then
         break
     fi
@@ -36,7 +36,7 @@ function testSet() {
     # get before value
     echo "get $1"
     # set cmd
-    echo "set $@"
+    echo "set $*"
     # get after value
     echo "get $1"
     # get error from server (or OK)
@@ -46,7 +46,7 @@ function testSet() {
 # get command with collecting possible error from linuxcncsvr
 function testGet() {
     cmd="$@"
-    echo "get $@"
+    echo "get $*"
     echo "get error"
 }
 

--- a/tests/mdi-queue/oword-queue-buster/test.sh
+++ b/tests/mdi-queue/oword-queue-buster/test.sh
@@ -28,7 +28,7 @@ while [  $TOGO -gt 0 ]; do
         break
     fi
     sleep 0.25
-    TOGO=$(($TOGO - 1))
+    TOGO=$((TOGO - 1))
 done
 if [  $TOGO -eq 0 ]; then
     echo "E: connection to linuxcncrsh timed out"
@@ -42,12 +42,14 @@ NUM_MDIS=1
 NUM_MDIS_LEFT=$NUM_MDIS
 TOOL=1
 for i in $(seq 0 1000); do
-    NUM_MDIS_LEFT=$(($NUM_MDIS_LEFT - 1))
+    NUM_MDIS_LEFT=$((NUM_MDIS_LEFT - 1))
     if [ $NUM_MDIS_LEFT -eq 0 ]; then
         echo "set mdi o<queue-buster> call [$TOOL]" >> lots-of-gcode
-        echo "P is 12345.000000" >> expected-gcode-output
-        echo "P is $((-1 * $TOOL)).000000" >> expected-gcode-output
-        echo "P is 54321.000000"  >> expected-gcode-output
+        {
+        echo "P is 12345.000000"
+        echo "P is $((-1 * TOOL)).000000"
+        echo "P is 54321.000000"
+        }  >> expected-gcode-output
 
         if [ $TOOL -eq 1 ]; then
             TOOL=2
@@ -55,7 +57,7 @@ for i in $(seq 0 1000); do
             TOOL=1
         fi
 
-        NUM_MDIS=$(($NUM_MDIS + 1))
+        NUM_MDIS=$((NUM_MDIS + 1))
         if [ $NUM_MDIS -gt 10 ]; then
             NUM_MDIS=1
         fi
@@ -68,25 +70,25 @@ done
 echo "P is -200.000000" >> expected-gcode-output
 
 (
-    echo hello EMC mt 1.0
-    echo set enable EMCTOO
+    echo "hello EMC mt 1.0"
+    echo "set enable EMCTOO"
 
-    echo set mode manual
-    echo set estop off
-    echo set machine on
+    echo "set mode manual"
+    echo "set estop off"
+    echo "set machine on"
 
-    echo set mode auto
-    echo set open dummy.ngc
+    echo "set mode auto"
+    echo "set open dummy.ngc"
 
-    echo set mode mdi
-    echo set mdi m100 p-100
-    echo set wait done
+    echo "set mode mdi"
+    echo "set mdi m100 p-100"
+    echo "set wait done"
 
     # here comes a big blob
     dd bs=4096 if=lots-of-gcode
 
-    echo set mdi m100 p-200
-    echo set wait done
+    echo "set mdi m100 p-200"
+    echo "set wait done"
 
     echo shutdown
 ) | nc localhost 5007

--- a/tests/mdi-queue/shared-checkresult
+++ b/tests/mdi-queue/shared-checkresult
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_DIR=$(dirname $1)
-cd $TEST_DIR
+TEST_DIR=$(dirname "$1")
+cd "$TEST_DIR" || { echo "E: Could not change directory to '$TEST_DIR'"; exit 1; }
 
 diff -u expected-gcode-output gcode-output

--- a/tests/mdi-queue/simple-queue-buster/test.sh
+++ b/tests/mdi-queue/simple-queue-buster/test.sh
@@ -28,7 +28,7 @@ while [  $TOGO -gt 0 ]; do
         break
     fi
     sleep 0.25
-    TOGO=$(($TOGO - 1))
+    TOGO=$((TOGO - 1))
 done
 if [  $TOGO -eq 0 ]; then
     echo connection to linuxcncrsh timed out
@@ -42,7 +42,7 @@ NUM_MDIS=1
 NUM_MDIS_LEFT=$NUM_MDIS
 TOOL=1
 for i in $(seq 0 1000); do
-    NUM_MDIS_LEFT=$(($NUM_MDIS_LEFT - 1))
+    NUM_MDIS_LEFT=$((NUM_MDIS_LEFT - 1))
     if [ $NUM_MDIS_LEFT -eq 0 ]; then
         echo "set mdi t$TOOL m6" >> lots-of-gcode
         if [ $TOOL -eq 1 ]; then
@@ -51,7 +51,7 @@ for i in $(seq 0 1000); do
             TOOL=1
         fi
 
-        NUM_MDIS=$(($NUM_MDIS + 1))
+        NUM_MDIS=$((NUM_MDIS + 1))
         if [ $NUM_MDIS -gt 10 ]; then
             NUM_MDIS=1
         fi
@@ -64,28 +64,28 @@ done
 echo "P is -2.000000" >> expected-gcode-output
 
 (
-    echo hello EMC mt 1.0
-    echo set enable EMCTOO
+    echo "hello EMC mt 1.0"
+    echo "set enable EMCTOO"
 
     # ask linuxcncrsh to not read the next command until it's done running
     # the current one
-    #echo set set_wait done
+    #echo "set set_wait done"
 
-    echo set mode manual
-    echo set estop off
-    echo set machine on
+    echo "set mode manual"
+    echo "set estop off"
+    echo "set machine on"
 
-    echo set mode mdi
-    echo set mdi m100 p-1
-    echo set wait done
+    echo "set mode mdi"
+    echo "set mdi m100 p-1"
+    echo "set wait done"
 
     # here comes a big blob
     dd bs=4096 if=lots-of-gcode
 
-    echo set mdi m100 p-2
-    echo set wait done
+    echo "set mdi m100 p-2"
+    echo "set wait done"
 
-    echo shutdown
+    echo "shutdown"
 ) | nc localhost 5007
 
 

--- a/tests/mdi-while-queuebuster-waitflag/test.sh
+++ b/tests/mdi-while-queuebuster-waitflag/test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 
-for i in `seq 20`; do
+# Variable 'i' is unused, just a loop count
+# shellcheck disable=SC2034
+for i in $(seq 20); do
     linuxcnc -r test.ini
     if grep -q '^[^+].*Segmentation fault' stderr; then
 	exit 1

--- a/tests/motion-logger/mountaindew/checkresult
+++ b/tests/motion-logger/mountaindew/checkresult
@@ -1,3 +1,3 @@
 #!/bin/sh
-cd $(dirname $1)
+cd "$(dirname "$1")" || { echo "E: Could not change directory to '$(dirname "$1")'"; exit 1; }
 diff -u expected.motion-logger out.motion-logger

--- a/tests/motion-logger/startup-gcode-abort/checkresult
+++ b/tests/motion-logger/startup-gcode-abort/checkresult
@@ -1,3 +1,3 @@
 #!/bin/sh
-cd $(dirname $1)
+cd "$(dirname "$1")" || { echo "E: Could not change directory to '$(dirname "$1")'"; exit 1; }
 diff -u expected.motion-logger out.motion-logger

--- a/tests/overrun/test.sh
+++ b/tests/overrun/test.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-TMPDIR=`mktemp -d /tmp/overrun.XXXXXX`
-trap "rm -rf $TMPDIR" 0 1 2 3 9 15
+TMPDIR=$(mktemp -d /tmp/overrun.XXXXXX)
+trap 'rm -rf "$TMPDIR"' 0 1 2 3 15
 
 TEST_HAL=$TMPDIR/test.hal
-echo loadusr -w echo overrun > $TMPDIR/test.hal
+echo loadusr -w echo overrun > "$TMPDIR/test.hal"
 
-! $RUNTESTS $TMPDIR 2>&1
+! $RUNTESTS "$TMPDIR" 2>&1

--- a/tests/stepgen.1/checkresult
+++ b/tests/stepgen.1/checkresult
@@ -1,12 +1,12 @@
 #!/bin/bash
 #prime the "old" states.  it seems that stepgen likes to start with phase-A=1
-read oa ob c < $1
+read -r oa ob c < "$1"
 exitval=0
 count=0
 # if a leads b, then the count goes up.  if b leads a, the count goes down
 # if a and b stay the same, the count stays the same
 # if a and b both change, it's an error
-while read a b c; do
+while read -r a b c; do
     case "$oa$a$ob$b" in
     0000) ;;
     0001) count=$((count-1));;
@@ -28,8 +28,8 @@ while read a b c; do
     esac
     oa=$a; ob=$b
     # if our count doesn't match the stepgen count, it's an error
-    if [ $c -ne $count ]; then echo "Counts don't match in the middle (We counted $count, they counted $c)"; exitval=1; fi
-done < $1
+    if [ "$c" -ne $count ]; then echo "Counts don't match in the middle (We counted $count, they counted $c)"; exitval=1; fi
+done < "$1"
 
 # if the end position isn't 1280, it's an error
 if [ $count -ne 1280 ]; then echo "Counts don't match at the end (We counted $count, should be 1280)"; exit 1; fi

--- a/tests/symbols.0/checkresult
+++ b/tests/symbols.0/checkresult
@@ -1,4 +1,4 @@
 #!/bin/sh
-grep -q 'test_use: dlopen: .*: undefined symbol: testuse' `dirname $1`/stderr \
-|| grep -q 'test_use.so: Undefined symbol "testuse"' `dirname $1`/stderr \
+grep -q 'test_use: dlopen: .*: undefined symbol: testuse' "$(dirname "$1")"/stderr \
+|| grep -q 'test_use.so: Undefined symbol "testuse"' "$(dirname "$1")"/stderr \
 || dmesg | grep -q 'test_use: Unknown symbol testuse'

--- a/tests/symbols.1/checkresult
+++ b/tests/symbols.1/checkresult
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
-tail -2 $1 | (
-    read v0
-    if [ $v0 -eq 0 ] ; then echo "Value0 should be nonzero"; exit 1; fi
-    read v1
-    if [ $v1 -ne 0 ] ; then echo "Value1 should be zero"; exit 1; fi
+tail -2 "$1" | (
+    read -r v0
+    if [ "$v0" -eq 0 ] ; then echo "Value0 should be nonzero"; exit 1; fi
+    read -r v1
+    if [ "$v1" -ne 0 ] ; then echo "Value1 should be zero"; exit 1; fi
 )

--- a/tests/t0/shared-checkresult
+++ b/tests/t0/shared-checkresult
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-TEST_DIR=$(dirname $1)
-cd $TEST_DIR
+TEST_DIR=$(dirname "$1")
+cd "$TEST_DIR" || { echo "E: Could not change directory to '$TEST_DIR'"; exit 1; }
 
 sed 's/-0\.000000/0.000000/g' <gcode-output >gcode-output.filtered && mv gcode-output.filtered gcode-output
 diff -u expected-gcode-output gcode-output

--- a/tests/threads.1/checkresult
+++ b/tests/threads.1/checkresult
@@ -1,4 +1,4 @@
 #!/bin/sh -e
 # Check that the tmax for a hal function is nonzero
-CYCLES=`cat $1`
+CYCLES=$(cat "$1")
 test ! -z "$CYCLES" -a "$CYCLES" -gt 0

--- a/tests/toolchanger/shared-checkresult
+++ b/tests/toolchanger/shared-checkresult
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEST_DIR=$(dirname $1)
-cd $TEST_DIR
+TEST_DIR=$(dirname "$1")
+cd "$TEST_DIR" || { echo "E: Could not change directory to '$TEST_DIR'"; exit 1; }
 
 diff -u expected-gcode-output gcode-output

--- a/tests/tooledit/test.sh
+++ b/tests/tooledit/test.sh
@@ -2,7 +2,7 @@
 # test if floating point numbers are formatted correctly
 
 if ! command -v xvfb-run &> /dev/null; then
-    echo "xvfb-run could not be found, we assume everything works" > /dev/stderr
+    echo "W: xvfb-run could not be found, we assume everything works" > /dev/stderr
     cat expected
     exit 0
 fi
@@ -11,20 +11,20 @@ fi
 #create temporary files so we don't write into write access problems
 infile=$(mktemp)
 outfile=$(mktemp)
-cat test.tbl > $infile
+cat test.tbl > "$infile"
 
 # run the test
-xvfb-run ${LINUXCNC_EMCSH/wish/tclsh} test.tcl $infile $outfile 2> tclerror.log;
+xvfb-run "${LINUXCNC_EMCSH/wish/tclsh}" test.tcl "$infile" "$outfile" 2> tclerror.log;
 
-if [ $(cat tclerror.log | wc -l) -ne 0 ]; then
+if [ "$(wc -l < tclerror.log)" -ne 0 ]; then
     cat tclerror.log
     exit 1
 fi
 
 # write the resulting tool table to stdout so the test framework can evaluate it
-cat $outfile
+cat "$outfile"
 
 # remove the temporary files
-rm $infile $outfile $outfile".bak"
+rm "$infile" "$outfile" "$outfile".bak
 
 exit 0


### PR DESCRIPTION
This PR addresses changes in test files. The changes include double quotes, cd || exit prblem, use $() instead of back-tick and read should add -r. Messages are in a more unified format starting with E:, W: or I:. The patch-set was created in cooperation with @smoe.