### PR TITLE
Fix shellcheck various

### DIFF
--- a/debian/update-dch-from-git
+++ b/debian/update-dch-from-git
@@ -1,23 +1,22 @@
 #!/bin/bash
 
-if [ ! -d debian -o ! -d src ]; then
+if [ ! -d debian ] || [ ! -d src ]; then
     echo "this script must be run from the root of the source tree (the directory with debian and src in it)"
     exit 1
 fi
 
-
 source scripts/githelper.sh
-githelper $1
+githelper "$1"
 
-GIT_VERSION=$(scripts/get-version-from-git $GIT_BRANCH)
+GIT_VERSION=$(scripts/get-version-from-git "$GIT_BRANCH")
 if [ $? -ne 0 ]; then
     echo "error determining version!"
     exit 1
 fi
 
-DEB_VERSION=`git show HEAD:debian/changelog | head -1 | sed 's/.*(\(.*\)).*/\1/'`
+DEB_VERSION=$(git show HEAD:debian/changelog | head -1 | sed 's/.*(\(.*\)).*/\1/')
 
-NEW_DEB_VERSION=$(echo $GIT_VERSION | sed -r 's/-pre/~pre/; s/-/./g')
+NEW_DEB_VERSION=$(echo "$GIT_VERSION" | sed -r 's/-pre/~pre/; s/-/./g')
 NEW_DEB_VERSION="1:${NEW_DEB_VERSION/v/}"
 
 if [ "$NEW_DEB_VERSION" = "$DEB_VERSION" ]; then
@@ -38,7 +37,7 @@ set -e
 (
 echo "linuxcnc ($NEW_DEB_VERSION) $CODENAME; urgency=low"
 echo
-git log --pretty=format:"  * %w(72,0,6)%s" $GIT_TAG..
+git log --pretty=format:"  * %w(72,0,6)%s" "${GIT_TAG}.."
 echo
 echo
 echo " -- buildbot <buildbot@example.com>  $(date -R)"

--- a/docs/src/asciideps
+++ b/docs/src/asciideps
@@ -22,10 +22,10 @@ includes () {
 
 images() {
 	DIR=$(dirname "$1")
-	sed -ne "s|^.*image:\{1,2\}\([^[]*\)\[.*\].*$|$DIR/\1|p" "$1"
+	sed -ne "s|^.*image:\{1,2\}\([^[]*\)\[.*\].*$|$DIR/\1|p" "$1" | tr '\n' ' '
 }
 
-INCLUDES=$(includes "$1")
+INCLUDES=$(includes "$1" | tr '\n' ' ')
 IMAGES=$(images "$1")
 for f in $INCLUDES; do
 	IMAGES="$IMAGES $(images "$f")"

--- a/docs/src/asciideps
+++ b/docs/src/asciideps
@@ -6,9 +6,9 @@ test -z "$1" && exit 0
 test -f "$1" || exit 1
 
 includes () {
-	DIR=`dirname "$1"`
+	DIR=$(dirname "$1")
 
-	for f in `sed -ne "s|^include::\(.*\)\[\]$|$DIR/\1|p" "$1"`; do
+	for f in $(sed -ne "s|^include::\(.*\)\[\]$|$DIR/\1|p" "$1"); do
 		# components_gen.adoc will contain only generated content
 		case "$f" in
 			*/components_gen.adoc)
@@ -21,16 +21,16 @@ includes () {
 }
 
 images() {
-	DIR=`dirname "$1"`
+	DIR=$(dirname "$1")
 	sed -ne "s|^.*image:\{1,2\}\([^[]*\)\[.*\].*$|$DIR/\1|p" "$1"
 }
 
-INCLUDES=`includes "$1"`
-IMAGES=`images "$1"`
+INCLUDES=$(includes "$1")
+IMAGES=$(images "$1")
 for f in $INCLUDES; do
-	IMAGES="$IMAGES `images $f`"
+	IMAGES="$IMAGES $(images "$f")"
 done
 
-echo "${1%%.txt}.dep :" $INCLUDES
-echo "${1%%.txt}.html: " $INCLUDES $IMAGES
-echo "${1%%.txt}.pdf: " $INCLUDES $IMAGES
+echo "${1%%.txt}.dep: $INCLUDES"
+echo "${1%%.txt}.html: $INCLUDES $IMAGES"
+echo "${1%%.txt}.pdf: $INCLUDES $IMAGES"

--- a/docs/src/checkref
+++ b/docs/src/checkref
@@ -10,24 +10,21 @@ fi
 LANGUAGE="$1"
 shift
 
-FILES="$@"
-
-if [ -z $(which linuxcnc-checklink) ]; then
+if [ -z "$(which linuxcnc-checklink)" ]; then
     echo "ERROR: checklink not found, install w3c-linkchecker for HTML link validation" 1>&2
     exit 1
 fi
 
 
 BAD_LINKS=0
-for F in $FILES; do
-    OUT=.checklink.$LANGUAGE.$(basename $F).tmp
-    rm -f $OUT
-    linuxcnc-checklink --quiet --exclude "(http|https|irc)://" $F  2>&1 | tee $OUT
-    grep -E -q 'List of (broken links and other issues|duplicate and empty anchors)' $OUT
-    if [ $? -ne 1 ]; then
+for F in "$@"; do
+    OUT=.checklink.$LANGUAGE.$(basename "$F").tmp
+    rm -f "$OUT"
+    linuxcnc-checklink --quiet --exclude "(http|https|irc)://" "$F"  2>&1 | tee "$OUT"
+    if grep -E -q 'List of (broken links and other issues|duplicate and empty anchors)' "$OUT"; then
         BAD_LINKS=1
     fi
-    rm -f $OUT
+    rm -f "$OUT"
 done
 
 if [ $BAD_LINKS -eq 1 ]; then

--- a/lib/python/qtvcp/designer/install_script
+++ b/lib/python/qtvcp/designer/install_script
@@ -17,7 +17,7 @@ while true; do
     echo ' 1 = No, exit'
     echo ' 2 = Yes, for a Run In Place installation'
     echo ' 3 = Yes, for a package installation'
-    read -p $'\nSelection? ' response
+    read -r -p $'\nSelection? ' response
     case $response in
         [1]* )  echo -e '\nInstallation complete, QtVCP screens are now available.\n'
                 exit;;
@@ -38,7 +38,7 @@ sudo apt-get install -y libpython3-dev
 
 # get the correct plugin file to copy
 # for run in place LinuxCNC installation
-if [ $response -eq 2 ]; then
+if [ "$response" -eq 2 ]; then
     if [ -f ~/linuxcnc-dev/lib/python/qtvcp/plugins/qtvcp_plugin.py ]; then
         pifile=~/linuxcnc-dev/lib/python/qtvcp/plugins/qtvcp_plugin.py
     else
@@ -47,12 +47,12 @@ if [ $response -eq 2 ]; then
             echo -e '\nrun in place installation not found'
             echo 'Enter base directory name e.g. linuxcnc-2.9'
             echo 'X to exit'
-            read -p $'\nDirectory? ' basedir
+            read -r -p $'\nDirectory? ' basedir
             case $basedir in
                 [Xx]* ) clear
                         exit;;
-                    * ) if [  -f ~/$basedir/lib/python/qtvcp/plugins/qtvcp_plugin.py ]; then
-                            pifile=~/$basedir/lib/python/qtvcp/plugins/qtvcp_plugin.py
+                    * ) if [  -f ~/"$basedir"/lib/python/qtvcp/plugins/qtvcp_plugin.py ]; then
+                            pifile=~/"$basedir"/lib/python/qtvcp/plugins/qtvcp_plugin.py
                             break
                         fi
                         ;;
@@ -60,13 +60,13 @@ if [ $response -eq 2 ]; then
         done
     fi
 # for full LinuxCNC installation
-elif [ $response -eq 3 ]; then
+elif [ "$response" -eq 3 ]; then
     # check for valid plugin file
     if [ -f /usr/lib/python3/dist-packages/qtvcp/plugins/qtvcp_plugin.py ]; then
         pifile=/usr/lib/python3/dist-packages/qtvcp/plugins/qtvcp_plugin.py
     else
 #        clear
-        echo -e '\n'$pifile 'not found in /usr/lib/python3/dist-packages/qtvcp/plugins/'
+        echo -e '\n'"$pifile "'not found in /usr/lib/python3/dist-packages/qtvcp/plugins/'
         echo -e '\ncannot continue designer installation\n'
         exit
     fi
@@ -80,19 +80,19 @@ if [ -f ~/.designer/plugins/python/qtvcp_plugin.py ]; then
     sudo rm ~/.designer/plugins/python/qtvcp_plugin.py
 fi
 echo -e '\ncreate plugin link at:\n~/.designer/plugins/python/\n'
-ln -s $pifile ~/.designer/plugins/python/
+ln -s "$pifile" ~/.designer/plugins/python/
 
-arch="`uname -m`"
+arch=$(uname -m)
 sopath=/usr/lib/$arch-linux-gnu/qt5/plugins/designer/
 p2sofile=libpyqt5_py2.so
 p3sofile=libpyqt5.so
 
 # ensure we have a python3 .so file
-if [ ! -f $sopath/$p3sofile ]; then
+if [ ! -f "$sopath/$p3sofile" ]; then
     # check if we have a python3 .so backup file from a python2 installation
-    if [ -f $sopath/$p3sofile.old ]; then
+    if [ -f "$sopath/$p3sofile.old" ]; then
         echo -e '\nrename libpyqt5.so.old file to libpyqt5.so'
-        sudo mv $sopath/$p3sofile.old $sopath/$p3sofile
+        sudo mv "$sopath/$p3sofile.old" "$sopath/$p3sofile"
     # otherwise report an error
     else
         echo -e '\nlibpyqt5.so is missing from:'
@@ -103,14 +103,14 @@ if [ ! -f $sopath/$p3sofile ]; then
 fi
 
 # remove python2 .so file if it exists
-if [ -f $sopath/$p2sofile ]; then
+if [ -f "$sopath/$p2sofile" ]; then
     echo -e '\nremove python2 .so file'
-    sudo rm $sopath/$p2sofile
+    sudo rm "$sopath/$p2sofile"
 fi
 
 #clear
 echo -e '\nInstallation complete, designer can be started with:'
 echo -e '\ndesigner -qt=5\n'
-if [ $response -eq 2 ]; then
+if [ "$response" -eq 2 ]; then
     echo -e 'After setting the rip-environment\n'
 fi

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -13,64 +13,64 @@ fi
 # See if cppcheck accepts --check-level
 EXHAUSTIVE=$(cppcheck --check-level=exhaustive --version > /dev/null 2>&1 && echo "--check-level=exhaustive")
 
-CPPCHKOPT="-j $nproc --force $EXHAUSTIVE"
-CPPCHKOPT="$CPPCHKOPT --enable=warning,performance,portability"
-CPPCHKOPT="$CPPCHKOPT -I$(realpath "$(dirname "$0")/../include")"
+CPPCHKOPT=( -j "$nproc" --force "$EXHAUSTIVE" )
+CPPCHKOPT+=( "--enable=warning,performance,portability" )
+CPPCHKOPT+=( "-I$(realpath "$(dirname "$0")/../include")" )
 
 # Even cppcheck 2.3 (debian 11) supports c++17 (undocumented)
-CCSTD="--std=c11 --language=c"
-CXSTD="--std=c++17 --language=c++"
+CCSTD=( --std=c11 --language=c )
+CXSTD=( --std=c++17 --language=c++ )
 
-CPPCHKCC="$CPPCHKOPT $CCSTD"
-CPPCHKCX="$CPPCHKOPT $CXSTD"
+CPPCHKCC=( "${CPPCHKOPT[@]}" "${CCSTD[@]}" )
+CPPCHKCX=( "${CPPCHKOPT[@]}" "${CXSTD[@]}" )
 
 # Do this from the source directory
-cd "$(dirname "$0")/../src"
+cd "$(dirname "$0")/../src" || exit
 
 docheck() {
-    files=$(find "$1" -maxdepth 1 \( -name "*.c" -o -name "*.h" \) )
-    [ ! -z "$files" ] && cppcheck -I"$1" $CPPCHKCC $files
+    mapfile -t files < <(find "$1" -maxdepth 1 \( -name "*.c" -o -name "*.h" \) )
+    [ "${#files[@]}" -gt 0 ] && cppcheck -I"$1" "${CPPCHKCC[@]}" "${files[@]}"
 
-    files=$(find "$1" -maxdepth 1 \( -name "*.cc" -o -name "*.hh" \) )
-    [ ! -z "$files" ] && cppcheck -I"$1" $CPPCHKCX $files
+    mapfile -t files < <(find "$1" -maxdepth 1 \( -name "*.cc" -o -name "*.hh" \) )
+    [ "${#files[@]}" -gt 0 ] && cppcheck -I"$1" "${CPPCHKCX[@]}" "${files[@]}"
 }
 
 # *** HAL files ***
 echo "I (1/4): checking HAL folders with both C and C++ code"
-for d in $(find hal/ -type d -not -name "*__pycache__")
+while IFS= read -r -d '' d
 do
     # Don't care about examples
     case "$d" in hal/user_comps/mb2hal/examples*) continue;; esac
 
     echo "I (1/4): checking $d"
     docheck "$d"
-done
+done < <(find hal/ -type d -not -name "*__pycache__" -print0)
 
 # *** EMC files ***
 echo "I (2/4): checking EMC folders with both C and C++ code"
-for d in $(find emc/ -type d -not -name "*__pycache__")
+while IFS= read -r -d '' d
 do
     # Will give Tcl problems
     case "$d" in emc/usr_intf/axis/extensions*) continue;; esac
 
     echo "I (2/4): checking $d"
     docheck "$d"
-done
+done < <(find emc/ -type d -not -name "*__pycache__" -print0)
 
 # *** NML files ***
 echo "I (3/4): checking LIBNML folders with both C and C++ code"
-for d in $(find libnml/ -type d -not -name "*__pycache__")
+while IFS= read -r -d '' d
 do
     echo "I (3/4): checking $d"
     docheck "$d"
-done
+done < <(find libnml/ -type d -not -name "*__pycache__" -print0)
 
 # *** RTAPI files ***
 echo "I (4/4): checking RTAPI folders with both C and C++ code"
-for d in $(find rtapi/ -type d -not -name "*__pycache__")
+while IFS= read -r -d '' d
 do
     echo "I (4/4): checking $d"
     docheck "$d"
-done
+done < <(find rtapi/ -type d -not -name "*__pycache__" -print0)
 
 exit 0

--- a/scripts/latency-test
+++ b/scripts/latency-test
@@ -1,12 +1,12 @@
 #!/bin/bash
-SCRIPT_LOCATION=$(dirname $(readlink -f $0));
-if [ -f $SCRIPT_LOCATION/rip-environment ] && [ -z "$EMC2_HOME" ]; then
-    . $SCRIPT_LOCATION/rip-environment
+SCRIPT_LOCATION=$(dirname "$(readlink -f "$0")");
+if [ -f "$SCRIPT_LOCATION/rip-environment" ] && [ -z "$EMC2_HOME" ]; then
+    . "$SCRIPT_LOCATION/rip-environment"
 fi
 
-T=`mktemp -d`
-trap 'cd /; [ -d $T ] && rm -rf $T' SIGINT SIGTERM EXIT
-cd $T
+T=$(mktemp -d)
+trap 'cd / && [ -d "$T" ] && rm -rf "$T"' SIGINT SIGTERM EXIT
+cd "$T" || { echo "E: Cannot change directory to '$T'"; exit 1; }
 node=$(uname -n)
 machine=$(uname  -m)
 date=$(date +%d%b%Y)
@@ -23,15 +23,15 @@ parse_time () {
     *us|*µs) icalc "1000*${1%us}" ;;
     *ms) icalc "1000*1000*${1%ms}" ;;
     *s)  icalc "1000*1000*1000*${1%s}" ;;
-    *)   if [ $1 -lt 1000 ]; then icalc "1000*$1"; else icalc "$1"; fi ;;
+    *)   if [ "$1" -lt 1000 ]; then icalc "1000*$1"; else icalc "$1"; fi ;;
     esac
 }
 
 human_time () {
     if [ "$1" -eq 0 ]; then echo "-"
-    elif [ "$1" -ge 1000000000 ]; then echo "$(calc $1/1000/1000/1000)s"
-    elif [ "$1" -ge 1000000 ]; then echo "$(calc $1/1000/1000)ms"
-    elif [ "$1" -ge 1000 ]; then echo "$(calc $1/1000)µs"
+    elif [ "$1" -ge 1000000000 ]; then echo "$(calc "$1"/1000/1000/1000)s"
+    elif [ "$1" -ge 1000000 ]; then echo "$(calc "$1"/1000/1000)ms"
+    elif [ "$1" -ge 1000 ]; then echo "$(calc "$1"/1000)µs"
     else echo "$1ns"
     fi
 }
@@ -48,7 +48,7 @@ usage () {
     echo "       latency-test 50000 1000000"
     echo ""
     echo "Defaults:     base-period=${BASE}nS servo-period=${SERVO}nS"
-    echo "Equivalently: base-period=$(human_time $BASE) servo-period=$(human_time $SERVO)"
+    echo "Equivalently: base-period=$(human_time "$BASE") servo-period=$(human_time "$SERVO")"
     echo ""
     echo "Times may be specified with suffix \"s\", \"ms\", \"us\" \"µs\", or \"ns\""
     echo "Times without a suffix and less than 1000 are taken to be in us;"
@@ -70,18 +70,18 @@ esac
 
 case $# in
 0) ;;
-1) BASE=0; SERVO=$(parse_time $1) ;;
-2) BASE=$(parse_time $1); SERVO=$(parse_time $2) ;;
+1) BASE=0; SERVO=$(parse_time "$1") ;;
+2) BASE=$(parse_time "$1"); SERVO=$(parse_time "$2") ;;
 *) usage;;
 esac
 
 if [ "$BASE" -gt "$SERVO" ]; then TEMP=$BASE; BASE=$SERVO; SERVO=$TEMP; fi
 if [ "$BASE" -eq "$SERVO" ]; then BASE=0; fi
 
-BASE_HUMAN=$(human_time $BASE)
-SERVO_HUMAN=$(human_time $SERVO)
+BASE_HUMAN=$(human_time "$BASE")
+SERVO_HUMAN=$(human_time "$SERVO")
 
-if [ $BASE -eq 0 ]; then
+if [ "$BASE" -eq 0 ]; then
 cat > lat.hal <<EOF
 loadrt threads name1=slow period1=$SERVO
 loadrt timedelta count=1
@@ -143,7 +143,7 @@ While the test is running, you should "abuse" the computer. Move windows around 
 <tablerow/><label text="Servo thread ($SERVO_HUMAN):"/><s32 halpin="sl"/><s32 halpin="sj" font="Helvetica 12 bold"/><s32 halpin="st"/>
 EOF
 
-if [ $BASE -ne 0 ]; then
+if [ "$BASE" -ne 0 ]; then
 cat >> lat.xml <<EOF
 <tablerow/><label text="Base thread ($BASE_HUMAN):"/><s32 halpin="bl"/><s32 halpin="bj" font="Helvetica 12 bold"/><s32 halpin="bt"/>
 EOF
@@ -157,7 +157,7 @@ cat >> lat.xml <<EOF
 </pyvcp>
 EOF
 
-if [ $BASE -eq 0 ]; then
+if [ "$BASE" -eq 0 ]; then
     SIGNALS="halcmd gets sj"
 else
     SIGNALS="halcmd gets sj; halcmd gets bj"
@@ -165,9 +165,9 @@ fi
 
 cat > latexit.sh <<EOF
 L=\$(($SIGNALS
-    if [ -f $HOME/.latency ]; then cat $HOME/.latency; fi
+    if [ -f "$HOME"/.latency ]; then cat "$HOME"/.latency; fi
     ) | sort -n | tail -1)
-echo \$L > $HOME/.latency
+echo \$L > "$HOME"/.latency
 EOF
 
 halrun lat.hal

--- a/scripts/realtime.in
+++ b/scripts/realtime.in
@@ -23,10 +23,12 @@ GREP=@GREP@
 PS=@PS@
 
 CheckKernel() {
+    # Shellcheck doesn't know about substitution
+    # shellcheck disable=SC2194
     case "@KERNEL_VERS@" in
     "") ;;
     *)
-	if [ `uname -r` != "@KERNEL_VERS@" ]; then
+	if [ "$(uname -r)" != "@KERNEL_VERS@" ]; then
 	    cat 1>&2 << EOF
 RTAPI requires the real-time kernel @KERNEL_VERS@ to run.  Before running
 this realtime application, reboot and choose this kernel at the boot menu.
@@ -47,7 +49,7 @@ CheckConfig(){
     prefix=@prefix@
     exec_prefix=@exec_prefix@
     sysconfdir=@sysconfdir@
-    if [ $RUN_IN_PLACE = yes ]; then
+    if [ "$RUN_IN_PLACE" = "yes" ]; then
         RTAPICONF=
         # check in the LinuxCNC scripts directory
         # $0 is the command to run this script
@@ -55,13 +57,13 @@ CheckConfig(){
         SCRIPT_DIR=${0%/*}
         # the path might be relative
         # convert it to an absolute path
-        SCRIPT_DIR=$(cd $SCRIPT_DIR ; pwd -P)
+        SCRIPT_DIR=$(realpath "$SCRIPT_DIR")
         # now look for rtapi.conf there
-        if [ -f $SCRIPT_DIR/rtapi.conf ] ; then
+        if [ -f "$SCRIPT_DIR/rtapi.conf" ] ; then
             RTAPICONF=$SCRIPT_DIR/rtapi.conf
         fi
     else
-        if [ -f $sysconfdir/linuxcnc/rtapi.conf ]; then
+        if [ -f "$sysconfdir/linuxcnc/rtapi.conf" ]; then
                 RTAPICONF=$sysconfdir/linuxcnc/rtapi.conf
         fi
     fi
@@ -75,8 +77,8 @@ CheckConfig(){
     FUSER="@FUSER@"
 
     # Import the config
-    source $RTAPICONF
-    if [ ! -e $RTLIB_DIR/.runinfo -a -e $RTLIB_DIR/emc2/.runinfo ]; then
+    source "$RTAPICONF"
+    if [ ! -e "$RTLIB_DIR/.runinfo" ] && [ -e "$RTLIB_DIR/emc2/.runinfo" ]; then
         # installed system: we don't want our modules mixed up with rtai
         RTLIB_DIR=$RTLIB_DIR/emc2
     fi
@@ -92,10 +94,10 @@ CheckConfig(){
     uspace) SHM_DEV=/dev/zero;;
     esac
     for  MOD in $MODULES ; do
-        eval MOD=\${MODPATH_$MOD}
+        eval MOD=\${MODPATH_"$MOD"}
         if [ -z "$MOD" ]; then continue; fi
-        if [ -L $MOD ]; then
-            MOD=${MOD%/*}/$(readlink $MOD)
+        if [ -L "$MOD" ]; then
+            MOD=${MOD%/*}/$(readlink "$MOD")
         fi
         MODULES_LOAD="$MODULES_LOAD $MOD"
         MOD="${MOD##*/}"
@@ -125,14 +127,14 @@ CheckStatus(){
         # check loaded/unloaded status of modules
         unset NOTLOADED
         for MOD in $MODULES_UNLOAD ; do
-            if "$LSMOD" | awk '{print $1}' | $GREP -x $MOD >/dev/null ; then
+            if "$LSMOD" | awk '{print $1}' | $GREP -x "$MOD" >/dev/null ; then
                 echo "$MOD is loaded"
             else
                 echo "$MOD is not loaded"
                 NOTLOADED=NOT
             fi
         done
-        if [ -z $NOTLOADED ]; then
+        if [ -z "$NOTLOADED" ]; then
             exit 0
         else
             exit 1
@@ -164,8 +166,8 @@ CheckMem(){
 Load(){
     CheckKernel
     for MOD in $MODULES_LOAD ; do
-	if ! [ -d /sys/module/`basename $MOD .ko` ]; then
-		$INSMOD $MOD || return $?
+	if ! [ -d "/sys/module/$(basename "$MOD" .ko)" ]; then
+		$INSMOD "$MOD" || return $?
 	fi
     done
     if [ "$DEBUG" != "" ] && [ -w /proc/rtapi/debug ] ; then
@@ -178,10 +180,10 @@ CheckLoaded(){
     # have the device ready for us in time.
     n=0
     while [ $n -lt 100 ]; do
-        [ -w $SHM_DEV ] && return 0
+        [ -w "$SHM_DEV" ] && return 0
         echo "." 1>&2
         sleep .1
-        n=$(($n+1))
+        n=$((n + 1))
     done
     echo "Can't write to $SHM_DEV - aborting" 1>&2
     exit 1
@@ -198,13 +200,13 @@ Unload(){
         local NPROCS
         while [ 5 -gt $((SECONDS-START)) ]; do
             NPROCS=$(ps -C rtapi_app -o stat= -o comm= | $GREP -v '^Z' | wc -l)
-            if [ $NPROCS -eq 0 ]; then
+            if [ "$NPROCS" -eq 0 ]; then
                 break
             fi
             sleep 0.1
         done
         NPROCS=$(ps -C rtapi_app -o stat= -o comm= | $GREP -v '^Z' | wc -l)
-        if [ $NPROCS -gt 0 ]; then
+        if [ "$NPROCS" -gt 0 ]; then
             echo "ERROR: rtapi_app failed to die" 1>&2
         fi
 
@@ -213,7 +215,7 @@ Unload(){
         ipcrm -M 0x48484c34 2>/dev/null ;# UUID_KEY
     esac
     for module in $MODULES_UNLOAD ; do
-        $RMMOD $module
+        $RMMOD "$module"
     done
 }
 
@@ -222,7 +224,7 @@ CheckUnloaded(){
     STATUS=
     for module in $MODULES_UNLOAD ; do
 	# check to see if the module is installed
-	if "$LSMOD" | awk '{print $1}' | $GREP -x $module >/dev/null ; then
+	if "$LSMOD" | awk '{print $1}' | $GREP -x "$module" >/dev/null ; then
 	    echo "ERROR: Could not unload '$module'"
 	    STATUS=error
 	fi

--- a/scripts/rtapi.conf.in
+++ b/scripts/rtapi.conf.in
@@ -43,11 +43,11 @@ elif [ "@RTAI@" = "5" ] ; then \
     MODPATH_rtai_sched=@MODPATH_rtai_sched@
     MODPATH_rtai_math=@MODPATH_rtai_math@
 else
-case `uname -r` in
+case $(uname -r) in
 *-rtai*)
     MODULES="rtai_hal rtai_sched"
-    MODPATH_rtai_hal=/usr/realtime-`uname -r`/modules/rtai_hal.ko
-    MODPATH_rtai_sched=/usr/realtime-`uname -r`/modules/rtai_sched.ko
+    MODPATH_rtai_hal=/usr/realtime-$(uname -r)/modules/rtai_hal.ko
+    MODPATH_rtai_sched=/usr/realtime-$(uname -r)/modules/rtai_sched.ko
 ;;
 *)  MODULES=
 esac

--- a/scripts/setup_designer.in
+++ b/scripts/setup_designer.in
@@ -17,7 +17,7 @@ while true; do
     echo ' 1 = No, exit'
     echo ' 2 = Yes, for a Run In Place installation'
     echo ' 3 = Yes, for a package installation'
-    read -p $'\nSelection? ' response
+    read -r -p $'\nSelection? ' response
     case $response in
         [1]* )  echo -e '\nInstallation complete, QtVCP screens are now available.\n'
                 exit;;
@@ -38,7 +38,7 @@ sudo apt-get install -y libpython3-dev
 
 # get the correct plugin file to copy
 # for run in place LinuxCNC installation
-if [ $response -eq 2 ]; then
+if [ "$response" -eq 2 ]; then
     if [ -f ~/linuxcnc-dev/lib/python/qtvcp/plugins/qtvcp_plugin.py ]; then
         pifile=~/linuxcnc-dev/lib/python/qtvcp/plugins/qtvcp_plugin.py
     else
@@ -47,12 +47,12 @@ if [ $response -eq 2 ]; then
             echo -e '\nrun in place installation not found'
             echo 'Enter base directory name e.g. linuxcnc-2.9'
             echo 'X to exit'
-            read -p $'\nDirectory? ' basedir
+            read -r -p $'\nDirectory? ' basedir
             case $basedir in
                 [Xx]* ) clear
                         exit;;
-                    * ) if [  -f ~/$basedir/lib/python/qtvcp/plugins/qtvcp_plugin.py ]; then
-                            pifile=~/$basedir/lib/python/qtvcp/plugins/qtvcp_plugin.py
+                    * ) if [  -f ~/"$basedir"/lib/python/qtvcp/plugins/qtvcp_plugin.py ]; then
+                            pifile=~/"$basedir"/lib/python/qtvcp/plugins/qtvcp_plugin.py
                             break
                         fi
                         ;;
@@ -60,13 +60,13 @@ if [ $response -eq 2 ]; then
         done
     fi
 # for full LinuxCNC installation
-elif [ $response -eq 3 ]; then
+elif [ "$response" -eq 3 ]; then
     # check for valid plugin file
     if [ -f /usr/lib/python3/dist-packages/qtvcp/plugins/qtvcp_plugin.py ]; then
         pifile=/usr/lib/python3/dist-packages/qtvcp/plugins/qtvcp_plugin.py
     else
 #        clear
-        echo -e '\n'$pifile 'not found in /usr/lib/python3/dist-packages/qtvcp/plugins/'
+        echo -e '\n'"$pifile"' not found in /usr/lib/python3/dist-packages/qtvcp/plugins/'
         echo -e '\ncannot continue designer installation\n'
         exit
     fi
@@ -80,7 +80,7 @@ if [ -f ~/.designer/plugins/python/qtvcp_plugin.py ]; then
     sudo rm ~/.designer/plugins/python/qtvcp_plugin.py
 fi
 echo -e '\ncreate plugin link at:\n~/.designer/plugins/python/\n'
-ln -s $pifile ~/.designer/plugins/python/
+ln -s "$pifile" ~/.designer/plugins/python/
 
 sopath=/usr/lib/x86_64-linux-gnu/qt5/plugins/designer/
 p2sofile=libpyqt5_py2.so
@@ -110,6 +110,6 @@ fi
 #clear
 echo -e '\nInstallation complete, designer can be started with:'
 echo -e '\ndesigner -qt=5\n'
-if [ $response -eq 2 ]; then
+if [ "$response" -eq 2 ]; then
     echo -e 'After setting the rip-environment\n'
 fi

--- a/src/move-if-change
+++ b/src/move-if-change
@@ -16,17 +16,13 @@
 # along with this program; if not, write to the Free Software
 # Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-if
-test -r $2
-then
-if
-cmp $1 $2 > /dev/null
-then
-echo $2 is unchanged
-rm -f $1
+if test -r "$2"; then
+    if cmp "$1" "$2" > /dev/null; then
+        echo "$2" is unchanged
+        rm -f "$1"
+    else
+        mv -f "$1" "$2"
+    fi
 else
-mv -f $1 $2
-fi
-else
-mv -f $1 $2
+    mv -f "$1" "$2"
 fi


### PR DESCRIPTION
This PR contains various updated scripts, mainly double quotes and $() instead of back-ticks. The patch-set was created in cooperation with @smoe.
The cppcheck.sh script has a more complex while/read loop to allow paths to be handled properly. Also options and file lists are handled in arrays to preserve the path in its entirety.
The docs/src/asciideps routine adds newline-to-space translation because quoted expansions are no longer word-split using IFS. Each individual file path in the collection of files in the variable is considered whitespace-free because the paths are relative to LCNC's topdir and it is assumed that no path or file name in the LCNC hierarchy contains white-space.