### PR TITLE
Partial shellcheck fixes

### DIFF
--- a/tests/build/header-sanity/test.sh
+++ b/tests/build/header-sanity/test.sh
@@ -1,13 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 set -xe 
 CPPFLAGS=$(pkg-config --silence-errors --cflags libtirpc)
-for i in $HEADERS/*.h; do
+for i in "$HEADERS"/*.h; do
     case $i in
     */rtapi_app.h) continue ;;
     esac
-    gcc ${CPPFLAGS} -DULAPI -I$HEADERS -E -x c $i > /dev/null
+    gcc ${CPPFLAGS} -DULAPI -I"$HEADERS" -E -x c "$i" > /dev/null
 done
-for i in $HEADERS/*.h $HEADERS/*.hh; do
+for i in "$HEADERS"/*.h "$HEADERS"/*.hh; do
     case $i in
     */rtapi_app.h) continue ;;
     */interp_internal.hh) continue ;;
@@ -17,5 +17,5 @@ for i in $HEADERS/*.h $HEADERS/*.hh; do
     else
         ELEVEN=-std=c++0x
     fi
-    g++ ${CPPFLAGS} $ELEVEN -DULAPI -I$HEADERS -E -x c++ $i > /dev/null
+    g++ ${CPPFLAGS} "$ELEVEN" -DULAPI -I"$HEADERS" -E -x c++ "$i" > /dev/null
 done

--- a/tests/build/ui/test.sh
+++ b/tests/build/ui/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -x
-g++ -I${HEADERS} \
+g++ -I"${HEADERS}" \
     nml-position-logger.cc \
     -L "${LIBDIR}" -lnml -llinuxcnc \
     -o /dev/null

--- a/tests/interp/compile/test.sh
+++ b/tests/interp/compile/test.sh
@@ -3,5 +3,5 @@ set -xe
 
 g++ -o use-rs274 use-rs274.cc \
     -Wall -Wextra -Wno-return-type -Wno-unused-parameter \
-    -I $HEADERS $PYTHON_CPPFLAGS -L "$LIBDIR" -Wl,-rpath,$LIBDIR $PYTHON_EXTRA_LDFLAGS $PYTHON_LIBS $PYTHON_EXTRA_LIBS -lrs274
+    -I "$HEADERS" $PYTHON_CPPFLAGS -L "$LIBDIR" -Wl,-rpath,"$LIBDIR" $PYTHON_EXTRA_LDFLAGS $PYTHON_LIBS $PYTHON_EXTRA_LIBS -lrs274
 LD_BIND_NOW=YesPlease ./use-rs274

--- a/tests/lowlevel/mutex/test.sh
+++ b/tests/lowlevel/mutex/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-gcc -O -I${HEADERS} test.c -o test -DULAPI -std=gnu99 -pthread || exit 1
+gcc -O -I"${HEADERS}" test.c -o test -DULAPI -std=gnu99 -pthread || exit 1
 ./test; exitval=$?
 rm -f test
 exit $exitval

--- a/tests/rtapi_printf.0/test.sh
+++ b/tests/rtapi_printf.0/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-g++ -DULAPI -I${HEADERS} -std=c++0x -I${HEADERS} \
-    -DSIM -rdynamic -L${LIBDIR} \
+g++ -DULAPI -I"${HEADERS}" -std=c++0x \
+    -DSIM -rdynamic -L"${LIBDIR}" \
     -o test_rtapi_vsnprintf test_rtapi_vsnprintf.c
 ./test_rtapi_vsnprintf


### PR DESCRIPTION
This PR add double quotes where immediately possible.

There are other cases in these files that do not allow for double quotes to work properly (like for CPPFLAGS). This will need to be resolved in another PR on a grander plan and scale.