### PR TITLE
Fix last -Wextra warnings

### DIFF
--- a/src/emc/motion/stashf_wrap.h
+++ b/src/emc/motion/stashf_wrap.h
@@ -42,7 +42,7 @@ const char *fmt, *efmt;
 	// after the format.
         char block[63 + 1];
         int fmt_len = efmt - fmt;
-	if(fmt_len >= sizeof(block))
+	if(fmt_len >= (int)sizeof(block))
 		fmt_len = sizeof(block) - 1;
         memcpy(block, fmt, fmt_len);
         block[fmt_len] = 0;

--- a/src/emc/rs274ngc/interp_o_word.cc
+++ b/src/emc/rs274ngc/interp_o_word.cc
@@ -295,7 +295,7 @@ int Interp::execute_call(setup_pointer settings,
 		plist.append(eblock->params[i]); // positional args
 	    current_frame->pystuff.impl->tupleargs = bp::tuple(plist);
 	    current_frame->pystuff.impl->kwargs = bp::dict();
-
+	    /* Fallthrough */
 	case CS_REEXEC_PYOSUB:
 	    if (settings->call_state ==  CS_REEXEC_PYOSUB)
 		CHP(read_inputs(settings));
@@ -440,6 +440,7 @@ int Interp::execute_return(setup_pointer settings, context_pointer current_frame
 	    }
 	}
 	// fall through to normal NGC return handling 
+	/* Fallthrough */
     case CT_NGC_OWORD_SUB:
     case CT_NGC_M98_SUB:
     case CT_NONE:  // sub definition

--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -761,7 +761,7 @@ static PyStructSequence_Desc tool_result_desc = {
 
 static PyTypeObject ToolResultType;
 
-static PyObject *Stat_tool_table(pyStatChannel *s, void *) {
+static PyObject *Stat_tool_table(pyStatChannel * /*s*/, void *) {
     PyObject *res;
     int j = 0;
 

--- a/src/hal/classicladder/protocol_modbus_slave.c
+++ b/src/hal/classicladder/protocol_modbus_slave.c
@@ -301,11 +301,13 @@ void SetVarFromModbusSlave( unsigned char FunctCode, int ModbusNum, int Value )
 		case MODBUS_FC_FORCE_COIL:
 		case MODBUS_FC_FORCE_COILS:
 			WriteVar( VAR_MEM_BIT, ModbusNum+OffsetForVars, Value );
+			break;
 		case MODBUS_FC_READ_HOLD_REGS:
 		case MODBUS_FC_READ_INPUT_REGS:
 		case MODBUS_FC_WRITE_HOLD_REG:
 		case MODBUS_FC_WRITE_HOLD_REGS:
 			WriteVar( VAR_MEM_WORD, ModbusNum+OffsetForVars, Value );
+			break;
 	}
 }
 int GetVarForModbusSlave( unsigned char FunctCode, int ModbusNum )

--- a/src/hal/user_comps/hy_gt_vfd.c
+++ b/src/hal/user_comps/hy_gt_vfd.c
@@ -261,10 +261,10 @@ int read_modbus_register(modbus_t *mb, modbus_register_t *reg) {
             switch (reg->type) {
             case REGISTER_FLOAT:
                 *reg->hal_pin_float = data * reg->multiplier;
-                ;;
+                break;
             case REGISTER_U32:
                 *reg->hal_pin_u32 = data;
-                ;;
+                break;
             }
             return 0;
         }

--- a/src/libnml/nml/nml.cc
+++ b/src/libnml/nml/nml.cc
@@ -2088,6 +2088,7 @@ NMLTYPE NML::str2msg(const char *string)
     case CMS_MISC_ERROR:
     case CMS_NO_MASTER_ERROR:
 	error_type = NML_INTERNAL_CMS_ERROR;
+	/* Fallthrough */
     default:
 	return -1;
     }


### PR DESCRIPTION
This PR solves the last few warnings when compiling with -Wextra:
* one signed/unsigned comparison,
* one unused parameter,
* three instances where intentional switch case fall-through is made explicit,
* four obviously missing breaks in switch cases.

It runs clean with both gcc 14.2.1 and clang 18.1.8. It still needs to be verified on older Debian instances, after which we should be able to add -Wextra in configure in a future PR.