### PR TITLE
Remove class instance passed by value and make then pass by const reference

### DIFF
--- a/src/emc/nml_intf/canon.hh
+++ b/src/emc/nml_intf/canon.hh
@@ -480,84 +480,84 @@ extern void STRAIGHT_FEED(int lineno,
 
 extern std::vector<unsigned int> nurbs_G5_knot_vector_creator(unsigned int n, unsigned int k);
 
-extern double nurbs_G5_Nmix(unsigned int i, unsigned int k, double u, std::vector<unsigned int> knot_vector);
+extern double nurbs_G5_Nmix(unsigned int i, unsigned int k, double u, const std::vector<unsigned int>& knot_vector);
 
 extern double nurbs_G5_Rden(double u, unsigned int k,
-                  std::vector<NURBS_CONTROL_POINT> nurbs_control_points,
-                  std::vector<unsigned int> knot_vector);
+                  const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points,
+                  const std::vector<unsigned int>& knot_vector);
 
 extern NURBS_PLANE_POINT nurbs_G5_point(double u, unsigned int k, 
-                  std::vector<NURBS_CONTROL_POINT> nurbs_control_points,
-                  std::vector<unsigned int> knot_vector);
+                  const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points,
+                  const std::vector<unsigned int>& knot_vector);
 
 extern NURBS_PLANE_POINT nurbs_G5_tangent(double u, unsigned int k,
-                  std::vector<NURBS_CONTROL_POINT> nurbs_control_points,
-                  std::vector<unsigned int> knot_vector);
+                  const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points,
+                  const std::vector<unsigned int>& knot_vector);
 
 /* Additional functions needed to calculate nurbs points G_6_2*/
 
-extern std::vector<double> nurbs_g6_knot_vector_creator(unsigned int n, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points);
+extern std::vector<double> nurbs_g6_knot_vector_creator(unsigned int n, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points);
 
-std::vector<double> nurbs_interval_span_knot_vector_creator(unsigned int n, unsigned int k, std::vector<double> knot_vector_);
+std::vector<double> nurbs_interval_span_knot_vector_creator(unsigned int n, unsigned int k, const std::vector<double>& knot_vector_);
 
-extern double nurbs_lderv(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_);
+extern double nurbs_lderv(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_);
 
-extern double nurbs_Sa1_b1_length_(double a1, double b1, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points,	std::vector<double> knot_vector_);
+extern double nurbs_Sa1_b1_length_(double a1, double b1, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_);
 
-extern std::vector<double> nurbs_lenght_vector_creator(unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_, std::vector<double> span_knot_vector);
+extern std::vector<double> nurbs_lenght_vector_creator(unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_, const std::vector<double>& span_knot_vector);
 
-extern double nurbs_lenght_tot(int j, std::vector<double> span_knot_vector, std::vector<double> lenght_vector);
+extern double nurbs_lenght_tot(int j, const std::vector<double>& span_knot_vector, const std::vector<double>& lenght_vector);
 
-extern double nurbs_lenght_l_u(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_, std::vector<double> span_knot_vector, std::vector<double> lenght_vector);
+extern double nurbs_lenght_l_u(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_, const std::vector<double>& span_knot_vector, const std::vector<double>& lenght_vector);
 
-extern std::vector<double> nurbs_Du_span_knot_vector_creator(unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_, std::vector<double> span_knot_vector);
+extern std::vector<double> nurbs_Du_span_knot_vector_creator(unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_, const std::vector<double>& span_knot_vector);
 
-extern std::vector<double> nurbs_costant_crator(std::vector<double> span_knot_vector, std::vector<double> lenght_vector, std::vector<double> Du_span_knot_vector);
+extern std::vector<double> nurbs_costant_crator(const std::vector<double>& span_knot_vector, const std::vector<double>& lenght_vector, const std::vector<double>& Du_span_knot_vector);
 
-extern double nurbs_uj_l(double l, std::vector<double> span_knot_vector, std::vector<double> lenght_vector, std::vector<double> nurbs_costant);
+extern double nurbs_uj_l(double l, const std::vector<double>& span_knot_vector, const std::vector<double>& lenght_vector, const std::vector<double>& nurbs_costant);
 
 /* Funzioni di supporto all'algoritmo di suddivisione */
-extern  std::vector<double> nurbs_G6_new_control_point_nurbs1(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_ );
+extern  std::vector<double> nurbs_G6_new_control_point_nurbs1(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_ );
 
-extern std::vector<double> nurbs_G6_new_control_point_nurbs2(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_ );
+extern std::vector<double> nurbs_G6_new_control_point_nurbs2(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_ );
 
-extern std::vector<double> nurbs_G6_knot_vector_new_creator_sgment(unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points);
+extern std::vector<double> nurbs_G6_knot_vector_new_creator_sgment(unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points);
 /* ... */
 
-extern double nurbs_G6_Nmix(unsigned int i, unsigned int k, double u, std::vector<double> knot_vector_);
+extern double nurbs_G6_Nmix(unsigned int i, unsigned int k, double u, const std::vector<double>& knot_vector_);
 
-extern std::vector< std::vector<double> > nurbs_G6_Nmix_creator(double u, unsigned int k, double n, std::vector<double> knot_vector_);
+extern std::vector< std::vector<double> > nurbs_G6_Nmix_creator(double u, unsigned int k, double n, const std::vector<double>& knot_vector_);
 
-extern double nurbs_G6_Rden(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_);
+extern double nurbs_G6_Rden(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_);
 
-extern NURBS_PLANE_POINT nurbs_G6_point(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_);
+extern NURBS_PLANE_POINT nurbs_G6_point(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_);
 
-extern double nurbs_G6_Rdenx(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_, std::vector< std::vector<double> > A6);
+extern double nurbs_G6_Rdenx(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_, const std::vector< std::vector<double> >& A6);
 
-extern NURBS_PLANE_POINT nurbs_G6_pointx(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_, std::vector< std::vector<double> > A6);
+extern NURBS_PLANE_POINT nurbs_G6_pointx(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_, const std::vector< std::vector<double> >& A6);
 
-extern NURBS_PLANE_POINT nurbs_G6_point_x(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_); 
+extern NURBS_PLANE_POINT nurbs_G6_point_x(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_);
 
-extern NURBS_PLANE_POINT nurbs_G6_tangent_x(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_);
+extern NURBS_PLANE_POINT nurbs_G6_tangent_x(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_);
 
 /*Funzioni di supporto all'algoritmo di suddivisione********************************************************************/
-extern  std::vector<double> nurbs_G6_new_control_point_nurbs1(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_ );
+extern  std::vector<double> nurbs_G6_new_control_point_nurbs1(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_ );
 
-extern std::vector<double> nurbs_G6_new_control_point_nurbs2(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_ );
+extern std::vector<double> nurbs_G6_new_control_point_nurbs2(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_ );
 
-extern std::vector<double> nurbs_G6_knot_vector_new_creator_sgment(unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points);
+extern std::vector<double> nurbs_G6_knot_vector_new_creator_sgment(unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points);
 
 /* End of NURBS functions*/
 
 
 /* Canon calls */
 
-extern void NURBS_G5_FEED(int lineno, std::vector<NURBS_CONTROL_POINT> nurbs_control_points, unsigned int nurbs_order, CANON_PLANE plane);
+extern void NURBS_G5_FEED(int lineno, const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points, unsigned int nurbs_order, CANON_PLANE plane);
 /* Move at the feed rate along an approximation of a NURBS with a variable number
  * of control points
  */
 
-extern void NURBS_G6_FEED(int lineno, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, unsigned int k, double feedrate, int l, CANON_PLANE plane);
+extern void NURBS_G6_FEED(int lineno, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, unsigned int k, double feedrate, int l, CANON_PLANE plane);
 // this is for G6xx
 
 extern double alpha_finder(double dx, double dy);
@@ -631,9 +631,9 @@ extern void USE_SPINDLE_FORCE();
 extern void USE_NO_SPINDLE_FORCE();
 
 /* Tool Functions */
-extern void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diameter,
+extern void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, const EmcPose& offset, double diameter,
                                  double frontangle, double backangle, int orientation);
-extern void USE_TOOL_LENGTH_OFFSET(EmcPose offset);
+extern void USE_TOOL_LENGTH_OFFSET(const EmcPose& offset);
 
 extern void CHANGE_TOOL();
 
@@ -1043,6 +1043,6 @@ extern void CANON_ERROR(const char *fmt, ...) __attribute__((format(printf,1,2))
 
 extern int     GET_EXTERNAL_OFFSET_APPLIED();
 extern EmcPose GET_EXTERNAL_OFFSETS();
-extern void UPDATE_TAG(StateTag tag);
+extern void UPDATE_TAG(const StateTag& tag);
 
 #endif				/* ifndef CANON_HH */

--- a/src/emc/nml_intf/emc.hh
+++ b/src/emc/nml_intf/emc.hh
@@ -365,18 +365,18 @@ extern int emcTrajForward();
 extern int emcTrajStep();
 extern int emcTrajResume();
 extern int emcTrajDelay(double delay);
-extern int emcTrajLinearMove(EmcPose end, int type, double vel,
+extern int emcTrajLinearMove(const EmcPose& end, int type, double vel,
                              double ini_maxvel, double acc, int indexer_jnum);
-extern int emcTrajCircularMove(EmcPose end, PM_CARTESIAN center, PM_CARTESIAN
+extern int emcTrajCircularMove(const EmcPose& end, const PM_CARTESIAN& center, const PM_CARTESIAN&
         normal, int turn, int type, double vel, double ini_maxvel, double acc);
 extern int emcTrajSetTermCond(int cond, double tolerance);
 extern int emcTrajSetSpindleSync(int spindle, double feed_per_revolution, bool wait_for_index);
-extern int emcTrajSetOffset(EmcPose tool_offset);
-extern int emcTrajSetHome(EmcPose home);
+extern int emcTrajSetOffset(const EmcPose& tool_offset);
+extern int emcTrajSetHome(const EmcPose& home);
 extern int emcTrajClearProbeTrippedFlag();
-extern int emcTrajProbe(EmcPose pos, int type, double vel, 
+extern int emcTrajProbe(const EmcPose& pos, int type, double vel,
                         double ini_maxvel, double acc, unsigned char probe_type);
-extern int emcTrajRigidTap(EmcPose pos, double vel, double ini_maxvel, double acc, double scale);
+extern int emcTrajRigidTap(const EmcPose& pos, double vel, double ini_maxvel, double acc, double scale);
 
 extern int emcTrajUpdate(EMC_TRAJ_STAT * stat);
 
@@ -401,7 +401,7 @@ extern int emcToolPrepare(int tool);
 extern int emcToolLoad();
 extern int emcToolUnload();
 extern int emcToolLoadToolTable(const char *file);
-extern int emcToolSetOffset(int pocket, int toolno, EmcPose offset, double diameter,
+extern int emcToolSetOffset(int pocket, int toolno, const EmcPose& offset, double diameter,
                             double frontangle, double backangle, int orientation);
 extern int emcToolSetNumber(int number);
 

--- a/src/emc/rs274ngc/interpmodule.cc
+++ b/src/emc/rs274ngc/interpmodule.cc
@@ -158,7 +158,7 @@ private:
     int line_number;
     std::string line_text;
 public:
-    InterpreterException(std::string error_message, int line_number, std::string line_text)  {
+    InterpreterException(const std::string& error_message, int line_number, const std::string& line_text)  {
 	this->error_message = error_message;
 	this->line_number = line_number;
 	this->line_text = line_text;
@@ -247,7 +247,7 @@ static int wrap_interp_read(Interp &interp, const char *command)
 static inline EmcPose get_tool_offset (Interp &interp)  {
     return interp._setup.tool_offset;
 }
-static inline void set_tool_offset(Interp &interp, EmcPose value)  {
+static inline void set_tool_offset(Interp &interp, const EmcPose& value)  {
     interp._setup.tool_offset = value;
 }
 static inline bool get_arc_not_allowed (Interp &interp)  {

--- a/src/emc/rs274ngc/nurbs_additional_functions.cc
+++ b/src/emc/rs274ngc/nurbs_additional_functions.cc
@@ -49,7 +49,7 @@ std::vector<unsigned int> nurbs_G5_knot_vector_creator(unsigned int n, unsigned 
 
 	}
 
-double nurbs_G5_Nmix(unsigned int i, unsigned int k, double u,	std::vector<unsigned int> knot_vector)
+double nurbs_G5_Nmix(unsigned int i, unsigned int k, double u, const std::vector<unsigned int>& knot_vector)
 	{
 	if(k == 1)
 		{
@@ -99,7 +99,7 @@ double nurbs_G5_Nmix(unsigned int i, unsigned int k, double u,	std::vector<unsig
 
 
 
-double nurbs_G5_Rden(double u, unsigned int k,	std::vector<NURBS_CONTROL_POINT> nurbs_control_points, std::vector<unsigned int> knot_vector)
+double nurbs_G5_Rden(double u, unsigned int k, const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points, const std::vector<unsigned int>& knot_vector)
 	{
 	unsigned int i;
 	double d = 0.0;
@@ -110,7 +110,7 @@ double nurbs_G5_Rden(double u, unsigned int k,	std::vector<NURBS_CONTROL_POINT> 
 	return d;
 	}
 
-NURBS_PLANE_POINT nurbs_G5_point(double u, unsigned int k,	std::vector<NURBS_CONTROL_POINT> nurbs_control_points, std::vector<unsigned int> knot_vector)
+NURBS_PLANE_POINT nurbs_G5_point(double u, unsigned int k, const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points, const std::vector<unsigned int>& knot_vector)
 	{
 	unsigned int i;
 	NURBS_PLANE_POINT point;
@@ -125,7 +125,7 @@ NURBS_PLANE_POINT nurbs_G5_point(double u, unsigned int k,	std::vector<NURBS_CON
 	}
 
 #define DU (1e-5)
-NURBS_PLANE_POINT nurbs_G5_tangent(double u, unsigned int k, std::vector<NURBS_CONTROL_POINT> nurbs_control_points, std::vector<unsigned int> knot_vector)
+NURBS_PLANE_POINT nurbs_G5_tangent(double u, unsigned int k, const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points, const std::vector<unsigned int>& knot_vector)
 	{
 	unsigned int n = nurbs_control_points.size() - 1;
 	double umax = n - k + 2;
@@ -153,7 +153,7 @@ static void unit_(NURBS_PLANE_POINT &p)
 		}
 	}
 
-std::vector<double> nurbs_g6_knot_vector_creator(unsigned int n, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points)
+std::vector<double> nurbs_g6_knot_vector_creator(unsigned int n, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points)
 	{
 	unsigned int i;
 	std::vector<double> knot_vector_;
@@ -164,7 +164,7 @@ std::vector<double> nurbs_g6_knot_vector_creator(unsigned int n, unsigned int k,
 	return knot_vector_;
 	}
 
-double nurbs_G6_Nmix(unsigned int i, unsigned int k, double u, std::vector<double> knot_vector_)
+double nurbs_G6_Nmix(unsigned int i, unsigned int k, double u, const std::vector<double>& knot_vector_)
 	{
 	if(k == 1)
 		{
@@ -213,7 +213,7 @@ double nurbs_G6_Nmix(unsigned int i, unsigned int k, double u, std::vector<doubl
 
 //A6 è la matrice dove sono memorizzati i valori delle funzioni di base Ni,p(u) per dato valore di u
 //A6 ist die Matrix, in der die Werte der Basisfunktionen Ni,p(u) für einen gegebenen Wert von u gespeichert sind
-std::vector< std::vector<double> > nurbs_G6_Nmix_creator(double u, unsigned int k, double n, std::vector<double> knot_vector)
+std::vector< std::vector<double> > nurbs_G6_Nmix_creator(double u, unsigned int k, double n, const std::vector<double>& knot_vector)
 	{
 	std::vector< std::vector<double> > A6; // array
 	//printf("u: %f k: %d n: %f (F: %s L: %d)\n", u, k, n, __FILE__, __LINE__);
@@ -238,7 +238,7 @@ std::vector< std::vector<double> > nurbs_G6_Nmix_creator(double u, unsigned int 
 	return A6;
 	}
 
-double nurbs_Rden_(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector)
+double nurbs_Rden_(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector)
 	{
 	unsigned int i;
 	double d = 0.0;
@@ -250,7 +250,7 @@ double nurbs_Rden_(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT>
 	}
 
 // nurbs_G6_point is unused?
-NURBS_PLANE_POINT nurbs_G6_point(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector)
+NURBS_PLANE_POINT nurbs_G6_point(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector)
 	{
 	unsigned int i;
 	NURBS_PLANE_POINT point;
@@ -264,7 +264,7 @@ NURBS_PLANE_POINT nurbs_G6_point(double u, unsigned int k, std::vector<NURBS_G6_
 	return point;
 	}
 
-double nurbs_Rdenx(double /*u*/, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> /*knot_vector*/, std::vector< std::vector<double> > A6)
+double nurbs_Rdenx(double /*u*/, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& /*knot_vector*/, const std::vector< std::vector<double> >& A6)
 	{
 	unsigned int i;
 	double d = 0.0;
@@ -276,7 +276,7 @@ double nurbs_Rdenx(double /*u*/, unsigned int k, std::vector<NURBS_G6_CONTROL_PO
 	}
 
 // Algoritmo Cox-Boor
-NURBS_PLANE_POINT nurbs_G6_pointx(double u, unsigned int k,	std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector, std::vector< std::vector<double> > A6)
+NURBS_PLANE_POINT nurbs_G6_pointx(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector, const std::vector< std::vector<double> >& A6)
 	{
 	unsigned int i;
 	NURBS_PLANE_POINT point;
@@ -292,7 +292,7 @@ NURBS_PLANE_POINT nurbs_G6_pointx(double u, unsigned int k,	std::vector<NURBS_G6
 
 //ALGORITMO DE_BOOR
 //////La funzione nurbs_G6_point_x calcola un punto C(u) della curva NURBS per dato valore del parametro u
-NURBS_PLANE_POINT nurbs_G6_point_x(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector)   // è una funzione
+NURBS_PLANE_POINT nurbs_G6_point_x(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector)   // è una funzione
 	{
 	NURBS_PLANE_POINT pointx;
 	pointx.NURBS_X = 0;
@@ -379,7 +379,7 @@ NURBS_PLANE_POINT nurbs_G6_point_x(double u, unsigned int k, std::vector<NURBS_G
 	}
 
 //ALGORITMO DI SUDDIVISIONE NURBS. La CURVA è suddivisa in due segmenti.La funzione calcola i punti di controllo del primo sgmento NURBS
-std::vector<double> nurbs_G6_new_control_point_nurbs1(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points,	std::vector<double> knot_vector)
+std::vector<double> nurbs_G6_new_control_point_nurbs1(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector)
 	{
 	std::vector<NURBS_CONTROL_POINT> nurbs_control_points_a;
 	std::vector<NURBS_CONTROL_POINT> nurbs_control_points_x;
@@ -482,7 +482,7 @@ std::vector<double> nurbs_G6_new_control_point_nurbs1(double u, unsigned int k, 
 
 //La funzione calcola i punti di controllo del secondo segmento NURBS
 // è una funzione
-std::vector<double> nurbs_G6_new_control_point_nurbs2(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points,	std::vector<double> knot_vector) 
+std::vector<double> nurbs_G6_new_control_point_nurbs2(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector)
 	{
 	std::vector<NURBS_CONTROL_POINT> nurbs_control_points_a;
 	std::vector<NURBS_CONTROL_POINT> nurbs_control_points_x;
@@ -598,7 +598,7 @@ std::vector<double> nurbs_G6_new_control_point_nurbs2(double u, unsigned int k, 
 	}
 
 //Funzione per ridefinire il vettore knot per il segmento 1 e 2  dopo la suddivisione
-std::vector<double> nurbs_G6_knot_vector_new_creator_sgment(unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points)
+std::vector<double> nurbs_G6_knot_vector_new_creator_sgment(unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points)
 	{
 	std::vector<double> knot_vector_sgment;
 	int n=nurbs_control_points.size()-1-k;
@@ -628,7 +628,7 @@ std::vector<double> nurbs_G6_knot_vector_new_creator_sgment(unsigned int k, std:
 
 //Per l'algoritmo DE-BOOR
 #define DU (1e-5)
-NURBS_PLANE_POINT nurbs_G6_tangent_x(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_)
+NURBS_PLANE_POINT nurbs_G6_tangent_x(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_)
 	{
 	NURBS_PLANE_POINT r, P1, P3;
 	//unsigned int n = nurbs_control_points.size() -k - 1;	// warning: unused variable ‘n’
@@ -652,7 +652,7 @@ NURBS_PLANE_POINT nurbs_G6_tangent_x(double u, unsigned int k, std::vector<NURBS
 /******************************************************************************************************************************************/
 // La funzione Nderv restituisce la derivata prima della funzione di base rispetto al parametro u
 // N'i,k(u)=.....
-double Nderv(unsigned int i, unsigned int k, double u, std::vector<double> knot_vector_)
+double Nderv(unsigned int i, unsigned int k, double u, const std::vector<double>& knot_vector_)
 	{
 	if(k == 1)
 		{
@@ -701,7 +701,7 @@ double Nderv(unsigned int i, unsigned int k, double u, std::vector<double> knot_
 
 //**********************************************************************************/
 //calcolo della derivata  della funzione di base razionale
-double Rderv(double u, unsigned int k, unsigned int i, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_,double f,double Rsk)
+double Rderv(double u, unsigned int k, unsigned int i, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_,double f,double Rsk)
 	{
 	double d = 0.0;
 	double Nik,DNik;
@@ -712,7 +712,7 @@ double Rderv(double u, unsigned int k, unsigned int i, std::vector<NURBS_G6_CONT
 	}
 
 // LA funzione Dnurbs_point calcola   la derivata della nurbs C'(u) in u  è una funzione
-NURBS_G6_DPLANE_POINT Dnurbs_point(double u, unsigned int k,	std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_)
+NURBS_G6_DPLANE_POINT Dnurbs_point(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_)
 	{
 	double DRik;
 	unsigned int i;
@@ -738,7 +738,7 @@ NURBS_G6_DPLANE_POINT Dnurbs_point(double u, unsigned int k,	std::vector<NURBS_G
 	}
 
 // Nel vettore sono definiti gli estremi degli intervalli di integrazione necessari a definire l'inversa della funzione lunghezza
-std::vector<double> nurbs_interval_span_knot_vector_creator(unsigned int n, unsigned int k, std::vector<double> knot_vector_)
+std::vector<double> nurbs_interval_span_knot_vector_creator(unsigned int n, unsigned int k, const std::vector<double>& knot_vector_)
 	{
 	std::vector<double> span_knot_vector;
 	double a, b,c,ac,cb, ac1,ac2, cb1, cb2;
@@ -771,7 +771,7 @@ std::vector<double> nurbs_interval_span_knot_vector_creator(unsigned int n, unsi
 	return span_knot_vector;
 	}
 
-double lderv(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_)
+double lderv(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_)
 	{
 	NURBS_G6_DPLANE_POINT DP1;
 	DP1 = Dnurbs_point(u,k,nurbs_control_points,knot_vector_);
@@ -784,7 +784,7 @@ double lderv(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs
 
 //Regola di Simpsn
 
-double Sa1_b1_length_(double a1, double b1, unsigned int k,	std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_)
+double Sa1_b1_length_(double a1, double b1, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_)
 	{
 	double Sa1_b1_,h,c1;
 	h=(b1-a1)/2;
@@ -794,7 +794,7 @@ double Sa1_b1_length_(double a1, double b1, unsigned int k,	std::vector<NURBS_G6
 	}
 
 // Premesso che ciascun span knot è suddiviso in due in due intervalli,di ciascun intervallo occorre calcolarne la lunghezza, nel vettore sono calcolate è memorizzate le lunghezze realative a ciascun intevallo di integrazione
-std::vector<double> nurbs_lenght_vector_creator(unsigned int k,	std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_, std::vector<double> span_knot_vector)
+std::vector<double> nurbs_lenght_vector_creator(unsigned int k,	const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_, const std::vector<double>& span_knot_vector)
 	{
 	std::vector<double> lenght_vector;
 	double a;
@@ -810,7 +810,7 @@ std::vector<double> nurbs_lenght_vector_creator(unsigned int k,	std::vector<NURB
 ///////////////////////////////////////////////////////////////////////////////////////
 
 // Funzione per calcolare la lunghezza totale della curva fino all'intervallo di integrazione dello span knot di estremo superiore bj, [aj,bj] dove j individua l'ultimo intervallo di integrazione.
-double nurbs_lenght_tot(int j, std::vector<double> /*span_knot_vector*/, std::vector<double> lenght_vector)
+double nurbs_lenght_tot(int j, const std::vector<double>& /*span_knot_vector*/, const std::vector<double>& lenght_vector)
 	{
 	double ltot=0;
 	for(int i=0; i<=j; ++i)
@@ -821,7 +821,7 @@ double nurbs_lenght_tot(int j, std::vector<double> /*span_knot_vector*/, std::ve
 	}
 
 // Funzione per il calcolo della lunghezza della curva per un qualsiasi valore di u. Tale funzione è stata impiegata per realizzare una verifica
-double lenght_l_u(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_, std::vector<double> span_knot_vector, std::vector<double> lenght_vector)
+double lenght_l_u(double u, unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_, const std::vector<double>& span_knot_vector, const std::vector<double>& lenght_vector)
 	{
 	double a,b,c,d,e,f,g,h,at=0;
 	//double l_u; // warning: ‘l_u’ may be used uninitialized
@@ -877,7 +877,7 @@ double lenght_l_u(double u, unsigned int k, std::vector<NURBS_G6_CONTROL_POINT> 
 	}
 
 //vettore dove sono memorizzate le derivate della funzione inversa della funzione lunghezza in corrispondenza u'j(lj) degli estremi degli intervalli di integrazione
-std::vector<double> nurbs_Du_span_knot_vector_creator(unsigned int k,	std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, std::vector<double> knot_vector_, std::vector<double> span_knot_vector)
+std::vector<double> nurbs_Du_span_knot_vector_creator(unsigned int k, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, const std::vector<double>& knot_vector_, const std::vector<double>& span_knot_vector)
 	{
 	std::vector<double> Du_span_knot_vector;
 	for(unsigned ii=0; ii<span_knot_vector.size(); ++ii)
@@ -891,7 +891,7 @@ std::vector<double> nurbs_Du_span_knot_vector_creator(unsigned int k,	std::vecto
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////777
 //In questo vettore sono memorizzati i coefficienti del polinomio di terzo grado impiegato per approssimare la funzione inversa della lunghezza u_l per ogni intervallo di intgrazione; ogni 6 posizioni sono memorizzati i valori relativi a ciascun intervallo di integrazione a_b_c_d_lj_lj1
-std::vector<double> nurbs_costant_crator(std::vector<double> span_knot_vector, std::vector<double> lenght_vector, std::vector<double> Du_span_knot_vector)
+std::vector<double> nurbs_costant_crator(const std::vector<double>& span_knot_vector, const std::vector<double>& lenght_vector, const std::vector<double>& Du_span_knot_vector)
 	{
 	std::vector<double> nurbs_costant;
 	double a,b,c,d,a1,b1,lj1,ll,lj;
@@ -937,7 +937,7 @@ std::vector<double> nurbs_costant_crator(std::vector<double> span_knot_vector, s
 	}
 
 //Funzione inversa u(l)
-double nurbs_uj_l(double l, std::vector<double> span_knot_vector, std::vector<double> lenght_vector, std::vector<double> nurbs_costant)
+double nurbs_uj_l(double l, const std::vector<double>& span_knot_vector, const std::vector<double>& lenght_vector, const std::vector<double>& nurbs_costant)
 	{
 	double a,b,c,d,lj1,lj,u_l=0,at2=0,at=0;
 	int j=0;

--- a/src/emc/sai/saicanon.cc
+++ b/src/emc/sai/saicanon.cc
@@ -312,7 +312,7 @@ void STOP_SPEED_FEED_SYNCH()
 /* Machining Functions */
 
 /* Machining Functions G_5_2 */
-void NURBS_G5_FEED(int /*lineno*/, std::vector<NURBS_CONTROL_POINT> nurbs_control_points, unsigned int /*nurbs_order*/, CANON_PLANE /*plane*/) {
+void NURBS_G5_FEED(int /*lineno*/, const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points, unsigned int /*nurbs_order*/, CANON_PLANE /*plane*/) {
   ECHO_WITH_ARGS("%lu, ...", (unsigned long)nurbs_control_points.size());
 
   _sai._program_position_x = nurbs_control_points[nurbs_control_points.size()].NURBS_X;
@@ -320,7 +320,7 @@ void NURBS_G5_FEED(int /*lineno*/, std::vector<NURBS_CONTROL_POINT> nurbs_contro
 }
 
 /* Machining Functions G_6_2 */
-void NURBS_G6_FEED(int /*lineno*/, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, unsigned int /*k*/, double /*feedrate*/, int /*l*/, CANON_PLANE /*plane*/) {
+void NURBS_G6_FEED(int /*lineno*/, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, unsigned int /*k*/, double /*feedrate*/, int /*l*/, CANON_PLANE /*plane*/) {
   //fprintf(_outfile, "%5d ", _line_number++);
   print_nc_line_number();
   fprintf(_outfile, "saicanon NURBS_G6_FEED_(%lu, ...)\n", (unsigned long)nurbs_control_points.size());
@@ -507,7 +507,7 @@ void USE_NO_SPINDLE_FORCE()
 {PRINT("USE_NO_SPINDLE_FORCE()\n");}
 
 /* Tool Functions */
-void SET_TOOL_TABLE_ENTRY(int idx, int toolno, EmcPose offset, double diameter,
+void SET_TOOL_TABLE_ENTRY(int idx, int toolno, const EmcPose& offset, double diameter,
                           double frontangle, double backangle, int orientation) {
 
 #ifdef TOOL_NML //{
@@ -539,7 +539,7 @@ void SET_TOOL_TABLE_ENTRY(int idx, int toolno, EmcPose offset, double diameter,
             frontangle, backangle, orientation);
 }
 
-void USE_TOOL_LENGTH_OFFSET(EmcPose offset)
+void USE_TOOL_LENGTH_OFFSET(const EmcPose& offset)
 {
     _sai._tool_offset = offset;
     ECHO_WITH_ARGS("%.4f %.4f %.4f, %.4f %.4f %.4f, %.4f %.4f %.4f",
@@ -1184,6 +1184,6 @@ StandaloneInterpInternals::StandaloneInterpInternals() :
   _toolchanger_reason(0)
 {
 }
-void UPDATE_TAG(StateTag /*tag*/){
+void UPDATE_TAG(const StateTag& /*tag*/){
     //Do nothing
 }

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -93,7 +93,7 @@ static int debug_velacc = 0;
 
 static StateTag _tag;
 
-void UPDATE_TAG(StateTag tag) {
+void UPDATE_TAG(const StateTag& tag) {
     canon_debug("--Got UPDATE_TAG: %d--\n",tag.fields[GM_FIELD_LINE_NUMBER]);
     _tag = tag;
 }
@@ -213,7 +213,7 @@ static void rotate_and_offset_xyz(PM_CARTESIAN & xyz) {
 			canon.toolOffset.tran.z);
 }
 
-static CANON_POSITION unoffset_and_unrotate_pos(const CANON_POSITION pos) {
+static CANON_POSITION unoffset_and_unrotate_pos(const CANON_POSITION& pos) {
     CANON_POSITION res;
 
     res = pos;
@@ -264,7 +264,7 @@ static void rotate_and_offset_pos(double &x, double &y, double &z, double &a, do
 }
 
 
-static CANON_POSITION unoffset_and_unrotate_pos(const EmcPose pos) {
+static CANON_POSITION unoffset_and_unrotate_pos(const EmcPose& pos) {
     CANON_POSITION res(pos);
     return unoffset_and_unrotate_pos(res);
 }
@@ -712,7 +712,7 @@ static AccelData getStraightAcceleration(double x, double y, double z,
     return out;
 }
 
-static AccelData getStraightAcceleration(CANON_POSITION pos)
+static AccelData getStraightAcceleration(const CANON_POSITION& pos)
 {
 
     return getStraightAcceleration(pos.x,
@@ -848,7 +848,7 @@ static VelData getStraightVelocity(double x, double y, double z,
     return out;
 }
 
-static VelData getStraightVelocity(CANON_POSITION pos)
+static VelData getStraightVelocity(const CANON_POSITION& pos)
 {
 
     return getStraightVelocity(pos.x,
@@ -994,7 +994,7 @@ linkable(double x, double y, double z,
 
 static void
 see_segment(int line_number,
-	    StateTag tag,
+	    const StateTag& tag,
 	    double x, double y, double z, 
             double a, double b, double c,
             double u, double v, double w) {
@@ -1380,8 +1380,8 @@ biarc(int lineno, double p0x, double p0y, double tsx, double tsy,
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_G5_FEED(int lineno,
-		   std::vector<NURBS_CONTROL_POINT>
-		   nurbs_control_points, unsigned int nurbs_order,
+		   const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points,
+		   unsigned int nurbs_order,
 		   CANON_PLANE /*plane*/)
 {
 	flush_segments();
@@ -1418,9 +1418,8 @@ void NURBS_G5_FEED(int lineno,
 // G6.2 Q_option=3=NICL NURBS interpolation with linear motion
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_FEED_G6_2_WITH_LINEAR_MOTION(int lineno,
-					std::vector<NURBS_G6_CONTROL_POINT>
-					nurbs_control_points,
-					std::vector<double>knot_vector,
+					const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points,
+					const std::vector<double>& knot_vector,
 					unsigned int k, double feedrate)
 {
 	flush_segments();
@@ -1552,7 +1551,6 @@ void NURBS_FEED_G6_2_WITH_LINEAR_MOTION(int lineno,
 			STRAIGHT_FEED(lineno, P1.NURBS_Y, p.y, P1.NURBS_X,
 				      p.a, p.b, p.c, p.u, p.v, p.w);
 		}
-		knot_vector.clear();
 		span_knot_vector.clear();
 		lenght_vector.clear();
 		Du_span_knot_vector.clear();
@@ -1633,7 +1631,6 @@ void NURBS_FEED_G6_2_WITH_LINEAR_MOTION(int lineno,
 			STRAIGHT_FEED(lineno, P1.NURBS_Y, p.y, P1.NURBS_X,
 				      p.a, p.b, p.c, p.u, p.v, p.w);
 		}
-		knot_vector.clear();
 		span_knot_vector.clear();
 		lenght_vector.clear();
 		Du_span_knot_vector.clear();
@@ -1645,9 +1642,8 @@ void NURBS_FEED_G6_2_WITH_LINEAR_MOTION(int lineno,
 // G6.2 Q_option=2=NICC NURBS interpolation with circular motion
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_FEED_G6_2_WITH_CIRCULAR_MOTION(int lineno,
-					  std::vector<NURBS_G6_CONTROL_POINT>
-					  nurbs_control_points,
-					  std::vector<double> knot_vector,
+					  const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points,
+					  const std::vector<double>& knot_vector,
 					  unsigned int k, double feedrate)
 {
 	flush_segments();
@@ -1763,7 +1759,6 @@ void NURBS_FEED_G6_2_WITH_CIRCULAR_MOTION(int lineno,
 			STRAIGHT_FEED(lineno, P1.NURBS_Y, p.y, P1.NURBS_X,
 				      p.a, p.b, p.c, p.u, p.v, p.w);
 		}
-		knot_vector.clear();
 		span_knot_vector.clear();
 		lenght_vector.clear();
 		Du_span_knot_vector.clear();
@@ -1844,7 +1839,6 @@ void NURBS_FEED_G6_2_WITH_CIRCULAR_MOTION(int lineno,
 			STRAIGHT_FEED(lineno, P1.NURBS_Y, p.y, P1.NURBS_X,
 				      p.a, p.b, p.c, p.u, p.v, p.w);
 		}
-		knot_vector.clear();
 		span_knot_vector.clear();
 		lenght_vector.clear();
 		Du_span_knot_vector.clear();
@@ -1856,9 +1850,8 @@ void NURBS_FEED_G6_2_WITH_CIRCULAR_MOTION(int lineno,
 // G6.2/G6.3 Q_option=1=NICU NURBS interpolation with biarc, du=const
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_FEED_G6_2_WITH_BIARCH_DU_CONST(int lineno,
-					  std::vector<NURBS_G6_CONTROL_POINT>
-					  nurbs_control_points,
-					  std::vector<double> knot_vector,
+					  const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points,
+					  const std::vector<double>& knot_vector,
 					  unsigned int k, double /*feedrate*/)
 {
 	double u = knot_vector[0];
@@ -1925,7 +1918,6 @@ void NURBS_FEED_G6_2_WITH_BIARCH_DU_CONST(int lineno,
 			STRAIGHT_FEED(lineno, P1.NURBS_Y, p.y, P1.NURBS_X,
 				      p.a, p.b, p.c, p.u, p.v, p.w);
 		}
-		knot_vector.clear();
 		A6.clear();
 	} else {
 		NURBS_PLANE_POINT P1;
@@ -1987,7 +1979,6 @@ void NURBS_FEED_G6_2_WITH_BIARCH_DU_CONST(int lineno,
 			STRAIGHT_FEED(lineno, P1.NURBS_Y, p.y, P1.NURBS_X,
 				      p.a, p.b, p.c, p.u, p.v, p.w);
 		}
-		knot_vector.clear();
 		A6.clear();
 	}
 }
@@ -2140,9 +2131,8 @@ void NURBS_FEED_DIVIDE(int lineno,
 //Non viene realizzata alcuna suddivisione in quanto il numero dei punti di controllo è <2*k =due volte l'ordine
 //No subdivision is made as the number of control points is <3*k = twice the order
 void NURBS_FEED_NO_SUBDIVISION(int lineno,
-			       std::vector<NURBS_G6_CONTROL_POINT>
-			       nurbs_control_points,
-			       std::vector<double> knot_vector,
+			       const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points,
+			       const std::vector<double>& knot_vector,
 			       unsigned int nurbs_order, double feedrate,
 			       int Q_option)
 {
@@ -2189,8 +2179,8 @@ void NURBS_FEED_NO_SUBDIVISION(int lineno,
 /* Canon calls G_6_2 */
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void NURBS_G6_FEED(int lineno,
-		   std::vector<NURBS_G6_CONTROL_POINT>
-		   nurbs_control_points, unsigned int nurbs_order,
+		   const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points,
+		   unsigned int nurbs_order,
 		   double feedrate, int Q_option, CANON_PLANE /*plane*/)
 {				// (L_option: NICU, NICL, NICC see publication from Lo Valvo and Drago) 
 	int n = nurbs_control_points.size() - 1 - nurbs_order;
@@ -2803,7 +2793,7 @@ void USE_NO_SPINDLE_FORCE(void)
 /* Tool Functions */
 
 /* this is called with distances in external (machine) units */
-void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diameter,
+void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, const EmcPose& offset, double diameter,
                           double frontangle, double backangle, int orientation) {
     auto o = std::make_unique<EMC_TOOL_SET_OFFSET>();
     flush_segments();
@@ -2821,7 +2811,7 @@ void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diamete
   EMC has no tool length offset. To implement it, we save it here,
   and apply it when necessary
   */
-void USE_TOOL_LENGTH_OFFSET(EmcPose offset)
+void USE_TOOL_LENGTH_OFFSET(const EmcPose& offset)
 {
     auto set_offset_msg = std::make_unique<EMC_TRAJ_SET_OFFSET>();
 

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -102,7 +102,7 @@ int emcToolPrepare(int tool) { return task_methods->emcToolPrepare(tool); }
 int emcToolLoad() { return task_methods->emcToolLoad(); }
 int emcToolUnload()  { return task_methods->emcToolUnload(); }
 int emcToolLoadToolTable(const char *file) { return task_methods->emcToolLoadToolTable(file); }
-int emcToolSetOffset(int pocket, int toolno, EmcPose offset, double diameter,
+int emcToolSetOffset(int pocket, int toolno, const EmcPose& offset, double diameter,
                      double frontangle, double backangle, int orientation) {
     return task_methods->emcToolSetOffset( pocket,  toolno,  offset,  diameter,
 					   frontangle,  backangle,  orientation); }
@@ -519,7 +519,7 @@ int Task::emcToolLoadToolTable(const char *file)//EMC_TOOL_LOAD_TOOL_TABLE_TYPE
     return 0;
 }
 
-int Task::emcToolSetOffset(int idx, int toolno, EmcPose offset, double diameter,
+int Task::emcToolSetOffset(int idx, int toolno, const EmcPose& offset, double diameter,
                      double frontangle, double backangle, int orientation)//EMC_TOOL_SET_OFFSET
 {
 

--- a/src/emc/task/taskclass.hh
+++ b/src/emc/task/taskclass.hh
@@ -62,7 +62,7 @@ public:
     virtual int emcCoolantMistOff();
     virtual int emcCoolantFloodOn();
     virtual int emcCoolantFloodOff();
-    virtual int emcToolSetOffset(int pocket, int toolno, EmcPose offset, double diameter,
+    virtual int emcToolSetOffset(int pocket, int toolno, const EmcPose& offset, double diameter,
 				 double frontangle, double backangle, int orientation);
     virtual int emcToolPrepare(int tool);
     virtual int emcToolLoad();

--- a/src/emc/task/taskintf.cc
+++ b/src/emc/task/taskintf.cc
@@ -1128,7 +1128,7 @@ int emcTrajSetMaxAcceleration(double acc)
     return 0;
 }
 
-int emcTrajSetHome(EmcPose home)
+int emcTrajSetHome(const EmcPose& home)
 {
 #ifdef ISNAN_TRAP
     if (std::isnan(home.tran.x) || std::isnan(home.tran.y) || std::isnan(home.tran.z) ||
@@ -1351,7 +1351,7 @@ double emcTrajGetAngularUnits()
     return TrajConfig.AngularUnits;
 }
 
-int emcTrajSetOffset(EmcPose tool_offset)
+int emcTrajSetOffset(const EmcPose& tool_offset)
 {
     emcmotCommand.command = EMCMOT_SET_OFFSET;
     emcmotCommand.tool_offset = tool_offset;
@@ -1377,7 +1377,7 @@ int emcTrajSetTermCond(int cond, double tolerance)
     return usrmotWriteEmcmotCommand(&emcmotCommand);
 }
 
-int emcTrajLinearMove(EmcPose end, int type, double vel, double ini_maxvel, double acc,
+int emcTrajLinearMove(const EmcPose& end, int type, double vel, double ini_maxvel, double acc,
                       int indexer_jnum)
 {
 #ifdef ISNAN_TRAP
@@ -1404,8 +1404,8 @@ int emcTrajLinearMove(EmcPose end, int type, double vel, double ini_maxvel, doub
     return usrmotWriteEmcmotCommand(&emcmotCommand);
 }
 
-int emcTrajCircularMove(EmcPose end, PM_CARTESIAN center,
-			PM_CARTESIAN normal, int turn, int type, double vel, double ini_maxvel, double acc)
+int emcTrajCircularMove(const EmcPose& end, const PM_CARTESIAN& center,
+			const PM_CARTESIAN& normal, int turn, int type, double vel, double ini_maxvel, double acc)
 {
 #ifdef ISNAN_TRAP
     if (std::isnan(end.tran.x) || std::isnan(end.tran.y) || std::isnan(end.tran.z) ||
@@ -1449,7 +1449,7 @@ int emcTrajClearProbeTrippedFlag()
     return usrmotWriteEmcmotCommand(&emcmotCommand);
 }
 
-int emcTrajProbe(EmcPose pos, int type, double vel, double ini_maxvel, double acc, unsigned char probe_type)
+int emcTrajProbe(const EmcPose& pos, int type, double vel, double ini_maxvel, double acc, unsigned char probe_type)
 {
 #ifdef ISNAN_TRAP
     if (std::isnan(pos.tran.x) || std::isnan(pos.tran.y) || std::isnan(pos.tran.z) ||
@@ -1473,7 +1473,7 @@ int emcTrajProbe(EmcPose pos, int type, double vel, double ini_maxvel, double ac
     return usrmotWriteEmcmotCommand(&emcmotCommand);
 }
 
-int emcTrajRigidTap(EmcPose pos, double vel, double ini_maxvel, double acc, double scale)
+int emcTrajRigidTap(const EmcPose& pos, double vel, double ini_maxvel, double acc, double scale)
 {
 #ifdef ISNAN_TRAP
     if (std::isnan(pos.tran.x) || std::isnan(pos.tran.y) || std::isnan(pos.tran.z)) {

--- a/src/emc/usr_intf/emcsched.cc
+++ b/src/emc/usr_intf/emcsched.cc
@@ -75,9 +75,9 @@ class SchedEntry {
     int getZone() const;
     void setZone(int z);
     string getFileName() const;
-    void setFileName(string s);
+    void setFileName(const string& s);
     string getProgramName() const;
-    void setProgramName(string s);
+    void setProgramName(const string& s);
     float getFeedOverride() const;
     void setFeedOverride(float f);
     float getSpindleOverride() const;
@@ -152,7 +152,7 @@ string SchedEntry::getFileName() const {
   return fileName;
   }
 
-void SchedEntry::setFileName(string s) {
+void SchedEntry::setFileName(const string& s) {
   fileName = s;
   }
 
@@ -160,7 +160,7 @@ string SchedEntry::getProgramName() const {
   return programName;
   }
 
-void SchedEntry::setProgramName(string s) {
+void SchedEntry::setProgramName(const string& s) {
   programName = s;
   }
 
@@ -320,7 +320,7 @@ void updateQueue() {
     }
   }
 
-int addProgram(int pri, int tag, float x, float y, float z, int azone, string progName, float feedOvr, float spindleOvr, int toolNum) {
+int addProgram(int pri, int tag, float x, float y, float z, int azone, const string& progName, float feedOvr, float spindleOvr, int toolNum) {
   SchedEntry p;
 
   p.setPriority(pri);

--- a/src/emc/usr_intf/emcsched.hh
+++ b/src/emc/usr_intf/emcsched.hh
@@ -37,7 +37,7 @@ typedef struct {
     int tool;
     } qRecType;
 
-extern int addProgram(int pri, int tag, float x, float y, float z, int azone, string progName, float feedOvr, float spindleOvr, int toolNum);
+extern int addProgram(int pri, int tag, float x, float y, float z, int azone, const string& progName, float feedOvr, float spindleOvr, int toolNum);
 extern void updateQueue();
 extern int getQueueSize();
 extern void clearQueue();

--- a/src/hal/hal.hh
+++ b/src/hal/hal.hh
@@ -14,10 +14,10 @@ enum class hal_dir{
 
 class hal{
     public:
-    static bool component_exists(std::string name){
+    static bool component_exists(const std::string& name){
         return halpr_find_comp_by_name(name.c_str()) != NULL;
     }
-    static bool pin_has_writer(std::string name){
+    static bool pin_has_writer(const std::string& name){
         hal_pin_t *pin = halpr_find_pin_by_name(name.c_str());
         if(!pin) {//pin does not exist
             return false;
@@ -28,7 +28,7 @@ class hal{
         }
         return false;
     }
-    static bool component_is_ready(std::string name){
+    static bool component_is_ready(const std::string& name){
         // Bad form to assume comp name exists - stop crashing!
         hal_comp_t *thecomp = halpr_find_comp_by_name(name.c_str());
         return thecomp && (thecomp->ready != 0);
@@ -54,21 +54,21 @@ class hal_comp{
     int comp_id;
     std::string comp_name;
     std::map<std::string,pin_t> map;
-    int add_pin_(std::string name, hal_dir dir, hal_pin<bool> pin){
+    int add_pin_(const std::string& name, hal_dir dir, hal_pin<bool> pin){
         return hal_pin_new(name.c_str(), HAL_BIT, static_cast<hal_pin_dir_t>(dir), (void **)(pin.ptr), comp_id);
     }
-    int add_pin_(std::string name, hal_dir dir, hal_pin<int32_t> pin){
+    int add_pin_(const std::string& name, hal_dir dir, hal_pin<int32_t> pin){
         return hal_pin_new(name.c_str(), HAL_S32, static_cast<hal_pin_dir_t>(dir), (void **)(pin.ptr), comp_id);
     }
-    int add_pin_(std::string name, hal_dir dir, hal_pin<uint32_t> pin){
+    int add_pin_(const std::string& name, hal_dir dir, hal_pin<uint32_t> pin){
         return hal_pin_new(name.c_str(), HAL_U32, static_cast<hal_pin_dir_t>(dir), (void **)(pin.ptr), comp_id);
     }
-    int add_pin_(std::string name, hal_dir dir, hal_pin<double> pin){
+    int add_pin_(const std::string& name, hal_dir dir, hal_pin<double> pin){
         return hal_pin_new(name.c_str(), HAL_FLOAT, static_cast<hal_pin_dir_t>(dir), (void **)(pin.ptr), comp_id);
     }
     public:
     int error = 0;
-    hal_comp(std::string name){
+    hal_comp(const std::string& name){
         comp_id = hal_init(name.c_str());
         comp_name = name;
         if(comp_id < 0){
@@ -79,7 +79,7 @@ class hal_comp{
     }
     hal_comp() = delete;
 
-    void newpin(std::string name, hal_type_t type, hal_dir dir){
+    void newpin(const std::string& name, hal_type_t type, hal_dir dir){
         auto& pin = map[name];
         switch(type){
             case HAL_BIT:
@@ -104,7 +104,7 @@ class hal_comp{
         }
     }
 
-    std::variant<double,bool,int32_t,uint32_t> getitem(std::string name){
+    std::variant<double,bool,int32_t,uint32_t> getitem(const std::string& name){
         auto pin = map[name];
         if (auto* v = std::get_if<hal_pin<double>>(&pin)) {
             return *v;
@@ -119,7 +119,7 @@ class hal_comp{
     }
 
     template<typename T>
-    void setitem(std::string name, T value){
+    void setitem(const std::string& name, T value){
         auto pin = map[name];
         if (auto* p = std::get_if<hal_pin<double>>(&pin)) {
             *p = value;
@@ -137,7 +137,7 @@ class hal_comp{
     }
 
     template<typename T>
-    void add_pin(std::string pin_name, hal_dir dir, hal_pin<T> &pin){
+    void add_pin(const std::string& pin_name, hal_dir dir, hal_pin<T> &pin){
         pin.ptr = (volatile T**)hal_malloc(8);
         if(!pin.ptr){
             error -= 1;

--- a/src/libnml/posemath/posemath.cc
+++ b/src/libnml/posemath/posemath.cc
@@ -292,8 +292,8 @@ PM_ROTATION_MATRIX::PM_ROTATION_MATRIX(double xx, double xy, double xz,
     /*! \todo FIXME-- need a matrix orthonormalization function pmMatNorm() */
 }
 
-PM_ROTATION_MATRIX::PM_ROTATION_MATRIX(PM_CARTESIAN _x, PM_CARTESIAN _y,
-    PM_CARTESIAN _z)
+PM_ROTATION_MATRIX::PM_ROTATION_MATRIX(const PM_CARTESIAN& _x, const PM_CARTESIAN& _y,
+    const PM_CARTESIAN& _z)
 {
     x = _x;
     y = _y;
@@ -640,7 +640,7 @@ double &PM_RPY::operator [] (int n) {
 
 // PM_POSE class
 
-PM_POSE::PM_POSE(PM_CARTESIAN v, PM_QUATERNION q)
+PM_POSE::PM_POSE(const PM_CARTESIAN& v, const PM_QUATERNION& q)
 {
     tran.x = v.x;
     tran.y = v.y;
@@ -703,7 +703,7 @@ PM_POSE::PM_POSE(PM_CCONST PM_POSE & p)
 #endif
 // PM_HOMOGENEOUS class
 
-PM_HOMOGENEOUS::PM_HOMOGENEOUS(PM_CARTESIAN v, PM_ROTATION_MATRIX m)
+PM_HOMOGENEOUS::PM_HOMOGENEOUS(const PM_CARTESIAN& v, const PM_ROTATION_MATRIX&	 m)
 {
     tran = v;
     rot = m;
@@ -763,7 +763,7 @@ PM_LINE::PM_LINE(PM_CCONST PM_LINE & l)
 }
 #endif
 
-int PM_LINE::init(PM_POSE start, PM_POSE end)
+int PM_LINE::init(const PM_POSE& start, const PM_POSE& end)
 {
     PmLine _line;
     PmPose _start, _end;
@@ -810,8 +810,8 @@ PM_CIRCLE::PM_CIRCLE(PM_CCONST PM_CIRCLE & c)
 }
 #endif
 
-int PM_CIRCLE::init(PM_POSE start, PM_POSE end,
-    PM_CARTESIAN center, PM_CARTESIAN normal, int turn)
+int PM_CIRCLE::init(const PM_POSE& start, const PM_POSE& end,
+    const PM_CARTESIAN& center, const PM_CARTESIAN& normal, int turn)
 {
     PmCircle _circle;
     PmPose _start, _end;
@@ -956,7 +956,7 @@ PM_ROTATION_MATRIX norm(PM_ROTATION_MATRIX m)
 
 // isNorm
 
-int isNorm(PM_CARTESIAN v)
+int isNorm(const PM_CARTESIAN& v)
 {
     PmCartesian _v;
 
@@ -965,7 +965,7 @@ int isNorm(PM_CARTESIAN v)
     return pmCartIsNorm(&_v);
 }
 
-int isNorm(PM_QUATERNION q)
+int isNorm(const PM_QUATERNION& q)
 {
     PmQuaternion _q;
 
@@ -974,7 +974,7 @@ int isNorm(PM_QUATERNION q)
     return pmQuatIsNorm(&_q);
 }
 
-int isNorm(PM_ROTATION_VECTOR r)
+int isNorm(const PM_ROTATION_VECTOR& r)
 {
     PmRotationVector _r;
 
@@ -983,7 +983,7 @@ int isNorm(PM_ROTATION_VECTOR r)
     return pmRotIsNorm(&_r);
 }
 
-int isNorm(PM_ROTATION_MATRIX m)
+int isNorm(const PM_ROTATION_MATRIX& m)
 {
     PmRotationMatrix _m;
 

--- a/src/libnml/posemath/posemath.h
+++ b/src/libnml/posemath/posemath.h
@@ -227,7 +227,7 @@ struct PM_ROTATION_MATRIX {
 #endif
     PM_ROTATION_MATRIX(double xx, double xy, double xz,
 	double yx, double yy, double yz, double zx, double zy, double zz);
-    PM_ROTATION_MATRIX(PM_CARTESIAN _x, PM_CARTESIAN _y, PM_CARTESIAN _z);
+    PM_ROTATION_MATRIX(const PM_CARTESIAN& _x, const PM_CARTESIAN& _y, const PM_CARTESIAN& _z);
     PM_ROTATION_MATRIX(PM_CONST PM_ROTATION_VECTOR PM_REF v);	/* conversion 
 								 */
     PM_ROTATION_MATRIX(PM_CONST PM_QUATERNION PM_REF q);	/* conversion 
@@ -346,7 +346,7 @@ struct PM_POSE {
 #ifdef INCLUDE_POSEMATH_COPY_CONSTRUCTORS
     PM_POSE(PM_CCONST PM_POSE & p);
 #endif
-    PM_POSE(PM_CARTESIAN v, PM_QUATERNION q);
+    PM_POSE(const PM_CARTESIAN& v, const PM_QUATERNION& q);
     PM_POSE(double x, double y, double z,
 	double s, double sx, double sy, double sz);
     PM_POSE(PM_CONST PM_HOMOGENEOUS PM_REF h);	/* conversion */
@@ -368,7 +368,7 @@ struct PM_HOMOGENEOUS {
 #ifdef INCLUDE_POSEMATH_COPY_CONSTRUCTORS
     PM_HOMOGENEOUS(PM_CCONST PM_HOMOGENEOUS & h);
 #endif
-    PM_HOMOGENEOUS(PM_CARTESIAN v, PM_ROTATION_MATRIX m);
+    PM_HOMOGENEOUS(const PM_CARTESIAN& v, const PM_ROTATION_MATRIX& m);
     PM_HOMOGENEOUS(PM_CONST PM_POSE PM_REF p);	/* conversion */
 
     /* operators */
@@ -390,7 +390,7 @@ struct PM_LINE {
 #endif
 
     /* functions */
-    int init(PM_POSE start, PM_POSE end);
+    int init(const PM_POSE& start, const PM_POSE& end);
     int point(double len, PM_POSE * point);
 
     /* data */
@@ -410,8 +410,8 @@ struct PM_CIRCLE {
 #endif
 
     /* functions */
-    int init(PM_POSE start, PM_POSE end,
-	PM_CARTESIAN center, PM_CARTESIAN normal, int turn);
+    int init(const PM_POSE& start, const PM_POSE& end,
+	const PM_CARTESIAN& center, const PM_CARTESIAN& normal, int turn);
     int point(double angle, PM_POSE * point);
 
     /* data */

--- a/tests/interp/compile/use-rs274.cc
+++ b/tests/interp/compile/use-rs274.cc
@@ -102,7 +102,7 @@ void STRAIGHT_FEED(int lineno,
     printf("-> %.1f %.1f\n", x, y);
 }
 
-void NURBS_G5_FEED(int lineno, std::vector<NURBS_CONTROL_POINT> nurbs_control_points, unsigned int k, CANON_PLANE plane) {
+void NURBS_G5_FEED(int lineno, const std::vector<NURBS_CONTROL_POINT>& nurbs_control_points, unsigned int k, CANON_PLANE plane) {
     double u = 0.0;
     unsigned int n = nurbs_control_points.size() - 1;
     double umax = n - k + 2;
@@ -120,7 +120,7 @@ void NURBS_G5_FEED(int lineno, std::vector<NURBS_CONTROL_POINT> nurbs_control_po
     knot_vector.clear();
 }
 
-void NURBS_G6_FEED(int lineno, std::vector<NURBS_G6_CONTROL_POINT> nurbs_control_points, unsigned int k, double feedrate, int L_option, CANON_PLANE plane) { // (L_option: NICU, NICL, NICC see publication from Lo Valvo and Drago) 
+void NURBS_G6_FEED(int lineno, const std::vector<NURBS_G6_CONTROL_POINT>& nurbs_control_points, unsigned int k, double feedrate, int L_option, CANON_PLANE plane) { // (L_option: NICU, NICL, NICC see publication from Lo Valvo and Drago)
 	}
 
 void RIGID_TAP(int lineno,
@@ -143,9 +143,9 @@ void WAIT_SPINDLE_ORIENT_COMPLETE(int spindle, double timeout) {}
 void LOCK_SPINDLE_Z() {}
 void USE_SPINDLE_FORCE() {}
 void USE_NO_SPINDLE_FORCE() {}
-void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, EmcPose offset, double diameter,
+void SET_TOOL_TABLE_ENTRY(int pocket, int toolno, const EmcPose& offset, double diameter,
                                  double frontangle, double backangle, int orientation) {}
-void USE_TOOL_LENGTH_OFFSET(EmcPose offset) {}
+void USE_TOOL_LENGTH_OFFSET(const EmcPose& offset) {}
 void CHANGE_TOOL() {}	
 void SELECT_TOOL(int tool) {}	
 void CHANGE_TOOL_NUMBER(int number) {}
@@ -259,7 +259,7 @@ int GET_EXTERNAL_AXIS_MASK() { return 7; }
 void FINISH(void) {}
 void ON_RESET(void) {}
 void CANON_ERROR(const char *fmt, ...) {}
-void UPDATE_TAG(StateTag tag) {}
+void UPDATE_TAG(const StateTag& tag) {}
 USER_DEFINED_FUNCTION_TYPE
     USER_DEFINED_FUNCTION[USER_DEFINED_FUNCTION_NUM];
 int GET_EXTERNAL_OFFSET_APPLIED() { return 0; };


### PR DESCRIPTION
There were considerable amount of places where complex structures/classes were passed as values to functions. These create unnecessary copy operations and impede performance. The correct way is to use const pass-by-reference. The issue was detected by cppcheck (passedByValue).

This PR changes all the instances from pass-by-value to const pass-by-reference. There were only few place where a parameter was altered in a function:
* An inch/mm conversion was demultiplexed instead of altering the passed parameter.
* There were instances where a parameter passed vector was cleared before exiting a function. This has no effect and the clear was removed.