### PR TITLE
Fix undefined signed 32-bit integer signed shift left by 31

### DIFF
--- a/src/emc/usr_intf/emcsched.cc
+++ b/src/emc/usr_intf/emcsched.cc
@@ -43,7 +43,7 @@
 #define MAX_PRIORITY 0x80000000
 #define POLYNOMIAL 0xD8  /* 11011 followed by 0's */
 #define WIDTH  (8 * sizeof(crc))
-#define TOPBIT (1 << (WIDTH - 1))
+#define TOPBIT (1u << (WIDTH - 1))
 
 typedef uint32_t crc;
 crc crcTable[256];

--- a/src/hal/drivers/hal_ppmc.c
+++ b/src/hal/drivers/hal_ppmc.c
@@ -1646,7 +1646,7 @@ static rtapi_u32 block(int min, int max)
 
     mask = 0;
     for ( n = min ; n <= max ; n++ ) {
-	mask |= ( 1 << n );
+	mask |= ( 1u << n );
     }
     return mask;
 }

--- a/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_rpspi.c
@@ -916,11 +916,11 @@ static void inline gpio_pull(unsigned pin, uint32_t pud)
 	reg_wr(&gpio->gppud, pud);
 	waste_150_cycles();
 	if(pin <= 31) {
-		reg_wr(&gpio->gppudclk0, 1 << pin);
+		reg_wr(&gpio->gppudclk0, 1u << pin);
 		waste_150_cycles();
 		reg_wr(&gpio->gppudclk0, 0);
 	} else if(pin <= 53) {
-		reg_wr(&gpio->gppudclk1, 1 << (pin - 32));
+		reg_wr(&gpio->gppudclk1, 1u << (pin - 32));
 		waste_150_cycles();
 		reg_wr(&gpio->gppudclk1, 0);
 	}

--- a/src/hal/drivers/mesa-hostmot2/pwmgen.c
+++ b/src/hal/drivers/mesa-hostmot2/pwmgen.c
@@ -668,7 +668,7 @@ void hm2_pwmgen_prepare_tram_write(hostmot2_t *hm2) {
 	}
         hm2->pwmgen.pwm_value_reg[i] = register_value * 65536;
         if (scaled_value < 0) {
-            hm2->pwmgen.pwm_value_reg[i] |= (1 << 31);
+            hm2->pwmgen.pwm_value_reg[i] |= (1u << 31);
         }
     }
 }

--- a/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
+++ b/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
@@ -462,11 +462,11 @@ static void gpio_pull(unsigned pin, uint32_t pud)
 	reg_wr(&gpio->gppud, pud);
 	waste_150_cycles();
 	if(pin <= 31) {
-		reg_wr(&gpio->gppudclk0, 1 << pin);
+		reg_wr(&gpio->gppudclk0, 1u << pin);
 		waste_150_cycles();
 		reg_wr(&gpio->gppudclk0, 0);
 	} else if(pin <= 53) {
-		reg_wr(&gpio->gppudclk1, 1 << (pin - 32));
+		reg_wr(&gpio->gppudclk1, 1u << (pin - 32));
 		waste_150_cycles();
 		reg_wr(&gpio->gppudclk1, 0);
 	}


### PR DESCRIPTION
Integers are 32 bit by default. Performing left shift of 31 on signed integers is undefined by the standard because it is an overflow condition. This happens in statements like <code>1 << 31</code>. The fix is to state them as unsigned: <code>1u << 31</code>.