### PR TITLE
Use prefix ++ on iterators

### DIFF
--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -623,7 +623,7 @@ private:
 	    auto p(h); --p;
 	    (*h)->do_finish((*p).get(),(*(++h)).get());
 	}
-	for(auto p=begin(); p!=end(); p++)
+	for(auto p=begin(); p!=end(); ++p)
 	    if((*p)->radius()<1e-3)
 		erase(p--);
     }
@@ -741,7 +741,7 @@ void g7x::pocket(int cycle, std::complex<double> location, iterator p,
 
     if(cycle==2) {
 	// This skips the initial roughing pass
-	for(; p!=end(); p++) {
+	for(; p!=end(); ++p) {
 	    if((*p)->dive(location,-1e9,out,p==begin()))
 		break;
 	}
@@ -756,13 +756,13 @@ void g7x::pocket(int cycle, std::complex<double> location, iterator p,
 		/* After the initial roughing pass, move along the final
 		   contour and we're done
 		*/
-		for(; p!=end(); p++)
+		for(; p!=end(); ++p)
 		    (*p)->climb_only(location,out);
 	    } else {
 		/* Move along the final contour until a pocket is found,
 		   then start cutting that pocket
 		*/
-		for(; p!=end(); p++) {
+		for(; p!=end(); ++p) {
 		    if((*p)->climb(location,out)) {
 			if(cycle==3) {
 			    if(imag(location)>imag(pocket_starts.back())
@@ -791,11 +791,11 @@ void g7x::pocket(int cycle, std::complex<double> location, iterator p,
 	    /* Our x coordinate is beyond the current segment, move onto
 	       the next
 	    */
-	    p++;
+	    ++p;
 	    continue;
 	}
 
-	for(auto ip=p; ip!=end(); ip++) {
+	for(auto ip=p; ip!=end(); ++ip) {
 	    segment::intersections_t is;
 	    (*ip)->intersection_z(location.imag(),is);
 	    if(is.empty())
@@ -857,13 +857,13 @@ void g7x::add_distance(double distance) {
 	if(distance<0)
 	    max_distance=-max_distance;
 
-	for(auto p=begin(); p!=end(); p++) {
+	for(auto p=begin(); p!=end(); ++p) {
 	    (*p)->offset(max_distance);
 	    if((*p)->radius()<1e-3)
 		erase(p--);
 	}
 
-	for(auto p=begin(); p!=--end(); p++) {
+	for(auto p=begin(); p!=--end(); ++p) {
 	    auto n=p; ++n;
 	    if(real((*p)->ep()-(*n)->sp())>1e-2) {
 		// insert connecting arc
@@ -874,11 +874,11 @@ void g7x::add_distance(double distance) {
 		auto center=(s->ep()+e->sp())/2.0;
 		emplace(n, std::make_unique<round_segment>(
 		    distance>0,(*p)->ep(),center,(*n)->sp()));
-		p++;
+		++p;
 	    }
 	}
 
-	for(auto p=begin(); p!=--end(); p++) {
+	for(auto p=begin(); p!=--end(); ++p) {
 	    if(!(*p)->monotonic()) {
 		std::cout << "Oops " << (*p)->sp()-(*p)->ep() << std::endl;
 		auto pp=p; --pp;
@@ -897,7 +897,7 @@ void g7x::add_distance(double distance) {
 	}
 	current_distance+=max_distance;
     }
-    for(auto p=begin(); p!=--end(); p++) {
+    for(auto p=begin(); p!=--end(); ++p) {
 	auto n=p; ++n;
 	auto mid=((*p)->ep()+(*n)->sp())/2.0;
 	(*p)->ep()=(*n)->sp()=mid;

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -978,7 +978,7 @@ linkable(double x, double y, double z,
     if(x==canon.endPoint.x && y==canon.endPoint.y && z==canon.endPoint.z) return false;
     
     for(std::vector<struct pt>::iterator it = chained_points.begin();
-            it != chained_points.end(); it++) {
+            it != chained_points.end(); ++it) {
         PM_CARTESIAN M(x-canon.endPoint.x, y-canon.endPoint.y, z-canon.endPoint.z),
                      B(canon.endPoint.x, canon.endPoint.y, canon.endPoint.z),
                      P(it->x, it->y, it->z);

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -529,7 +529,7 @@ static PyObject *pyhal_get_pins(PyObject *_self, PyObject * /*o*/) {
   EXCEPTION_IF_NOT_LIVE(NULL);
 
   PyObject *d = PyDict_New();
-  for(itemmap::iterator i = self->items->begin(); i != self->items->end(); i++) {
+  for(itemmap::iterator i = self->items->begin(); i != self->items->end(); ++i) {
     halitem * pin = &(i->second);
     name = strdup(i->first.c_str());
     PyDict_SetItemString(d, name, pyhal_read_common(pin));


### PR DESCRIPTION
Using a prefix ++ operator on iterators is often more efficient (detected by cppcheck). This PR fixes the detected instances.