### PR TITLE
Fix printf/scanf format signed/unsigned

### DIFF
--- a/src/emc/nml_intf/emc_nml.hh
+++ b/src/emc/nml_intf/emc_nml.hh
@@ -116,7 +116,7 @@ class EMC_SET_DEBUG:public RCS_CMD_MSG {
     // For internal NML/CMS use only.
     void update(CMS * cms);
 
-    int debug;
+    unsigned debug;
 };
 
 

--- a/src/emc/nml_intf/emcglb.c
+++ b/src/emc/nml_intf/emcglb.c
@@ -26,7 +26,7 @@ char emc_nmlfile[LINELEN] = EMC2_DEFAULT_NMLFILE;
 char rs274ngc_startup_code[LINELEN] =
     DEFAULT_RS274NGC_STARTUP_CODE;
 
-int emc_debug = 0;		/* initially no debug messages */
+unsigned emc_debug = 0;		/* initially no debug messages */
 
 double emc_task_cycle_time = DEFAULT_EMC_TASK_CYCLE_TIME;
 

--- a/src/emc/nml_intf/emcglb.h
+++ b/src/emc/nml_intf/emcglb.h
@@ -38,7 +38,7 @@ extern "C" {
    get these into Tk automatically */
 
     // there's also an emc_Debug function in emc/usr_intf/emcsh.cc
-    extern int emc_debug;
+    extern unsigned emc_debug;
 
     // EMC_DEBUG_* flag definitions moved to debugflags.h
 

--- a/src/emc/task/emcsvr.cc
+++ b/src/emc/task/emcsvr.cc
@@ -83,14 +83,14 @@ static int iniLoad(const char *filename)
 
     // set flags if RCS_DEBUG in ini file
     if ((inistring = inifile.Find("RCS_DEBUG", "EMC"))) {
-        static long int flags;
+        long unsigned int flags;
         if (sscanf(*inistring, "%lx", &flags) < 1) {
             perror("failed to parse [EMC] RCS_DEBUG");
         }
         // clear all flags
         clear_rcs_print_flag(PRINT_EVERYTHING);
         // set parsed flags
-        set_rcs_print_flag(flags);
+        set_rcs_print_flag((long)flags);
     }
     // output infinite RCS errors by default
     max_rcs_errors_to_print = -1;

--- a/src/emc/task/emctaskmain.cc
+++ b/src/emc/task/emctaskmain.cc
@@ -710,7 +710,7 @@ void readahead_waiting(void)
 	    int was_open = taskplanopen;
 	    if (was_open) {
 		emcTaskPlanClose();
-		if (emc_debug & EMC_DEBUG_INTERP && was_open) {
+		if ((emc_debug & EMC_DEBUG_INTERP) && was_open) {
 		    rcs_print
 			("emcTaskPlanClose() called at %s:%d\n",
 			 __FILE__, __LINE__);
@@ -3146,14 +3146,14 @@ static int iniLoad(const char *filename)
 
     // set flags if RCS_DEBUG in ini file
     if ((inistring = inifile.Find("RCS_DEBUG", "EMC"))) {
-        static long int flags;
+        long unsigned int flags;
         if (sscanf(*inistring, "%lx", &flags) < 1) {
             perror("failed to parse [EMC] RCS_DEBUG");
         }
         // clear all flags
         clear_rcs_print_flag(PRINT_EVERYTHING);
         // set parsed flags
-        set_rcs_print_flag(flags);
+        set_rcs_print_flag((long)flags);
     }
     // output infinite RCS errors by default
     max_rcs_errors_to_print = -1;

--- a/src/emc/tooldata/tool_watch.cc
+++ b/src/emc/tooldata/tool_watch.cc
@@ -53,17 +53,17 @@ int main(int argc, char **argv) {
 #else
   fprintf(stderr,"tool_watch: TOOLTABLE:mmap\n");
 #endif
-    fprintf(stderr,"%8ld EMC_STAT\n",sizeof(EMC_STAT));
-    fprintf(stderr,"%8ld   EMC_IO_STAT\n",sizeof(EMC_IO_STAT));
-    fprintf(stderr,"%8ld    EMC_TOOL_STAT\n",sizeof(EMC_TOOL_STAT));
-    fprintf(stderr,"%8ld     EMC_COOLANT_STAT\n",sizeof(EMC_COOLANT_STAT));
-    fprintf(stderr,"%8ld     EMC_AUX_STAT\n",sizeof(EMC_AUX_STAT));
-    fprintf(stderr,"%8ld   EMC_TASK_STAT\n",sizeof(EMC_TASK_STAT));
-    fprintf(stderr,"%8ld   EMC_MOTION_STAT\n",sizeof(EMC_MOTION_STAT));
-    fprintf(stderr,"%8ld     EMC_TRAJ_STAT\n",sizeof(EMC_TRAJ_STAT));
-    fprintf(stderr,"%8ld     EMC_JOINT_STAT\n",sizeof(EMC_JOINT_STAT));
-    fprintf(stderr,"%8ld     EMC_AXIS_STAT\n",sizeof(EMC_AXIS_STAT));
-    fprintf(stderr,"%8ld     EMC_SPINDLE_STAT\n",sizeof(EMC_SPINDLE_STAT));
+    fprintf(stderr,"%8zu EMC_STAT\n",sizeof(EMC_STAT));
+    fprintf(stderr,"%8zu   EMC_IO_STAT\n",sizeof(EMC_IO_STAT));
+    fprintf(stderr,"%8zu    EMC_TOOL_STAT\n",sizeof(EMC_TOOL_STAT));
+    fprintf(stderr,"%8zu     EMC_COOLANT_STAT\n",sizeof(EMC_COOLANT_STAT));
+    fprintf(stderr,"%8zu     EMC_AUX_STAT\n",sizeof(EMC_AUX_STAT));
+    fprintf(stderr,"%8zu   EMC_TASK_STAT\n",sizeof(EMC_TASK_STAT));
+    fprintf(stderr,"%8zu   EMC_MOTION_STAT\n",sizeof(EMC_MOTION_STAT));
+    fprintf(stderr,"%8zu     EMC_TRAJ_STAT\n",sizeof(EMC_TRAJ_STAT));
+    fprintf(stderr,"%8zu     EMC_JOINT_STAT\n",sizeof(EMC_JOINT_STAT));
+    fprintf(stderr,"%8zu     EMC_AXIS_STAT\n",sizeof(EMC_AXIS_STAT));
+    fprintf(stderr,"%8zu     EMC_SPINDLE_STAT\n",sizeof(EMC_SPINDLE_STAT));
     fprintf(stderr,"\n");
 
     header();hdr_ct=1;

--- a/src/emc/usr_intf/halui.cc
+++ b/src/emc/usr_intf/halui.cc
@@ -1430,14 +1430,14 @@ static int iniLoad(const char *filename)
 
     // set flags if RCS_DEBUG in ini file
     if ((inistring = inifile.Find("RCS_DEBUG", "EMC"))) {
-        static long int flags;
+        long unsigned int flags;
         if (sscanf(*inistring, "%lx", &flags) < 1) {
             perror("failed to parse [EMC] RCS_DEBUG");
         }
         // clear all flags
         clear_rcs_print_flag(PRINT_EVERYTHING);
         // set parsed flags
-        set_rcs_print_flag(flags);
+        set_rcs_print_flag((long)flags);
     }
     // output infinite RCS errors by default
     max_rcs_errors_to_print = -1;

--- a/src/emc/usr_intf/shcom.cc
+++ b/src/emc/usr_intf/shcom.cc
@@ -1302,14 +1302,14 @@ int iniLoad(const char *filename)
 
     // set flags if RCS_DEBUG in ini file
     if ((inistring = inifile.Find("RCS_DEBUG", "EMC"))) {
-        static long int flags;
+        long unsigned int flags;
         if (sscanf(*inistring, "%lx", &flags) < 1) {
             perror("failed to parse [EMC] RCS_DEBUG");
         }
         // clear all flags
         clear_rcs_print_flag(PRINT_EVERYTHING);
         // set parsed flags
-        set_rcs_print_flag(flags);
+        set_rcs_print_flag((long)flags);
     }
     // output infinite RCS errors by default
     max_rcs_errors_to_print = -1;

--- a/src/hal/classicladder/config_gtk.c
+++ b/src/hal/classicladder/config_gtk.c
@@ -467,7 +467,7 @@ void GetIOSettings( char ForInputs )
 					case 2:
 						text = (char *)gtk_entry_get_text((GtkEntry *)*IOParamEntry);
 						if ( DeviceTypeValue==DEVICE_TYPE_DIRECT_ACCESS )
-							sscanf( text, "%X", &pConf->SubDevOrAdr );
+							sscanf( text, "%X", (unsigned *)&pConf->SubDevOrAdr );
 						else
 							pConf->SubDevOrAdr = atoi( text );
 						break;

--- a/src/hal/components/panelui.c
+++ b/src/hal/components/panelui.c
@@ -310,7 +310,7 @@ int main(int argc, char **argv)
             last_sample = this_sample;
         }
         if ( tag ) {
-            printf ( "%d ", this_sample-1 );
+            printf ( "%u ", this_sample-1 );
         }
         /* get raw value, mask keyup and keydown codes */
         /* compute row and column */

--- a/src/hal/components/sampler_usr.c
+++ b/src/hal/components/sampler_usr.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 	    last_sample = this_sample;
 	}
 	if ( tag ) {
-	    printf ( "%d ", this_sample-1 );
+	    printf ( "%u ", this_sample-1 );
 	}
 	for ( n = 0 ; n < num_pins; n++ ) {
 	    switch ( hal_stream_element_type(&stream, n) ) {

--- a/src/hal/user_comps/mb2hal/mb2hal.c
+++ b/src/hal/user_comps/mb2hal/mb2hal.c
@@ -237,7 +237,7 @@ void *link_loop_and_logic(void *thrd_link_num)
             }
             else if (ret != retOK) {  //transaction failure but link OK
                 (**this_mb_tx->num_errors)++;
-                ERR(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] transaction failure, num_errors[%d]",
+                ERR(this_mb_tx->cfg_debug, "mb_tx_num[%d] mb_links[%d] thread[%d] fd[%d] transaction failure, num_errors[%u]",
                     this_mb_tx_num, this_mb_tx->mb_link_num, this_mb_link_num, modbus_get_socket(this_mb_link->modbus), **this_mb_tx->num_errors);
                 // Clear any unread data. Otherwise the link might get out of sync
                 modbus_flush(this_mb_link->modbus);

--- a/src/hal/user_comps/pi500_vfd/pi500_vfd.comp
+++ b/src/hal/user_comps/pi500_vfd/pi500_vfd.comp
@@ -134,7 +134,7 @@ bool pi500_getStatus(modbus_t* ctx, pi500_status* status)
 void print_modbus_error(struct __comp_state *__comp_inst, const char* msg)
 {
 	fprintf(stderr, 
-		"Error: pi500_vfd slave(%d): %s - Modbus error (%d) -  %s\n",
+		"Error: pi500_vfd slave(%u): %s - Modbus error (%d) -  %s\n",
 		mbslaveaddr,
 		msg,
 		errno,

--- a/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
+++ b/src/hal/user_comps/wj200_vfd/wj200_vfd.comp
@@ -174,7 +174,7 @@ bool wj200_getStatus(modbus_t* ctx, wj200_status* status)
 void print_modbus_error(struct __comp_state *__comp_inst, const char* msg)
 {
 	fprintf(stderr,
-		"Error: wj200_vfd slave(%d): %s - Modbus error (%d) -  %s\n",
+		"Error: wj200_vfd slave(%u): %s - Modbus error (%d) -  %s\n",
 		mbslaveaddr,
 		msg,
 		errno,

--- a/src/hal/utils/halcmd_commands.cc
+++ b/src/hal/utils/halcmd_commands.cc
@@ -2485,7 +2485,7 @@ static const char *data_value2(int type, void *valptr)
 	value_str = buf;
 	break;
     case HAL_U32:
-	snprintf(buf, 14, "%ld", (unsigned long)*((hal_u32_t *) valptr));
+	snprintf(buf, 14, "%lu", (unsigned long)*((hal_u32_t *) valptr));
 	value_str = buf;
 	break;
     case HAL_S64:

--- a/src/hal/utils/halrmt.c
+++ b/src/hal/utils/halrmt.c
@@ -1878,7 +1878,7 @@ static void getThreadInfo(char *pattern, connectionRecType *context)
         }
 	}
 
-        snprintf(context->outBuf, sizeof(context->outBuf), "THREAD %s %11d %s %d %d",
+        snprintf(context->outBuf, sizeof(context->outBuf), "THREAD %s %11u %s %u %u",
 	  tptr->name, 
 	  (unsigned int)tptr->period, 
 	  (tptr->uses_fp ? "YES" : "NO "),  
@@ -2072,7 +2072,7 @@ static char *data_value2(int type, void *valptr)
 	value_str = buf;
 	break;
     case HAL_U32:
-	snprintf(buf, 14, "%ld", (unsigned long)*((hal_u32_t *) valptr));
+	snprintf(buf, 14, "%lu", (unsigned long)*((hal_u32_t *) valptr));
 	value_str = buf;
 	break;
     default:

--- a/src/hal/utils/upci.c
+++ b/src/hal/utils/upci.c
@@ -202,7 +202,7 @@ int upci_scan_bus(void)
 	devices[num_devs++] = dev;
 	n = sscanf(lineptr,
 	    "%hx %x %x %x %x %x %x %x %x %x %x %x %x %x %x %x %x",
-	    &busdevfunc, &vendordev, &(dev->p.irq),
+	    &busdevfunc, &vendordev, (unsigned *)&(dev->p.irq),
 	    &dev->p.base_addr[0],  &dev->p.base_addr[1], &dev->p.base_addr[2],
 	    &dev->p.base_addr[3],  &dev->p.base_addr[4], &dev->p.base_addr[5],
 	    &dev->p.rom_base_addr,

--- a/src/libnml/cms/cms_aup.cc
+++ b/src/libnml/cms/cms_aup.cc
@@ -517,7 +517,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(unsigned int &x)
 		x);
 	}
 	end_current_string[7] = 0;
-	sprintf(end_current_string, "%-6d", x);
+	sprintf(end_current_string, "%-6u", x);
 	if (end_current_string[7] != 0 && warning_count < warning_count_max) {
 	    warning_count++;
 	    rcs_print_error
@@ -631,7 +631,7 @@ CMS_STATUS CMS_ASCII_UPDATER::update(unsigned long int &x)
 
     if (encoding) {
 	end_current_string[15] = 0;
-	sprintf(end_current_string, "%-14ld", x);
+	sprintf(end_current_string, "%-14lu", x);
 	if (end_current_string[15] != 0 && warning_count < warning_count_max) {
 	    warning_count++;
 	    rcs_print_error

--- a/src/libnml/cms/cms_dup.cc
+++ b/src/libnml/cms/cms_dup.cc
@@ -530,7 +530,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(unsigned int &x)
 		("CMS_DISPLAY_ASCII_UPDATER: unsigned int %d is too large. (Use type long.)\n",
 		x);
 	}
-	snprintf(end_current_string, max_length_current_string-(end_current_string - begin_current_string), "%6d,", x);
+	snprintf(end_current_string, max_length_current_string-(end_current_string - begin_current_string), "%6u,", x);
     } else {
 	if (0 == end_current_string[0]) {
 	    x = 0;
@@ -635,7 +635,7 @@ CMS_STATUS CMS_DISPLAY_ASCII_UPDATER::update(unsigned long int &x)
     }
 
     if (encoding) {
-	snprintf(end_current_string, max_length_current_string-(end_current_string - begin_current_string), "%ld,", x);
+	snprintf(end_current_string, max_length_current_string-(end_current_string - begin_current_string), "%lu,", x);
 
     } else {
 	if (0 == end_current_string[0]) {

--- a/src/rtapi/rtai_ulapi.c
+++ b/src/rtapi/rtai_ulapi.c
@@ -351,7 +351,7 @@ void rtapi_printall(void)
 	    printf("    key     = %d\n", shmems[n].key);
 	    printf("    rtusers = %d\n", shmems[n].rtusers);
 	    printf("    ulusers = %d\n", shmems[n].ulusers);
-	    printf("    size    = %ld\n", shmems[n].size);
+	    printf("    size    = %lu\n", shmems[n].size);
 	    printf("    bitmap  = ");
 	    for (m = 0; m <= RTAPI_MAX_MODULES; m++) {
 		if (test_bit(m, shmems[n].bitmap)) {
@@ -386,7 +386,7 @@ void rtapi_printall(void)
 	    printf("    key    = %d\n", fifos[n].key);
 	    printf("    reader = %d\n", fifos[n].reader);
 	    printf("    writer = %d\n", fifos[n].writer);
-	    printf("    size   = %ld\n", fifos[n].size);
+	    printf("    size   = %lu\n", fifos[n].size);
 	}
     }
     for (n = 0; n <= RTAPI_MAX_IRQS; n++) {

--- a/src/rtapi/uspace_rtapi_parport.cc
+++ b/src/rtapi/uspace_rtapi_parport.cc
@@ -50,7 +50,7 @@ static void map_parports() {
         }
         struct portinfo pi;
         pi.port_id = i;
-        if(fscanf(f, "%hd %hd", &pi.base, &pi.base_hi) != 2) {
+        if(fscanf(f, "%hu %hu", &pi.base, &pi.base_hi) != 2) {
             rtapi_print_msg(RTAPI_MSG_ERR, "Failed to parse base-addr for port #%d\n", i);
             fclose(f);
             continue;


### PR DESCRIPTION
This PR fixes printf/scanf formats as indicated by cppcheck:
* printf conversion specifiers must be unsigned when the argument is unsigned,
* scanf conversion "requires" an unsigned argument when the conversion specifiers is unsigned. Some instances are fixed by cast because changing the actual variable type may be problematic.
