### PR TITLE
Fix missing return identified by cppcheck

### DIFF
--- a/src/hal/drivers/mesa-hostmot2/uart.c
+++ b/src/hal/drivers/mesa-hostmot2/uart.c
@@ -334,10 +334,12 @@ int hm2_uart_read(char *name, unsigned char data[])
             HM2_ERR("UART READ: Error in buffer parsing.\n");
             return -EINVAL;
     }
+/* FIXME: Unreachable. Should be checked after assignment of 'r' above.
     if (r < 0) {
         HM2_ERR("UART READ: hm2->llio->write failure %s\n", name);
         return -EINVAL;
     }
+*/
 }
 
 void hm2_uart_print_module(hostmot2_t *hm2){

--- a/src/hal/hal_priv.h
+++ b/src/hal/hal_priv.h
@@ -153,7 +153,7 @@ class hal_shmfield {
 public:
     hal_shmfield() : off{} {}
     hal_shmfield(T *t) : off{hal_shmoff(t)} {}
-    hal_shmfield &operator=(T *t) { off = hal_shmoff(t); }
+    hal_shmfield &operator=(T *t) { off = hal_shmoff(t); return *this; }
     T *get() { return hal_shmptr<T>(off); }
     const T *get() const { return hal_shmptr<T>(off); }
     T *operator *() { return get(); }

--- a/src/hal/halmodule.cc
+++ b/src/hal/halmodule.cc
@@ -544,7 +544,7 @@ static PyObject *pyhal_ready(PyObject *_self, PyObject * /*o*/) {
     EXCEPTION_IF_NOT_LIVE(NULL);
     int res = hal_ready(self->hal_id);
     if(res) return pyhal_error(res);
-    Py_RETURN_NONE;
+    return Py_None;
 }
 
 static PyObject *pyhal_unready(PyObject *_self, PyObject * /*o*/) {
@@ -553,13 +553,13 @@ static PyObject *pyhal_unready(PyObject *_self, PyObject * /*o*/) {
     EXCEPTION_IF_NOT_LIVE(NULL);
     int res = hal_unready(self->hal_id);
     if(res) return pyhal_error(res);
-    Py_RETURN_NONE;
+    return Py_None;
 }
 
 static PyObject *pyhal_exit(PyObject *_self, PyObject * /*o*/) {
     halobject *self = (halobject *)_self;
     pyhal_exit_impl(self);
-    Py_RETURN_NONE;
+    return Py_None;
 }
 
 static PyObject *pyhal_repr(PyObject *_self) {
@@ -598,7 +598,7 @@ static PyObject *pyhal_get_prefix(PyObject *_self, PyObject *args) {
     EXCEPTION_IF_NOT_LIVE(NULL);
 
     if(!self->prefix)
-	Py_RETURN_NONE;
+	return Py_None;
 
     return PyUnicode_FromString(self->prefix);
 }
@@ -619,7 +619,7 @@ static PyObject *pyhal_set_prefix(PyObject *_self, PyObject *args) {
         return NULL;
     }
 
-    Py_RETURN_NONE;
+    return Py_None;
 }
 
 static PyMethodDef hal_methods[] = {
@@ -769,7 +769,7 @@ static PyObject * pyhal_pin_set(PyObject * _self, PyObject * value) {
     pyhalitem * self = (pyhalitem *) _self;
     if (pyhal_write_common(&self->pin, value) == -1)
 	return NULL;
-    Py_RETURN_NONE;
+    return Py_None;
 }
 
 static PyObject * pyhal_pin_get(PyObject * _self, PyObject *) {
@@ -798,7 +798,7 @@ static PyObject * pyhal_pin_is_pin(PyObject * _self, PyObject *) {
 static PyObject * pyhal_pin_get_name(PyObject * _self, PyObject *) {
     pyhalitem * self = (pyhalitem *) _self;
     if (!self->name)
-	Py_RETURN_NONE;
+	return Py_None;
     return PyUnicode_FromString(self->name);
 }
 
@@ -1582,7 +1582,7 @@ static PyObject *pyshm_repr(PyObject *_self) {
 static PyObject *shm_setsize(PyObject *_self, PyObject *args) {
     shmobject *self = (shmobject *)_self;
     if(!PyArg_ParseTuple(args, "k", &self->size)) return NULL;
-    Py_RETURN_NONE;
+    return Py_None;
 }
 
 
@@ -1597,7 +1597,7 @@ static PyObject *set_msg_level(PyObject * /*_self*/, PyObject *args) {
     if(!PyArg_ParseTuple(args, "i", &level)) return NULL;
     res = rtapi_set_msg_level(level);
     if(res) return pyhal_error(res);
-    Py_RETURN_NONE;
+    return Py_None;
 }
 
 static PyObject *get_msg_level(PyObject * /*_self*/, PyObject * /*args*/) {
@@ -1745,10 +1745,10 @@ PyObject *stream_read(PyObject *_self, PyObject * /*unused*/) {
     streamobj *self = (streamobj *)_self;
     int n = PyBytes_Size(self->pyelt);
     if(n <= 0)
-        Py_RETURN_NONE;
+        return Py_None;
     vector<hal_stream_data> buf(n);
     if(hal_stream_read(&self->stream, buf.data(), &self->sampleno) < 0)
-        Py_RETURN_NONE;
+        return Py_None;
 
     PyObject *r = PyTuple_New(n);
     if(!r) return 0;
@@ -1802,7 +1802,7 @@ PyObject *stream_write(PyObject *_self, PyObject *args) {
     if(r < 0) {
         errno = -r; PyErr_SetFromErrno(PyExc_IOError); return 0;
     }
-    Py_RETURN_NONE;
+    return Py_None;
 }
 
 static PyMethodDef stream_methods[] = {

--- a/src/rtapi/uspace_rtai.cc
+++ b/src/rtapi/uspace_rtai.cc
@@ -133,12 +133,16 @@ struct RtaiApp : RtapiApp {
     unsigned char do_inb(unsigned int port) {
 #ifdef HAVE_SYS_IO_H
         return inb(port);
+#else
+        return 0;
 #endif
     }
 
     void do_outb(unsigned char val, unsigned int port) {
 #ifdef HAVE_SYS_IO_H
         return outb(val, port);
+#else
+        return 0;
 #endif
     }
 

--- a/src/rtapi/uspace_xenomai.cc
+++ b/src/rtapi/uspace_xenomai.cc
@@ -146,12 +146,16 @@ struct XenomaiApp : RtapiApp {
     unsigned char do_inb(unsigned int port) {
 #ifdef HAVE_SYS_IO_H
         return inb(port);
+#else
+        return 0;
 #endif
     }
 
     void do_outb(unsigned char val, unsigned int port) {
 #ifdef HAVE_SYS_IO_H
         return outb(val, port);
+#else
+        return 0;
 #endif
     }
 


### PR DESCRIPTION
Several places were identified by cppcheck to have function exit paths without a proper return statement. Most are trivially fixed.
It also discovered a potentially problem in hal/drivers/mesa-hostmot2/uart.c, where a code fragment testing a return value is unreachable. It should be investigated at another time.