### PR TITLE
Fix cppcheck initialization lists

### DIFF
--- a/src/emc/nml_intf/emcops.cc
+++ b/src/emc/nml_intf/emcops.cc
@@ -152,19 +152,20 @@ EMC_TASK_STAT_MSG(EMC_TASK_STAT_TYPE, sizeof(EMC_TASK_STAT))
     queuedMDIcommands = 0;
 }
 
-EMC_TOOL_STAT::EMC_TOOL_STAT():
-EMC_TOOL_STAT_MSG(EMC_TOOL_STAT_TYPE, sizeof(EMC_TOOL_STAT))
+EMC_TOOL_STAT::EMC_TOOL_STAT()
+  : EMC_TOOL_STAT_MSG(EMC_TOOL_STAT_TYPE, sizeof(EMC_TOOL_STAT)),
+    pocketPrepped(0), // idx
+    toolInSpindle(0), // toolno
+    toolFromPocket(0) // tool_from_pocket
+#ifndef TOOL_NML // {
+    , toolTableCurrent(tooldata_entry_init())
+#endif
 {
-    pocketPrepped = 0; // idx
-    toolInSpindle = 0; // toolno
-    toolFromPocket = 0; // tool_from_pocket
 #ifdef TOOL_NML //{
     int idx;
     for (idx = 0; idx < CANON_POCKETS_MAX; idx++) {
         toolTable[idx] = tooldata_entry_init();
     }
-#else //}{
-    toolTableCurrent = tooldata_entry_init();
 #endif //}
 }
 

--- a/src/emc/rs274ngc/interp_find.cc
+++ b/src/emc/rs274ngc/interp_find.cc
@@ -713,7 +713,7 @@ double Interp::find_turn(double x1,      //!< X-coordinate of start point
   return (theta);
 }
 
-int Interp::find_tool_index(setup_pointer /*settings*/, int toolno, int *index)
+int Interp::find_tool_index(setup_pointer settings, int toolno, int *index)
 {
 
 #ifdef TOOL_NML //{
@@ -722,6 +722,7 @@ int Interp::find_tool_index(setup_pointer /*settings*/, int toolno, int *index)
         return INTERP_OK;
     }
 #else //}{
+    (void)settings;
     // special case is included in tooldata_find_index_for_tool()
 #endif //}
 
@@ -731,7 +732,7 @@ int Interp::find_tool_index(setup_pointer /*settings*/, int toolno, int *index)
     return INTERP_OK;
 }
 
-int Interp::find_tool_pocket(setup_pointer /*settings*/, int toolno, int *pocket)
+int Interp::find_tool_pocket(setup_pointer settings, int toolno, int *pocket)
 {
 #ifdef TOOL_NML //{
     if(!settings->random_toolchanger && toolno == 0) {
@@ -739,6 +740,7 @@ int Interp::find_tool_pocket(setup_pointer /*settings*/, int toolno, int *pocket
         return INTERP_OK;
     }
 #else //}{
+    (void)settings;
     // special case is included in tooldata_find_index_for_tool()
 #endif //}
     int idx = tooldata_find_index_for_tool(toolno);

--- a/src/emc/rs274ngc/interp_g7x.cc
+++ b/src/emc/rs274ngc/interp_g7x.cc
@@ -641,10 +641,11 @@ private:
 
 public:
     g7x() = default;
-    g7x(g7x const &other) : std::list<std::unique_ptr<segment>>() {
-	delta=other.delta;
-	escape=other.escape;
-	flip_state=other.flip_state;
+    g7x(g7x const &other)
+          : std::list<std::unique_ptr<segment>>(),
+            delta(other.delta),
+            escape(other.escape),
+            flip_state(other.flip_state) {
 	for(const auto &p : other)
 	    emplace_back(p->dup());
     }

--- a/src/emc/tooldata/tooldata_nml.cc
+++ b/src/emc/tooldata/tooldata_nml.cc
@@ -37,7 +37,7 @@ int tool_nml_register(CANON_TOOL_TABLE *tblptr)
     return 0;
 } //tool_nml_register
 
-void tooldata_last_index_set(int idx)
+void tooldata_last_index_set(int /*idx*/)
 {
     return; //not used with nml
 } //tooldata_last_index_set()

--- a/src/emc/usr_intf/emcsched.cc
+++ b/src/emc/usr_intf/emcsched.cc
@@ -86,18 +86,16 @@ class SchedEntry {
     void setTool(int t);
   };
 
-SchedEntry::SchedEntry() {
-    priority = 0;
-    tagId = 0;
-    xpos = 0.0;
-    ypos = 0.0;
-    zpos = 0.0;
-    zone = 0;
-    fileName = "";
-    feedOverride = 100.0;
-    spindleOverride = 100.0;
-    tool = 1;
-  }
+SchedEntry::SchedEntry()
+    : priority(0), tagId(0),
+      xpos(0.0), ypos(0.0), zpos(0.0),
+      zone(0),
+      programName(""), fileName(""),
+      feedOverride(100.0),
+      spindleOverride(100.0),
+      tool(1)
+{
+}
 
 list<SchedEntry> q;
 

--- a/src/libnml/buffer/shmem.cc
+++ b/src/libnml/buffer/shmem.cc
@@ -54,34 +54,21 @@ static inline bool not_zero(double x)
 /* SHMEM Member Functions. */
 
 /* Constructor for hard coded tests. */
-SHMEM::SHMEM(const char * /*n*/, long s, int /*nt*/, key_t k, int m):CMS(s)
+SHMEM::SHMEM(const char * /*n*/, long s, int /*nt*/, key_t k, int m)
+  : CMS(s), fast_mode(0), key(k), bsem_key(-1), shm(NULL), sem(NULL), master(m)
 {
-    /* Set pointers to null so only properly opened pointers are closed. */
-    shm = NULL;
-//  sem = NULL;
-
-    /* save constructor args */
-    master = m;
-    key = k;
-
     /* open the shared mem buffer and create mutual exclusion semaphore */
     open();
 }
 
 /* Constructor for use with cms_config. */
-SHMEM::SHMEM(const char *bufline, const char *procline, int set_to_server,
-    int set_to_master):CMS(bufline, procline, set_to_server)
+SHMEM::SHMEM(const char *bufline, const char *procline, int set_to_server, int set_to_master)
+  : CMS(bufline, procline, set_to_server), bsem_key(-1),
+    second_read(0), shm(NULL), sem(NULL), sem_delay(0.00001),
+    use_os_sem(1), use_os_sem_only(1), mutex_type(OS_SEM_MUTEX)
 {
     /* Set pointers to null so only properly opened pointers are closed. */
-    shm = NULL;
-    sem = NULL;
-    sem_delay = 0.00001;
     char *semdelay_equation;
-    use_os_sem = 1;
-    use_os_sem_only = 1;
-    mutex_type = OS_SEM_MUTEX;
-    bsem_key = -1;
-    second_read = 0;
 
     if (status < 0) {
 	rcs_print_error("SHMEM: status = %d\n", status);

--- a/src/libnml/posemath/posemath.cc
+++ b/src/libnml/posemath/posemath.cc
@@ -292,12 +292,9 @@ PM_ROTATION_MATRIX::PM_ROTATION_MATRIX(double xx, double xy, double xz,
     /*! \todo FIXME-- need a matrix orthonormalization function pmMatNorm() */
 }
 
-PM_ROTATION_MATRIX::PM_ROTATION_MATRIX(const PM_CARTESIAN& _x, const PM_CARTESIAN& _y,
-    const PM_CARTESIAN& _z)
+PM_ROTATION_MATRIX::PM_ROTATION_MATRIX(const PM_CARTESIAN& _x, const PM_CARTESIAN& _y, const PM_CARTESIAN& _z)
+    : x(_x), y(_y), z(_z)
 {
-    x = _x;
-    y = _y;
-    z = _z;
 }
 
 PM_ROTATION_MATRIX::PM_ROTATION_MATRIX(PM_CONST PM_ROTATION_VECTOR PM_REF v)
@@ -370,10 +367,8 @@ PM_CARTESIAN & PM_ROTATION_MATRIX::operator [](int n) {
 
 #ifdef INCLUDE_POSEMATH_COPY_CONSTRUCTORS
 PM_ROTATION_MATRIX::PM_ROTATION_MATRIX(PM_CCONST PM_ROTATION_MATRIX & m)
+    : x(m.x), y(m.y), z(m.z)
 {
-    x = m.x;
-    y = m.y;
-    z = m.z;
 }
 #endif
 // PM_QUATERNION class
@@ -696,17 +691,15 @@ double &PM_POSE::operator [] (int n) {
 
 #ifdef INCLUDE_POSEMATH_COPY_CONSTRUCTORS
 PM_POSE::PM_POSE(PM_CCONST PM_POSE & p)
+    : tran(p.tran), rot(p.rot)
 {
-    tran = p.tran;
-    rot = p.rot;
 }
 #endif
 // PM_HOMOGENEOUS class
 
 PM_HOMOGENEOUS::PM_HOMOGENEOUS(const PM_CARTESIAN& v, const PM_ROTATION_MATRIX&	 m)
+    : tran(v), rot(m)
 {
-    tran = v;
-    rot = m;
 }
 
 PM_HOMOGENEOUS::PM_HOMOGENEOUS(PM_CONST PM_POSE PM_REF p)
@@ -746,9 +739,8 @@ PM_CARTESIAN & PM_HOMOGENEOUS::operator [](int n) {
 
 #ifdef INCLUDE_POSEMATH_COPY_CONSTRUCTORS
 PM_HOMOGENEOUS::PM_HOMOGENEOUS(PM_CCONST PM_HOMOGENEOUS & h)
+    : tran(h.tran), rot(h.rot)
 {
-    tran = h.tran;
-    rot = h.rot;
 }
 #endif
 
@@ -756,10 +748,8 @@ PM_HOMOGENEOUS::PM_HOMOGENEOUS(PM_CCONST PM_HOMOGENEOUS & h)
 
 #ifdef INCLUDE_POSEMATH_COPY_CONSTRUCTORS
 PM_LINE::PM_LINE(PM_CCONST PM_LINE & l)
+    : start(l.start), end(l.end), uVec(l.uVec)
 {
-    start = l.start;
-    end = l.end;
-    uVec = l.uVec;
 }
 #endif
 
@@ -798,15 +788,10 @@ int PM_LINE::point(double len, PM_POSE * point)
 
 #ifdef INCLUDE_POSEMATH_COPY_CONSTRUCTORS
 PM_CIRCLE::PM_CIRCLE(PM_CCONST PM_CIRCLE & c)
+    : center(c.center), normal(c.normal),
+      rTan(c.rTan), rPerp(c.rPerp), rHelix(c.rHelix),
+      radius(c.radius), angle(c.angle), spiral(c.spiral)
 {
-    center = c.center;
-    normal = c.normal;
-    rTan = c.rTan;
-    rPerp = c.rPerp;
-    rHelix = c.rHelix;
-    radius = c.radius;
-    angle = c.angle;
-    spiral = c.spiral;
 }
 #endif
 


### PR DESCRIPTION
Initialization in modern C++ is done in the constructor with initialization lists (as identified by cppcheck). This PR rewrites parts of the constructors to use initialization lists.

Also fixed are a few minor problems when configured with --enable-toolnml. A different code-path is exposed with that option, requiring a previously commented out function's parameter and exposed one additional unused parameter.