### PR TITLE
AXIS GUI feature to allow DRO-type axis behavior when touching off

### DIFF
--- a/docs/src/gui/axis.adoc
+++ b/docs/src/gui/axis.adoc
@@ -512,16 +512,23 @@ image::images/touchoff.png["Touch Off Window",align="center"]
 
 See also the Machine menu options: 'Touch part' and 'Touch part holder'.
 
+.Actual Position Touch Off
+An axis may be configured in the .INI file to incorporate the actual position value for an axis into the touch off calculation, either adding or subtracting this value.  This is primarily useful for machines which have a non-motorized axis such as a quill with an encoder.  When this feature is enabled for an axis, the title bar of the touch off window will indicate *(system ACTUAL)*.
+
+See <<axis:touchoff-actual>> for more information.
+
 .Tool Touch Off
 By pressing the 'Tool Touch Off' button the tool length and offsets of
 the currently loaded tool will be changed so that the current tool tip
 position matches the entered coordinate.
+
 
 .Tool Touch Off Window
 image::images/tooltouchoff.png["Tool Touch Off Window",align="center"]
 
 See also the 'Tool touch off to workpiece' and 'Tool touch off to fixture'
 options in the Machine menu.
+
 
 .Override Limits
 By pressing Override Limits, the machine will temporarily be allowed
@@ -983,6 +990,24 @@ preview on certain parts that are already working OK).
 - (AXIS,notify,the_text) Displays the_text as an info display
 
 This display can be useful in the AXIS preview when (debug,message) comments are not displayed.
+
+[[axis:touchoff-actual]]
+=== Touch Off using Actual Position
+The Touch Off feature can optionally incorporate the actual axis position value into the calculation for the offset.  This is primarily used in cases where a non-motorized axis such as the quill in a milling machine provides feedback to LinuxCNC via an encoder, but there is no motor to control movement.  This allows AXIS to provide a DRO display for such an axis with working touch off capability.
+
+This feature is enabled on an axis by altering the appropriate '[AXIS_x]' section of the .INI file.  Add an option named 'TOUCHOFF_ACTUAL' and set the value to 'PLUS' or 'MINUS' depending on how you want to apply the actual position to the offset.
+
+Example:
+
+[source,{ini}]
+----
+[AXIS_Z]
+TOUCHOFF_ACTUAL = MINUS
+----
+
+Ordinarily, only the commanded position of an axis is used to set this offset, meaning it does not work properly because non-motorized axes are never commanded to move and thus their commanded position is always 0.
+
+Touch off sends a 'G10 L20' command to the MDI to set the new offset value.  The value applied is normally just the value entered into the dialog box. When this feature is enabled, it will either add or subtract the current position value from the value entered in the dialog, depending on how it is configured.
 
 [[sec:axis-axisui-pins]]
 == Axisui(((AXIS: axisui pins)))

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -2798,7 +2798,7 @@ class TclCommands(nf.TclCommands):
         # calculation.  this is for unmotorized axes where the commanded position does not change, but actual does via an external encoder.
         if axis_letter_upper in position_tuple_order and inifile.find("AXIS_%s" % axis_letter_upper, "TOUCHOFF_ACTUAL") is not None:
             axis_idx = position_tuple_order.index(axis_letter_upper)
-            new_axis_value = str(float(new_axis_value) + s.actual_position[axis_idx])
+            new_axis_value = str(float(new_axis_value) - s.actual_position[axis_idx])
 
         offset_command = "G10 L20 %s %c[[%s]*%.12f]" % (system.split()[0], axis_letter_upper, new_axis_value, scale)
         c.mdi(offset_command)

--- a/src/emc/usr_intf/axis/scripts/axis.py
+++ b/src/emc/usr_intf/axis/scripts/axis.py
@@ -2765,12 +2765,15 @@ class TclCommands(nf.TclCommands):
 
     def touch_off_system(event=None, new_axis_value = None):
         global system
+        axis_letter = vars.ja_rbutton.get()
+        axis_letter_upper = axis_letter.upper()
+        position_tuple_order = "XYZABCUVW"
+
         if not manual_ok(): return
-        offset_axis = trajcoordinates.index(vars.ja_rbutton.get())
         if new_axis_value is None:
             new_axis_value, system = prompt_touchoff(
                 title=_("Touch Off (system)"),
-                text=_("Enter %s coordinate relative to %%s:") % vars.ja_rbutton.get().upper(),
+                text=_("Enter %s coordinate relative to %%s:") % axis_letter_upper,
                 default=0.0,
                 tool_only=False,
                 system=vars.touch_off_system.get()
@@ -2784,14 +2787,20 @@ class TclCommands(nf.TclCommands):
         ensure_mode(linuxcnc.MODE_MDI)
         s.poll()
 
-        linear_axis = vars.ja_rbutton.get() in "xyzuvw"
+        linear_axis = axis_letter in "xyzuvw"
         if linear_axis and vars.metric.get(): scale = 1/25.4
         else: scale = 1
 
         if linear_axis and 210 in s.gcodes:
             scale *= 25.4
 
-        offset_command = "G10 L20 %s %c[[%s]*%.12f]" % (system.split()[0], vars.ja_rbutton.get(), new_axis_value, scale)
+        # set TOUCHOFF_ACTUAL = TRUE under the appropriate [AXIS_x] section in the .INI file to incorporate the actual position into the touch-off
+        # calculation.  this is for unmotorized axes where the commanded position does not change, but actual does via an external encoder.
+        if axis_letter_upper in position_tuple_order and inifile.find("AXIS_%s" % axis_letter_upper, "TOUCHOFF_ACTUAL") is not None:
+            axis_idx = position_tuple_order.index(axis_letter_upper)
+            new_axis_value = str(float(new_axis_value) + s.actual_position[axis_idx])
+
+        offset_command = "G10 L20 %s %c[[%s]*%.12f]" % (system.split()[0], axis_letter_upper, new_axis_value, scale)
         c.mdi(offset_command)
         c.wait_complete()
 


### PR DESCRIPTION
I have a mill with a non-motorized quill (Z), but it has a magnetic encoder feeding back to LinuxCNC.  My goal was to simply view the Z axis like a traditional DRO within the AXIS GUI, and most importantly, be able to "touch off" in different WCS.

With this axis, the "commanded position" never changes (because it's never instructed to move or jogged), but the "actual position" does (via the encoder).  The "Touch Off" feature in AXIS doesn't have any effect because the underlying G10 L20 command is only aware of the commanded position.

This is a small patch to change the touch_off_system function in AXIS GUI to incorporate both the touch-off value entered by the user as well as the current axis position into the value sent to the G10 L20 command that does the actual "touch-off" process.  It is only active on an axis when TOUCHOFF_ACTUAL=TRUE is set for the desired axis, e.g. in the [AXIS_Z] section of the .INI file.
