### PR TITLE
Use C++20 as compile standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        image: ["debian:bullseye", "debian:bookworm", "debian:sid"]
+        image: ["debian:bookworm", "debian:sid"]
     container:
       image: ${{ matrix.image }}
       # IPC_OWNER is needed for shmget IPC_CREAT
@@ -176,7 +176,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        image: ["debian:bullseye", "debian:bookworm", "debian:sid"]
+        image: ["debian:bookworm", "debian:sid"]
     container:
       image: ${{ matrix.image }}
       # IPC_OWNER is needed for shmget IPC_CREAT

--- a/src/Makefile
+++ b/src/Makefile
@@ -255,7 +255,6 @@ OPT := -Os $(INTEGER_OVERFLOW_FLAGS)
 DEBUG := $(DEBUG) -g -Wall -D_FORTIFY_SOURCE=2
 CFLAGS := $(INCLUDE) $(OPT) $(DEBUG) -DULAPI -std=gnu11 -Werror=implicit-function-declaration $(CFLAGS) $(CPPFLAGS) $(EXTRA_DEBUG)
 CXXFLAGS := $(INCLUDE) $(OPT) $(DEBUG) -DULAPI -Werror=overloaded-virtual $(CXXFLAGS) $(CPPFLAGS) $(EXTRA_DEBUG)
-CXXFLAGS += -std=gnu++20
 # In Debian 11, any inclusion of <boost/python.hpp> leads to several
 # diagnostics from included headers about deprecated features. LinuxCNC does
 # not directly use these deprecated features, but it does use boost::python.

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -39,7 +39,7 @@ m4_include([m4/ax_python.m4])
 m4_include([m4/ax_python_devel.m4])
 m4_include([m4/ax_boost_base.m4])
 m4_include([m4/ax_boost_python.m4])
-AX_CXX_COMPILE_STDCXX(17, , mandatory)
+AX_CXX_COMPILE_STDCXX(20, , mandatory)
 
 AC_MSG_CHECKING(build toplevel)
 BUILD_TOPLEVEL="$(cd ..; pwd -P)"
@@ -405,14 +405,6 @@ if test -z "$CC"; then
 elif ! test `$CC -dumpversion | cut -d '.' -f 1` -gt 2 ; then
   AC_MSG_ERROR([Compilers older than gcc 3.x are no longer supported])
 fi
-
-# Set flags for C and C++ if supported
-for commonflag in -Wno-stringop-truncation ; do
-  if echo "int main() { return 0;}" | $CC -Werror $commonflag -E - > /dev/null; then
-    CFLAGS="${CFLAGS:+$CFLAGS }$flag"
-    CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$flag"
-  fi
-done
 
 AC_MSG_CHECKING([for usability of linux/hidraw.h])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
@@ -1559,7 +1551,7 @@ AC_SUBST([READLINE_LIBS])
 # if you don't have nls tools, allow a way out!
 
 AC_ARG_ENABLE(nls,
-    AS_HELP_STRING([--disable-nls], [Don't use NLS.]),
+    AS_HELP_STRING([--disable-nls], [Do not use NLS.]),
               USE_NLS=no, USE_NLS=yes)
 AC_SUBST(USE_NLS)
 
@@ -1669,6 +1661,37 @@ AC_CHECK_HEADERS(X11/Xmu/Xmu.h,[],[AC_MSG_ERROR([Required Xmu header missing.  I
 
 AC_SUBST([LIBPYTHON])
 AC_SUBST([SITEPY])
+
+#
+# Add extra options to CFLAGS and CXXFLAGS
+#
+add_to_cflags() {
+    # Add $1 to CFLAGS and CXXFLAGS if not already there
+    if test -z "$1"; then return; fi
+    if echo "$CFLAGS" | grep -q -w -v -- "$1"; then
+        CFLAGS="${CFLAGS:+$CFLAGS }$1"
+    fi
+    if echo "$CXXFLAGS" | grep -q -w -v -- "$1"; then
+        CXXFLAGS="${CXXFLAGS:+$CXXFLAGS }$1"
+    fi
+}
+
+# Always add -Wextra
+add_to_cflags "-Wextra"
+
+# The last thing before subst-exporting CFLAGS and CXXFLAGS is to add -Werror
+# if requested. Doing it earlier causes conf-tests to fail that are supposed to
+# succeed when they generate warnings.
+AC_ARG_ENABLE(werror,
+    AS_HELP_STRING(
+      [--enable-werror],
+      [Treat all compiler warnings as errors (-Werror).],
+    ),
+    [
+      case "$enableval" in
+        (yes) add_to_cflags "-Werror" ;;
+      esac
+    ])
 
 AC_SUBST([CFLAGS])
 AC_SUBST([CPPFLAGS])


### PR DESCRIPTION
This PR changes the required C++ standard to C++20, as discussed in #3296. The consequence is that Bullseye/Debian 11 is dropped as supported distribution and removed from CI.

Also fixed in this PR:
* Drop useless compiler-flag test in configure. It is never added to CFLAGS/CXXFLAGS anyway due to a spelling error (<code>flag</code> vs. <code>commonflag</code>). Regardless, the tested compiler-flag is unnecessary because the code has already been fixed (and the test always failed on clang). If compiler-flags are required you should add CFLAGS= or CXXFLAGS= to the configure command-line.
* Remove a contraction in an explanatory text (Don't -> Do not) because vim has trouble syntax highlighting beyond it.
* Always add compiler-flag <code>-Wextra</code>. We are currently completely warning free. Lets keep it that way.
* Add a configure option <code>--enable-werror</code> to set the <code>-Werror</code> compiler-flag. In the near future this should be added to CI's rip-and-test and rip-and-test-clang tests to stay warning free.