### PR TITLE
Remove duplicated non-virtual base-class method

### DIFF
--- a/src/libnml/nml/nmlmsg.cc
+++ b/src/libnml/nml/nmlmsg.cc
@@ -95,12 +95,3 @@ void NMLmsg::clear()
 	size = sizeof(NMLmsg);
     }
 }
-
-/* Error message stub for base class. */
- /* update should only be called with derived classes. */
-void NMLmsg::update(CMS * cms)
-{
-    rcs_print_error("update called for NMLmsg base class.");
-    rcs_print_error("(This is an error.)\n");
-    cms->status = CMS_MISC_ERROR;
-}

--- a/src/libnml/nml/nmlmsg.hh
+++ b/src/libnml/nml/nmlmsg.hh
@@ -56,8 +56,6 @@ class NMLmsg {
     NMLTYPE type;		/* Each derived type should have a unique id */
     long size;			/* The size is used so that the entire buffer 
 				   is not copied unnecessarily. */
-
-    void update(CMS *);
 };
 
 // This is just a symbol passed to the RCS Java Tools (CodeGen, RCS-Design, RCS-Diagnostis)


### PR DESCRIPTION
A non-virtual method cannot be "properly" overloaded. It is also a pointless construct because the base-class method claims it should never be called. Therefore, it should not exists at all, resulting in it never being called (and the compiler will error if you try).

This particular method cannot be made virtual because of the vtable, which cannot be located in shared memory (pointers are not valid across shmem maps). Anyway, there is no point in having it at all in the base-class. Derived classes must declare and define it where necessary.

Cppcheck found this issue [duplInheritedMember] and this PR is the first part of fixing the this problem class. This PR roughly halves the reported instances of the warning.