### PR TITLE
Undo quoting of HALCOMMAND

### DIFF
--- a/scripts/linuxcnc.in
+++ b/scripts/linuxcnc.in
@@ -954,7 +954,9 @@ HALCOMMAND=$($INIVAR -ini "$INIFILE" -var HALCMD -sec HAL -num $NUM 2> /dev/null
 while [ -n "$HALCOMMAND" ] ; do
     if [ -n "$HALCOMMAND" ] ; then
 	echo "Running HAL command: $HALCOMMAND" >> "$PRINT_FILE"
-	if ! $HALCMD "$HALCOMMAND" && [ -z "$DASHK" ]; then
+        # The HALCOMMAND must be word-split
+        # shellcheck disable=SC2086
+	if ! $HALCMD $HALCOMMAND && [ -z "$DASHK" ]; then
 	    echo "INI file HAL command $HALCOMMAND failed."
 	    Cleanup
 	    exit 1


### PR DESCRIPTION
The variable HALCOMMAND is expected to be word-split in the expansion of the halcmd call. It got quoted in the shellcheck fixes. This fixes #3328.