### PR TITLE
Remove split read timeout message

### DIFF
--- a/src/emc/motion/usrmotintf.cc
+++ b/src/emc/motion/usrmotintf.cc
@@ -137,7 +137,8 @@ int usrmotReadEmcmotStatus(emcmot_status_t * s)
 	}
 	/* inc counter and try again, max three times */
     } while ( ++split_read_count < 3 );
-    rcs_print("%s: Split read timeout\n", __FUNCTION__);
+    /* A timeout is harmless. It will be tried again, soon enough */
+    /* rcs_print("%s: Split read timeout\n", __FUNCTION__); */
     return EMCMOT_COMM_SPLIT_READ_TIMEOUT;
 }
 


### PR DESCRIPTION
The message is misleading to users. It is harmless to timeout here because it will be tried again shortly after.