### PR TITLE
Fix various problems and bugs detected by cppcheck

### DIFF
--- a/src/emc/canterp/canterp.cc
+++ b/src/emc/canterp/canterp.cc
@@ -586,7 +586,7 @@ int Canterp::execute(const char *line) {
     }
 
     if (!strcmp(the_command_name, "ORIENT_SPINDLE")) {
-	if (3 != sscanf(the_command_args, "%d %lf %s", &i1, &d1, s1)) {
+	if (3 != sscanf(the_command_args, "%d %lf %255s", &i1, &d1, s1)) {
 	    return INTERP_ERROR;
 	}
 	if (!strcmp(s1, "CANON_CLOCKWISE")) {

--- a/src/emc/ini/initraj.cc
+++ b/src/emc/ini/initraj.cc
@@ -280,7 +280,7 @@ static int loadTraj(EmcIniFile *trajInifile)
                     continue;    // position t at index of next non-zero mark
                 }
                 // there is a mark, so read the string for a value
-                if (1 == sscanf(&homes[len], "%s", home) &&
+                if (1 == sscanf(&homes[len], "%255s", home) &&
                     1 == sscanf(home, "%lf", &d)) {
                     // got an entry, index into coordinateMark[] is 't'
                     if (t == 0)

--- a/src/emc/ini/initraj.cc
+++ b/src/emc/ini/initraj.cc
@@ -295,12 +295,15 @@ static int loadTraj(EmcIniFile *trajInifile)
                         homePose.b = d;
                     else if (t == 5)
                         homePose.c = d;
+/*
+ * The following have no effect. The loop only counts [0..5].
                     else if (t == 6)
                         homePose.u = d;
                     else if (t == 7)
                         homePose.v = d;
                     else
                         homePose.w = d;
+*/
 
                     // position string ptr past this value
                     len += strlen(home);

--- a/src/emc/ini/initraj.cc
+++ b/src/emc/ini/initraj.cc
@@ -280,7 +280,7 @@ static int loadTraj(EmcIniFile *trajInifile)
                     continue;    // position t at index of next non-zero mark
                 }
                 // there is a mark, so read the string for a value
-                if (1 == sscanf(&homes[len], "%255s", home) &&
+                if (1 == sscanf(&homes[len], "%254s", home) &&
                     1 == sscanf(home, "%lf", &d)) {
                     // got an entry, index into coordinateMark[] is 't'
                     if (t == 0)

--- a/src/emc/motion/motion.c
+++ b/src/emc/motion/motion.c
@@ -212,9 +212,13 @@ static rtapi_msg_handler_t old_handler = NULL;
 static void emc_message_handler(msg_level_t level, const char *fmt, va_list ap)
 {
     va_list apc;
+    // False positive. Cppcheck does not seem to know the properties of va_copy()
+    // cppcheck-suppress va_list_usedBeforeStarted
     va_copy(apc, ap);
+    // cppcheck-suppress va_list_usedBeforeStarted
     if(level == RTAPI_MSG_ERR) emcmotErrorPutfv(emcmotError, fmt, apc);
     if(old_handler) old_handler(level, fmt, ap);
+    // cppcheck-suppress va_list_usedBeforeStarted
     va_end(apc);
 }
 

--- a/src/emc/task/emccanon.cc
+++ b/src/emc/task/emccanon.cc
@@ -2039,7 +2039,7 @@ void NURBS_FEED_DIVIDE(int lineno,
 		// ridefinisco Control_point per il primo SGMENTO (1) NURBS
 		// ich definiere Control_point für die ersten SGMENTO (1) NURBS neu
 		nurbs_control_points.clear();
-		NURBS_G6_CONTROL_POINT CPU;
+		NURBS_G6_CONTROL_POINT CPU = {};
 		if (j_segment == 0) {
 			for (unsigned j = 0;
 			     j < nurbs_control_points1.size(); ++j) {

--- a/src/emc/task/signalhandler.cc
+++ b/src/emc/task/signalhandler.cc
@@ -138,6 +138,8 @@ int main(int argc, const char *argv[]) {
     sleep(10);  // during which a SIGUSR2 will generate a backtrace
 
     void *foo = 0;
+    // Fully intentional
+    // cppcheck-suppress nullPointer
     memset(foo,0,47); // this segfault would warp us into the gdb window
 
     return 0;

--- a/src/emc/usr_intf/sockets.c
+++ b/src/emc/usr_intf/sockets.c
@@ -259,7 +259,7 @@ char* sockGetError(void)
 #else
   static char retString[256];
   long err;
-  char* tmp;
+  char* tmp = NULL;
 
   err = WSAGetLastError();
 

--- a/src/emc/usr_intf/sockets.c
+++ b/src/emc/usr_intf/sockets.c
@@ -276,9 +276,12 @@ char* sockGetError(void)
 
     /* append the message text after the error code and ensure a terminating
        character ends the string */
+  // The 'tmp' buffer is allocated by FormatMessage().
+  // cppcheck-suppress nullPointer
   strncpy(retString + strlen(retString), tmp, 
           sizeof(retString) - strlen(retString) - 1);
   retString[sizeof(retString) - 1] = '\0';
+  LocalFree(tmp);
 
   return retString;
 #endif

--- a/src/hal/classicladder/arrays.c
+++ b/src/hal/classicladder/arrays.c
@@ -315,7 +315,7 @@ int ClassicLadder_AllocAll()
 #endif
     VarWordArray = (int *) pByte;
  	   pByte += SIZE_VAR_WORD_ARRAY * sizeof(int);
-    VarFloatArray =(double *) pByte;
+    VarFloatArray =(double *)(void *)pByte;
            pByte += SIZE_VAR_FLOAT_ARRAY * sizeof(double);
     // Allocate last for alignment reasons.
     VarArray = (TYPE_FOR_BOOL_VAR *) pByte;

--- a/src/hal/classicladder/edit.c
+++ b/src/hal/classicladder/edit.c
@@ -1367,7 +1367,7 @@ void EditElementInRung(double x,double y)
 		if (EditDatas.NumElementSelectedInToolBar==EDIT_LONG_CONNECTION)
 		{
 			int ScanX = RungX;
-			while(EditDatas.Rung.Element[ScanX][RungY].Type==ELE_FREE && ScanX<RUNG_WIDTH-1 )
+			while(ScanX<RUNG_WIDTH-1 && EditDatas.Rung.Element[ScanX][RungY].Type==ELE_FREE)
 			{
 				EditDatas.Rung.Element[ScanX++][RungY].Type = ELE_CONNECTION;
 			}

--- a/src/hal/classicladder/edit_gtk.c
+++ b/src/hal/classicladder/edit_gtk.c
@@ -390,7 +390,7 @@ void InitAllForToolbar( void )
 
 void CreateOneToolbar( GtkWidget * Box, int NumTable, char * PtrOnToolTipsText[][NBR_ELE_TOOLBAR_X_MAX] )
 {
-	StrElement ToolBarEle;
+	StrElement ToolBarEle = {};
 	int ScanToolBarX,ScanToolBarY;
 	GSList * PtrListRadiosBtn = NULL;
 	StrToolbarDatas * pToolbarDatas = &ToolbarDatas[ NumTable ];

--- a/src/hal/components/stepgen.c
+++ b/src/hal/components/stepgen.c
@@ -312,11 +312,11 @@
 MODULE_AUTHOR("John Kasunich");
 MODULE_DESCRIPTION("Step Pulse Generator for EMC HAL");
 MODULE_LICENSE("GPL");
-int step_type[] = { [0 ... MAX_CHAN-1] = -1 } ;
+int step_type[MAX_CHAN] = { [0 ... MAX_CHAN-1] = -1 } ;
 RTAPI_MP_ARRAY_INT(step_type,MAX_CHAN,"stepping types for up to 16 channels");
 char *ctrl_type[MAX_CHAN];
 RTAPI_MP_ARRAY_STRING(ctrl_type,MAX_CHAN,"control type (pos or vel) for up to 16 channels");
-int user_step_type[] = { [0 ... MAX_CYCLE-1] = -1 };
+int user_step_type[MAX_CYCLE] = { [0 ... MAX_CYCLE-1] = -1 };
 RTAPI_MP_ARRAY_INT(user_step_type, MAX_CYCLE,
 	"lookup table for user-defined step type");
 

--- a/src/hal/drivers/cpuinfo.c
+++ b/src/hal/drivers/cpuinfo.c
@@ -33,7 +33,7 @@ int get_rpi_revision(void)
     FILE *fp;
     char buffer[1024];
     char *r;
-    unsigned int revision;
+    unsigned int revision = 0;
 
     if ((fp = fopen("/sys/firmware/devicetree/base/model", "r")) == NULL)
         return -1;

--- a/src/hal/drivers/hal_bb_gpio.c
+++ b/src/hal/drivers/hal_bb_gpio.c
@@ -218,20 +218,18 @@ int rtapi_app_main(void) {
             if (pin < 300)
                 pin += 700;
 
-            if(pin < 801 || pin > 946 || (pin > 846 && pin < 901)) {
-                rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: invalid pin number '%d'.  Valid pins are 801-846 for P8 pins, 901-946 for P9 pins.\n", modname, pin);
-                hal_exit(comp_id);
-                return -1;
-            }
-
-            if(pin < 900) {
+            if(pin >= 801 && pin <= 846) {
                 pin -= 800;
                 bbpin = &p8_pins[pin];
                 header = 8;
-            } else {
+            } else if(pin >= 901 && pin <= 946) {
                 pin -= 900;
                 bbpin = &p9_pins[pin];
                 header = 9;
+            } else {
+                rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: invalid pin number '%d'.  Valid pins are 801-846 for P8 pins, 901-946 for P9 pins.\n", modname, pin);
+                hal_exit(comp_id);
+                return -1;
             }
 
             if(bbpin->claimed != 0) {
@@ -294,20 +292,18 @@ int rtapi_app_main(void) {
             if (pin < 300)
                 pin += 700;
 
-            if(pin < 801 || pin > 946 || (pin > 846 && pin < 901)) {
-                rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: invalid pin number '%d'.  Valid pins are 801-846 for P8 pins, 901-946 for P9 pins.\n", modname, pin);
-                hal_exit(comp_id);
-                return -1;
-            }
-
-            if(pin < 900) {
+            if(pin >= 801 && pin <= 846) {
                 pin -= 800;
                 bbpin = &p8_pins[pin];
                 header = 8;
-            } else {
+            } else if(pin >= 901 && pin <= 946) {
                 pin -= 900;
                 bbpin = &p9_pins[pin];
                 header = 9;
+            } else {
+                rtapi_print_msg(RTAPI_MSG_ERR, "%s: ERROR: invalid pin number '%d'.  Valid pins are 801-846 for P8 pins, 901-946 for P9 pins.\n", modname, pin);
+                hal_exit(comp_id);
+                return -1;
             }
 
             if(bbpin->claimed != 0) {

--- a/src/hal/drivers/mesa-hostmot2/sserial.c
+++ b/src/hal/drivers/mesa-hostmot2/sserial.c
@@ -1549,7 +1549,7 @@ fail1:
                                 case 64:
                                     shift = 0;
                                 }
-                            if (abs(((int)(p->s64_param) - (int)(p->s64_written)) >> shift) > 2) break;
+                            if (labs((p->s64_param - p->s64_written) >> shift) > 2) break;
                             *inst->state2 = 2; // increment indices
                             return *inst->state2;
                         default:

--- a/src/hal/drivers/mesa-hostmot2/tram.c
+++ b/src/hal/drivers/mesa-hostmot2/tram.c
@@ -58,6 +58,8 @@ int hm2_register_tram_read_region(hostmot2_t *hm2, rtapi_u16 addr, rtapi_u16 siz
 
     rtapi_list_add_tail(&tram_entry->list, &hm2->tram_read_entries);
 
+    // Not a memory leak. The 'tram_entry' is part of the list.
+    // cppcheck-suppress memleak
     return 0;
 }
 
@@ -77,6 +79,8 @@ int hm2_register_tram_write_region(hostmot2_t *hm2, rtapi_u16 addr, rtapi_u16 si
 
     rtapi_list_add_tail(&tram_entry->list, &hm2->tram_write_entries);
 
+    // Not a memory leak. The 'tram_entry' is part of the list.
+    // cppcheck-suppress memleak
     return 0;
 }
 

--- a/src/hal/user_comps/vfdb_vfd/vfdb_vfd.c
+++ b/src/hal/user_comps/vfdb_vfd/vfdb_vfd.c
@@ -336,7 +336,7 @@ int read_ini(param_pointer p)
                 "even",'E',
                 "odd", 'O',
                 "none", 'N',
-                NULL) == KEYWORD_INVALID)
+                (void *)NULL) == KEYWORD_INVALID)
             return -1;
         p->parity = value;
     } else {

--- a/src/hal/user_comps/vfs11_vfd/vfs11_vfd.c
+++ b/src/hal/user_comps/vfs11_vfd/vfs11_vfd.c
@@ -466,7 +466,7 @@ int read_ini(param_pointer p)
 		    "even",'E', 
 		    "odd", 'O', 
 		    "none", 'N',
-		    NULL) == KEYWORD_INVALID)
+		    (void *)NULL) == KEYWORD_INVALID)
 	    return -1;
 	p->parity = value;
 
@@ -475,7 +475,7 @@ int read_ini(param_pointer p)
 		    "up", MODBUS_RTU_RTS_UP,
 		    "down", MODBUS_RTU_RTS_DOWN, 
 		    "none", MODBUS_RTU_RTS_NONE,
-		    NULL) == KEYWORD_INVALID)
+		    (void *)NULL) == KEYWORD_INVALID)
 	    return -1;
 #else
 	if (iniFind(p->fp, "RTS_MODE", p->section) != NULL) {
@@ -488,14 +488,14 @@ int read_ini(param_pointer p)
 	if (findkwd(p,"SERIAL_MODE", &p->serial_mode,
 		    "rs232", MODBUS_RTU_RS232,
 		    "rs485", MODBUS_RTU_RS485,
-		    NULL) == KEYWORD_INVALID)
+		    (void *)NULL) == KEYWORD_INVALID)
 	    return -1;
 
 	if (findkwd(p, "TYPE", &p->type,
 		    "rtu", TYPE_RTU, 
 		    "tcpserver", TYPE_TCP_SERVER, 
 		    "tcpclient", TYPE_TCP_CLIENT, 
-		    NULL) == NAME_NOT_FOUND) {
+		    (void *)NULL) == NAME_NOT_FOUND) {
 	    fprintf(stderr, "%s: missing required TYPE in section %s\n", 
 		    p->progname, p->section);
 	    return -1;

--- a/src/hal/user_comps/xhc-hb04.cc
+++ b/src/hal/user_comps/xhc-hb04.cc
@@ -677,7 +677,7 @@ int read_ini_file(char *filename)
 	}
 
 	while ((bt = iniFile.Find("BUTTON", section, nb_buttons+1)) && nb_buttons < NB_MAX_BUTTONS) {
-		if (sscanf(*bt, "%x:%s", &xhc.buttons[nb_buttons].code, xhc.buttons[nb_buttons].pin_name) !=2 ) {
+		if (sscanf(*bt, "%x:%255s", &xhc.buttons[nb_buttons].code, xhc.buttons[nb_buttons].pin_name) !=2 ) {
 			fprintf(stderr, "%s: syntax error\n", *bt);
 			return -1;
 		}

--- a/src/hal/user_comps/xhc-whb04b-6/hal.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.cc
@@ -58,7 +58,7 @@ void Hal::freeSimulatedPin(void** pin)
     if (*pin != nullptr)
     {
         free(*pin);
-        pin = nullptr;
+        *pin = nullptr;
     }
 }
 // ----------------------------------------------------------------------
@@ -573,11 +573,6 @@ void Hal::init(const MetaButtonCodes* metaButtons, const KeyCodes& keyCodes)
     newHalBit(HAL_OUT, &(memory->out.axisCSelect), mHalCompId, "%s.halui.axis.c.select", mComponentPrefix);
 
     mIsInitialized = true;
-}
-// ----------------------------------------------------------------------
-bool Hal::isInitialized()
-{
-    return mIsInitialized;
 }
 // ----------------------------------------------------------------------
 real_t Hal::getAxisXPosition(bool absolute) const

--- a/src/hal/user_comps/xhc-whb04b-6/hal.h
+++ b/src/hal/user_comps/xhc-whb04b-6/hal.h
@@ -345,7 +345,7 @@ public:
     void init(const MetaButtonCodes* metaButtons, const KeyCodes& codes);
     //! \return true if void init(const MetaButtonCodes*, const KeyCodes&) has been called beforehand,
     //! false otherwise
-    bool isInitialized();
+    bool isInitialized() const { return mIsInitialized; };
     //! \return true if simulation mode is enabled, false otherwise
     bool isSimulationModeEnabled() const;
     //! indicates the program has been invoked in hal mode or normal

--- a/src/hal/utils/scope_disp.c
+++ b/src/hal/utils/scope_disp.c
@@ -515,7 +515,7 @@ static int handle_click(GtkWidget *widget, GdkEventButton *event, gpointer data)
     } else {
         int z = select_trace(event->x, event->y);
         int new_channel = z & 0xff;
-        int channel_part = z >> 8;
+        int channel_part = (unsigned)z >> 8;
 
         disp->selected_part = channel_part;
 

--- a/src/libnml/cms/cms_cfg.cc
+++ b/src/libnml/cms/cms_cfg.cc
@@ -496,7 +496,7 @@ int hostname_matches_bufferline(char *bufline)
     }
     while (j < num_my_hostent_addresses && j < 16) {
 	k = 0;
-	while (buffer_hostent_ptr->h_addr_list[k] != 0 && k < 16) {
+	while (k < 16 && buffer_hostent_ptr->h_addr_list[k] != 0) {
 	    if (!memcmp
 		(my_hostent_addresses[j], buffer_hostent_ptr->h_addr_list[k],
 		    my_hostent.h_length)) {

--- a/src/libnml/rcs/rcs_print.cc
+++ b/src/libnml/rcs/rcs_print.cc
@@ -173,20 +173,22 @@ void convert_print_list_to_lines()
 		    temp_buf = (char *) malloc(strlen(string_from_list) + 1);
 		    rtapi_strlcpy(temp_buf, string_from_list, strlen(string_from_list) + 1);
 		} else {
-		    temp_buf = (char *) realloc(temp_buf, strlen(temp_buf)
-			+ strlen(string_from_list) + 1);
-		    strcat(temp_buf, string_from_list);
+		    char *ra = (char *) realloc(temp_buf, strlen(temp_buf) + strlen(string_from_list) + 1);
+		    if(ra) {
+			temp_buf = ra;
+			strcat(temp_buf, string_from_list);
+		    }
 		}
 		rcs_print_list->delete_current_node();
 	    } else {
 		if (temp_buf != NULL) {
-		    temp_buf = (char *) realloc(temp_buf, strlen(temp_buf)
-			+ strlen(string_from_list) + 1);
-		    strcat(temp_buf, string_from_list);
-		    rcs_print_list->delete_current_node();
-		    rcs_print_list->store_after_current_node(temp_buf,
-			strlen(temp_buf)
-			+ 1, 1);
+		    char *ra = (char *) realloc(temp_buf, strlen(temp_buf) + strlen(string_from_list) + 1);
+		    if(ra) {
+			temp_buf = ra;
+			strcat(temp_buf, string_from_list);
+			rcs_print_list->delete_current_node();
+			rcs_print_list->store_after_current_node(temp_buf, strlen(temp_buf) + 1, 1);
+		    }
 		    free(temp_buf);
 		    temp_buf = NULL;
 		} else if (next_line[1] != 0) {
@@ -214,9 +216,8 @@ void update_lines_table()
     }
     if (NULL != rcs_print_list) {
 	convert_print_list_to_lines();
-	rcs_lines_table = (char **) malloc(sizeof(char *)
-	    * rcs_print_list->list_size);
-	if (NULL != rcs_print_list) {
+	rcs_lines_table = (char **) malloc(sizeof(char *) * rcs_print_list->list_size);
+	if (NULL != rcs_lines_table) {
 	    char *string_from_list;
 	    string_from_list = (char *) rcs_print_list->get_head();
 	    int i = 0;

--- a/src/libnml/rcs/rcs_print.cc
+++ b/src/libnml/rcs/rcs_print.cc
@@ -276,7 +276,7 @@ int separate_words(char **_dest, int _max, char *_src)
     }
     rtapi_strxcpy(word_buffer, _src);
     _dest[0] = strtok(word_buffer, " \n\r\t");
-    for (i = 0; NULL != _dest[i] && i < _max - 1; i++) {
+    for (i = 0; i < _max - 1 && NULL != _dest[i]; i++) {
 	_dest[i + 1] = strtok(NULL, " \n\r\t");
     }
     if (_dest[_max - 1] == NULL && i == _max - 1) {


### PR DESCRIPTION
This PR has an assortment of fixes for cppcheck detected problems and some are real bugs. Fixes include:
* The hal/drivers/mesa-hostmot2/sserial.c had a 5 year old warning "fix" that demoted 64-bit values to int. That fix ignored the actual use-case and resulted in a 32-bit value being shifted by 48 and failing the intended test.
* Several instances had array index tests that were performed <i>after</i> the array index dereference. These tests needed to be reversed.
* Pushing NULL as a (string list) terminating argument in an vararg function may fail because NULL is not guaranteed to be a pointer. It must be force-cast to pointer to become a proper terminator.
* Multiple places where variables were not properly initialized.
* realloc() can fail and it will leak memory if the argument pointer is reassigned before testing.
* Several cppcheck false positives or intentional constructs were marked to have the message suppressed.
* Limit sscanf %s format to the argument buffer size minus one (like in <code>%255s</code>).
* A buffer free intended to clear the pointer variable but was missing a dereference.