### PR TITLE
Fix 25 year old typo

### DIFF
--- a/docs/src/gcode/overview.adoc
+++ b/docs/src/gcode/overview.adoc
@@ -1182,7 +1182,7 @@ position of each item on the line, but by the following list:
 * Set distance mode (G90, G91).
 * Set retract mode (G98, G99).
 * Go to reference location (G28, G30) or change coordinate system
-  data (G10) or set axis offsets (G52, G92, G92.1, G92.2, G94).
+  data (G10) or set axis offsets (G52, G92, G92.1, G92.2, G92.3).
 * Perform motion (G0 to G3, G33, G38.n, G73, G76, G80 to G89), as modified
   (possibly) by G53.
 * Stop (M0, M1, M2, M30, M60).


### PR DESCRIPTION
I assume the code actually does the right thing, as I think it would be quite obvious if not, but I just noticed this typo in the original spec (https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=823374) and saw it's been copied to the LinuxCNC docs as well.

G94 is actually executed first and is duplicated here, instead of the much more sensible G92.3, which is missing.