### PR TITLE
Do not use __DATE__ and __TIME__ macros

### DIFF
--- a/src/hal/user_comps/xhc-whb04b-6/main.cc
+++ b/src/hal/user_comps/xhc-whb04b-6/main.cc
@@ -50,7 +50,7 @@ static int printUsage(const char* programName, const char* deviceName, bool isEr
     {
         os = &std::cerr;
     }
-    *os << programName << " version " << PACKAGE_VERSION << " " << __DATE__ << " " << __TIME__ << endl
+    *os << programName << " version " << PACKAGE_VERSION << endl
         << endl
         << "SYNOPSIS" << endl
         << "    " << programName << " [-h | --help] | [-H] [OPTIONS] " << endl

--- a/src/libnml/rcs/rcsversion.h
+++ b/src/libnml/rcs/rcsversion.h
@@ -22,8 +22,4 @@
 static const int lib_major_version = LIB_MAJOR_VERSION;
 static const int lib_minor_version = LIB_MINOR_VERSION;
 
-static const char __attribute__ ((unused)) * rcs_version_info_string =
-    "@(#)" " $Info: NML Library version " LIB_VERSION " Compiled on  "
-    __DATE__ " at " __TIME__ " for Linux. $ \n";
-
 #endif


### PR DESCRIPTION
Debian packaging complains about non-reproducible builds. The reason are using the \_\_DATE\_\_ and \_\_TIME\_\_ macros. They change for each build, hence non-reproducible.

This PR removes both macros' use. There is no harm in doing so. One place it was a static string never used anywhere ever (rcs revision system left-over) and the other a console message where the LCNC version is good enough.