### PR TITLE
Fix -Wextra in RT componentized code

### DIFF
--- a/docs/src/hal/comp.adoc
+++ b/docs/src/hal/comp.adoc
@@ -31,6 +31,7 @@ component ddt "Compute the derivative of the input function";
 pin in float in;
 pin out float out;
 variable double old;
+option period no;
 function _;
 license "GPL"; // indicates GPL v2 or later
 ;;
@@ -173,7 +174,7 @@ If neither 'count' nor 'names' is specified, a single numbered instance is creat
 
 Functions are implicitly passed the 'period' parameter which is the time in nanoseconds of the last period to execute the component.
 Functions which use floating-point can also refer to 'fperiod' which is the floating-point time in seconds, or (period*1e-9).
-This can be useful in components that need the timing information.
+This can be useful in components that need the timing information. See also 'option period' below.
 
 == Syntax
 
@@ -292,18 +293,24 @@ r"\fIexample\fB"
 
 The currently defined options are:
 
-* 'option singleton yes' - (default: no)
-  Do not create a 'count' module parameter, and always create a single instance.
-  With 'singleton', items are named 'component-name.item-name' and without 'singleton', items for numbered instances are named 'component-name.<num>.item-name'.
-* 'option default_count number' - (default: 1)
-  Normally, the module parameter 'count' defaults to 1. If specified, the 'count' will default to this value instead.
-* 'option count_function yes' - (default: no)
-  Normally, the number of instances to create is specified in the module parameter 'count';
-  if 'count_function' is specified, the value returned by the function 'int get_count(void)' is used instead, and the 'count' module parameter is not defined.
-* 'option rtapi_app no' - (default: yes)
+* 'option singleton yes' - (default: no) +
+  Do not create a 'count' module parameter, and always create a single instance. With
+  'singleton', items are named 'component-name.item-name' and without 'singleton', items for
+  numbered instances are named 'component-name.<num>.item-name'.
+
+* 'option default_count number' - (default: 1) +
+  Normally, the module parameter 'count' defaults to 1. If specified, the 'count' will default
+  to this value instead.
+
+* 'option count_function yes' - (default: no) +
+  Normally, the number of instances to create is specified in the module parameter 'count'; if
+  'count_function' is specified, the value returned by the function 'int get_count(void)' is
+  used instead, and the 'count' module parameter is not defined.
+
+* 'option rtapi_app no' - (default: yes) +
   Normally, the functions `rtapi_app_main()` and `rtapi_app_exit()` are automatically defined.
   With 'option rtapi_app no', they are not, and must be provided in the C code.
-  Use the following prototypes:
+  Use the following prototypes: +
 +
 ----
 `int rtapi_app_main(void);`
@@ -339,7 +346,7 @@ When implementing your own `rtapi_app_main()`, call the function `int export(cha
   This function may process the commandline arguments or take other actions.
   Its return type is 'void'; it may call 'exit()' if it wishes to terminate rather than create a HAL component (e.g., because the commandline arguments were invalid).
 
-* 'option extra_link_args "..."' - (default: "")
+* 'option extra_link_args "..."' - (default: "") +
    This option is ignored if the option 'userspace' (see above) is set to 'no'.
    When linking a non-realtime component, the arguments given are inserted in the link line.
    Note that because compilation takes place in a temporary directory,
@@ -347,7 +354,7 @@ When implementing your own `rtapi_app_main()`, call the function `int export(cha
    This option can be set in the halcompile command-line with -extra-link-args="-L.....".
    This alternative provides a way to set extra flags in cases where the input file is a .c file rather than a .comp file.
 
-* 'option extra_compile_args "..."' - (default: "")
+* 'option extra_compile_args "..."' - (default: "") +
    This option is ignored if the option 'userspace' (see above) is set to 'no'.
    When compiling a non-realtime component, the arguments given are inserted in the compiler command line.
    If the input file is a .c file this option can be set in the halcompile command-line with --extra-compile-args="-I.....".
@@ -358,6 +365,14 @@ When implementing your own `rtapi_app_main()`, call the function `int export(cha
 
 * 'option tpmod yes' - (default: no) +
   Module is a custom Trajectory Planning (tp) module loaded using `[TRAJ]TPMOD=`__modulename__ .
+
+* 'option period no' - (default: yes) +
+  Control the implicit 'period' parameter of the function(s) defined in the component. A
+  standard function has an implicit parameter 'period'. Many components do no use the 'period'
+  parameter and would cause a "unused parameter" compiler warning. Setting 'option period no'
+  creates a function declaration omitting the 'period' parameter preventing the warning.
+  Setting this option will also prevent 'fperiod' from being defined, as it depends on
+  'period'.
 
 If an option's VALUE is not specified, then it is equivalent to specifying 'option … yes'. +
 The result of assigning an inappropriate value to an option is undefined. +
@@ -432,7 +447,7 @@ they will generally be referred to using the macros below.
 The details of `struct __comp_state` and these macros may change from one version of 'halcompile' to the next.
 
 * `FUNCTION(`__name__`)` - Use this macro to begin the definition of a realtime function, which was previously declared with 'function NAME'.
-  The function includes a parameter 'period' which is the integer number of nanoseconds between calls to the function.
+  The function includes a parameter 'period' which is the integer number of nanoseconds between calls to the function. See also 'option period' above.
 * `EXTRA_SETUP()` - Use this macro to begin the definition of the function called to perform extra setup of this instance.
   Return a negative UNIX 'errno' value to indicate failure (e.g., 'return -EBUSY' on failure to reserve an I/O port), or 0 to indicate success.
 * `EXTRA_CLEANUP()` - Use this macro to begin the definition of the function called to perform extra cleanup of the component.
@@ -450,7 +465,7 @@ When the item is a conditional item, it is only legal to refer to it when its 'c
 * 'variable_name' - For each variable 'variable_name' there is a macro which allows the name to be used on its own to refer to the variable.
   When 'variable_name' is an array, the normal C-style subscript is used: 'variable_name[idx]'.
 * 'data' - If "option data" is specified, this macro allows access to the instance data.
-* 'fperiod' - The floating-point number of seconds between calls to this realtime function.
+* 'fperiod' - The floating-point number of seconds between calls to this realtime function. See also 'option period' above.
 * `FOR_ALL_INSTS() {`...`}` - For non-realtime components.
   This macro iterates over all the defined instances.
   Inside the body of the loop, the 'pin_name', 'parameter_name', and 'data' macros work as they do in realtime functions.
@@ -505,6 +520,7 @@ The file name must match the component name.
 component constant;
 pin out float out;
 param r float value = 1.0;
+option period no;
 function _;
 license "GPL"; // indicates GPL v2 or later
 ;;
@@ -526,6 +542,7 @@ component sincos;
 pin out float sin_;
 pin out float cos_;
 pin in float theta;
+option period no;
 function _;
 license "GPL"; // indicates GPL v2 or later
 ;;
@@ -548,6 +565,7 @@ param r unsigned ioaddr;
 
 function _;
 
+option period no;
 option count_function;
 option extra_setup;
 option extra_cleanup;
@@ -613,6 +631,7 @@ This realtime component illustrates use of fixed-size arrays:
 component arraydemo "4-bit Shift register";
 pin in bit in;
 pin out bit out-# [4];
+option period no;
 function _ nofp;
 license "GPL"; // indicates GPL v2 or later
 ;;
@@ -654,6 +673,7 @@ pin in bit in-##[16 : personality & 0xff];
 pin out bit and if personality & 0x100;
 pin out bit or if personality & 0x200;
 pin out bit xor if personality & 0x400;
+option period no;
 function _ nofp;
 description """
 Experimental general 'logic function' component.  Can perform 'and', 'or'
@@ -706,6 +726,7 @@ pin in s32 in;
 pin out bit out1;
 pin out bit out2;
 
+option period no;
 function _;
 license "GPL";
 ;;

--- a/src/hal/components/abs.comp
+++ b/src/hal/components/abs.comp
@@ -21,6 +21,7 @@ pin out bit sign "Sign of input, false for positive, true for negative" ;
 pin out bit is_positive "TRUE if input is positive, FALSE if input is 0 or negative";
 pin out bit is_negative "TRUE if input is negative, FALSE if input is 0 or positive";
 
+option period no;
 function _;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/abs_s32.comp
+++ b/src/hal/components/abs_s32.comp
@@ -21,6 +21,7 @@ pin out bit sign "Sign of input, false for positive, true for negative" ;
 pin out bit is_positive "TRUE if input is positive, FALSE if input is 0 or negative";
 pin out bit is_negative "TRUE if input is negative, FALSE if input is 0 or positive";
 
+option period no;
 function _ nofp;
 license "GPL";
 author "Sebastian Kuzminsky";

--- a/src/hal/components/abs_s64.comp
+++ b/src/hal/components/abs_s64.comp
@@ -23,6 +23,7 @@ pin out bit sign "Sign of input, false for positive, true for negative" ;
 pin out bit is_positive "true if input is positive, false if input is 0 or negative";
 pin out bit is_negative "true if input is negative, false if input is 0 or positive";
 
+option period no;
 function _ nofp;
 license "GPL";
 author "ArcEye based on code from Sebastian Kuzminsky";

--- a/src/hal/components/and2.comp
+++ b/src/hal/components/and2.comp
@@ -14,6 +14,7 @@ Otherwise,
 \\fBout=FALSE\\fR
 .RE"""
 ;
+option period no;
 function _ nofp;
 see_also """
 \\fBlogic\\fR(9),

--- a/src/hal/components/bin2gray.comp
+++ b/src/hal/components/bin2gray.comp
@@ -4,6 +4,7 @@ pin in unsigned in "binary code in";
 pin out unsigned out "gray code out";
 license "GPL";
 author "Andy Pugh";
+option period no;
 function _ nofp;
 ;;
 out = (in >> 1) ^ in;

--- a/src/hal/components/biquad.comp
+++ b/src/hal/components/biquad.comp
@@ -98,6 +98,8 @@ typedef struct {
 
 EXTRA_SETUP()
 {
+    (void)prefix;
+    (void)extra_arg;
     data.lastEnable = 0;
 
     return(0);

--- a/src/hal/components/bitslice.comp
+++ b/src/hal/components/bitslice.comp
@@ -9,6 +9,7 @@ author "Andy Pugh";
 license "GPL2+";
 function _ nofp;
 option personality yes;
+option period no;
 ;;
 int i;
 for (i = 0; i < personality ; i++){

--- a/src/hal/components/bitwise.comp
+++ b/src/hal/components/bitwise.comp
@@ -11,6 +11,7 @@ pin out u32 out-xnor "The inverse of the bitwise XOR";
 author "Andy Pugh";
 license "GPL 2+";
 function _ nofp;
+option period no;
 ;;
 
 out_and = (in0 & in1);

--- a/src/hal/components/bldc.comp
+++ b/src/hal/components/bldc.comp
@@ -515,7 +515,7 @@ FUNCTION(_) {
             phase_angle -= floor(phase_angle);
             
             if (! (ph & old_ph)){ hall_error = 1;}
-            if (pattern != old_pattern){hall_error = 0;}
+            if (pattern != (unsigned)old_pattern){hall_error = 0;}
 
             if (force_trap) break;
 
@@ -797,7 +797,7 @@ FUNCTION(_) {
             return;
 
         case 0x400: // Hall Output
-            for (i = 0; P[(output_pattern << 3) + i] != ph && i < 8 ; i++) {}
+            for (i = 0; P[(output_pattern << 3) + i] != ((unsigned)ph & 0xff) && i < 8 ; i++) {}
             hall1_out = (i & 0x04);
             hall2_out = (i & 0x02);
             hall3_out = (i & 0x01);
@@ -849,6 +849,7 @@ FUNCTION(_) {
 }
 
 EXTRA_SETUP(){
+    (void)prefix;
     int i;
     char c;
     for (i = 0; cfg[extra_arg][i] != 0 && i < NUM_TAG ; i++){

--- a/src/hal/components/blend.comp
+++ b/src/hal/components/blend.comp
@@ -24,6 +24,7 @@ pin out float out "Output value.";
 
 param rw bit open "If true, select values outside the range 0.0 to 1.0 give values outside the range in2 to in1.  If false, outputs are clamped to the the range in2 to in1";
 
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/carousel.comp
+++ b/src/hal/components/carousel.comp
@@ -547,6 +547,7 @@ FUNCTION(_){
 }
 
 EXTRA_SETUP(){
+    (void)prefix;
     if (pockets[extra_arg] > 0) default_pockets = pockets[extra_arg];
     if (encoding[extra_arg] == NULL) {
         //it's already default_code

--- a/src/hal/components/charge_pump.comp
+++ b/src/hal/components/charge_pump.comp
@@ -30,6 +30,7 @@ have a base period of 100,000ns that is 0.0001 seconds and the formula would be
 1/(0.0001 x 2) = 5,000 Hz or 5 kHz. Two additional outputs are provided that run
 a factor of 2 and 4 slower for hardware that requires a lower frequency.""";
 license "GPL";
+option period no;
 author "Jeff Epler";
 ;;
 FUNCTION(_) {

--- a/src/hal/components/clarke2.comp
+++ b/src/hal/components/clarke2.comp
@@ -15,6 +15,7 @@ pin in float a;
 pin in float b "first two phases of three phase input";
 pin out float x;
 pin out float y "cartesian components of output";
+option period no;
 function _;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/clarke3.comp
+++ b/src/hal/components/clarke3.comp
@@ -14,6 +14,7 @@ pin in float c "three phase input vector";
 pin out float x;
 pin out float y "cartesian components of output";
 pin out float h "homopolar component of output";
+option period no;
 function _;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/clarkeinv.comp
+++ b/src/hal/components/clarkeinv.comp
@@ -10,6 +10,7 @@ pin in float theta "rotation angle: 0.00 to 1.00 = 0 to 360 degrees";
 pin out float a;
 pin out float b;
 pin out float c "three phase output vector";
+option period no;
 function _;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/comp.comp
+++ b/src/hal/components/comp.comp
@@ -12,6 +12,7 @@ separated by distance \\fBhyst\\fR around the point where \\fBin1\\fR = \\fBin0\
 Keep in mind that floating point calculations are never absolute
 and it is wise to always set \\fBhyst\\fR if you intend to use equal """;
 
+option period no;
 function _ fp "Update the comparator";
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/constant.comp
+++ b/src/hal/components/constant.comp
@@ -1,6 +1,7 @@
 component constant "Use a parameter to set the value of a pin";
 pin out float out;
 param rw float value;
+option period no;
 function _;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/conv.comp.in
+++ b/src/hal/components/conv.comp.in
@@ -3,6 +3,7 @@ pin in @IN@ in;
 pin out @OUT@ out;
 @CC@pin out bit out_of_range "TRUE when 'in' is not in the range of @OUT@";
 @CC@param rw bit clamp """If TRUE, then clamp to the range of @OUT@.  If FALSE, then allow the value to "wrap around".""";
+option period no;
 function _ @FP@ "Update 'out' based on 'in'";
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/corexy_by_hal.comp
+++ b/src/hal/components/corexy_by_hal.comp
@@ -47,6 +47,7 @@ switches triggered by the \\fB j0,j1 motor\\fR positions.
 (man kins for more information)
 """;
 
+option period no;
 license "GPL";
 author "Dewey Garrett based on forum post from nbremond";
 ;;

--- a/src/hal/components/dbounce.comp
+++ b/src/hal/components/dbounce.comp
@@ -8,7 +8,8 @@ pin in  bit in;
 pin out bit out;
 pin in  u32 delay = 5;
 
-variable int state;
+variable unsigned state;
+option period no;
 function _ nofp;
 license "GPL";
 author "Dewey Garrett";

--- a/src/hal/components/deadzone.comp
+++ b/src/hal/components/deadzone.comp
@@ -4,6 +4,7 @@ param rw float threshold = 1.0 "The dead zone is \\fBcenter\\fR \\(+- (\\fBthres
 pin in float in;
 pin out float out;
 
+option period no;
 function _ "Update \\fBout\\fR based on \\fBin\\fR and the parameters.";
 
 license "GPL";

--- a/src/hal/components/demux.comp
+++ b/src/hal/components/demux.comp
@@ -21,6 +21,7 @@ see_also "\\fBselect8\\fR(9)";
 license "GPL 2+";
 author "Andy Pugh";
 
+option period no;
 function _;
 
 ;;

--- a/src/hal/components/differential.comp
+++ b/src/hal/components/differential.comp
@@ -29,6 +29,7 @@ pin out float motor1-cmd "position command to motor1 (based on roll & pitch inpu
 pin in float motor0-fb "position feedback from motor0";
 pin in float motor1-fb "position feedback from motor1";
 
+option period no;
 function _;
 license "GPL";
 author "Sebastian Kuzminsky";

--- a/src/hal/components/div2.comp
+++ b/src/hal/components/div2.comp
@@ -35,6 +35,7 @@ This is simple mathematics. """;
 license "GPL"; // indicates GPL v2 or later
 author "Noel Rodes";
 see_also "mult2(9), invert(9) ";
+option period no;
 function _;
 
 ;;

--- a/src/hal/components/eoffset_per_angle.comp
+++ b/src/hal/components/eoffset_per_angle.comp
@@ -99,6 +99,7 @@ variable int  err_stop = 0;
 option data the_data;
 //---------------------------------------------------------------------
 
+option period no;
 function _;
 license "GPL";
 author "Dewey Garrett";

--- a/src/hal/components/estop_latch.comp
+++ b/src/hal/components/estop_latch.comp
@@ -71,6 +71,7 @@ pin in bit reset;
 pin out bit ok_out = false;
 pin out bit fault_out = true;
 pin out bit watchdog;
+option period no;
 function _ nofp;
 option data estop_data;
 license "GPL";

--- a/src/hal/components/feedcomp.comp
+++ b/src/hal/components/feedcomp.comp
@@ -22,6 +22,7 @@ pin in float vel "Current velocity";
 param rw float feed "Feed rate reference value";
 notes "Note that if enable is false, out = in.";
 
+option period no;
 function _;
 license "GPL";
 author "Eric H. Johnson";

--- a/src/hal/components/filter_kalman.comp
+++ b/src/hal/components/filter_kalman.comp
@@ -55,6 +55,7 @@ param  rw float     Rk = 1.17549e-38       "Estimation of the noise covariances 
 param  rw float     Qk = 1.17549e-38       "Estimation of the noise covariances (observation).";
 
 option extra_setup yes;
+option period no;
 
 function _ "Update \\fBxk-out\\fR based on \\fBzk\\fR input.";
 
@@ -87,6 +88,7 @@ static void print_info(const int id, const D in_val, const D out_val) {
 }
 
 EXTRA_SETUP() {
+    (void)prefix;
     cidx = extra_arg; // Let us hope 'extra_arg' will forever contain component index.
     return 0;
 }

--- a/src/hal/components/flipflop.comp
+++ b/src/hal/components/flipflop.comp
@@ -7,6 +7,7 @@ pin io bit out "output";
 pin io bit out-not "inverted output";
 option data flipflop_data;
 
+option period no;
 function _ nofp;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/gantry.comp
+++ b/src/hal/components/gantry.comp
@@ -70,6 +70,7 @@ When a joint home switch trips, the commanded velocity will drop immediately fro
 """;
 license "GPL";
 author "Charles Steinkuehler";
+option period no;
 variable float offset[7] = 0.0;
 variable float prev_cmd = 0.0;
 variable int   fb_joint = 0;

--- a/src/hal/components/gearchange.comp
+++ b/src/hal/components/gearchange.comp
@@ -19,6 +19,7 @@ Since it is assumed that gear 2 is "high gear", \\fBscale2\\fR must be
 greater than 1, and will be reset to 1 if set lower.""";
 param rw bit reverse = 0 "Set to 1 to reverse the spindle in second gear.";
 
+option period no;
 function _;
 license "GPL";
 author "Stephen Wille Padnos";

--- a/src/hal/components/gray2bin.comp
+++ b/src/hal/components/gray2bin.comp
@@ -5,6 +5,7 @@ pin out unsigned out "binary code out";
 license "GPL";
 author "Andy Pugh";
 function _ nofp;
+option period no;
 ;;
 unsigned int mask;
 out = in;

--- a/src/hal/components/histobins.comp
+++ b/src/hal/components/histobins.comp
@@ -66,11 +66,12 @@ pin out float  mean;
 // user may interrogate availablebins to determine this compiled-in limit
 pin out s32 availablebins = 200; //MAXBINNUMBER
 
+option period no;
 function _ fp;
 
 variable int bin[200]; // MAXBINNUMBER
 variable int first = 1;
-variable int last_nbins    = 0;
+variable unsigned last_nbins    = 0;
 
 variable hal_float_t maxvalue;
 
@@ -86,10 +87,10 @@ author "Dewey Garrett";
 ;;
 
 hal_float_t invalue;
-int i;
+unsigned i;
 int idx;
 check = index;
-if (   (nbins > availablebins)
+if (   (nbins > (unsigned)availablebins)
     || (nbins < 1)
    ) {
   input_error = 1;
@@ -143,7 +144,7 @@ check = index; // user should verify check==index for reading values
 // -1 value indicates illegal index
 if (index < 0) {
   binvalue = -1;
-} else if (index < nbins) {
+} else if (index < (int)nbins) {
   binvalue = bin[index];
 } else {
   binvalue = -1;

--- a/src/hal/components/homecomp.comp
+++ b/src/hal/components/homecomp.comp
@@ -68,6 +68,9 @@ RTAPI_MP_STRING(home_parms,"Example home parms");
 
 // EXTRA_SETUP is executed before rtapi_app_main()
 EXTRA_SETUP() {
+    (void)__comp_inst;
+    (void)prefix;
+    (void)extra_arg;
     if (!home_parms) {home_parms = "no_home_parms";}
     rtapi_print("@@@%s:%s: home_parms=%s\n",__FILE__,__FUNCTION__,home_parms);
 #ifndef HOMING_BASE
@@ -378,31 +381,37 @@ static int makepins(int id,int njoints)
 void homeMotFunctions(void(*pSetRotaryUnlock)(int,int)
                      ,int (*pGetRotaryIsUnlocked)(int)
                      )
-{ return; }
+{
+    (void)pSetRotaryUnlock;
+    (void)pGetRotaryIsUnlocked;
+    return;
+}
 
 int  homing_init(int id,
                  double servo_period,
                  int n_joints,
                  int n_extrajoints,
                  emcmot_joint_t* pjoints) {
+     (void)servo_period;
+     (void)n_extrajoints;
      joints = pjoints;
      return makepins(id,n_joints);
 }
 bool do_homing(void)                                 {return 1;}
 bool get_allhomed()                                  {return 1;}
-bool get_homed(int jno)                              {return 1;}
-bool get_home_is_idle(int jno)                       {return 1;}
-bool get_home_is_synchronized(int jno)               {return 0;}
-bool get_home_needs_unlock_first(int jno)            {return 0;}
-int  get_home_sequence(int jno)                      {return 0;}
-bool get_homing(int jno)                             {return 0;}
-bool get_homing_at_index_search_wait(int jno)        {return 0;}
+bool get_homed(int jno)                              { (void)jno; return 1;}
+bool get_home_is_idle(int jno)                       { (void)jno; return 1;}
+bool get_home_is_synchronized(int jno)               { (void)jno; return 0;}
+bool get_home_needs_unlock_first(int jno)            { (void)jno; return 0;}
+int  get_home_sequence(int jno)                      { (void)jno; return 0;}
+bool get_homing(int jno)                             { (void)jno; return 0;}
+bool get_homing_at_index_search_wait(int jno)        { (void)jno; return 0;}
 bool get_homing_is_active()                          {return 0;}
-bool get_index_enable(int jno)                       {return 0;}
-void read_homing_in_pins(int njoints)                {return;}
-void do_home_joint(int jno)                          {return;}
-void set_unhomed(int jno,motion_state_t motstate)    {return;}
-void do_cancel_homing(int jno)                       {return;}
+bool get_index_enable(int jno)                       { (void)jno; return 0;}
+void read_homing_in_pins(int njoints)                { (void)njoints; return;}
+void do_home_joint(int jno)                          { (void)jno; return;}
+void set_unhomed(int jno,motion_state_t motstate)    { (void)jno; (void)motstate; return;}
+void do_cancel_homing(int jno)                       { (void)jno; return;}
 void set_joint_homing_params(int    jno,
                              double offset,
                              double home,
@@ -412,13 +421,32 @@ void set_joint_homing_params(int    jno,
                              int    home_flags,
                              int    home_sequence,
                              bool   volatile_home
-                             )                       {return;}
+                             )
+{
+    (void)jno;
+    (void)offset;
+    (void)home;
+    (void)home_final_vel;
+    (void)home_search_vel;
+    (void)home_latch_vel;
+    (void)home_flags;
+    (void)home_sequence;
+    (void)volatile_home;
+    return;
+}
 void update_joint_homing_params (int    jno,
                                  double offset,
                                  double home,
                                  int    home_sequence
-                                )                    {return;}
-void write_homing_out_pins(int njoints)              {return;}
+                                )
+{
+    (void)jno;
+    (void)offset;
+    (void)home;
+    (void)home_sequence;
+    return;
+}
+void write_homing_out_pins(int njoints)              { (void)njoints; return;}
 #endif  // } end SKELETON example minimal api implementation
 //=====================================================================
 

--- a/src/hal/components/hypot.comp
+++ b/src/hal/components/hypot.comp
@@ -3,6 +3,7 @@ pin in float in0;
 pin in float in1;
 pin in float in2;
 pin out float out "out = sqrt(in0^2 + in1^2 + in2^2)";
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/ilowpass.comp
+++ b/src/hal/components/ilowpass.comp
@@ -29,6 +29,7 @@ towards the input value in each period.""";
 
 variable double value;
 
+option period no;
 function _ "Update the output based on the input and parameters.";
 
 license "GPL";

--- a/src/hal/components/invert.comp
+++ b/src/hal/components/invert.comp
@@ -22,6 +22,7 @@ pin in float in "Analog input value";
 pin out float out "Analog output value";
 param rw float deadband "The \\fBout\\fR will be zero if \\fBin\\fR is between -\\fBdeadband\\fR and +\\fBdeadband\\fR.";
 
+option period no;
 function _;
 license "GPL";
 author "Stephen Wille Padnos";

--- a/src/hal/components/joyhandle.comp
+++ b/src/hal/components/joyhandle.comp
@@ -43,6 +43,7 @@ An additional offset component can be set in special cases (default = 0).
 All values can be adjusted for each instance separately.
 """;
 
+option period no;
 function _;
 license "GPL";
 author "Paul Willutzki";

--- a/src/hal/components/knob2float.comp
+++ b/src/hal/components/knob2float.comp
@@ -27,6 +27,7 @@ param rw float min_out=0.0 "Minimum output value, further decreases in count wil
 
 option data knob2float_data;
 
+option period no;
 function _;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/laserpower.comp
+++ b/src/hal/components/laserpower.comp
@@ -30,6 +30,7 @@ description """During operation laserpower must be scaled proportionally to actu
                     This allows vector power to be scaled along moves.
             """;
 
+option period no;
 function _;
 license "GPL";
 

--- a/src/hal/components/led_dim.comp
+++ b/src/hal/components/led_dim.comp
@@ -46,6 +46,7 @@ The output is calculated using the CIE 1931 formula.
 """;
 license "GPL";
 author "Alexander Rössler";
+option period no;
 variable hal_float_t last_in = 0.0;
 ;;
 #include "rtapi_math.h"

--- a/src/hal/components/limit1.comp
+++ b/src/hal/components/limit1.comp
@@ -3,6 +3,7 @@ pin in float in;
 pin out float out;
 pin in float min_=-1e20;
 pin in float max_=1e20;
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/limit_axis.comp
+++ b/src/hal/components/limit_axis.comp
@@ -30,6 +30,7 @@ license "GPL";
 
 option extra_setup 1;
 
+option period no;
 function _;
 
 pin out bit error-no-range "error pin indicating that no range matches the fb";
@@ -105,7 +106,7 @@ FUNCTION(_){
       min_output = min_limit(i);
       // Found our limits, stop looking
       error_no_range = 0;
-      if (i != current_range){
+      if (i != (int)current_range){
         rtapi_print_msg(RTAPI_MSG_INFO, "limit_axis: Switching to Range %d\n", i);
         current_range = i;
       }
@@ -124,6 +125,8 @@ FUNCTION(_){
 }
 
 EXTRA_SETUP(){
+    (void)prefix;
+    (void)extra_arg;
     if (personality > 10) personality = 10;
     if (personality < 2) personality = 2;
     return 0;

--- a/src/hal/components/lincurve.comp
+++ b/src/hal/components/lincurve.comp
@@ -33,6 +33,7 @@ pin io float out-io "The output value, compatible with PID gains";
 variable unsigned i = 0;
 
 option extra_setup 1;
+option period no;
 
 author "Andy Pugh";
 license "GPL";
@@ -63,6 +64,8 @@ FUNCTION(_){
 }
 
 EXTRA_SETUP(){
+	(void)prefix;
+	(void)extra_arg;
 	if (personality > 16) personality = 16;
 	if (personality < 2) personality = 2;
 	return 0;

--- a/src/hal/components/logic.comp
+++ b/src/hal/components/logic.comp
@@ -79,6 +79,7 @@ see_also """
 """;
 license "GPL";
 author "Jeff Epler";
+option period no;
 ;;
 FUNCTION(_) {
     int i, a=1, o=0, x=0;

--- a/src/hal/components/lowpass.comp
+++ b/src/hal/components/lowpass.comp
@@ -34,6 +34,7 @@ pin in float in;
 pin out float out " out += (in - out) * gain ";
 pin in bit load "When TRUE, copy \\fBin\\fR to \\fBout\\fR instead of applying the filter equation.";
 param rw float gain;
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/lut5.comp
+++ b/src/hal/components/lut5.comp
@@ -141,6 +141,7 @@ see_also """
 """;
 license "GPL";
 author "Jeff Epler";
+option period no;
 ;;
 
 FUNCTION(_) {

--- a/src/hal/components/maj3.comp
+++ b/src/hal/components/maj3.comp
@@ -24,6 +24,7 @@ pin out bit out;
 
 param rw bit invert;
 
+option period no;
 function _ nofp;
 
 license "GPL";

--- a/src/hal/components/match8.comp
+++ b/src/hal/components/match8.comp
@@ -17,6 +17,7 @@ pin in bit b5;
 pin in bit b6;
 pin in bit b7;
 pin out bit out "true only if in is true and a[m] matches b[m] for m = 0 thru 7";
+option period no;
 function _ nofp;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/matrixkins.comp
+++ b/src/hal/components/matrixkins.comp
@@ -248,6 +248,8 @@ int kinematicsForward(const double *j,
                       const KINEMATICS_FORWARD_FLAGS * fflags,
                       KINEMATICS_INVERSE_FLAGS * iflags)
 {
+    (void)fflags;
+    (void)iflags;
     // For forward kinematics (joint to axis position) we
     // need the inverse of the 3x3 matrix.
     //
@@ -299,6 +301,8 @@ int kinematicsInverse(const EmcPose * pos,
                       const KINEMATICS_INVERSE_FLAGS * iflags,
                       KINEMATICS_FORWARD_FLAGS * fflags)
 {
+    (void)iflags;
+    (void)fflags;
     double a = haldata->C_xx;
     double b = haldata->C_xy;
     double c = haldata->C_xz;

--- a/src/hal/components/max31855.comp
+++ b/src/hal/components/max31855.comp
@@ -40,6 +40,7 @@ pin out unsigned fault_flags.# [15 : (personality & 0xf)]  "Fault flags: 0x1  = 
 variable unsigned data_frame [15];
 variable unsigned state = 1;
 
+option period no;
 function bitbang_spi fp;
 license "GPL";
 author "Joseph Calderon";
@@ -49,7 +50,7 @@ author "Joseph Calderon";
 #include "rtapi_math.h"
 
 static float accpoly(float *v, size_t n, float p) {
-  int i;
+  size_t i;
   float ret = 0;
   for (i = 0; i < n; i++) {
     ret += v[i] * pow(p, i);

--- a/src/hal/components/mesa_pktgyro_test.comp
+++ b/src/hal/components/mesa_pktgyro_test.comp
@@ -47,6 +47,7 @@ pin out s32 rxbytes  "Number of Bytes received or negative Error code";
 variable char *name; // PktUART name
 
 option extra_setup yes;
+option period no;
 
 function receive;
 
@@ -113,6 +114,7 @@ FUNCTION(receive){
 #endif
 
 EXTRA_SETUP(){ // the names parameters are passed in 'prefix'.
+	(void)extra_arg;
 	if (prefix[0] == 'm'){ // should be the 'm' of hm2_....
 		rtapi_print_msg(0, "mesa_pktuart_test can not be loaded using the 'count' "
 						"parameter, see man mesa_uart for details\n");

--- a/src/hal/components/message.comp
+++ b/src/hal/components/message.comp
@@ -72,6 +72,7 @@ variable hal_bit_t prev_edge = TRUE;
  
 option extra_setup yes;
  
+option period no;
 function _ nofp "Display a message";
 license "GPL v2";
 author "Les Newell";
@@ -110,6 +111,7 @@ FUNCTION(_){
 }
  
 EXTRA_SETUP(){
+    (void)prefix;
     myidx = extra_arg;
     if(myidx<0 || myidx >15)
     {

--- a/src/hal/components/millturn.comp
+++ b/src/hal/components/millturn.comp
@@ -31,6 +31,7 @@ chapter (docs/src/motion/switchkins.txt)
 // The fpin pin is not accessible in kinematics functions.
 // Use the *_setup() function for pins and params used by kinematics.
 pin out s32 fpin=0"pin to demonstrate use of a conventional (non-kinematics) function fdemo";
+option period no;
 function fdemo;
 license "GPL";
 author "David Mueller";
@@ -150,6 +151,8 @@ int kinematicsForward(const double *j,
                       const KINEMATICS_FORWARD_FLAGS * fflags,
                       KINEMATICS_INVERSE_FLAGS * iflags)
 {
+    (void)fflags;
+    (void)iflags;
     static bool gave_msg;
     // define forward kinematic models using case structure for
     // for switchable kinematics
@@ -188,6 +191,8 @@ int kinematicsInverse(const EmcPose * pos,
                       const KINEMATICS_INVERSE_FLAGS * iflags,
                       KINEMATICS_FORWARD_FLAGS * fflags)
 {
+    (void)iflags;
+    (void)fflags;
     is_ready = 1; // Inverse is not called until homed for KINEMATICS_BOTH
 
     // Update the kinematic joints specified by the

--- a/src/hal/components/minmax.comp
+++ b/src/hal/components/minmax.comp
@@ -3,6 +3,7 @@ pin in float in;
 pin in bit reset "When reset is asserted, 'in' is copied to the outputs";
 pin out float max_;
 pin out float min_;
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/moveoff.comp
+++ b/src/hal/components/moveoff.comp
@@ -488,6 +488,7 @@ FUNCTION(read_inputs) {
 } //read_inputs
 
 FUNCTION(write_outputs) {
+    (void)period;
     int r;
     // move with limits on position, velocity, acceleration
     for (r = 0; r < personality; r++) {
@@ -537,6 +538,8 @@ FUNCTION(write_outputs) {
 } //write_outputs
 
 EXTRA_SETUP() {
+    (void)prefix;
+    (void)extra_arg;
     if (personality == 0) personality = 3;
     return 0;
 }

--- a/src/hal/components/mult2.comp
+++ b/src/hal/components/mult2.comp
@@ -2,6 +2,7 @@ component mult2 "Product of two inputs";
 pin in float in0;
 pin in float in1;
 pin out float out "out = in0 * in1";
+option period no;
 function _;
 license "GPL";
 author "John Kasunich";

--- a/src/hal/components/multiswitch.comp
+++ b/src/hal/components/multiswitch.comp
@@ -36,6 +36,7 @@ Ignore the "personality" parameter, that is auto-generated.""";
 function _ ;
 option extra_setup yes;
 option count_function yes;
+option period no;
 
 variable int old_up = 0;
 variable int old_down = 0;
@@ -58,7 +59,7 @@ FUNCTION(_) {
     old_down = down;
     
     if (position < 0) position = top_position;
-    if (position > top_position) position = 0;
+    if ((unsigned)position > top_position) position = 0;
     
     for (i = 0 ; i < personality; i++){
         bit(i) = (i == position);
@@ -67,6 +68,7 @@ FUNCTION(_) {
 }
 
 EXTRA_SETUP(){
+    (void)prefix;
     personality = cfg[extra_arg];
     top_position = personality - 1;
     return 0;

--- a/src/hal/components/mux2.comp
+++ b/src/hal/components/mux2.comp
@@ -3,6 +3,7 @@ pin in bit sel;
 pin out float out "Follows the value of in0 if sel is FALSE, or in1 if sel is TRUE";
 pin in float in1;
 pin in float in0;
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/mux4.comp
+++ b/src/hal/components/mux4.comp
@@ -24,6 +24,7 @@ pin in float in0;
 pin in float in1;
 pin in float in2;
 pin in float in3;
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/mux8.comp
+++ b/src/hal/components/mux8.comp
@@ -41,6 +41,7 @@ pin in float in4;
 pin in float in5;
 pin in float in6;
 pin in float in7;
+option period no;
 function _;
 license "GPL";
 author "Stuart Stevenson";

--- a/src/hal/components/near.comp
+++ b/src/hal/components/near.comp
@@ -8,6 +8,7 @@ pin out bit out """
 \\fBscale\\fR (i.e., for in1 positive, in1/scale <= in2 <= in1*scale), OR
 if their absolute difference is no greater than \\fBdifference\\fR (i.e.,
 |in1-in2| <= difference).  \\fBout\\fR is false otherwise.""";
+option period no;
 function _;
 license "GPL";
 author "Chris Radek";

--- a/src/hal/components/not.comp
+++ b/src/hal/components/not.comp
@@ -11,5 +11,6 @@ see_also """
 """;
 license "GPL";
 author "Jeff Epler";
+option period no;
 ;;
 FUNCTION(_) { out = ! in; }

--- a/src/hal/components/offset.comp
+++ b/src/hal/components/offset.comp
@@ -29,6 +29,7 @@ pin out float fb_out "The feedback output value";
 
 license "GPL";
 author "Jeff Epler";
+option period no;
 ;;
 
 FUNCTION(update_feedback) { fb_out = fb_in - offset; }

--- a/src/hal/components/ohmic.comp
+++ b/src/hal/components/ohmic.comp
@@ -69,6 +69,7 @@ pin in  float volt_divider = 4.9         "The divide ratio";
 pin out bit   ohmic_on                   "True if ohmic circuit is closed (material is sensed)";
 pin out float ohmic_volts                "Calculated ohmic voltage";
 
+option period no;
 function _;
 license "GPL";
 ;;

--- a/src/hal/components/oneshot.comp
+++ b/src/hal/components/oneshot.comp
@@ -49,6 +49,8 @@ typedef struct {
 } internal;
 
 EXTRA_SETUP(){
+    (void)prefix;
+    (void)extra_arg;
     data.timer = 0.0;
     data.old_in = 0;
     return 0;

--- a/src/hal/components/or2.comp
+++ b/src/hal/components/or2.comp
@@ -19,5 +19,6 @@ see_also """
 """;
 license "GPL";
 author "Jeff Epler";
+option period no;
 ;;
 FUNCTION(_) { out = in0 || in1; }

--- a/src/hal/components/orient.comp
+++ b/src/hal/components/orient.comp
@@ -13,6 +13,7 @@ variable int   last_enable = 0;
 variable int    debounce = 0; // to prevent the in-position triggering with the spindle moving
 
 option fp yes;
+option period no;
 
 function _ "Update \\fBcommand\\fR based on \\fBenable\\fR, \\fBposition\\fR, \\fBmode\\fR and \\fBangle\\fR.";
 author "Michael Haberler";

--- a/src/hal/components/plasmac.comp
+++ b/src/hal/components/plasmac.comp
@@ -2425,7 +2425,7 @@ FUNCTION(_) {
     stop_type_out = stop_type;
 
     /* debug print */
-    if(debug_print && state_old != state){
+    if(debug_print && state_old != (int)state){
         state_old = state;
         switch(state){
             case 0:

--- a/src/hal/components/raster.comp
+++ b/src/hal/components/raster.comp
@@ -56,6 +56,7 @@ description """The raster component converts a single raster program line to las
                
             
 
+option period no;
 function _;
 license "GPL";
 
@@ -214,7 +215,7 @@ FUNCTION(_) {
             } else if(!read_int(program_ptr, &count) || (count < 2)) {
                 state = FAULT;
                 fault_code = ERROR_INVALID_COUNT;
-            } else if(hal_port_readable(program_ptr) != ((bpp / 4) * count)) {
+            } else if((int)hal_port_readable(program_ptr) != ((bpp / 4) * count)) {
                 state = FAULT;
                 fault_code = ERROR_PROGWRONGSIZE;
             } else {

--- a/src/hal/components/reset.comp
+++ b/src/hal/components/reset.comp
@@ -49,6 +49,7 @@ pin in  bit     reset_bit    = false  "Bit reset value";
 pin in  bit     retriggerable = true  "Allow additional edges to reset";
 pin in  bit     rising        = true  "Trigger on rising edge";
 pin in  bit     falling       = false "Trigger on falling edge";
+option period no;
 function _  fp "Update the output value";
 description """
 Component to reset IO signals.

--- a/src/hal/components/safety_latch.comp
+++ b/src/hal/components/safety_latch.comp
@@ -67,6 +67,7 @@ pin out bit ok_out = true "Ok output";
 
 variable hal_bit_t last_reset = false;
 
+option period no;
 function _ nofp;
 license "GPL";
 author "Alexander Rössler";

--- a/src/hal/components/sample_hold.comp
+++ b/src/hal/components/sample_hold.comp
@@ -2,6 +2,7 @@ component sample_hold "Sample and Hold";
 pin in s32 in;
 pin in bit hold;
 pin out s32 out;
+option period no;
 function _ nofp;
 see_also "\\fBtristate\\fR(9)";
 license "GPL";

--- a/src/hal/components/scale.comp
+++ b/src/hal/components/scale.comp
@@ -3,6 +3,7 @@ pin in float in;
 pin in float gain;
 pin in float offset;
 pin out float out "out = in * gain + offset";
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/scaled_s32_sums.comp
+++ b/src/hal/components/scaled_s32_sums.comp
@@ -10,6 +10,7 @@ pin in float scale2 = 1.0;
 pin in float scale3 = 1.0;
 pin out s32 out_s;
 pin out float out_f "out-s = out-f = (in0 * scale0) + (in1 * scale1) + (in2 * scale2) + (in3 * scale3)";
+option period no;
 function _;
 license "GPL";
 author "Chris S Morley";

--- a/src/hal/components/select8.comp
+++ b/src/hal/components/select8.comp
@@ -2,6 +2,7 @@ component select8 "8-bit binary match detector";
 pin in bit enable = TRUE "Set enable to FALSE to cause all outputs to be set FALSE.";
 pin in s32 sel "The number of the output to set TRUE.  All other outputs well be set FALSE.";
 pin out bit out#[8] "Output bits.  If enable is set and the sel input is between 0 and 7, then the corresponding output bit will be set true.";
+option period no;
 function _ nofp;
 see_also "\\fBdemux\\fR(9)";
 license "GPL";

--- a/src/hal/components/sim_axis_hardware.comp
+++ b/src/hal/components/sim_axis_hardware.comp
@@ -158,6 +158,7 @@ pin out bit Vbothsw_homesw_out;
 
 pin in float limit_offset =.01 "how much the limit switches are offset from inputted position. added to max, subtracted from min";
 
+option period no;
 function update fp;
 license "GPL";
 author "Chris S Morley";

--- a/src/hal/components/sim_matrix_kb.comp
+++ b/src/hal/components/sim_matrix_kb.comp
@@ -16,6 +16,7 @@ variable int keyup = 0x80;
 variable int nokeychange = 0x40;
 variable int last[64];
 
+option period no;
 function _;
 license "GPL";
 author "Chris S Morley";

--- a/src/hal/components/sim_parport.comp
+++ b/src/hal/components/sim_parport.comp
@@ -124,6 +124,7 @@ pin out bit pin_15_in_not;
 
 pin in float reset_time;
 
+option period no;
 function read nofp;
 function write nofp;
 function reset nofp;
@@ -180,6 +181,6 @@ FUNCTION(write) {
 }
 
 FUNCTION(reset) {
-
-return;
+    (void)__comp_inst;
+    return;
 }

--- a/src/hal/components/sphereprobe.comp
+++ b/src/hal/components/sphereprobe.comp
@@ -13,6 +13,7 @@ pin in signed r "Radius of hemisphere in counts";
 
 pin out bit probe-out;
 
+option period no;
 function _ nofp "update probe-out based on inputs";
 ;;
 #undef abs

--- a/src/hal/components/spindle_monitor.comp
+++ b/src/hal/components/spindle_monitor.comp
@@ -9,6 +9,7 @@ pin out bit spindle-underspeed;
 param rw unsigned level "state machine state";
 param rw float threshold;
 
+option period no;
 function _;
 license "gpl v2 or higher";
 author "Sebastian Kuzminsky";

--- a/src/hal/components/sum2.comp
+++ b/src/hal/components/sum2.comp
@@ -6,6 +6,7 @@ param rw float gain0 = 1.0;
 param rw float gain1 = 1.0;
 param rw float offset;
 pin out float out "out = in0 * gain0 + in1 * gain1 + offset";
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/thc.comp
+++ b/src/hal/components/thc.comp
@@ -85,6 +85,7 @@ param rw float correction_vel "The amount of change in user units per period to 
 variable float offset;
 variable float last_z_in;
 
+option period no;
 function _;
 
 ;;

--- a/src/hal/components/thcud.comp
+++ b/src/hal/components/thcud.comp
@@ -89,6 +89,7 @@ param rw float velocity_tol "The deviation percent from planned velocity";
 // Global Variables
 variable float last_z_in;
 
+option period no;
 function _;
 
 ;;

--- a/src/hal/components/threadtest.comp
+++ b/src/hal/components/threadtest.comp
@@ -1,5 +1,6 @@
 component threadtest "LinuxCNC HAL component for testing thread behavior";
 pin out unsigned count;
+option period no;
 function increment nofp;
 function reset nofp;
 license "GPL";

--- a/src/hal/components/toggle.comp
+++ b/src/hal/components/toggle.comp
@@ -15,6 +15,7 @@ pin in bit in "button input";
 pin io bit out "on/off output";
 param rw u32 debounce = 2 "debounce delay in periods";
 option data toggle_data;
+option period no;
 
 function _ nofp;
 license "GPL";
@@ -35,7 +36,7 @@ FUNCTION(_) {
     if ( in ) {
 	/* pressed */
 	data.debounce_cntr++;
-	if ( data.debounce_cntr >= debounce ) {
+	if ( data.debounce_cntr >= (int)debounce ) {
 	    data.debounce_cntr = debounce;
 	    if ( data.debounced == 0 ) {
 		/* toggle output */

--- a/src/hal/components/toggle2nist.comp
+++ b/src/hal/components/toggle2nist.comp
@@ -39,6 +39,7 @@ variable int debounce_cntr;
 variable unsigned debounce_set;
 variable int state;
 
+option period no;
 function _ nofp;
 license "GPL";
 author "Anders Wallin, David Mueller";
@@ -53,7 +54,7 @@ FUNCTION(_)  {
 
     if (in && state == 0 )  { /* input has changed from debounced 0 -> 1 */
         debounce_cntr++;
-        if ( debounce_cntr >= debounce_set ) {
+        if ( debounce_cntr >= (int)debounce_set ) {
             if (!is_on) { /* turn ON if it's off */
                 on=1;
                 off=0;
@@ -66,7 +67,7 @@ FUNCTION(_)  {
         }
     } else if (!in && state == 1) { /* input has changed from debounced 1 -> 0 */
         debounce_cntr++;
-        if ( debounce_cntr >= debounce_set ) {
+        if ( debounce_cntr >= (int)debounce_set ) {
             state = 0;
             debounce_cntr = 0;
         }

--- a/src/hal/components/tristate_bit.comp
+++ b/src/hal/components/tristate_bit.comp
@@ -4,6 +4,7 @@ pin in bit in_ "Input value";
 pin io bit out "Output value";
 pin in bit enable "When TRUE, copy in to out";
 
+option period no;
 function _ nofp "If \\fBenable\\fR is TRUE, copy \\fBin\\fR to \\fBout\\fR.";
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/tristate_float.comp
+++ b/src/hal/components/tristate_float.comp
@@ -4,6 +4,7 @@ pin in float in_ "Input value";
 pin io float out "Output value";
 pin in bit enable "When TRUE, copy in to out";
 
+option period no;
 function _  "If \\fBenable\\fR is TRUE, copy \\fBin\\fR to \\fBout\\fR.";
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/updown.comp
+++ b/src/hal/components/updown.comp
@@ -10,6 +10,7 @@ param rw s32 min "If clamp or wrap is set, count will never be less than this nu
 variable int oldup;
 variable int olddown;
 variable int first = 1;
+option period no;
 function _ nofp "Process inputs and update count if necessary";
 license "GPL";
 author "Stephen Wille Padnos";

--- a/src/hal/components/userkins.comp
+++ b/src/hal/components/userkins.comp
@@ -51,6 +51,7 @@ for a machine with identity kinematics for an xyz machine employing 3 joints (mo
 // The fpin pin is not accessible in kinematics functions.
 // Use the *_setup() function for pins and params used by kinematics.
 pin out s32 fpin=0"pin to demonstrate use of a conventional (non-kinematics) function fdemo";
+option period no;
 function fdemo;
 license "GPL";
 author "Dewey Garrett";
@@ -135,6 +136,8 @@ int kinematicsForward(const double *j,
                       const KINEMATICS_FORWARD_FLAGS * fflags,
                       KINEMATICS_INVERSE_FLAGS * iflags)
 {
+    (void)fflags;
+    (void)iflags;
     static bool gave_msg;
     // [KINS]JOINTS=3
     pos->tran.x = j[0]; // X coordinate
@@ -162,6 +165,8 @@ int kinematicsInverse(const EmcPose * pos,
                       const KINEMATICS_INVERSE_FLAGS * iflags,
                       KINEMATICS_FORWARD_FLAGS * fflags)
 {
+    (void)iflags;
+    (void)fflags;
     is_ready = 1; // Inverse is not called until homed for KINEMATICS_BOTH
 
     // Update the kinematic joints specified by the

--- a/src/hal/components/wcomp.comp
+++ b/src/hal/components/wcomp.comp
@@ -7,6 +7,7 @@ pin out bit under "True if \\fBin\\fR is less than or equal to \\fBmin\\fR";
 pin out bit over "True if \\fBin\\fR is greater than or equal to \\fBmax\\fR";
 notes "If \\fBmax\\fR <= \\fBmin\\fR then the behavior is undefined.";
 
+option period no;
 function _;
 license "GPL";
 author "Jeff Epler";

--- a/src/hal/components/xhc_hb04_util.comp
+++ b/src/hal/components/xhc_hb04_util.comp
@@ -39,6 +39,7 @@ pin out float divide_by_k_out;
 pin in  float k = 1.0;
 
 option data xhc_data;
+option period no;
 
 variable double value0;
 variable double value1;

--- a/src/hal/components/xor2.comp
+++ b/src/hal/components/xor2.comp
@@ -23,6 +23,7 @@ see_also """
 """;
 license "GPL";
 author "John Kasunich";
+option period no;
 ;;
 FUNCTION(_) {
     if (( in0 && !in1 ) || ( in1 && !in0 )) {

--- a/src/hal/components/xyzab_tdr_kins.comp
+++ b/src/hal/components/xyzab_tdr_kins.comp
@@ -144,6 +144,8 @@ int kinematicsForward(const double *j,
                       KINEMATICS_INVERSE_FLAGS * iflags)
 
 {
+    (void)fflags;
+    (void)iflags;
     double x_rot_point = *(haldata->x_rot_point);
     double y_rot_point = *(haldata->y_rot_point);
     double z_rot_point = *(haldata->z_rot_point);
@@ -206,6 +208,8 @@ int kinematicsInverse(const EmcPose * pos,
                       const KINEMATICS_INVERSE_FLAGS * iflags,
                       KINEMATICS_FORWARD_FLAGS * fflags)
 {
+    (void)iflags;
+    (void)fflags;
     double x_rot_point = *(haldata->x_rot_point);
     double y_rot_point = *(haldata->y_rot_point);
     double z_rot_point = *(haldata->z_rot_point);

--- a/src/hal/components/xyzacb_trsrn.comp
+++ b/src/hal/components/xyzacb_trsrn.comp
@@ -9,6 +9,7 @@ description
 // The fpin pin is not accessible in kinematics functions.
 // Use the *_setup() function for pins and params used by kinematics.
 pin out s32 fpin=0"pin to demonstrate use of a conventional (non-kinematics) function fdemo";
+option period no;
 function fdemo;
 
 license "GPL";
@@ -182,6 +183,8 @@ int kinematicsForward(const double *j,
                       const KINEMATICS_FORWARD_FLAGS * fflags,
                       KINEMATICS_INVERSE_FLAGS * iflags)
 {
+    (void)fflags;
+    (void)iflags;
     static bool gave_msg;
 
     // START of custom variable declaration for Forward kinematics
@@ -349,6 +352,8 @@ int kinematicsInverse(const EmcPose * pos,
                       const KINEMATICS_INVERSE_FLAGS * iflags,
                       KINEMATICS_FORWARD_FLAGS * fflags)
 {
+    (void)iflags;
+    (void)fflags;
     is_ready = 1; // Inverse is not called until homed for KINEMATICS_BOTH
 
     // START of custom variable declaration for Forward kinematics

--- a/src/hal/components/xyzbca_trsrn.comp
+++ b/src/hal/components/xyzbca_trsrn.comp
@@ -9,6 +9,7 @@ description
 // The fpin pin is not accessible in kinematics functions.
 // Use the *_setup() function for pins and params used by kinematics.
 pin out s32 fpin=0"pin to demonstrate use of a conventional (non-kinematics) function fdemo";
+option period no;
 function fdemo;
 
 license "GPL";
@@ -181,6 +182,8 @@ int kinematicsForward(const double *j,
                       const KINEMATICS_FORWARD_FLAGS * fflags,
                       KINEMATICS_INVERSE_FLAGS * iflags)
 {
+    (void)fflags;
+    (void)iflags;
     static bool gave_msg;
 
     // START of custom variable declaration for Forward kinematics
@@ -353,6 +356,8 @@ int kinematicsInverse(const EmcPose * pos,
                       const KINEMATICS_INVERSE_FLAGS * iflags,
                       KINEMATICS_FORWARD_FLAGS * fflags)
 {
+    (void)iflags;
+    (void)fflags;
     is_ready = 1; // Inverse is not called until homed for KINEMATICS_BOTH
 
     // START of custom variable declaration for Forward kinematics

--- a/src/hal/drivers/mesa_7i65.comp
+++ b/src/hal/drivers/mesa_7i65.comp
@@ -158,6 +158,7 @@ static int read(void *subdata) {
 }
 
 EXTRA_SETUP(){
+    (void)prefix;
     int i, r;
     char *name = bspi_chans[extra_arg]; // This is the string which identifies board and instance
 

--- a/src/hal/drivers/mesa_uart.comp
+++ b/src/hal/drivers/mesa_uart.comp
@@ -46,6 +46,7 @@ pin out s32 rx-bytes "Number of Bytes received";
 variable char *name; // UART name
 
 option extra_setup yes;
+option period no;
 
 function send;
 function receive;
@@ -85,6 +86,7 @@ FUNCTION(receive){
 }
     
 EXTRA_SETUP(){ // the names parameters are passed in 'prefix'. You just have to know that. 
+    (void)extra_arg;
     if (prefix[0] == 'm'){ // should be the 'h' of hm2_....
         rtapi_print_msg(0, "mesa_uart can not be loaded using the 'count' "
                         "parameter, see man mesa_uart for details\n");

--- a/src/hal/drivers/serport.comp
+++ b/src/hal/drivers/serport.comp
@@ -39,6 +39,7 @@ option count_function;
 option extra_setup;
 option extra_cleanup;
 option constructable no;
+option period no;
 
 function read nofp;
 function write nofp;
@@ -60,6 +61,7 @@ int get_count(void) {
 }
 
 EXTRA_SETUP() {
+    (void)prefix;
     rtapi_print_msg(RTAPI_MSG_INFO, "requesting I/O region 0x%x\n",
 			io[extra_arg]);
     if(!rtapi_request_region(io[extra_arg], 7, "serport")) {


### PR DESCRIPTION
This PR fixes the second part of real-time, all components, in the -Wextra warnings cleanup.

It is the other split part of #3333, which was reverted to WIP. The fixes include unused parameters and few signed/unsigned issues.

Aditionally, as discussed in #3333, halcompile has been updated to include <code>option period yes|no</code> that controls the component function's prototype declaration. Component functions that do not use the period parameter generate a warning "unused parameter" when compiling with -Wextra.
The default halcompile setting, <code>option period yes</code>, is the same as the current situation, as is omitting the option altogether, where the period parameter is included. Setting <code>option period no</code> will generate code that prevents the parameter from being added, thus fixing the warning.

All affected components have been updated in this PR. The halcompile documentation now includes a description of the new option.

A separate PR will update the Makefile to set the appropriate compiler options, which will also incorporate the issue described in #3343.