### PR TITLE
Suppress grep {t,y}elling about file-not-found

### DIFF
--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -437,7 +437,7 @@ checkref_zh_CN: $(DOC_TARGETS_HTML_ZH_CN) $(DOC_DIR)/html/zh_CN/gcode.html .html
 	@$(DOC_SRCDIR)/checkref Chinese $^
 
 MAN_SRCS_NOSO = $(patsubst $(DOC_DIR)/man/%,%, \
-			$(shell grep -L '^\.so ' $(MAN_SRCS)))
+			$(shell grep -s -L '^\.so ' $(MAN_SRCS)))
 
 PDF_MAN_ORDER := man1/linuxcnc.1 $(filter-out %/linuxcnc.1, $(filter man1/%, $(MAN_SRCS_NOSO))) \
 	man3/hal.3 $(filter-out %/undocumented.3hal %/hal.3, $(filter man3/%.3hal, $(MAN_SRCS_NOSO))) \


### PR DESCRIPTION
Grep complains when a file is not found but given as argument. This results in many and duplicated messages with a <code>make manpages</code> because the file-list expansion to grep initially contains many files that have not yet been generated. This PR stops the complaining.