### PR TITLE
Avoid calculations with void pointers

### DIFF
--- a/src/hal/drivers/hal_bb_gpio.c
+++ b/src/hal/drivers/hal_bb_gpio.c
@@ -96,7 +96,7 @@ int configure_gpio_port(int n) {
 	    return -errno;
 	}
 	// point at CM_PER_GPIOn_CLKCTRL register for port n
-	regptr = cm_per + CM_PER_GPIO1_CLKCTRL_OFFSET + 4*(n-1);
+	regptr = (void *)((char *)cm_per + CM_PER_GPIO1_CLKCTRL_OFFSET + 4*(n-1));
 	regvalue = *regptr;
 	// check for port enabled
 	if ( (regvalue & CM_PER_GPIO_CLKCTRL_MODMODE_MASK ) != CM_PER_GPIO_CLKCTRL_MODMODE_ENABLED ) {
@@ -113,10 +113,10 @@ int configure_gpio_port(int n) {
         return -errno;
     }
 
-    gpio_ports[n]->oe_reg = gpio_ports[n]->gpio_addr + GPIO_OE;
-    gpio_ports[n]->setdataout_reg = gpio_ports[n]->gpio_addr + GPIO_SETDATAOUT;
-    gpio_ports[n]->clrdataout_reg = gpio_ports[n]->gpio_addr + GPIO_CLEARDATAOUT;
-    gpio_ports[n]->datain_reg = gpio_ports[n]->gpio_addr + GPIO_DATAIN;
+    gpio_ports[n]->oe_reg = (void *)((char *)gpio_ports[n]->gpio_addr + GPIO_OE);
+    gpio_ports[n]->setdataout_reg = (void *)((char *)gpio_ports[n]->gpio_addr + GPIO_SETDATAOUT);
+    gpio_ports[n]->clrdataout_reg = (void *)((char *)gpio_ports[n]->gpio_addr + GPIO_CLEARDATAOUT);
+    gpio_ports[n]->datain_reg = (void *)((char *)gpio_ports[n]->gpio_addr + GPIO_DATAIN);
 
 
     rtapi_print("memmapped gpio port %d to %p, oe: %p, set: %p, clr: %p\n", n, gpio_ports[n]->gpio_addr, gpio_ports[n]->oe_reg, gpio_ports[n]->setdataout_reg, gpio_ports[n]->clrdataout_reg);
@@ -466,7 +466,7 @@ off_t start_addr_for_port(int port) {
 
 
 void configure_pin(bb_gpio_pin *pin, char mode) {
-    volatile unsigned int *control_reg = control_module + pin->control_offset;
+    volatile unsigned int *control_reg = (void *)((char *)control_module + pin->control_offset);
     pin->claimed = mode;
     switch(mode) {
         case 'O':

--- a/src/hal/drivers/hal_evoreg.c
+++ b/src/hal/drivers/hal_evoreg.c
@@ -169,15 +169,15 @@ int rtapi_app_main(void)
     outw(0x82c9,base); /* set indexregister */
 
     /* Set all outputs to zero */
-    writew(0, port_data_array->io_base + 0x20); /* digital out 0-15  */
-    writew(0, port_data_array->io_base + 0x40); /* digital out 16-23 */
-    writew(0, port_data_array->io_base + 0x60); /* DAC 1 */
-    writew(0, port_data_array->io_base + 0x80); /* DAC 2 */
-    writew(0, port_data_array->io_base + 0xa0); /* DAC 3 */
+    writew(0, (char *)port_data_array->io_base + 0x20); /* digital out 0-15  */
+    writew(0, (char *)port_data_array->io_base + 0x40); /* digital out 16-23 */
+    writew(0, (char *)port_data_array->io_base + 0x60); /* DAC 1 */
+    writew(0, (char *)port_data_array->io_base + 0x80); /* DAC 2 */
+    writew(0, (char *)port_data_array->io_base + 0xa0); /* DAC 3 */
     /* Reset Encoder's */
-    writew(0, port_data_array->io_base + 0x02); /* ENCODER 1 */
-    writew(0, port_data_array->io_base + 0x0a); /* ENCODER 2 */
-    writew(0, port_data_array->io_base + 0x12); /* ENCODER 3 */
+    writew(0, (char *)port_data_array->io_base + 0x02); /* ENCODER 1 */
+    writew(0, (char *)port_data_array->io_base + 0x0a); /* ENCODER 2 */
+    writew(0, (char *)port_data_array->io_base + 0x12); /* ENCODER 3 */
     
     /* STEP 3: export the pin(s) */
 
@@ -289,14 +289,14 @@ static void update_port(void *arg, long period)
     port = arg;
 
 /* write DAC's */
-    writew((*(port->dac_out[0])/10 * 0x7fff), port->io_base + 0x60);
-    writew((*(port->dac_out[1])/10 * 0x7fff), port->io_base + 0x80);
-    writew((*(port->dac_out[2])/10 * 0x7fff), port->io_base + 0xa0);
+    writew((*(port->dac_out[0])/10 * 0x7fff), (char *)port->io_base + 0x60);
+    writew((*(port->dac_out[1])/10 * 0x7fff), (char *)port->io_base + 0x80);
+    writew((*(port->dac_out[2])/10 * 0x7fff), (char *)port->io_base + 0xa0);
 
 /* Read Encoders, improve the 16bit hardware counters to 32bit and scale the values */
     raw_counts[0] = (__u16) readw(port->io_base);
-    raw_counts[1] = (__u16) readw(port->io_base + 0x08 );
-    raw_counts[2] = (__u16) readw(port->io_base + 0x10 );
+    raw_counts[1] = (__u16) readw((char *)port->io_base + 0x08 );
+    raw_counts[2] = (__u16) readw((char *)port->io_base + 0x10 );
 
     port->counts[0] += (__s16) (raw_counts[0] - port->raw_counts_old[0]);
     port->raw_counts_old[0] = raw_counts[0];
@@ -313,20 +313,20 @@ static void update_port(void *arg, long period)
 
 
 /* read digital inputs */
-     tmp = readw(port->io_base + 0x20);       /* digital input 0-15 */
+     tmp = readw((char *)port->io_base + 0x20);       /* digital input 0-15 */
       mask = 0x01;
 	for (pin=0 ; pin < 16 ; pin++) {
 	*port->digital_in[pin] = (tmp & mask) ? 1:0 ;
 	mask <<= 1;
 	}
-     tmp = readw(port->io_base + 0x40);       /* digital input 16-31 */
+     tmp = readw((char *)port->io_base + 0x40);       /* digital input 16-31 */
       mask = 0x01;
 	for (pin=16 ; pin < 32 ; pin++) {
 	*port->digital_in[pin] = (tmp & mask) ? 1:0 ;
 	mask <<= 1;
 	}
 
-     tmp = readw(port->io_base + 0x60);       /* digital input 32-45 */
+     tmp = readw((char *)port->io_base + 0x60);       /* digital input 32-45 */
       mask = 0x01;
 	for (pin=32 ; pin < 46 ; pin++) {
 	*port->digital_in[pin] = (tmp & mask) ? 1:0 ;
@@ -343,7 +343,7 @@ static void update_port(void *arg, long period)
         mask <<= 1;
         }
      }
-     writew( tmp, port->io_base + 0x20);  /* digital output 0-15 */
+     writew( tmp, (char *)port->io_base + 0x20);  /* digital output 0-15 */
 
 
      tmp = 0x0;
@@ -354,6 +354,6 @@ static void update_port(void *arg, long period)
         mask <<= 1;
         }
      }
-     writew( tmp, port->io_base + 0x40);  /* digital output 16-23 */
+     writew( tmp, (char *)port->io_base + 0x40);  /* digital output 16-23 */
 
 }

--- a/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i43.c
@@ -201,17 +201,18 @@ static void hm2_7i43_nanosleep(unsigned long int nanoseconds) {
 int hm2_7i43_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, int size) {
     int bytes_remaining = size;
     hm2_7i43_t *board = this->private;
+    char *cptr = buffer;
 
     hm2_7i43_epp_addr16(addr | HM2_7I43_ADDR_AUTOINCREMENT, board);
 
     for (; bytes_remaining > 3; bytes_remaining -= 4) {
-        *((rtapi_u32*)buffer) = hm2_7i43_epp_read32(board);
-        buffer += 4;
+        *((rtapi_u32*)cptr) = hm2_7i43_epp_read32(board);
+        cptr += 4;
     }
 
     for ( ; bytes_remaining > 0; bytes_remaining --) {
-        *((rtapi_u8*)buffer) = hm2_7i43_epp_read(board);
-        buffer ++;
+        *((rtapi_u8*)cptr) = hm2_7i43_epp_read(board);
+        cptr++;
     }
 
     if (hm2_7i43_epp_check_for_timeout(board)) {
@@ -231,17 +232,18 @@ int hm2_7i43_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, int siz
 int hm2_7i43_write(hm2_lowlevel_io_t *this, rtapi_u32 addr, const void *buffer, int size) {
     int bytes_remaining = size;
     hm2_7i43_t *board = this->private;
+    const char *cptr = buffer;
 
     hm2_7i43_epp_addr16(addr | HM2_7I43_ADDR_AUTOINCREMENT, board);
 
     for (; bytes_remaining > 3; bytes_remaining -= 4) {
-        hm2_7i43_epp_write32(*((rtapi_u32*)buffer), board);
-        buffer += 4;
+        hm2_7i43_epp_write32(*((rtapi_u32*)cptr), board);
+        cptr += 4;
     }
 
     for ( ; bytes_remaining > 0; bytes_remaining --) {
-        hm2_7i43_epp_write(*((rtapi_u8*)buffer), board);
-        buffer ++;
+        hm2_7i43_epp_write(*((rtapi_u8*)cptr), board);
+        cptr++;
     }
 
     if (hm2_7i43_epp_check_for_timeout(board)) {

--- a/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_7i90.c
@@ -197,17 +197,18 @@ static void hm2_7i90_nanosleep(unsigned long int nanoseconds) {
 int hm2_7i90_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, int size) {
     int bytes_remaining = size;
     hm2_7i90_t *board = this->private;
+    char *cptr = buffer;
 
     hm2_7i90_epp_addr16(addr | HM2_7I90_ADDR_AUTOINCREMENT, board);
 
     for (; bytes_remaining > 3; bytes_remaining -= 4) {
-        *((rtapi_u32*)buffer) = hm2_7i90_epp_read32(board);
-        buffer += 4;
+        *((rtapi_u32*)cptr) = hm2_7i90_epp_read32(board);
+        cptr += 4;
     }
 
     for ( ; bytes_remaining > 0; bytes_remaining --) {
-        *((rtapi_u8*)buffer) = hm2_7i90_epp_read(board);
-        buffer ++;
+        *((rtapi_u8*)cptr) = hm2_7i90_epp_read(board);
+        cptr++;
     }
 
     if (hm2_7i90_epp_check_for_timeout(board)) {
@@ -227,17 +228,18 @@ int hm2_7i90_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, int siz
 int hm2_7i90_write(hm2_lowlevel_io_t *this, rtapi_u32 addr, const void *buffer, int size) {
     int bytes_remaining = size;
     hm2_7i90_t *board = this->private;
+    const char *cptr = buffer;
 
     hm2_7i90_epp_addr16(addr | HM2_7I90_ADDR_AUTOINCREMENT, board);
 
     for (; bytes_remaining > 3; bytes_remaining -= 4) {
-        hm2_7i90_epp_write32(*((rtapi_u32*)buffer), board);
-        buffer += 4;
+        hm2_7i90_epp_write32(*((rtapi_u32*)cptr), board);
+        cptr += 4;
     }
 
     for ( ; bytes_remaining > 0; bytes_remaining --) {
-        hm2_7i90_epp_write(*((rtapi_u8*)buffer), board);
-        buffer ++;
+        hm2_7i90_epp_write(*((rtapi_u8*)cptr), board);
+        cptr++;
     }
 
     if (hm2_7i90_epp_check_for_timeout(board)) {

--- a/src/hal/drivers/mesa-hostmot2/hm2_pci.c
+++ b/src/hal/drivers/mesa-hostmot2/hm2_pci.c
@@ -213,12 +213,13 @@ MODULE_DEVICE_TABLE(pci, hm2_pci_tbl);
 
 static int hm2_pci_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, int size) {
     hm2_pci_t *board = this->private;
-    void *src = board->base + addr;
+    char *src = (char *)board->base + addr;
+    char *dst = buffer;
 
     while (size > 0) {
-        *(rtapi_u32*)buffer = *(rtapi_u32*)src;
+        *(rtapi_u32*)dst = *(rtapi_u32*)src;
         src += 4;
-        buffer += 4;
+        dst += 4;
         size -=4;
     }
 
@@ -227,12 +228,13 @@ static int hm2_pci_read(hm2_lowlevel_io_t *this, rtapi_u32 addr, void *buffer, i
 
 static int hm2_pci_write(hm2_lowlevel_io_t *this, rtapi_u32 addr, const void *buffer, int size) {
     hm2_pci_t *board = this->private;
-    void *dest = board->base + addr;
+    char *dest = (char *)board->base + addr;
+    const char *src = buffer;
 
     while (size > 0) {
-        *(rtapi_u32*)dest = *(rtapi_u32*)buffer;
+        *(rtapi_u32*)dest = *(rtapi_u32*)src;
         dest += 4;
-        buffer += 4;
+        src += 4;
         size -=4;
     }
 

--- a/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
+++ b/src/hal/drivers/mesa-hostmot2/spix_rpi3.c
@@ -425,9 +425,9 @@ static int peripheral_map(uintptr_t membase, size_t memsize)
 	// the wild.
 	// Lets just say, when somebody decides to change the world, then we'll
 	// fix all this code too.
-	gpio = (bcm2835_gpio_t *)(peripheralmem + (BCM2835_GPIO_OFFSET / sizeof(*peripheralmem)));
-	spi  = (bcm2835_spi_t *)(peripheralmem + (BCM2835_SPI_OFFSET  / sizeof(*peripheralmem)));
-	aux  = (bcm2835_aux_t *)(peripheralmem + (BCM2835_AUX_OFFSET  / sizeof(*peripheralmem)));
+	gpio = (bcm2835_gpio_t *)((char *)peripheralmem + BCM2835_GPIO_OFFSET);
+	spi  = (bcm2835_spi_t  *)((char *)peripheralmem + BCM2835_SPI_OFFSET);
+	aux  = (bcm2835_aux_t  *)((char *)peripheralmem + BCM2835_AUX_OFFSET);
 
 	LL_INFO("Mapped peripherals from 0x%p (size 0x%08x) to gpio:0x%p, spi:0x%p, aux:0x%p\n",
 			(void *)membase, (uint32_t)peripheralsize, gpio, spi, aux);

--- a/src/hal/hal_lib.c
+++ b/src/hal/hal_lib.c
@@ -798,7 +798,7 @@ int hal_pin_new(const char *name, hal_type_t type, hal_pin_dir_t dir,
     memset(&new->dummysig, 0, sizeof(hal_data_u));
     rtapi_snprintf(new->name, sizeof(new->name), "%s", name);
     /* make 'data_ptr' point to dummy signal */
-    *data_ptr_addr = comp->shmem_base + SHMOFF(&(new->dummysig));
+    *data_ptr_addr = (char *)comp->shmem_base + SHMOFF(&(new->dummysig));
     /* search list for 'name' and insert new structure */
     prev = &(hal_data->pin_list_ptr);
     next = *prev;
@@ -1246,7 +1246,7 @@ int hal_link(const char *pin_name, const char *sig_name)
     /* everything is OK, make the new link */
     data_ptr_addr = SHMPTR(pin->data_ptr_addr);
     comp = SHMPTR(pin->owner_ptr);
-    data_addr = comp->shmem_base + sig->data_ptr;
+    data_addr = (char *)comp->shmem_base + sig->data_ptr;
     *data_ptr_addr = data_addr;
 
     /* if the pin is a HAL_PORT the buffer belongs to the signal, port pins not linked
@@ -3483,7 +3483,7 @@ static void unlink_pin(hal_pin_t * pin)
     /* make pin's 'data_ptr' point to its dummy signal */
     data_ptr_addr = SHMPTR(pin->data_ptr_addr);
     comp = SHMPTR(pin->owner_ptr);
-    dummy_addr = comp->shmem_base + SHMOFF(&(pin->dummysig));
+    dummy_addr = (void *)((char *)comp->shmem_base + SHMOFF(&(pin->dummysig)));
     *data_ptr_addr = dummy_addr;
 
     /* copy current signal value to dummy */

--- a/src/hal/utils/upci.c
+++ b/src/hal/utils/upci.c
@@ -541,7 +541,7 @@ __u8 upci_read_u8(int rd, __u32 offset)
 	data = inb(port);
     } else {
 	/* region is memory */
-	ptr = (__u8 *)(reg->mapped_ptr + offset);
+	ptr = (__u8 *)reg->mapped_ptr + offset;
 	data = *ptr;
     }
     return data;
@@ -561,7 +561,7 @@ __s8 upci_read_s8(int rd, __u32 offset)
 	port = reg->base_addr + offset;
 	data = inb(port);
     } else {
-	ptr = (__s8 *)(reg->mapped_ptr + offset);
+	ptr = (__s8 *)reg->mapped_ptr + offset;
 	data = *ptr;
     }
     return data;
@@ -581,7 +581,7 @@ __u16 upci_read_u16(int rd, __u32 offset)
 	port = reg->base_addr + offset;
 	data = inw(port);
     } else {
-	ptr = (__u16 *)(reg->mapped_ptr + offset);
+	ptr = (__u16 *)((__u8 *)reg->mapped_ptr + offset);
 	data = *ptr;
     }
     return data;
@@ -601,7 +601,7 @@ __s16 upci_read_s16(int rd, __u32 offset)
 	port = reg->base_addr + offset;
 	data = inw(port);
     } else {
-	ptr = (__s16 *)(reg->mapped_ptr + offset);
+	ptr = (__s16 *)((__u8 *)reg->mapped_ptr + offset);
 	data = *ptr;
     }
     return data;
@@ -621,7 +621,7 @@ __u32 upci_read_u32(int rd, __u32 offset)
 	port = reg->base_addr + offset;
 	data = inl(port);
     } else {
-	ptr = (__u32 *)(reg->mapped_ptr + offset);
+	ptr = (__u32 *)((__u8 *)reg->mapped_ptr + offset);
 	data = *ptr;
     }
     return data;
@@ -641,7 +641,7 @@ __s32 upci_read_s32(int rd, __u32 offset)
 	port = reg->base_addr + offset;
 	data = inl(port);
     } else {
-	ptr = (__s32 *)(reg->mapped_ptr + offset);
+	ptr = (__s32 *)((__u8 *)reg->mapped_ptr + offset);
 	data = *ptr;
     }
     return data;
@@ -663,7 +663,7 @@ void upci_write_u8(int rd, __u32 offset, __u8 data)
 	outb(data, port);
     } else {
 	/* region is memory */
-	ptr = (__u8 *)(reg->mapped_ptr + offset);
+	ptr = (__u8 *)reg->mapped_ptr + offset;
 	*ptr = data;
     }
     return;
@@ -683,7 +683,7 @@ void upci_write_s8(int rd, __u32 offset, __s8 data)
 	port = reg->base_addr + offset;
 	outb(data, port);
     } else {
-	ptr = (__s8 *)(reg->mapped_ptr + offset);
+	ptr = (__s8 *)reg->mapped_ptr + offset;
 	*ptr = data;
     }
     return;
@@ -703,7 +703,7 @@ void upci_write_u16(int rd, __u32 offset, __u16 data)
 	port = reg->base_addr + offset;
 	outw(data, port);
     } else {
-	ptr = (__u16 *)(reg->mapped_ptr + offset);
+	ptr = (__u16 *)((__u8 *)reg->mapped_ptr + offset);
 	*ptr = data;
     }
     return;
@@ -723,7 +723,7 @@ void upci_write_s16(int rd, __u32 offset, __s16 data)
 	port = reg->base_addr + offset;
 	outw(data, port);
     } else {
-	ptr = (__s16 *)(reg->mapped_ptr + offset);
+	ptr = (__s16 *)((__u8 *)reg->mapped_ptr + offset);
 	*ptr = data;
     }
     return;
@@ -743,7 +743,7 @@ void upci_write_u32(int rd, __u32 offset, __u32 data)
 	port = reg->base_addr + offset;
 	outl(data, port);
     } else {
-	ptr = (__u32 *)(reg->mapped_ptr + offset);
+	ptr = (__u32 *)((__u8 *)reg->mapped_ptr + offset);
 	*ptr = data;
     }
     return;
@@ -763,7 +763,7 @@ void upci_write_s32(int rd, __u32 offset, __s32 data)
 	port = reg->base_addr + offset;
 	outl(data, port);
     } else {
-	ptr = (__s32 *)(reg->mapped_ptr + offset);
+	ptr = (__s32 *)((__u8 *)reg->mapped_ptr + offset);
 	*ptr = data;
     }
     return;


### PR DESCRIPTION
Cppcheck indicated several instances where calculations were performed using void pointers. The problem is that sizeof(void) is undefined in the C/C++ standards. Most compilers use the value of one (1), but it is better to use char pointer in calculations and cast back to void pointer where appropriate. This PR fixes all instances of void pointer calculations.